### PR TITLE
Merge tool-call-filter model output fix into fork

### DIFF
--- a/.changeset/spotty-wings-smash.md
+++ b/.changeset/spotty-wings-smash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added an option for ToolCallFilter to preserve compact model-facing tool output while removing raw results.

--- a/packages/core/src/processor-provider/providers/index.ts
+++ b/packages/core/src/processor-provider/providers/index.ts
@@ -76,6 +76,7 @@ export const toolCallFilterProvider: ProcessorProvider = {
   configSchema: z.object({
     exclude: z.array(z.string()).optional(),
     preserveLatestStep: z.boolean().optional(),
+    preserveModelOutput: z.boolean().optional(),
   }),
   availablePhases: ['processInput', 'processInputStep'] as ProcessorPhase[],
   createProcessor(config) {

--- a/packages/core/src/processors/processors/tool-call-filter.test.ts
+++ b/packages/core/src/processors/processors/tool-call-filter.test.ts
@@ -120,6 +120,135 @@ describe('ToolCallFilter', () => {
       }
     });
 
+    it('should preserve compact model output while excluding raw tool results when enabled', async () => {
+      const filter = new ToolCallFilter({ preserveModelOutput: true });
+
+      const rawResult = {
+        rows: Array.from({ length: 20 }, (_, index) => ({ id: index, value: `raw-${index}` })),
+        diagnostics: { retainedOnlyForApp: true },
+      };
+      const modelOutput = { type: 'text', value: 'Weather summary: sunny, 72F' };
+
+      const messages: MastraDBMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          content: {
+            format: 2,
+            content: '',
+            parts: [
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'call' as const,
+                  toolCallId: 'call-1',
+                  toolName: 'weather',
+                  args: { location: 'NYC' },
+                },
+              },
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'result' as const,
+                  toolCallId: 'call-1',
+                  toolName: 'weather',
+                  args: { location: 'NYC' },
+                  result: rawResult,
+                },
+                providerMetadata: {
+                  mastra: {
+                    modelOutput,
+                  },
+                },
+              },
+            ],
+          },
+          createdAt: new Date(),
+        },
+      ];
+
+      const messageList = new MessageList();
+      messageList.add(messages, 'input');
+
+      const result = await filter.processInput({
+        messages,
+        messageList,
+        abort: mockAbort,
+      });
+
+      const resultMessages = Array.isArray(result) ? result : result.get.all.db();
+      expect(resultMessages).toHaveLength(1);
+
+      const parts = resultMessages[0]!.content.parts;
+      expect(parts).toHaveLength(1);
+      expect(parts[0]).toMatchObject({
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'result',
+          toolCallId: 'call-1',
+          toolName: 'weather',
+          result: modelOutput,
+        },
+        providerMetadata: {
+          mastra: {
+            modelOutput,
+          },
+        },
+      });
+      expect(JSON.stringify(resultMessages)).not.toContain('retainedOnlyForApp');
+
+      const filteredList = new MessageList();
+      filteredList.add(resultMessages, 'memory');
+      const prompt = await filteredList.get.all.aiV5.llmPrompt();
+      expect(JSON.stringify(prompt)).toContain('Weather summary: sunny, 72F');
+      expect(JSON.stringify(prompt)).not.toContain('retainedOnlyForApp');
+    });
+
+    it('should still remove model output tool results by default', async () => {
+      const filter = new ToolCallFilter();
+
+      const messages: MastraDBMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          content: {
+            format: 2,
+            content: '',
+            parts: [
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'result' as const,
+                  toolCallId: 'call-1',
+                  toolName: 'weather',
+                  args: {},
+                  result: { raw: true },
+                },
+                providerMetadata: {
+                  mastra: {
+                    modelOutput: { type: 'text', value: 'compact' },
+                  },
+                },
+              },
+            ],
+          },
+          createdAt: new Date(),
+        },
+      ];
+
+      const messageList = new MessageList();
+      messageList.add(messages, 'input');
+
+      const result = await filter.processInput({
+        messages,
+        messageList,
+        abort: mockAbort,
+      });
+
+      const resultMessages = Array.isArray(result) ? result : result.get.all.db();
+      expect(resultMessages).toHaveLength(0);
+    });
+
     it('should handle messages without tool calls', async () => {
       const filter = new ToolCallFilter();
 
@@ -446,6 +575,67 @@ describe('ToolCallFilter', () => {
         expect(weatherInvocations).toHaveLength(0);
         expect(calculatorInvocations.length).toBeGreaterThan(0);
       }
+    });
+
+    it('should preserve model output only for excluded tools when enabled', async () => {
+      const filter = new ToolCallFilter({ exclude: ['weather'], preserveModelOutput: true });
+
+      const weatherModelOutput = { type: 'text', value: 'Weather summary: sunny' };
+      const messages: MastraDBMessage[] = [
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          content: {
+            format: 2,
+            content: '',
+            parts: [
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'result' as const,
+                  toolCallId: 'call-weather',
+                  toolName: 'weather',
+                  args: { location: 'NYC' },
+                  result: { rawWeather: true },
+                },
+                providerMetadata: {
+                  mastra: {
+                    modelOutput: weatherModelOutput,
+                  },
+                },
+              },
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'result' as const,
+                  toolCallId: 'call-calculator',
+                  toolName: 'calculator',
+                  args: { expression: '2+2' },
+                  result: { value: 4 },
+                },
+              },
+            ],
+          },
+          createdAt: new Date(),
+        },
+      ];
+
+      const messageList = new MessageList();
+      messageList.add(messages, 'input');
+
+      const result = await filter.processInput({
+        messages,
+        messageList,
+        abort: mockAbort,
+      });
+
+      const resultMessages = Array.isArray(result) ? result : result.get.all.db();
+      const parts = resultMessages[0]!.content.parts.filter((part: any) => part.type === 'tool-invocation');
+
+      expect(parts).toHaveLength(2);
+      expect((parts[0] as any).toolInvocation.result).toEqual(weatherModelOutput);
+      expect((parts[1] as any).toolInvocation.result).toEqual({ value: 4 });
+      expect(JSON.stringify(resultMessages)).not.toContain('rawWeather');
     });
 
     it('should exclude multiple specified tools', async () => {

--- a/packages/core/src/processors/processors/tool-call-filter.ts
+++ b/packages/core/src/processors/processors/tool-call-filter.ts
@@ -7,9 +7,14 @@ type ToolLikePart = {
   type: string;
   toolCallId?: string;
   toolName?: string;
+  providerMetadata?: {
+    mastra?: unknown;
+  };
   toolInvocation?: {
+    state?: string;
     toolName?: string;
     toolCallId?: string;
+    result?: unknown;
   };
 };
 
@@ -38,6 +43,13 @@ export type ToolCallFilterOptions = {
    * @default true
    */
   preserveLatestStep?: boolean;
+  /**
+   * Keep completed tool results that have providerMetadata.mastra.modelOutput,
+   * replacing the raw result with that compact model-facing projection.
+   *
+   * @default false
+   */
+  preserveModelOutput?: boolean;
 };
 
 /**
@@ -50,15 +62,18 @@ export class ToolCallFilter implements Processor {
   name = 'ToolCallFilter';
   private exclude: string[] | 'all';
   private preserveLatestStep: boolean;
+  private preserveModelOutput: boolean;
 
   /**
    * Create a filter for tool calls and results.
    * @param options Configuration options
    * @param options.exclude List of specific tool names to exclude. If not provided, all tool calls are excluded.
    * @param options.preserveLatestStep Keep the latest step's tool calls and results during processInputStep.
+   * @param options.preserveModelOutput Keep completed tool results that have providerMetadata.mastra.modelOutput.
    */
   constructor(options: ToolCallFilterOptions = {}) {
     this.preserveLatestStep = options.preserveLatestStep ?? true;
+    this.preserveModelOutput = options.preserveModelOutput ?? false;
 
     // If no options or exclude is provided, exclude all tools
     if (!options || !options.exclude) {
@@ -104,6 +119,34 @@ export class ToolCallFilter implements Processor {
   private getToolParts(message: MastraDBMessage): Array<MessagePart & ToolLikePart> {
     if (!message.content?.parts) return [];
     return message.content.parts.filter((part): part is MessagePart & ToolLikePart => this.isToolPart(part));
+  }
+
+  private getModelOutput(part: MessagePart & ToolLikePart): unknown {
+    const mastraMetadata = part.providerMetadata?.mastra;
+    if (!mastraMetadata || typeof mastraMetadata !== 'object') {
+      return undefined;
+    }
+
+    return (mastraMetadata as Record<string, unknown>).modelOutput;
+  }
+
+  private compactToolResultPart(part: MessagePart & ToolLikePart): (MessagePart & ToolLikePart) | null {
+    if (!this.preserveModelOutput || part.type !== 'tool-invocation' || part.toolInvocation?.state !== 'result') {
+      return null;
+    }
+
+    const modelOutput = this.getModelOutput(part);
+    if (modelOutput == null) {
+      return null;
+    }
+
+    return {
+      ...part,
+      toolInvocation: {
+        ...part.toolInvocation,
+        result: modelOutput,
+      },
+    };
   }
 
   private collectToolCallIds(parts: MessagePart[], toolCallIds: Set<string>) {
@@ -265,17 +308,24 @@ export class ToolCallFilter implements Processor {
 
         const filteredParts = originalParts
           ? this.removeOrphanStepStarts(
-              originalParts.filter(part => {
+              originalParts.flatMap(part => {
                 if (!this.isToolPart(part)) {
-                  return true;
+                  return [part];
                 }
 
-                return this.shouldKeepTool(
-                  this.getToolName(part),
-                  this.getToolCallId(part),
-                  preservedToolCallIds,
-                  excludedToolCallIds,
-                );
+                if (
+                  this.shouldKeepTool(
+                    this.getToolName(part),
+                    this.getToolCallId(part),
+                    preservedToolCallIds,
+                    excludedToolCallIds,
+                  )
+                ) {
+                  return [part];
+                }
+
+                const compactPart = this.compactToolResultPart(part);
+                return compactPart ? [compactPart] : [];
               }),
             )
           : undefined;


### PR DESCRIPTION
## Summary
- replay the fork-only tool-call-filter model output fix on top of current fork main
- keep PR #7 processInputStep / preserveLatestStep behavior while adding preserveModelOutput
- add focused ToolCallFilter coverage and changeset

## Validation
- git diff --check fork/main..HEAD
- pnpm --filter ./packages/core exec vitest run src/processors/processors/tool-call-filter.test.ts (blocked in temp worktree: vitest/test setup artifacts unavailable without package-local install)
- pnpm build:core (blocked in temp worktree: package-local tsup binary unavailable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation

When an AI tool runs and returns results, the ToolCallFilter now has an option to keep only the "cleaned-up" version of that result (designed for the AI to understand) while throwing away the raw, detailed result data. This makes conversations with the AI cleaner and more focused.

## Overview

This PR integrates a tool-call-filter model output preservation feature that allows the `ToolCallFilter` processor to selectively retain compact, model-optimized tool outputs while filtering out raw tool result data. The change introduces the `preserveModelOutput` configuration option, enabling cleaner AI prompt generation by excluding verbose tool diagnostics.

## Changes

### Configuration & Schema
- Updated the `toolCallFilterProvider` schema in the processor provider configuration to include an optional `preserveModelOutput: boolean` setting

### Core Implementation
- Added `preserveModelOutput` option to `ToolCallFilterOptions` with a default value of `false`
- Implemented logic to extract `providerMetadata.mastra.modelOutput` and use it as a replacement for raw tool results when the option is enabled
- Refactored the tool-part filtering logic from a simple `filter` operation to `flatMap` to enable conditional transformation of individual tool invocations

### Test Coverage
Added three comprehensive test cases validating:
1. When `preserveModelOutput` is enabled, compact model-projected outputs are retained in tool-invocation results while raw diagnostics are excluded
2. When the option is not set (default), model output tool results are removed entirely
3. When combined with the `exclude` list, preservation applies only to excluded tool names while other results remain unaffected

### Documentation
Added changeset documenting the new feature for `@mastra/core`

## Backward Compatibility
The feature maintains full backward compatibility by defaulting `preserveModelOutput` to `false`, preserving existing behavior when the option is not explicitly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->