### PR TITLE
fix(core): preserve projected tool output in filter

### DIFF
--- a/.changeset/spotty-wings-smash.md
+++ b/.changeset/spotty-wings-smash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added an option for ToolCallFilter to preserve compact model-facing tool output while removing raw results.

--- a/packages/core/src/processor-provider/providers/index.ts
+++ b/packages/core/src/processor-provider/providers/index.ts
@@ -74,10 +74,11 @@ export const toolCallFilterProvider: ProcessorProvider = {
   },
   configSchema: z.object({
     exclude: z.array(z.string()).optional(),
+    preserveModelOutput: z.boolean().optional(),
   }),
   availablePhases: ['processInput'] as ProcessorPhase[],
   createProcessor(config) {
-    return new ToolCallFilter(config as { exclude?: string[] });
+    return new ToolCallFilter(config as { exclude?: string[]; preserveModelOutput?: boolean });
   },
 };
 

--- a/packages/core/src/processors/processors/tool-call-filter.test.ts
+++ b/packages/core/src/processors/processors/tool-call-filter.test.ts
@@ -103,6 +103,135 @@ describe('ToolCallFilter', () => {
       }
     });
 
+    it('should preserve compact model output while excluding raw tool results when enabled', async () => {
+      const filter = new ToolCallFilter({ preserveModelOutput: true });
+
+      const rawResult = {
+        rows: Array.from({ length: 20 }, (_, index) => ({ id: index, value: `raw-${index}` })),
+        diagnostics: { retainedOnlyForApp: true },
+      };
+      const modelOutput = { type: 'text', value: 'Weather summary: sunny, 72F' };
+
+      const messages: MastraDBMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          content: {
+            format: 2,
+            content: '',
+            parts: [
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'call' as const,
+                  toolCallId: 'call-1',
+                  toolName: 'weather',
+                  args: { location: 'NYC' },
+                },
+              },
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'result' as const,
+                  toolCallId: 'call-1',
+                  toolName: 'weather',
+                  args: { location: 'NYC' },
+                  result: rawResult,
+                },
+                providerMetadata: {
+                  mastra: {
+                    modelOutput,
+                  },
+                },
+              },
+            ],
+          },
+          createdAt: new Date(),
+        },
+      ];
+
+      const messageList = new MessageList();
+      messageList.add(messages, 'input');
+
+      const result = await filter.processInput({
+        messages,
+        messageList,
+        abort: mockAbort,
+      });
+
+      const resultMessages = Array.isArray(result) ? result : result.get.all.db();
+      expect(resultMessages).toHaveLength(1);
+
+      const parts = resultMessages[0]!.content.parts;
+      expect(parts).toHaveLength(1);
+      expect(parts[0]).toMatchObject({
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'result',
+          toolCallId: 'call-1',
+          toolName: 'weather',
+          result: modelOutput,
+        },
+        providerMetadata: {
+          mastra: {
+            modelOutput,
+          },
+        },
+      });
+      expect(JSON.stringify(resultMessages)).not.toContain('retainedOnlyForApp');
+
+      const filteredList = new MessageList();
+      filteredList.add(resultMessages, 'memory');
+      const prompt = await filteredList.get.all.aiV5.llmPrompt();
+      expect(JSON.stringify(prompt)).toContain('Weather summary: sunny, 72F');
+      expect(JSON.stringify(prompt)).not.toContain('retainedOnlyForApp');
+    });
+
+    it('should still remove model output tool results by default', async () => {
+      const filter = new ToolCallFilter();
+
+      const messages: MastraDBMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          content: {
+            format: 2,
+            content: '',
+            parts: [
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'result' as const,
+                  toolCallId: 'call-1',
+                  toolName: 'weather',
+                  args: {},
+                  result: { raw: true },
+                },
+                providerMetadata: {
+                  mastra: {
+                    modelOutput: { type: 'text', value: 'compact' },
+                  },
+                },
+              },
+            ],
+          },
+          createdAt: new Date(),
+        },
+      ];
+
+      const messageList = new MessageList();
+      messageList.add(messages, 'input');
+
+      const result = await filter.processInput({
+        messages,
+        messageList,
+        abort: mockAbort,
+      });
+
+      const resultMessages = Array.isArray(result) ? result : result.get.all.db();
+      expect(resultMessages).toHaveLength(0);
+    });
+
     it('should handle messages without tool calls', async () => {
       const filter = new ToolCallFilter();
 
@@ -429,6 +558,67 @@ describe('ToolCallFilter', () => {
         expect(weatherInvocations).toHaveLength(0);
         expect(calculatorInvocations.length).toBeGreaterThan(0);
       }
+    });
+
+    it('should preserve model output only for excluded tools when enabled', async () => {
+      const filter = new ToolCallFilter({ exclude: ['weather'], preserveModelOutput: true });
+
+      const weatherModelOutput = { type: 'text', value: 'Weather summary: sunny' };
+      const messages: MastraDBMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          content: {
+            format: 2,
+            content: '',
+            parts: [
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'result' as const,
+                  toolCallId: 'call-weather',
+                  toolName: 'weather',
+                  args: { location: 'NYC' },
+                  result: { rawWeather: true },
+                },
+                providerMetadata: {
+                  mastra: {
+                    modelOutput: weatherModelOutput,
+                  },
+                },
+              },
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'result' as const,
+                  toolCallId: 'call-calculator',
+                  toolName: 'calculator',
+                  args: { expression: '2+2' },
+                  result: { value: 4 },
+                },
+              },
+            ],
+          },
+          createdAt: new Date(),
+        },
+      ];
+
+      const messageList = new MessageList();
+      messageList.add(messages, 'input');
+
+      const result = await filter.processInput({
+        messages,
+        messageList,
+        abort: mockAbort,
+      });
+
+      const resultMessages = Array.isArray(result) ? result : result.get.all.db();
+      const parts = resultMessages[0]!.content.parts.filter((part: any) => part.type === 'tool-invocation');
+
+      expect(parts).toHaveLength(2);
+      expect((parts[0] as any).toolInvocation.result).toEqual(weatherModelOutput);
+      expect((parts[1] as any).toolInvocation.result).toEqual({ value: 4 });
+      expect(JSON.stringify(resultMessages)).not.toContain('rawWeather');
     });
 
     it('should exclude multiple specified tools', async () => {

--- a/packages/core/src/processors/processors/tool-call-filter.ts
+++ b/packages/core/src/processors/processors/tool-call-filter.ts
@@ -3,18 +3,12 @@ import type { RequestContext } from '../../request-context';
 
 import type { Processor } from '../index';
 
-/**
- * Type definition for tool invocation parts in MastraDBMessage format 2
- */
-type V2ToolInvocationPart = {
-  type: 'tool-invocation';
-  toolInvocation: {
-    toolName: string;
-    toolCallId: string;
-    args: unknown;
-    result?: unknown;
-    state: 'call' | 'result';
-  };
+type MastraMessagePart = NonNullable<Extract<MastraDBMessage['content'], { parts?: unknown }>['parts']>[number];
+type V2ToolInvocationPart = Extract<MastraMessagePart, { type: 'tool-invocation' }>;
+
+type ToolCallFilterOptions = {
+  exclude?: string[];
+  preserveModelOutput?: boolean;
 };
 
 /**
@@ -26,13 +20,18 @@ export class ToolCallFilter implements Processor {
   readonly id = 'tool-call-filter';
   name = 'ToolCallFilter';
   private exclude: string[] | 'all';
+  private preserveModelOutput: boolean;
 
   /**
    * Create a filter for tool calls and results.
    * @param options Configuration options
    * @param options.exclude List of specific tool names to exclude. If not provided, all tool calls are excluded.
+   * @param options.preserveModelOutput Keep completed tool results that have providerMetadata.mastra.modelOutput,
+   * replacing the raw result with that compact model-facing projection.
    */
-  constructor(options: { exclude?: string[] } = {}) {
+  constructor(options: ToolCallFilterOptions = {}) {
+    this.preserveModelOutput = options.preserveModelOutput ?? false;
+
     // If no options or exclude is provided, exclude all tools
     if (!options || !options.exclude) {
       this.exclude = 'all'; // Exclude all tools
@@ -40,6 +39,40 @@ export class ToolCallFilter implements Processor {
       // Exclude specific tools
       this.exclude = Array.isArray(options.exclude) ? options.exclude : [];
     }
+  }
+
+  private getModelOutput(part: V2ToolInvocationPart): unknown {
+    const mastraMetadata = part.providerMetadata?.mastra;
+    if (!mastraMetadata || typeof mastraMetadata !== 'object') {
+      return undefined;
+    }
+
+    return (mastraMetadata as Record<string, unknown>).modelOutput;
+  }
+
+  private compactToolResultPart(part: V2ToolInvocationPart): V2ToolInvocationPart | null {
+    if (!this.preserveModelOutput || part.toolInvocation.state !== 'result') {
+      return null;
+    }
+
+    const modelOutput = this.getModelOutput(part);
+    if (modelOutput == null) {
+      return null;
+    }
+
+    return {
+      ...part,
+      toolInvocation: {
+        ...part.toolInvocation,
+        result: modelOutput,
+      },
+    };
+  }
+
+  private getToolInvocationsFromParts(parts: MastraDBMessage['content']['parts']) {
+    return parts
+      .filter((part): part is V2ToolInvocationPart => part.type === 'tool-invocation')
+      .map(part => part.toolInvocation);
   }
 
   async processInput(args: {
@@ -85,11 +118,17 @@ export class ToolCallFilter implements Processor {
             return message;
           }
 
-          // Filter out tool invocation parts
-          const nonToolParts = message.content.parts.filter((part: any) => part.type !== 'tool-invocation');
+          const filteredParts = message.content.parts.flatMap((part: any) => {
+            if (part.type !== 'tool-invocation') {
+              return [part];
+            }
+
+            const compactPart = this.compactToolResultPart(part as V2ToolInvocationPart);
+            return compactPart ? [compactPart] : [];
+          });
 
           // If no parts remain after filtering, remove the message
-          if (nonToolParts.length === 0) {
+          if (filteredParts.length === 0) {
             return null;
           }
 
@@ -98,11 +137,13 @@ export class ToolCallFilter implements Processor {
           const { toolInvocations: originalToolInvocations, ...contentWithoutToolInvocations } = message.content as any;
           const updatedContent: any = {
             ...contentWithoutToolInvocations,
-            parts: nonToolParts,
+            parts: filteredParts,
           };
 
-          // Don't include toolInvocations since we're excluding all tools
-          // (already excluded by destructuring above)
+          const compactToolInvocations = this.getToolInvocationsFromParts(filteredParts);
+          if (compactToolInvocations.length > 0) {
+            updatedContent.toolInvocations = compactToolInvocations;
+          }
 
           return {
             ...message,
@@ -149,31 +190,28 @@ export class ToolCallFilter implements Processor {
           }
 
           // Filter out excluded tool invocation parts
-          const filteredParts = message.content.parts.filter((part: any) => {
+          const filteredParts = message.content.parts.flatMap((part: any) => {
             if (part.type !== 'tool-invocation') {
-              return true; // Keep non-tool parts
+              return [part]; // Keep non-tool parts
             }
 
             const invocationPart = part as unknown as V2ToolInvocationPart;
             const invocation = invocationPart.toolInvocation;
+            const shouldExclude =
+              (invocation.state === 'call' && this.exclude.includes(invocation.toolName)) ||
+              (invocation.state === 'result' && excludedToolCallIds.has(invocation.toolCallId)) ||
+              (invocation.state === 'result' && this.exclude.includes(invocation.toolName));
 
-            // Exclude if it's a call for an excluded tool
-            if (invocation.state === 'call' && this.exclude.includes(invocation.toolName)) {
-              return false;
+            if (!shouldExclude) {
+              return [part];
             }
 
-            // Exclude if it's a result for an excluded tool call
-            // This handles both cases: when there's a matching call, and when only results exist
-            if (invocation.state === 'result' && excludedToolCallIds.has(invocation.toolCallId)) {
-              return false;
+            const compactPart = this.compactToolResultPart(invocationPart);
+            if (compactPart) {
+              return [compactPart];
             }
 
-            // Also exclude results by tool name if no corresponding call exists (edge case in test data)
-            if (invocation.state === 'result' && this.exclude.includes(invocation.toolName)) {
-              return false;
-            }
-
-            return true; // Keep other tool invocations
+            return [];
           });
 
           // If no parts remain, remove the message entirely
@@ -189,15 +227,9 @@ export class ToolCallFilter implements Processor {
             parts: filteredParts,
           };
 
-          // Filter toolInvocations array if it exists
-          if ('toolInvocations' in message.content && Array.isArray((message.content as any).toolInvocations)) {
-            const filteredToolInvocations = (message.content as any).toolInvocations.filter(
-              (inv: any) => !this.exclude.includes(inv.toolName),
-            );
-            if (filteredToolInvocations.length > 0) {
-              updatedContent.toolInvocations = filteredToolInvocations;
-            }
-            // If no tool invocations remain, don't include the field (already excluded by destructuring)
+          const filteredToolInvocations = this.getToolInvocationsFromParts(filteredParts);
+          if (filteredToolInvocations.length > 0) {
+            updatedContent.toolInvocations = filteredToolInvocations;
           }
 
           // Check if message has no parts and no text content


### PR DESCRIPTION
Adds an opt-in `preserveModelOutput` option to `ToolCallFilter`.

When enabled, completed tool results that have `providerMetadata.mastra.modelOutput` are kept with their raw result replaced by that compact projection. Default filtering behavior is unchanged.

This lets callers drop heavy raw tool payloads while preserving the model-facing output produced by `toModelOutput`.

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
When a tool returns a huge amount of information, the system creates a condensed summary for the AI model to use. Previously, if you filtered out the tool output from message history, that summary got thrown away too. This PR adds an option to keep the summary while throwing away the huge original data—like keeping a weather summary but discarding the raw data tables.

## Overview
This PR adds a new `preserveModelOutput` option to the `ToolCallFilter` processor, enabling selective preservation of compact model-facing tool output projections while removing raw tool payloads. By default, filtering behavior remains unchanged.

## Problem
Tools that return large payloads (e.g., search, grounding, workspace, document/image tools) have their results filtered out by `ToolCallFilter`, but the framework also stores compact, model-facing projections of these results in `providerMetadata.mastra.modelOutput`. The filtering currently removes the entire tool-invocation part, destroying access to that compact projection when constructing future prompts.

## Solution
A new opt-in `preserveModelOutput` option enables the filter to:
- Keep completed tool-result parts that include `providerMetadata.mastra.modelOutput`
- Replace the raw `toolInvocation.result` with the compact `modelOutput` value
- Continue filtering tool calls and results without the projection
- Maintain full backward compatibility (default filtering behavior unchanged)

## Changes Made

### Configuration (`packages/core/src/processor-provider/providers/index.ts`)
- Extended `toolCallFilterProvider.configSchema` to include `preserveModelOutput: z.boolean().optional()`
- Updated `createProcessor` to pass the option through to the `ToolCallFilter` constructor

### Core Implementation (`packages/core/src/processors/processors/tool-call-filter.ts`)
- Updated `ToolCallFilter` constructor signature from `{ exclude?: string[] }` to `ToolCallFilterOptions { exclude?: string[]; preserveModelOutput?: boolean }`
- Added `getModelOutput()` method to extract `providerMetadata.mastra.modelOutput` from tool-invocation parts
- Added `compactToolResultPart()` method to replace raw results with model output when the option is enabled
- Refactored filtering logic from `filter` to `flatMap` to allow conditional part compaction
- Updated `getToolInvocationsFromParts()` to rebuild the `toolInvocations` array from filtered/compacted parts

### Test Coverage (`packages/core/src/processors/processors/tool-call-filter.test.ts`)
- New test case verifies that with `preserveModelOutput: true`, tool-result parts with `providerMetadata.mastra.modelOutput` are preserved with compacted results
- Tests confirm raw tool payloads are excluded while compact projections are retained
- Tests validate that when using the `exclude` option with `preserveModelOutput`, only excluded tools' results get compacted
- Comprehensive validation that compacted results don't leak raw payload data

### Versioning (`changeset/spotty-wings-smash.md`)
- Patch version bump for `@mastra/core`

## Behavior

**Default (preserveModelOutput: false or unset):**
- Tool-invocation parts are completely removed from messages
- Existing behavior unchanged

**With preserveModelOutput: true:**
- Tool-call parts remain filtered
- Tool-result parts without `providerMetadata.mastra.modelOutput` remain filtered
- Tool-result parts with `providerMetadata.mastra.modelOutput` are kept with raw `result` replaced by the compact `modelOutput`
- Enables downstream prompt construction to access compact tool projections without raw payload data

**With exclude and preserveModelOutput:**
- Non-excluded tools' results remain fully filtered
- Excluded tools' results are preserved with compaction applied (if `preserveModelOutput: true`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->