### PR TITLE
Merge ToolCallFilter compact output PR into fork

### DIFF
--- a/.changeset/funky-coins-sing.md
+++ b/.changeset/funky-coins-sing.md
@@ -1,0 +1,13 @@
+---
+'@mastra/core': minor
+---
+
+Added `preserveModelOutput` to `ToolCallFilter` so filtered tool history can keep compact model-facing output without raw tool args or results.
+
+```ts
+import { ToolCallFilter } from '@mastra/core/processors';
+
+const filter = new ToolCallFilter({
+  preserveModelOutput: true,
+});
+```

--- a/docs/src/content/en/docs/agents/processors.mdx
+++ b/docs/src/content/en/docs/agents/processors.mdx
@@ -387,6 +387,14 @@ new ToolCallFilter({
 })
 ```
 
+Set `preserveModelOutput: true` to keep compact `toModelOutput` history for filtered completed tool results. The filter keeps only the model-facing output and removes raw tool args and raw results.
+
+```typescript
+new ToolCallFilter({
+  preserveModelOutput: true,
+})
+```
+
 See the [`ToolCallFilter` reference](/reference/processors/tool-call-filter) for configuration options and the [Memory Processors](/docs/memory/memory-processors#manual-control-and-deduplication) page for pre-memory filtering.
 
 ### `ToolSearchProcessor`

--- a/docs/src/content/en/reference/processors/tool-call-filter.mdx
+++ b/docs/src/content/en/reference/processors/tool-call-filter.mdx
@@ -57,6 +57,21 @@ const filterStepHistory = new ToolCallFilter({
             isOptional: true,
             defaultValue: 'true',
           },
+          {
+            name: 'filterAfterToolSteps',
+            type: 'number',
+            description:
+              'Preserves tool calls and results from this many recent tool-producing steps during processInputStep. When set, this takes precedence over preserveLatestStep',
+            isOptional: true,
+          },
+          {
+            name: 'preserveModelOutput',
+            type: 'boolean',
+            description:
+              'Keeps compact model-facing output from filtered completed tool results while removing raw tool args and raw results',
+            isOptional: true,
+            defaultValue: 'false',
+          },
         ],
       },
     ],
@@ -135,6 +150,37 @@ Set `preserveLatestStep` to `false` to remove all matching tool calls and result
 ```typescript
 new ToolCallFilter({
   preserveLatestStep: false,
+})
+```
+
+Set `filterAfterToolSteps` to preserve tool calls and results from a fixed number of recent tool-producing steps:
+
+```typescript
+new ToolCallFilter({
+  filterAfterToolSteps: 2,
+})
+```
+
+Set `filterAfterToolSteps` to `0` to remove all previous tool calls and results on each step.
+
+## Preserve compact model output
+
+Set `preserveModelOutput` to `true` to retain compact `toModelOutput` history for filtered completed tool results. This keeps only the model-facing output as text in the prompt and removes raw tool args and raw tool results.
+
+Only completed tool results with `providerMetadata.mastra.modelOutput` are preserved. Tool calls, incomplete results, and results without stored model output are still filtered.
+
+```typescript
+new ToolCallFilter({
+  preserveModelOutput: true,
+})
+```
+
+Combine `preserveModelOutput` with `exclude` to preserve compact output only for filtered tools:
+
+```typescript
+new ToolCallFilter({
+  exclude: ['searchDatabase'],
+  preserveModelOutput: true,
 })
 ```
 

--- a/packages/core/src/processor-provider/providers/index.ts
+++ b/packages/core/src/processor-provider/providers/index.ts
@@ -76,6 +76,7 @@ export const toolCallFilterProvider: ProcessorProvider = {
   configSchema: z.object({
     exclude: z.array(z.string()).optional(),
     preserveLatestStep: z.boolean().optional(),
+    filterAfterToolSteps: z.number().optional(),
     preserveModelOutput: z.boolean().optional(),
   }),
   availablePhases: ['processInput', 'processInputStep'] as ProcessorPhase[],

--- a/packages/core/src/processors/processors/tool-call-filter.test.ts
+++ b/packages/core/src/processors/processors/tool-call-filter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 
 import { MessageList } from '../../agent/message-list';
 import type { MastraDBMessage } from '../../memory/types';
+import { toolCallFilterProvider } from '../../processor-provider/providers';
 
 import { ToolCallFilter } from './tool-call-filter';
 
@@ -182,20 +183,11 @@ describe('ToolCallFilter', () => {
       const parts = resultMessages[0]!.content.parts;
       expect(parts).toHaveLength(1);
       expect(parts[0]).toMatchObject({
-        type: 'tool-invocation',
-        toolInvocation: {
-          state: 'result',
-          toolCallId: 'call-1',
-          toolName: 'weather',
-          result: modelOutput,
-        },
-        providerMetadata: {
-          mastra: {
-            modelOutput,
-          },
-        },
+        type: 'text',
+        text: 'weather result:\nWeather summary: sunny, 72F',
       });
       expect(JSON.stringify(resultMessages)).not.toContain('retainedOnlyForApp');
+      expect(JSON.stringify(resultMessages)).not.toContain('location');
 
       const filteredList = new MessageList();
       filteredList.add(resultMessages, 'memory');
@@ -630,12 +622,25 @@ describe('ToolCallFilter', () => {
       });
 
       const resultMessages = Array.isArray(result) ? result : result.get.all.db();
-      const parts = resultMessages[0]!.content.parts.filter((part: any) => part.type === 'tool-invocation');
+      const parts = resultMessages[0]!.content.parts;
+      const textParts = parts.filter((part: any) => part.type === 'text');
+      const toolParts = parts.filter((part: any) => part.type === 'tool-invocation');
 
-      expect(parts).toHaveLength(2);
-      expect((parts[0] as any).toolInvocation.result).toEqual(weatherModelOutput);
-      expect((parts[1] as any).toolInvocation.result).toEqual({ value: 4 });
+      expect(textParts).toHaveLength(1);
+      expect(textParts[0]).toMatchObject({ text: 'weather result:\nWeather summary: sunny' });
+      expect(toolParts).toHaveLength(1);
+      expect((toolParts[0] as any).toolInvocation.result).toEqual({ value: 4 });
       expect(JSON.stringify(resultMessages)).not.toContain('rawWeather');
+    });
+
+    it('should expose step filtering and model output options through the processor provider config', async () => {
+      const parsedConfig = toolCallFilterProvider.configSchema.parse({
+        filterAfterToolSteps: 0,
+        preserveModelOutput: true,
+      });
+      const processor = toolCallFilterProvider.createProcessor(parsedConfig);
+
+      expect(processor).toBeInstanceOf(ToolCallFilter);
     });
 
     it('should exclude multiple specified tools', async () => {
@@ -1016,6 +1021,51 @@ describe('ToolCallFilter', () => {
   });
 
   describe('processInputStep', () => {
+    it('should filter all previous tool calls when filterAfterToolSteps is 0', async () => {
+      const filter = new ToolCallFilter({ filterAfterToolSteps: 0 });
+      const messages = [
+        {
+          id: 'msg-1',
+          role: 'user',
+          content: {
+            format: 2,
+            parts: [{ type: 'text' as const, text: 'Use a tool.' }],
+          },
+          createdAt: new Date(),
+        },
+        {
+          id: 'msg-2',
+          role: 'assistant',
+          content: {
+            format: 2,
+            parts: [
+              {
+                type: 'tool-invocation' as const,
+                toolInvocation: {
+                  state: 'result' as const,
+                  toolCallId: 'old-call',
+                  toolName: 'search',
+                  args: { q: 'old' },
+                  result: 'OLD_TOOL_RESULT',
+                },
+              },
+              { type: 'text' as const, text: 'Tool completed.' },
+            ],
+          },
+          createdAt: new Date(),
+        },
+      ] as unknown as MastraDBMessage[];
+
+      const messageList = new MessageList();
+      messageList.add(messages, 'input');
+
+      const result = await filter.processInputStep(createProcessInputStepArgs(messageList));
+
+      expect(result.modelContextMessages).toHaveLength(2);
+      expect(JSON.stringify(result.modelContextMessages)).not.toContain('OLD_TOOL_RESULT');
+      expect(JSON.stringify(result.modelContextMessages)).toContain('Tool completed.');
+    });
+
     it('should run at each step and preserve the latest step tool result by default', async () => {
       const filter = new ToolCallFilter();
 

--- a/packages/core/src/processors/processors/tool-call-filter.ts
+++ b/packages/core/src/processors/processors/tool-call-filter.ts
@@ -44,8 +44,13 @@ export type ToolCallFilterOptions = {
    */
   preserveLatestStep?: boolean;
   /**
+   * Preserve tool calls and results from this many recent tool-producing steps when processInputStep runs.
+   * When set, this takes precedence over preserveLatestStep.
+   */
+  filterAfterToolSteps?: number;
+  /**
    * Keep completed tool results that have providerMetadata.mastra.modelOutput,
-   * replacing the raw result with that compact model-facing projection.
+   * replacing the filtered tool part with compact text-only model-facing output.
    *
    * @default false
    */
@@ -62,6 +67,7 @@ export class ToolCallFilter implements Processor {
   name = 'ToolCallFilter';
   private exclude: string[] | 'all';
   private preserveLatestStep: boolean;
+  private filterAfterToolSteps: number | undefined;
   private preserveModelOutput: boolean;
 
   /**
@@ -69,10 +75,12 @@ export class ToolCallFilter implements Processor {
    * @param options Configuration options
    * @param options.exclude List of specific tool names to exclude. If not provided, all tool calls are excluded.
    * @param options.preserveLatestStep Keep the latest step's tool calls and results during processInputStep.
+   * @param options.filterAfterToolSteps Preserve tool calls and results from this many recent tool-producing steps during processInputStep.
    * @param options.preserveModelOutput Keep completed tool results that have providerMetadata.mastra.modelOutput.
    */
   constructor(options: ToolCallFilterOptions = {}) {
     this.preserveLatestStep = options.preserveLatestStep ?? true;
+    this.filterAfterToolSteps = options.filterAfterToolSteps;
     this.preserveModelOutput = options.preserveModelOutput ?? false;
 
     // If no options or exclude is provided, exclude all tools
@@ -130,7 +138,7 @@ export class ToolCallFilter implements Processor {
     return (mastraMetadata as Record<string, unknown>).modelOutput;
   }
 
-  private compactToolResultPart(part: MessagePart & ToolLikePart): (MessagePart & ToolLikePart) | null {
+  private getPreservedModelOutputPart(part: MessagePart & ToolLikePart): MessagePart | null {
     if (!this.preserveModelOutput || part.type !== 'tool-invocation' || part.toolInvocation?.state !== 'result') {
       return null;
     }
@@ -140,13 +148,65 @@ export class ToolCallFilter implements Processor {
       return null;
     }
 
+    const text = this.modelOutputToText(modelOutput);
+    if (!text) {
+      return null;
+    }
+
     return {
-      ...part,
-      toolInvocation: {
-        ...part.toolInvocation,
-        result: modelOutput,
-      },
-    };
+      type: 'text',
+      text: `${part.toolInvocation.toolName} result:\n${text}`,
+    } as MessagePart;
+  }
+
+  private modelOutputToText(modelOutput: unknown): string | null {
+    if (typeof modelOutput === 'string') {
+      return modelOutput;
+    }
+
+    if (typeof modelOutput === 'number' || typeof modelOutput === 'boolean' || typeof modelOutput === 'bigint') {
+      return String(modelOutput);
+    }
+
+    if (Array.isArray(modelOutput)) {
+      const text = modelOutput
+        .map(part => this.modelOutputToText(part))
+        .filter((part): part is string => Boolean(part))
+        .join('\n');
+      return text || this.safeStringify(modelOutput);
+    }
+
+    if (modelOutput && typeof modelOutput === 'object') {
+      const output = modelOutput as Record<string, unknown>;
+      if (output.type === 'text') {
+        if (typeof output.value === 'string') {
+          return output.value;
+        }
+        if (typeof output.text === 'string') {
+          return output.text;
+        }
+      }
+
+      if ('value' in output) {
+        return this.modelOutputToText(output.value);
+      }
+
+      if ('text' in output && typeof output.text === 'string') {
+        return output.text;
+      }
+
+      return this.safeStringify(modelOutput);
+    }
+
+    return null;
+  }
+
+  private safeStringify(value: unknown): string | null {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return null;
+    }
   }
 
   private collectToolCallIds(parts: MessagePart[], toolCallIds: Set<string>) {
@@ -324,8 +384,8 @@ export class ToolCallFilter implements Processor {
                   return [part];
                 }
 
-                const compactPart = this.compactToolResultPart(part);
-                return compactPart ? [compactPart] : [];
+                const modelOutputPart = this.getPreservedModelOutputPart(part);
+                return modelOutputPart ? [modelOutputPart] : [];
               }),
             )
           : undefined;
@@ -390,6 +450,36 @@ export class ToolCallFilter implements Processor {
     return { messages: filteredMessages, changed };
   }
 
+  private getRecentToolStepToolCallIds(args: ProcessInputStepArgs): Set<string> {
+    const state = args.state as {
+      toolCallFilterSeenToolCallIds?: string[];
+      toolCallFilterStepToolCallIds?: string[][];
+    };
+    const seenToolCallIds = new Set(state.toolCallFilterSeenToolCallIds ?? []);
+    const responseToolCallIds = this.getMessageToolCallIds(args.messageList.get.response.db());
+    const newToolCallIds = [...responseToolCallIds].filter(toolCallId => !seenToolCallIds.has(toolCallId));
+
+    state.toolCallFilterSeenToolCallIds = [...new Set([...seenToolCallIds, ...newToolCallIds])];
+    state.toolCallFilterStepToolCallIds = [...(state.toolCallFilterStepToolCallIds ?? []), newToolCallIds];
+
+    const preserveStepCount = Math.max(0, this.filterAfterToolSteps ?? 0);
+    const recentStepToolCallIds =
+      preserveStepCount === 0 ? [] : state.toolCallFilterStepToolCallIds.slice(-preserveStepCount).flat();
+
+    return new Set(recentStepToolCallIds);
+  }
+
+  private getMessageToolCallIds(messages: MastraDBMessage[]): Set<string> {
+    const toolCallIds = new Set<string>();
+
+    for (const message of messages) {
+      this.collectToolCallIds(message.content?.parts ?? [], toolCallIds);
+      this.collectToolInvocationIds([message], toolCallIds);
+    }
+
+    return toolCallIds;
+  }
+
   async processInput(args: {
     messages: MastraDBMessage[];
     messageList: MessageList;
@@ -402,7 +492,10 @@ export class ToolCallFilter implements Processor {
   }
 
   async processInputStep(args: ProcessInputStepArgs): Promise<ProcessInputStepResult> {
-    const preservedToolCallIds = this.getLatestStepToolCallIds(args.steps, args.messages);
+    const preservedToolCallIds =
+      this.filterAfterToolSteps === undefined
+        ? this.getLatestStepToolCallIds(args.steps, args.messages)
+        : this.getRecentToolStepToolCallIds(args);
     const result = this.filterMessages(args.messages, preservedToolCallIds);
     if (!result.changed) {
       return {};


### PR DESCRIPTION
## Summary
- replay/adapt upstream PR mastra-ai/mastra#16060 onto current fork main
- add filterAfterToolSteps provider/config support while preserving fork main modelContextMessages behavior
- preserve compact model output as text-only prompt context so raw tool args/results are removed
- add docs, focused coverage, and changeset

## Validation
- git diff --check fork/main..HEAD
- pnpm --filter ./packages/core exec vitest run src/processors/processors/tool-call-filter.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds smarter cleanup for tool history in AI conversations. Instead of showing the model all the messy raw tool data, it can now keep just the clean, friendly summary that was meant for the model while throwing away the technical details. It also lets you control how much of the recent tool history to keep when cleaning up old messages.

## Overview

Adapts upstream PR mastra-ai/mastra#16060 onto the fork's main branch to introduce two new `ToolCallFilter` configuration options for more flexible tool history management in AI agent prompts.

## Key Changes

### New `preserveModelOutput` Option
- When enabled, filtered tool results retain only the compact, model-facing `toModelOutput` text instead of keeping raw tool arguments and results
- Converts preserved `providerMetadata.mastra.modelOutput` tool results into new text-only message parts
- Supports string, primitive, array, and common object shapes with safe JSON fallback
- Only applies when completed tool results include `providerMetadata.mastra.modelOutput`
- Can be combined with `exclude` to preserve compact output for selected filtered tools

### New `filterAfterToolSteps` Option
- Controls how many of the most recent tool-producing steps to preserve during `processInputStep`
- Takes explicit precedence over `preserveLatestStep`
- Implements stateful tracking of tool call IDs and per-step batches in processor state
- Setting to `0` removes all previous tool call results from `modelContextMessages`

### Configuration & Provider Support
- Exposed both options via processor-provider configuration through `toolCallFilterProvider.configSchema`
- Allows configuration through `createProcessor(config as ToolCallFilterOptions)`

## Documentation & Testing
- Updated documentation in `docs/agents/processors.mdx` with configuration example
- Added comprehensive reference documentation in `docs/reference/tool-call-filter.mdx` covering both new options with usage examples
- Added focused test coverage including:
  - Validation of compact model output formatting as text-only parts
  - Tests for `filterAfterToolSteps: 0` behavior
  - Processor-provider configuration exposure verification
  - Mixed-content test refinements for text vs. tool-invocation parts
- Published changeset noting the minor version update for `@mastra/core`

## Files Modified
- `.changeset/funky-coins-sing.md` (new)
- `docs/src/content/en/docs/agents/processors.mdx`
- `docs/src/content/en/reference/processors/tool-call-filter.mdx`
- `packages/core/src/processor-provider/providers/index.ts`
- `packages/core/src/processors/processors/tool-call-filter.test.ts`
- `packages/core/src/processors/processors/tool-call-filter.ts`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->