### PR TITLE
fix(ai-sdk): emit native harness tool approvals

### DIFF
--- a/.changeset/sixty-turkeys-smash.md
+++ b/.changeset/sixty-turkeys-smash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Added native AI SDK tool approval requests to harness UI message streams.

--- a/client-sdks/ai-sdk/src/harness.test.ts
+++ b/client-sdks/ai-sdk/src/harness.test.ts
@@ -11,6 +11,7 @@ class FakeHarness {
   options: { windowMs?: number; maxWaitMs?: number } | undefined;
   unsubscribed = false;
   subscribeCalls = 0;
+  currentRunId: string | null = null;
 
   constructor(state: HarnessDisplayState) {
     this.state = state;
@@ -18,6 +19,10 @@ class FakeHarness {
 
   getDisplayState(): Readonly<HarnessDisplayState> {
     return this.state;
+  }
+
+  getCurrentRunId(): string | null {
+    return this.currentRunId;
   }
 
   subscribeDisplayState(
@@ -173,9 +178,14 @@ describe('harnessToUIMessageStream', () => {
     const harness = new FakeHarness(state);
     const reader = harnessToUIMessageStream(harness, { include: ['hitl'] }).getReader();
 
-    const chunks = await readChunks(reader, 3);
+    const chunks = await readChunks(reader, 4);
     expect(chunks[0]).toEqual({ type: 'start', messageId: 'm1' });
-    const snapshot = expectSnapshot(chunks[1]);
+    expect(chunks[1]).toEqual({
+      type: 'tool-approval-request',
+      approvalId: 'call-1',
+      toolCallId: 'call-1',
+    });
+    const snapshot = expectSnapshot(chunks[2]);
     expect(snapshot.data.domains).toEqual({
       hitl: {
         approval: { toolCallId: 'call-1', toolName: 'write_file', args: { path: 'a.ts' } },
@@ -186,7 +196,55 @@ describe('harnessToUIMessageStream', () => {
     });
     expect(snapshot.data.currentMessage?.text).toBeUndefined();
     expect(snapshot.data.currentMessage?.content).toEqual([]);
-    expect(chunks[2]).toEqual({ type: 'finish' });
+    expect(chunks[3]).toEqual({ type: 'finish' });
+  });
+
+  it('emits native AI SDK approval requests once from pending HITL approval state', async () => {
+    const state = createState({
+      isRunning: true,
+      pendingApproval: { toolCallId: 'call-1', toolName: 'write_file', args: { path: 'a.ts' } },
+    });
+    const harness = new FakeHarness(state);
+    harness.currentRunId = 'run-123';
+    const reader = harnessToUIMessageStream(harness, { include: ['hitl'], sendStart: false }).getReader();
+
+    expect(await readChunks(reader, 2)).toMatchObject([
+      {
+        type: 'tool-approval-request',
+        approvalId: 'run-123::call-1',
+        toolCallId: 'call-1',
+      },
+      { type: 'data-mastra-harness-snapshot', data: { sequence: 1 } },
+    ]);
+
+    harness.emit(state);
+    expect(await readChunk(reader)).toMatchObject({
+      type: 'data-mastra-harness-snapshot',
+      data: { sequence: 2 },
+    });
+
+    harness.emit(createState({ isRunning: true }));
+    expect(await readChunk(reader)).toMatchObject({
+      type: 'data-mastra-harness-snapshot',
+      data: { sequence: 3 },
+    });
+
+    harness.emit(
+      createState({
+        isRunning: true,
+        pendingApproval: { toolCallId: 'call-1', toolName: 'write_file', args: { path: 'a.ts' } },
+      }),
+    );
+    expect(await readChunks(reader, 2)).toMatchObject([
+      {
+        type: 'tool-approval-request',
+        approvalId: 'run-123::call-1',
+        toolCallId: 'call-1',
+      },
+      { type: 'data-mastra-harness-snapshot', data: { sequence: 4 } },
+    ]);
+
+    await reader.cancel();
   });
 
   it('represents HITL state appearing and clearing in replacing snapshots', async () => {

--- a/client-sdks/ai-sdk/src/harness.ts
+++ b/client-sdks/ai-sdk/src/harness.ts
@@ -33,6 +33,7 @@ export interface HarnessToUIMessageStreamOptions {
 
 export interface HarnessLike {
   getDisplayState(): Readonly<HarnessDisplayState>;
+  getCurrentRunId?(): string | null;
   subscribeDisplayState(
     listener: HarnessDisplayStateListener,
     options?: HarnessDisplayStateSubscriptionOptions,
@@ -115,6 +116,7 @@ type HarnessUITextChunk =
   | { type: 'tool-input-start'; toolCallId: string; toolName: string }
   | { type: 'tool-input-delta'; toolCallId: string; inputTextDelta: string }
   | { type: 'tool-input-available'; toolCallId: string; toolName: string; input: unknown }
+  | { type: 'tool-approval-request'; approvalId: string; toolCallId: string }
   | { type: 'tool-output-available'; toolCallId: string; output: unknown }
   | { type: 'tool-output-error'; toolCallId: string; errorText: string };
 
@@ -157,12 +159,16 @@ type EmitContext = {
   reasoning: StreamTextState;
   tools: Map<string, NativeToolStreamState>;
   finalizedTools: Set<string>;
+  emittedApprovalKey: string | null;
   lastSnapshot: HarnessUISnapshotData | null;
   sequence: number;
   sendStart: boolean;
   sendFinish: boolean;
   started: boolean;
+  getCurrentRunId: () => string | null;
 };
+
+const APPROVAL_ID_SEPARATOR = '::';
 
 export function harnessToUIMessageStream(
   harness: HarnessLike,
@@ -190,11 +196,13 @@ export function harnessToUIMessageStream(
         reasoning: { id: null, value: '', open: false },
         tools: new Map(),
         finalizedTools: new Set(),
+        emittedApprovalKey: null,
         lastSnapshot: null,
         sequence: 0,
         sendStart,
         sendFinish,
         started: false,
+        getCurrentRunId: () => harness.getCurrentRunId?.() ?? null,
       };
 
       const closeStream = () => {
@@ -288,6 +296,10 @@ function emitDisplayState(state: HarnessDisplayState, context: EmitContext): voi
 
   if (context.include.has('tools')) {
     emitNativeToolChunks(state, context);
+  }
+
+  if (context.include.has('tools') || context.include.has('hitl')) {
+    emitNativeToolApprovalRequest(state, context);
   }
 
   context.sequence += 1;
@@ -453,6 +465,31 @@ function emitNativeToolChunks(state: HarnessDisplayState, context: EmitContext):
       context.finalizedTools.delete(toolCallId);
     }
   }
+}
+
+function emitNativeToolApprovalRequest(state: HarnessDisplayState, context: EmitContext): void {
+  const approval = state.pendingApproval;
+  if (!approval) {
+    context.emittedApprovalKey = null;
+    return;
+  }
+
+  const approvalId = createApprovalId(context.getCurrentRunId(), approval.toolCallId);
+  const approvalKey = `${approvalId}:${approval.toolCallId}`;
+  if (context.emittedApprovalKey === approvalKey) {
+    return;
+  }
+
+  context.controller.enqueue({
+    type: 'tool-approval-request',
+    approvalId,
+    toolCallId: approval.toolCallId,
+  });
+  context.emittedApprovalKey = approvalKey;
+}
+
+function createApprovalId(runId: string | null, toolCallId: string): string {
+  return runId ? `${runId}${APPROVAL_ID_SEPARATOR}${toolCallId}` : toolCallId;
 }
 
 function createSnapshotData(

--- a/docs/src/content/en/reference/ai-sdk/harness-to-ui-message-stream.mdx
+++ b/docs/src/content/en/reference/ai-sdk/harness-to-ui-message-stream.mdx
@@ -114,12 +114,13 @@ The stream emits normal AI SDK UI chunks for assistant text and reasoning when t
   { "type": "tool-input-start", "toolCallId": "call-1", "toolName": "write_file" },
   { "type": "tool-input-delta", "toolCallId": "call-1", "inputTextDelta": "{\"path\"" },
   { "type": "tool-input-available", "toolCallId": "call-1", "toolName": "write_file", "input": {} },
+  { "type": "tool-approval-request", "approvalId": "run-1::call-1", "toolCallId": "call-1" },
   { "type": "tool-output-available", "toolCallId": "call-1", "output": {} },
   { "type": "tool-output-error", "toolCallId": "call-1", "errorText": "Tool execution failed" }
 ]
 ```
 
-Tool approvals, suspensions, questions, and plan approvals remain in the structured snapshot because those states need stable Harness identifiers and resume metadata.
+Tool approvals are also included in the structured `hitl` snapshot so UIs that render Harness-specific approval controls still have the tool name and arguments. Suspensions, questions, and plan approvals remain snapshot-only because those states need stable Harness identifiers and resume metadata.
 
 It also emits a durable custom data part with a stable ID:
 


### PR DESCRIPTION
Closes #18.\n\nThis updates harnessToUIMessageStream so pending Harness tool approvals emit the native AI SDK v6 tool-approval-request chunk. The structured hitl snapshot still includes the approval metadata for Harness-specific controls.\n\nIt uses the Harness run id when available so the approval id matches the existing Mastra v6 native approval resume path.\n\nVerified with:\n\npnpm --filter @mastra/ai-sdk test src/harness.test.ts\npnpm --filter @mastra/ai-sdk build:lib\npnpm --filter @mastra/ai-sdk lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR makes Harness tool approvals speak the same language as the AI SDK's approval system. When a tool needs approval in Harness, it now sends a special "approval request" message that the AI SDK can understand and display to users, while keeping all the Harness-specific details behind the scenes for technical systems to use.

---

## Changes Summary

### Core Implementation (`harness.ts`)
- Extended the `HarnessLike` interface with an optional `getCurrentRunId()` method to retrieve the current run ID
- Added a new `tool-approval-request` message type to the UI stream chunk union
- Updated the stream emitter to track approval emission state and cache the last snapshot/sequence/run state
- Implemented approval-request emission logic that triggers when `tools` or `hitl` domains are included, emitting `tool-approval-request` for `state.pendingApproval` exactly once per approval (deduplicated via an approval key derived from run ID + tool call ID)
- Added `createApprovalId` helper function to construct approval IDs using a `::` separator, enabling alignment with Mastra v6's native approval resume path

### Tests (`harness.test.ts`)
- Added `currentRunId` state and `getCurrentRunId()` method to `FakeHarness` for deterministic approval ID generation in tests
- Updated HITL domain filtering test to expect an additional streamed chunk (now expects 4 chunks with `finish` at index 3)
- Added new test validating that native AI SDK HITL tool approval requests are emitted only once when a pending HITL approval state is present, with correct `approvalId` formatting (e.g., `run-123::call-1`)
- Verified behavior when harness state is re-emitted unchanged or transitions

### Documentation (`harness-to-ui-message-stream.mdx`)
- Updated documented `tools` stream output to explicitly show AI SDK tool approval lifecycle chunks (`tool-approval-request` with `approvalId`/`toolCallId`)
- Clarified that tool approvals are included in both the structured `hitl` snapshot (preserving tool name and arguments for UIs) and the native approval stream chunks

### Release
- Added changeset for `@mastra/ai-sdk` with a `patch` version bump documenting the addition of native AI SDK tool approval requests to harness UI message streams

<!-- end of auto-generated comment: release notes by coderabbit.ai -->