### PR TITLE
fix(core): keep evented prompt-only processor returns exclusive

### DIFF
--- a/.changeset/lemon-lands-behave.md
+++ b/.changeset/lemon-lands-behave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed workflow processor steps so prompt-only context remains exclusive in both workflow engines when legacy processors return canonical messages too.

--- a/packages/core/src/workflows/evented/evented-workflow.test.ts
+++ b/packages/core/src/workflows/evented/evented-workflow.test.ts
@@ -18,6 +18,8 @@ import type {
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { Agent } from '../../agent';
+import { MessageList } from '../../agent/message-list';
+import type { MastraDBMessage } from '../../agent/message-list';
 import { EventEmitterPubSub } from '../../events/event-emitter';
 import { Mastra } from '../../mastra';
 import type { Processor } from '../../processors';
@@ -32,6 +34,20 @@ import { createStep, createWorkflow } from '.';
 
 // Shared storage instance
 const sharedStorage = new MockStore();
+
+const createDbMessage = (
+  id: string,
+  text: string,
+  role: 'user' | 'assistant' | 'system' = 'user',
+): MastraDBMessage => ({
+  id,
+  role,
+  content: {
+    format: 2,
+    parts: [{ type: 'text', text }],
+  },
+  createdAt: new Date(),
+});
 
 // @ts-expect-error - TS2589: EventedWorkflow types cause excessively deep type instantiation
 createWorkflowTestSuite({
@@ -408,6 +424,41 @@ describe('Workflow (Evented Engine Specific)', () => {
     } finally {
       await mastra.stopEventEngine();
     }
+  });
+
+  it('should return only prompt-only modelContextMessages when inputStep returns both message fields', async () => {
+    const canonicalMessage = createDbMessage('canonical', 'canonical input');
+    const promptOnlyMessage = createDbMessage('prompt-only', 'prompt-only input');
+    const rewrittenPromptMessage = createDbMessage('rewritten-prompt', 'rewritten prompt input');
+    const messageList = new MessageList().add([canonicalMessage], 'input');
+
+    const processor: Processor = {
+      id: 'evented-prompt-only-step-both-fields',
+      processInputStep: async () => ({
+        messages: [canonicalMessage],
+        modelContextMessages: [rewrittenPromptMessage],
+      }),
+    };
+
+    const step = createStep(processor);
+    const result = await step.execute({
+      inputData: {
+        phase: 'inputStep',
+        messages: [canonicalMessage],
+        modelContextMessages: [promptOnlyMessage],
+        messageList,
+        stepNumber: 0,
+        systemMessages: [],
+      },
+    } as Parameters<typeof step.execute>[0]);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        modelContextMessages: [rewrittenPromptMessage],
+      }),
+    );
+    expect(result).not.toHaveProperty('messages');
+    expect(messageList.get.all.db()).toEqual([canonicalMessage]);
   });
 
   // Note: Streaming Legacy tests removed - they duplicated Streaming tests.

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -1308,6 +1308,17 @@ function createStepFromProcessor<TProcessorId extends string>(
                 processorMessageList.stopRecording();
                 throw error;
               }
