### PR TITLE
Merge read-only observational memory fix into fork

### DIFF
--- a/.changeset/tricky-dryers-yell.md
+++ b/.changeset/tricky-dryers-yell.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed read-only observational memory so existing context is still loaded.

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -145,6 +145,110 @@ function createInMemoryStorage(): InMemoryMemory {
   return new InMemoryMemory({ db });
 }
 
+describe('ObservationalMemoryProcessor read-only mode', () => {
+  it('loads stored context without starting observation side effects', async () => {
+    const { MessageList } = await import('@mastra/core/agent');
+    const { RequestContext } = await import('@mastra/core/di');
+
+    const storage = createInMemoryStorage();
+    const threadId = 'read-only-om-thread';
+    const resourceId = 'read-only-om-resource';
+
+    await storage.saveThread({
+      thread: {
+        id: threadId,
+        resourceId,
+        title: 'Read-only OM',
+        createdAt: new Date('2025-01-01T08:00:00Z'),
+        updatedAt: new Date('2025-01-01T08:00:00Z'),
+        metadata: {},
+      },
+    });
+
+    await storage.saveMessages({
+      messages: [
+        {
+          id: 'stored-user-1',
+          role: 'user',
+          content: { format: 2, parts: [{ type: 'text', text: 'Stored read-only context' }] },
+          type: 'text',
+          createdAt: new Date('2025-01-01T09:00:00Z'),
+          threadId,
+          resourceId,
+        } as any,
+      ],
+    });
+
+    const mockModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop' as const,
+        usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+        content: [{ type: 'text' as const, text: 'ok' }],
+        warnings: [],
+      }),
+    });
+
+    const om = new ObservationalMemory({
+      storage,
+      scope: 'thread',
+      model: mockModel as any,
+      observation: { messageTokens: 1, bufferTokens: false },
+      reflection: { observationTokens: 1 },
+    });
+
+    const baseMemoryProvider = createMemoryProvider(om);
+    const memoryProvider: MemoryContextProvider = {
+      getContext: vi.fn(baseMemoryProvider.getContext),
+      persistMessages: vi.fn(baseMemoryProvider.persistMessages),
+    };
+
+    const beginTurnSpy = vi.spyOn(om, 'beginTurn');
+    const observeSpy = vi.spyOn(om, 'observe');
+    const bufferSpy = vi.spyOn(om, 'buffer');
+    const persistSpy = vi.spyOn(om, 'persistMessages');
+    const emitProgressSpy = vi.spyOn(om, 'emitProgress');
+
+    const processor = new ObservationalMemoryProcessor(om, memoryProvider);
+    const messageList = new MessageList({ threadId, resourceId });
+    const requestContext = new RequestContext();
+    requestContext.set('MastraMemory', {
+      thread: { id: threadId },
+      resourceId,
+      memoryConfig: { readOnly: true },
+    });
+
+    const state: Record<string, unknown> = {};
+
+    await processor.processInputStep({
+      messageList,
+      messages: [],
+      requestContext,
+      stepNumber: 0,
+      state,
+      steps: [],
+      systemMessages: [],
+      model: mockModel as any,
+      retryCount: 0,
+      abort: (() => {
+        throw new Error('aborted');
+      }) as any,
+    });
+
+    expect(memoryProvider.getContext).toHaveBeenCalledTimes(1);
+    expect(memoryProvider.getContext).toHaveBeenCalledWith({ threadId, resourceId });
+    expect(messageList.get.all.db().map(m => m.id)).toContain('stored-user-1');
+
+    expect(state.__omTurn).toBeUndefined();
+    expect(beginTurnSpy).not.toHaveBeenCalled();
+    expect(observeSpy).not.toHaveBeenCalled();
+    expect(bufferSpy).not.toHaveBeenCalled();
+    expect(persistSpy).not.toHaveBeenCalled();
+    expect(memoryProvider.persistMessages).not.toHaveBeenCalled();
+    expect(emitProgressSpy).not.toHaveBeenCalled();
+  });
+});
+
 function createStreamCapableMockModel(config: Record<string, any>) {
   if (config.doGenerate && !config.doStream) {
     const originalDoGenerate = config.doGenerate;

--- a/packages/memory/src/processors/observational-memory/observation-turn/load-memory-context.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/load-memory-context.ts
@@ -1,0 +1,25 @@
+import type { MessageList } from '@mastra/core/agent';
+
+import type { MemoryContextProvider } from '../processor';
+
+export async function loadMemoryContextMessages({
+  memory,
+  messageList,
+  threadId,
+  resourceId,
+}: {
+  memory: MemoryContextProvider;
+  messageList: MessageList;
+  threadId: string;
+  resourceId?: string;
+}): Promise<Awaited<ReturnType<MemoryContextProvider['getContext']>>> {
+  const ctx = await memory.getContext({ threadId, resourceId });
+
+  for (const msg of ctx.messages) {
+    if (msg.role !== 'system') {
+      messageList.add(msg, 'memory');
+    }
+  }
+
+  return ctx;
+}

--- a/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
+++ b/packages/memory/src/processors/observational-memory/observation-turn/turn.ts
@@ -8,6 +8,7 @@ import type { ObservationalMemory } from '../observational-memory';
 import type { MemoryContextProvider } from '../processor';
 import type { ObservationModelContext } from '../types';
 
+import { loadMemoryContextMessages } from './load-memory-context';
 import { ObservationStep } from './step';
 import type { ObservationTurnHooks, TurnContext, TurnResult } from './types';
 
@@ -120,14 +121,12 @@ export class ObservationTurn {
     this.memory = memory;
 
     if (memory) {
-      const ctx = await memory.getContext({ threadId: this.threadId, resourceId: this.resourceId });
-
-      // Add historical messages to the MessageList, filtering out system messages
-      for (const msg of ctx.messages) {
-        if (msg.role !== 'system') {
-          this.messageList.add(msg, 'memory');
-        }
-      }
+      const ctx = await loadMemoryContextMessages({
+        memory,
+        messageList: this.messageList,
+        threadId: this.threadId,
+        resourceId: this.resourceId,
+      });
 
       this._context = {
         messages: ctx.messages,

--- a/packages/memory/src/processors/observational-memory/processor.ts
+++ b/packages/memory/src/processors/observational-memory/processor.ts
@@ -7,6 +7,7 @@ import type { ObservationalMemoryRecord } from '@mastra/core/storage';
 import { OBSERVATION_CONTINUATION_HINT } from './constants';
 import { omDebug } from './debug';
 import type { ObservationTurn } from './observation-turn/index';
+import { loadMemoryContextMessages } from './observation-turn/load-memory-context';
 import type { ObservationalMemory } from './observational-memory';
 import { isOmReproCaptureEnabled, safeCaptureJson, writeProcessInputStepReproCapture } from './repro-capture';
 import { insertTemporalGapMarkers } from './temporal-markers';
@@ -140,8 +141,14 @@ export class ObservationalMemoryProcessor implements Processor<'observational-me
         ? (safeCaptureJson(messageList.serialize()) as ReturnType<MessageList['serialize']>)
         : null;
 
-      // ── Read-only fast path: skip turn creation and observation lifecycle ──
+      // ── Read-only path: load existing context, skip observation lifecycle ──
       if (readOnly) {
+        await loadMemoryContextMessages({
+          memory: this.memory,
+          messageList,
+          threadId,
+          resourceId,
+        });
         return messageList;
       }
 


### PR DESCRIPTION
## Summary
- replay upstream PR mastra-ai/mastra#16059 on top of current fork main
- load stored observational memory context in read-only mode without creating turns or observation side effects
- include regression coverage and changeset

## Validation
- git diff --check fork/main..HEAD
- pnpm --filter ./packages/memory exec vitest run src/processors/observational-memory/__tests__/observational-memory.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes how the system handles saved conversations when in "read-only" mode. Instead of ignoring previously stored messages, it now loads them into memory so they're available to use, but without creating new conversation turns or triggering any side effects—like reading from a book without writing in it.

## Overview

Replays upstream changes that fix read-only observational memory behavior. Previously, read-only mode would skip loading stored conversation context entirely. The fix ensures stored context is loaded and available in the message list while still preventing turn creation and observation side effects.

## Changes

### New Helper Function
- **`loadMemoryContextMessages`** — A new exported async helper in `packages/memory/src/processors/observational-memory/observation-turn/load-memory-context.ts` that retrieves stored memory context and adds it to the message list (excluding system messages), then returns the context object.

### Refactored Processing Logic
- **`ObservationTurn.start()`** — Delegated historical message loading to the new helper function, simplifying the inline flow.
- **`ObservationalMemoryProcessor.processInputStep()`** — Updated the read-only fast path to call `loadMemoryContextMessages()`, ensuring stored context is loaded while still skipping observation lifecycle and turn creation.

### Testing & Versioning
- **Regression test** — Added comprehensive test in `packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts` verifying that read-only mode loads historical context exactly once, includes stored messages in the message list, and skips all observational side effects (turn initialization, observation, buffering, persistence, and progress emission).
- **Changeset** — Added patch-level release metadata for `@mastra/memory` documenting the read-only observational memory correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->