### PR TITLE
fix(core): keep prompt-only processor workflow returns exclusive

### DIFF
--- a/.changeset/orange-dryers-push.md
+++ b/.changeset/orange-dryers-push.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed processor workflows so prompt-only model context returns do not also include canonical messages.

--- a/packages/core/src/workflows/processor-step.test.ts
+++ b/packages/core/src/workflows/processor-step.test.ts
@@ -452,7 +452,7 @@ describe('createStep with Processor', () => {
       );
     });
 
-    it('should keep inputStep message returns prompt-only when modelContextMessages is active', async () => {
+    it('should return only prompt-only modelContextMessages when modelContextMessages is active', async () => {
       const processInputStepMock = async ({ messages }) => {
         return messages.filter(m => m.id !== 'remove-me');
       };
@@ -463,11 +463,8 @@ describe('createStep with Processor', () => {
       };
 
       const step = createStep(processor);
-      const messages = [
-        { id: 'keep-me', role: 'user', content: { format: 2, parts: [{ type: 'text', text: 'keep' }] } },
-        { id: 'remove-me', role: 'assistant', content: { format: 2, parts: [{ type: 'text', text: 'remove' }] } },
-      ] as MastraDBMessage[];
-      const messageList = createMockMessageList(messages);
+      const messages = [createDbMessage('keep-me', 'keep'), createDbMessage('remove-me', 'remove', 'assistant')];
+      const messageList = new MessageList().add(messages, 'input');
       const inputData = {
         phase: 'inputStep' as const,
         messages,
@@ -479,14 +476,13 @@ describe('createStep with Processor', () => {
 
       const result = await step.execute({ inputData } as any);
 
-      expect(messageList.removeByIds).not.toHaveBeenCalled();
-      expect(messageList.add).not.toHaveBeenCalled();
       expect(result).toEqual(
         expect.objectContaining({
-          messages: [messages[0]],
           modelContextMessages: [messages[0]],
         }),
       );
+      expect(result).not.toHaveProperty('messages');
+      expect(messageList.get.all.db()).toEqual(messages);
     });
 
     it('should keep prompt-only processInputStep MessageList mutations prompt-only', async () => {

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1358,19 +1358,24 @@ function createStepFromProcessor<TProcessorId extends string>(
                 }
               }
 
-              // Preserve messages in return - passThrough doesn't include messages,
-              // so we must explicitly include it to avoid losing it for subsequent steps.
               const nextModelContextMessages =
                 validatedResult.modelContextMessages ??
                 (returnPassThrough.modelContextMessages !== undefined && validatedResult.messages
                   ? stripPromptOnlySystemMessages(validatedResult.messages)
                   : undefined);
-              const nextMessages = nextModelContextMessages ?? validatedResult.messages ?? returnMessages;
+              if (nextModelContextMessages !== undefined) {
+                const { messages: _messages, ...validatedWithoutMessages } = validatedResult;
+                return {
+                  ...returnPassThrough,
+                  ...validatedWithoutMessages,
+                  modelContextMessages: nextModelContextMessages,
+                  ...(currentMessageId ? { messageId: validatedResult.messageId ?? currentMessageId } : {}),
+                };
+              }
               return {
                 ...returnPassThrough,
-                messages: nextMessages,
+                messages: validatedResult.messages ?? returnMessages,
                 ...validatedResult,
-                ...(nextModelContextMessages !== undefined ? { modelContextMessages: nextModelContextMessages } : {}),
                 ...(currentMessageId ? { messageId: validatedResult.messageId ?? currentMessageId } : {}),
               };
             }


### PR DESCRIPTION
Fixes #14.

Processor workflows could forward both `messages` and `modelContextMessages` once prompt-only model context was active. The newer processor runner rejects that mixed shape, which broke PapersFlow live routing with `Processor doxa-input-processor returned both messages and modelContextMessages`.

This keeps the prompt-only branch exclusive: when `modelContextMessages` is active, the workflow returns only `modelContextMessages` and leaves canonical messages out of the step output.

Validated with:
`pnpm --filter ./packages/core exec vitest run src/workflows/processor-step.test.ts`
`pnpm --filter ./packages/core check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The PR fixes a bug where a message processing system was accidentally sending two different types of messages at the same time when it should only send one. This confused the system and caused it to crash. The fix ensures that when using a special "prompt-only" mode for messages, the system only returns that type and stops trying to also send the old-style messages.

---

## Overview

Processor workflows were incorrectly returning both `messages` and `modelContextMessages` simultaneously when prompt-only model context was active, causing the processor runner to reject the mixed output with an error. This PR ensures that when `modelContextMessages` is the active return shape, canonical `messages` are excluded from the workflow output.

---

## Changes

**`.changeset/orange-dryers-push.md`**  
Changeset entry documenting a patch version bump for `@mastra/core` with the workflow fix description.

**`packages/core/src/workflows/processor-step.test.ts`**  
Regression test refactored to validate the prompt-only behavior. Updated to use `createDbMessage` and a real `MessageList` instance, with assertions verifying that `step.execute` returns only `modelContextMessages` (without a `messages` field) while maintaining expected `messageList` contents.

**`packages/core/src/workflows/workflow.ts`**  
Core fix in the `inputStep` processor execution path. The workflow now:
- Derives `nextModelContextMessages` from `validatedResult.modelContextMessages` or by processing `validatedResult.messages` when prompt-only mode is enabled
- Conditionally returns different output shapes: when `nextModelContextMessages` is present, it omits `messages` from the payload and includes only `modelContextMessages` and an updated `messageId`; otherwise returns the standard merged payload with `messages` preserved

---

## Validation

Tests run:
- `pnpm --filter ./packages/core exec vitest run src/workflows/processor-step.test.ts`
- `pnpm --filter ./packages/core check`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->