+              if (
+                passThrough.modelContextMessages !== undefined &&
+                result &&
+                !(result instanceof MessageList) &&
+                !Array.isArray(result) &&
+                'messages' in result &&
+                'modelContextMessages' in result
+              ) {
+                const { messages: _messages, ...resultWithoutMessages } = result;
+                result = resultWithoutMessages;
+              }
 
               const validatedResult = await ProcessorRunner.validateAndFormatProcessInputStepResult(result, {
                 messageList: processorMessageList,
@@ -1376,25 +1387,23 @@ function createStepFromProcessor<TProcessorId extends string>(
                 }
               }
 
-              // Preserve messages in return - passThrough doesn't include messages,
-              // so we must explicitly include it to avoid losing it for subsequent steps.
-              if (validatedResult.modelContextMessages) {
+              const nextModelContextMessages =
+                validatedResult.modelContextMessages ??
+                (returnPassThrough.modelContextMessages !== undefined && validatedResult.messages
+                  ? stripPromptOnlySystemMessages(validatedResult.messages)
+                  : undefined);
+              if (nextModelContextMessages !== undefined) {
+                const { messages: _messages, ...validatedWithoutMessages } = validatedResult;
                 return {
                   ...returnPassThrough,
-                  ...validatedResult,
-                  ...(currentMessageId ? { messageId: validatedResult.messageId ?? currentMessageId } : {}),
-                };
-              }
-              if (returnPassThrough.modelContextMessages) {
-                return {
-                  ...returnPassThrough,
-                  ...validatedResult,
+                  ...validatedWithoutMessages,
+                  modelContextMessages: nextModelContextMessages,
                   ...(currentMessageId ? { messageId: validatedResult.messageId ?? currentMessageId } : {}),
                 };
               }
               return {
                 ...returnPassThrough,
-                messages: returnMessages,
+                messages: validatedResult.messages ?? returnMessages,
                 ...validatedResult,
                 ...(currentMessageId ? { messageId: validatedResult.messageId ?? currentMessageId } : {}),
               };

--- a/packages/core/src/workflows/processor-step.test.ts
+++ b/packages/core/src/workflows/processor-step.test.ts
@@ -485,6 +485,41 @@ describe('createStep with Processor', () => {
       expect(messageList.get.all.db()).toEqual(messages);
     });
 
+    it('should drop canonical messages when prompt-only inputStep returns both message fields', async () => {
+      const canonicalMessage = createDbMessage('canonical', 'canonical input');
+      const promptOnlyMessage = createDbMessage('prompt-only', 'prompt-only input');
+      const rewrittenPromptMessage = createDbMessage('rewritten-prompt', 'rewritten prompt input');
+      const messageList = new MessageList().add([canonicalMessage], 'input');
+
+      const processor: Processor = {
+        id: 'prompt-only-step-both-fields',
+        processInputStep: async () => ({
+          messages: [canonicalMessage],
+          modelContextMessages: [rewrittenPromptMessage],
+        }),
+      };
+
+      const step = createStep(processor);
+      const result = await step.execute({
+        inputData: {
+          phase: 'inputStep' as const,
+          messages: [canonicalMessage],
+          modelContextMessages: [promptOnlyMessage],
+          messageList,
+          stepNumber: 0,
+          systemMessages: [],
+        },
+      } as Parameters<typeof step.execute>[0]);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          modelContextMessages: [rewrittenPromptMessage],
+        }),
+      );
+      expect(result).not.toHaveProperty('messages');
+      expect(messageList.get.all.db()).toEqual([canonicalMessage]);
+    });
+
     it('should keep prompt-only processInputStep MessageList mutations prompt-only', async () => {
       const canonicalMessage = createDbMessage('canonical', 'canonical input');
       const promptOnlyMessage = createDbMessage('prompt-only', 'prompt-only input');

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1286,6 +1286,17 @@ function createStepFromProcessor<TProcessorId extends string>(
                 processorMessageList.stopRecording();
                 throw error;
               }
+              if (
+                passThrough.modelContextMessages !== undefined &&
+                result &&
+                !(result instanceof MessageList) &&
+                !Array.isArray(result) &&
+                'messages' in result &&
+                'modelContextMessages' in result
+              ) {
+                const { messages: _messages, ...resultWithoutMessages } = result;
+                result = resultWithoutMessages;
+              }
 
               const validatedResult = await ProcessorRunner.validateAndFormatProcessInputStepResult(result, {
                 messageList: processorMessageList,


### PR DESCRIPTION
Closes #16.\n\n## Summary\n- normalize prompt-only processor inputStep results before validation when legacy processors return both `messages` and `modelContextMessages`\n- port PR #15's exclusive return shape to the evented workflow processor path\n- add default and evented workflow regression tests\n\n## Validation\n- `pnpm --filter ./packages/core exec vitest run src/workflows/processor-step.test.ts src/workflows/evented/evented-workflow.test.ts`\n- `pnpm --filter ./packages/core check`\n\nInternal PapersFlow context: this is required before rebuilding the local `@mastra/core` tarball; no public package publish is intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a bug where processors (functions that handle messages in workflows) could return two types of messages at once when they should only return one type in "prompt-only" mode. The fix makes sure that when a processor accidentally returns both types, we throw away the regular "messages" and keep only the "prompt-only messages" to maintain the exclusive return rule. This fix is applied to both the normal and evented workflow engines, with tests added to prevent regressions.

## Changes

### Changeset
Updated `.changeset/lemon-lands-behave.md` to document the `@mastra/core` patch fixing workflow processor behavior so prompt-only context remains exclusive in both workflow engines when legacy processors return canonical messages.

### Test Coverage
- **`packages/core/src/workflows/processor-step.test.ts`**: Added regression test for the default workflow path verifying that when `inputStep` in prompt-only mode receives both `messages` and `modelContextMessages`, the step result exposes only `modelContextMessages` while leaving the underlying message list unchanged.

- **`packages/core/src/workflows/evented/evented-workflow.test.ts`**: Added regression test for the evented workflow engine with the same validation—ensuring exclusive return of `modelContextMessages` while preserving the original canonical input message in the `MessageList`.

### Core Fixes
- **`packages/core/src/workflows/workflow.ts`** (default path): Added normalization logic that conditionally strips the `messages` field from processor results when `modelContextMessages` is present and the processor returned a non-`MessageList`, non-array object containing both fields. This normalized result is then passed to validation.

- **`packages/core/src/workflows/evented/workflow.ts`** (evented path): Added similar normalization in the `processInputStep` execution path before validation. Refactored the return object construction to compute `nextModelContextMessages` based on validated results and conditionally derive from stripped messages when returning model-context-only, replacing previous branching logic.

## Impact

This change ensures consistent enforcement of exclusive returns across both default and evented workflow processors in prompt-only mode, maintaining backward compatibility with legacy processors that return both message types while properly enforcing the exclusivity constraint moving forward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->