### PR TITLE
feat(core): list harness awaiting inputs

### DIFF
--- a/.changeset/list-awaiting-inputs.md
+++ b/.changeset/list-awaiting-inputs.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Add `harness.listAwaitingInputs()` for scoped pending Harness input enumeration.

--- a/.changeset/list-awaiting-inputs.md
+++ b/.changeset/list-awaiting-inputs.md
@@ -1,5 +1,11 @@
 ---
-'@mastra/core': patch
+'@mastra/core': minor
 ---
 
 Add `harness.listAwaitingInputs()` for scoped pending Harness input enumeration.
+
+```ts
+const pendingInputs = await harness.listAwaitingInputs({ threadId });
+```
+
+The method returns pending input objects such as tool approvals, tool suspensions, questions, and plan approvals with their `id`, `kind`, durability flag, and resource/thread scope where available. This is a non-breaking public API addition.

--- a/packages/core/src/harness/harness-awaiting-input.test.ts
+++ b/packages/core/src/harness/harness-awaiting-input.test.ts
@@ -4,9 +4,9 @@ import z from 'zod';
 import { Agent } from '../agent';
 import { Mastra } from '../mastra';
 import { InMemoryStore } from '../storage';
-import type { WorkflowRunState } from '../workflows';
 import { MastraLanguageModelV2Mock } from '../test-utils/llm-mock';
 import { createTool } from '../tools';
+import type { WorkflowRunState } from '../workflows';
 
 import { Harness } from './harness';
 
@@ -73,10 +73,14 @@ function createSuspendedSnapshot({
   runId,
   toolCallId,
   suspendPayload,
+  threadId = 'thread-1',
+  resourceId = 'resource-1',
 }: {
   runId: string;
   toolCallId: string;
   suspendPayload: Record<string, unknown>;
+  threadId?: string;
+  resourceId?: string;
 }): WorkflowRunState {
   return {
     runId,
@@ -85,8 +89,8 @@ function createSuspendedSnapshot({
     context: {
       input: {
         state: {
-          threadId: 'thread-1',
-          resourceId: 'resource-1',
+          threadId,
+          resourceId,
         },
       },
       'tool-call': {
@@ -289,6 +293,7 @@ describe('Harness awaiting input durability', () => {
     });
     await otherHarness.init();
     await expect(otherHarness.getAwaitingInput({ id: 'approval-call' })).resolves.toBeNull();
+    await expect(otherHarness.listAwaitingInputs()).resolves.toEqual([]);
 
     const harness = new Harness({
       id: 'approval-harness',
@@ -340,6 +345,111 @@ describe('Harness awaiting input durability', () => {
     );
   });
 
+  it('lists durable awaiting inputs scoped by resource and thread', async () => {
+    const storage = new InMemoryStore();
+    await storage.init();
+    const workflowsStore = await storage.getStore('workflows');
+    if (!workflowsStore) {
+      throw new Error('Expected workflows store to be available for awaiting-input test setup');
+    }
+
+    await workflowsStore.persistWorkflowSnapshot({
+      workflowName: 'agentic-loop',
+      runId: 'thread-1-run',
+      resourceId: 'resource-1',
+      snapshot: createSuspendedSnapshot({
+        runId: 'thread-1-run',
+        toolCallId: 'thread-1-call',
+        threadId: 'thread-1',
+        suspendPayload: {
+          type: 'approval',
+          toolCallId: 'thread-1-call',
+          toolName: 'writeFile',
+          args: { path: 'THREAD_1.md' },
+        },
+      }),
+      updatedAt: new Date(Date.now() + 1_000),
+    });
+    await workflowsStore.persistWorkflowSnapshot({
+      workflowName: 'agentic-loop',
+      runId: 'thread-2-run',
+      resourceId: 'resource-1',
+      snapshot: createSuspendedSnapshot({
+        runId: 'thread-2-run',
+        toolCallId: 'thread-2-call',
+        threadId: 'thread-2',
+        suspendPayload: {
+          type: 'suspension',
+          toolCallId: 'thread-2-call',
+          toolName: 'confirmAction',
+          args: { action: 'deploy' },
+        },
+      }),
+      updatedAt: new Date(Date.now() + 2_000),
+    });
+    await workflowsStore.persistWorkflowSnapshot({
+      workflowName: 'agentic-loop',
+      runId: 'other-resource-run',
+      resourceId: 'other-resource',
+      snapshot: createSuspendedSnapshot({
+        runId: 'other-resource-run',
+        toolCallId: 'other-resource-call',
+        resourceId: 'other-resource',
+        suspendPayload: {
+          type: 'approval',
+          toolCallId: 'other-resource-call',
+          toolName: 'writeFile',
+        },
+      }),
+    });
+
+    const agent = new Agent({
+      id: 'list-awaiting-inputs-agent',
+      name: 'List Awaiting Inputs Agent',
+      instructions: 'You write files.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createTextStream() }),
+      }),
+    });
+
+    const harness = new Harness({
+      id: 'list-awaiting-inputs-harness',
+      resourceId: 'resource-1',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent }],
+    });
+    await harness.init();
+
+    await expect(harness.listAwaitingInputs()).resolves.toMatchObject([
+      {
+        id: 'thread-2-call',
+        kind: 'tool_suspension',
+        durable: true,
+        runId: 'thread-2-run',
+        threadId: 'thread-2',
+        resourceId: 'resource-1',
+      },
+      {
+        id: 'thread-1-call',
+        kind: 'tool_approval',
+        durable: true,
+        runId: 'thread-1-run',
+        threadId: 'thread-1',
+        resourceId: 'resource-1',
+      },
+    ]);
+
+    await expect(harness.listAwaitingInputs({ threadId: 'thread-1' })).resolves.toMatchObject([
+      {
+        id: 'thread-1-call',
+        kind: 'tool_approval',
+        threadId: 'thread-1',
+      },
+    ]);
+
+    await expect(harness.listAwaitingInputs({ resourceId: 'other-resource' })).resolves.toEqual([]);
+  });
+
   it('reports questions and plans as live-session-only awaiting inputs', async () => {
     const agent = new Agent({
       id: 'live-only-agent',
@@ -369,6 +479,14 @@ describe('Harness awaiting input durability', () => {
       durable: false,
       questionId: 'q-1',
     });
+    await expect(harness.listAwaitingInputs()).resolves.toMatchObject([
+      {
+        id: 'q-1',
+        kind: 'question',
+        durable: false,
+        questionId: 'q-1',
+      },
+    ]);
 
     const result = await harness.resumeAwaitingInput({ id: 'q-1', resumeData: 'Yes' });
     expect(result.status).toBe('live_session_only');

--- a/packages/core/src/harness/harness-awaiting-input.test.ts
+++ b/packages/core/src/harness/harness-awaiting-input.test.ts
@@ -491,4 +491,31 @@ describe('Harness awaiting input durability', () => {
     const result = await harness.resumeAwaitingInput({ id: 'q-1', resumeData: 'Yes' });
     expect(result.status).toBe('live_session_only');
   });
+
+  it('keeps live awaiting inputs scoped to the resource where they were created', async () => {
+    const agent = new Agent({
+      id: 'live-scope-agent',
+      name: 'Live Scope Agent',
+      instructions: 'You ask questions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createTextStream() }),
+      }),
+    });
+
+    const harness = new Harness({
+      id: 'live-scope-harness',
+      resourceId: 'resource-1',
+      modes: [{ id: 'default', name: 'Default', default: true, agent }],
+    });
+
+    (harness as any).emit({
+      type: 'ask_question',
+      questionId: 'q-1',
+      question: 'Continue?',
+    });
+    harness.setResourceId({ resourceId: 'resource-2' });
+
+    await expect(harness.listAwaitingInputs()).resolves.toEqual([]);
+    await expect(harness.getAwaitingInput({ id: 'q-1' })).resolves.toBeNull();
+  });
 });

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -2801,20 +2801,23 @@ export class Harness<TState = {}> {
     resourceId = this.resourceId,
     threadId,
   }: HarnessListAwaitingInputsOptions): HarnessAwaitingInput[] {
-    if (resourceId !== this.resourceId) return [];
-    if (threadId && threadId !== this.currentThreadId) return [];
-
     const inputs: HarnessAwaitingInput[] = [];
     const pendingApproval = this.displayState.pendingApproval;
-    if (pendingApproval) {
+    const pendingApprovalResourceId = pendingApproval?.resourceId ?? this.resourceId;
+    const pendingApprovalThreadId = pendingApproval?.threadId ?? this.currentThreadId ?? undefined;
+    if (
+      pendingApproval &&
+      pendingApprovalResourceId === resourceId &&
+      (!threadId || pendingApprovalThreadId === threadId)
+    ) {
       inputs.push({
         id: pendingApproval.toolCallId,
         kind: 'tool_approval',
         durable: false,
         runId: this.currentRunId ?? undefined,
-        modeId: this.currentModeId,
-        threadId: this.currentThreadId ?? undefined,
-        resourceId: this.resourceId,
+        modeId: pendingApproval.modeId ?? this.currentModeId,
+        threadId: pendingApprovalThreadId,
+        resourceId: pendingApprovalResourceId,
         toolCallId: pendingApproval.toolCallId,
         toolName: pendingApproval.toolName,
         args: pendingApproval.args,
@@ -2823,15 +2826,21 @@ export class Harness<TState = {}> {
     }
 
     const pendingSuspension = this.displayState.pendingSuspension;
-    if (pendingSuspension) {
+    const pendingSuspensionResourceId = pendingSuspension?.resourceId ?? this.resourceId;
+    const pendingSuspensionThreadId = pendingSuspension?.threadId ?? this.currentThreadId ?? undefined;
+    if (
+      pendingSuspension &&
+      pendingSuspensionResourceId === resourceId &&
+      (!threadId || pendingSuspensionThreadId === threadId)
+    ) {
       inputs.push({
         id: pendingSuspension.toolCallId,
         kind: 'tool_suspension',
         durable: false,
         runId: this.pendingSuspensionRunId ?? this.currentRunId ?? undefined,
-        modeId: this.currentModeId,
-        threadId: this.currentThreadId ?? undefined,
-        resourceId: this.resourceId,
+        modeId: pendingSuspension.modeId ?? this.currentModeId,
+        threadId: pendingSuspensionThreadId,
+        resourceId: pendingSuspensionResourceId,
         toolCallId: pendingSuspension.toolCallId,
         toolName: pendingSuspension.toolName,
         args: pendingSuspension.args,
@@ -2842,14 +2851,20 @@ export class Harness<TState = {}> {
     }
 
     const pendingQuestion = this.displayState.pendingQuestion;
-    if (pendingQuestion) {
+    const pendingQuestionResourceId = pendingQuestion?.resourceId ?? this.resourceId;
+    const pendingQuestionThreadId = pendingQuestion?.threadId ?? this.currentThreadId ?? undefined;
+    if (
+      pendingQuestion &&
+      pendingQuestionResourceId === resourceId &&
+      (!threadId || pendingQuestionThreadId === threadId)
+    ) {
       inputs.push({
         id: pendingQuestion.questionId,
         kind: 'question',
         durable: false,
-        modeId: this.currentModeId,
-        threadId: this.currentThreadId ?? undefined,
-        resourceId: this.resourceId,
+        modeId: pendingQuestion.modeId ?? this.currentModeId,
+        threadId: pendingQuestionThreadId,
+        resourceId: pendingQuestionResourceId,
         questionId: pendingQuestion.questionId,
         question: pendingQuestion.question,
         options: pendingQuestion.options,
@@ -2858,14 +2873,20 @@ export class Harness<TState = {}> {
     }
 
     const pendingPlanApproval = this.displayState.pendingPlanApproval;
-    if (pendingPlanApproval) {
+    const pendingPlanApprovalResourceId = pendingPlanApproval?.resourceId ?? this.resourceId;
+    const pendingPlanApprovalThreadId = pendingPlanApproval?.threadId ?? this.currentThreadId ?? undefined;
+    if (
+      pendingPlanApproval &&
+      pendingPlanApprovalResourceId === resourceId &&
+      (!threadId || pendingPlanApprovalThreadId === threadId)
+    ) {
       inputs.push({
         id: pendingPlanApproval.planId,
         kind: 'plan_approval',
         durable: false,
-        modeId: this.currentModeId,
-        threadId: this.currentThreadId ?? undefined,
-        resourceId: this.resourceId,
+        modeId: pendingPlanApproval.modeId ?? this.currentModeId,
+        threadId: pendingPlanApprovalThreadId,
+        resourceId: pendingPlanApprovalResourceId,
         planId: pendingPlanApproval.planId,
         title: pendingPlanApproval.title,
         plan: pendingPlanApproval.plan,
@@ -3481,6 +3502,9 @@ export class Harness<TState = {}> {
           toolCallId: event.toolCallId,
           toolName: event.toolName,
           args: event.args,
+          modeId: this.currentModeId,
+          threadId: this.currentThreadId ?? undefined,
+          resourceId: this.resourceId,
         };
         break;
 
@@ -3491,6 +3515,9 @@ export class Harness<TState = {}> {
           args: event.args,
           suspendPayload: event.suspendPayload,
           resumeSchema: event.resumeSchema,
+          modeId: this.currentModeId,
+          threadId: this.currentThreadId ?? undefined,
+          resourceId: this.resourceId,
         };
         break;
 
@@ -3501,6 +3528,9 @@ export class Harness<TState = {}> {
           question: event.question,
           options: event.options,
           selectionMode: event.selectionMode,
+          modeId: this.currentModeId,
+          threadId: this.currentThreadId ?? undefined,
+          resourceId: this.resourceId,
         };
         break;
 
@@ -3509,6 +3539,9 @@ export class Harness<TState = {}> {
           planId: event.planId,
           title: event.title,
           plan: event.plan,
+          modeId: this.currentModeId,
+          threadId: this.currentThreadId ?? undefined,
+          resourceId: this.resourceId,
         };
         break;
 

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -8,13 +8,12 @@ import type { TracingContext, TracingOptions } from '../observability';
 import { RequestContext } from '../request-context';
 import { toStandardSchema } from '../schema';
 import type { StandardSchemaWithJSON } from '../schema';
-import type { WorkflowRun } from '../storage/types';
-import type { WorkflowRunState } from '../workflows';
 import type { MemoryStorage } from '../storage/domains/memory/base';
-import type { ObservationalMemoryRecord } from '../storage/types';
+import type { ObservationalMemoryRecord, WorkflowRun } from '../storage/types';
 import { getProjectedToolPayload, hasProjectedToolPayload } from '../tools/payload-projection';
 import type { ToolPayloadProjectionPhase } from '../tools/types';
 import { safeStringify } from '../utils';
+import type { WorkflowRunState } from '../workflows';
 import { Workspace } from '../workspace/workspace';
 import type { WorkspaceConfig } from '../workspace/workspace';
 
@@ -37,6 +36,7 @@ import type {
   HarnessEvent,
   HarnessEventListener,
   HarnessGetAwaitingInputOptions,
+  HarnessListAwaitingInputsOptions,
   HarnessMessage,
   HarnessMessageContent,
   HarnessMode,
@@ -2509,6 +2509,30 @@ export class Harness<TState = {}> {
   }
 
   /**
+   * Return pending awaiting inputs visible to this Harness resource.
+   * Durable tool approvals and suspensions are read from workflow storage when available.
+   */
+  async listAwaitingInputs({ resourceId = this.resourceId, threadId }: HarnessListAwaitingInputsOptions = {}): Promise<
+    HarnessAwaitingInput[]
+  > {
+    if (resourceId !== this.resourceId) return [];
+
+    const inputs = new Map<string, HarnessAwaitingInput>();
+    const durableInputs = await this.listDurableAwaitingInputs({ resourceId, threadId });
+    for (const input of durableInputs) {
+      inputs.set(input.id, input);
+    }
+
+    for (const input of this.listLiveAwaitingInputs({ resourceId, threadId })) {
+      if (!inputs.has(input.id)) {
+        inputs.set(input.id, input);
+      }
+    }
+
+    return Array.from(inputs.values());
+  }
+
+  /**
    * Resume a pending awaiting-input id.
    * Durable tool approval and suspension states can be resumed from a fresh Harness instance.
    */
@@ -2770,10 +2794,21 @@ export class Harness<TState = {}> {
   }
 
   private getLiveAwaitingInput(id: string): HarnessAwaitingInput | null {
+    return this.listLiveAwaitingInputs({}).find(input => input.id === id) ?? null;
+  }
+
+  private listLiveAwaitingInputs({
+    resourceId = this.resourceId,
+    threadId,
+  }: HarnessListAwaitingInputsOptions): HarnessAwaitingInput[] {
+    if (resourceId !== this.resourceId) return [];
+    if (threadId && threadId !== this.currentThreadId) return [];
+
+    const inputs: HarnessAwaitingInput[] = [];
     const pendingApproval = this.displayState.pendingApproval;
-    if (pendingApproval?.toolCallId === id) {
-      return {
-        id,
+    if (pendingApproval) {
+      inputs.push({
+        id: pendingApproval.toolCallId,
         kind: 'tool_approval',
         durable: false,
         runId: this.currentRunId ?? undefined,
@@ -2784,13 +2819,13 @@ export class Harness<TState = {}> {
         toolName: pendingApproval.toolName,
         args: pendingApproval.args,
         requireToolApproval: (this.state as Record<string, unknown>).yolo !== true,
-      };
+      });
     }
 
     const pendingSuspension = this.displayState.pendingSuspension;
-    if (pendingSuspension?.toolCallId === id) {
-      return {
-        id,
+    if (pendingSuspension) {
+      inputs.push({
+        id: pendingSuspension.toolCallId,
         kind: 'tool_suspension',
         durable: false,
         runId: this.pendingSuspensionRunId ?? this.currentRunId ?? undefined,
@@ -2803,35 +2838,41 @@ export class Harness<TState = {}> {
         suspendPayload: pendingSuspension.suspendPayload,
         resumeSchema: pendingSuspension.resumeSchema,
         requireToolApproval: (this.state as Record<string, unknown>).yolo !== true,
-      };
+      });
     }
 
     const pendingQuestion = this.displayState.pendingQuestion;
-    if (pendingQuestion?.questionId === id) {
-      return {
-        id,
+    if (pendingQuestion) {
+      inputs.push({
+        id: pendingQuestion.questionId,
         kind: 'question',
         durable: false,
+        modeId: this.currentModeId,
+        threadId: this.currentThreadId ?? undefined,
+        resourceId: this.resourceId,
         questionId: pendingQuestion.questionId,
         question: pendingQuestion.question,
         options: pendingQuestion.options,
         selectionMode: pendingQuestion.selectionMode,
-      };
+      });
     }
 
     const pendingPlanApproval = this.displayState.pendingPlanApproval;
-    if (pendingPlanApproval?.planId === id) {
-      return {
-        id,
+    if (pendingPlanApproval) {
+      inputs.push({
+        id: pendingPlanApproval.planId,
         kind: 'plan_approval',
         durable: false,
+        modeId: this.currentModeId,
+        threadId: this.currentThreadId ?? undefined,
+        resourceId: this.resourceId,
         planId: pendingPlanApproval.planId,
         title: pendingPlanApproval.title,
         plan: pendingPlanApproval.plan,
-      };
+      });
     }
 
-    return null;
+    return inputs;
   }
 
   private async getDurableAwaitingInput(id: string): Promise<HarnessAwaitingInput | null> {
@@ -2845,6 +2886,51 @@ export class Harness<TState = {}> {
     });
 
     return run ? this.getAwaitingInputFromWorkflowRun({ id, run }) : null;
+  }
+
+  private async listDurableAwaitingInputs({
+    resourceId = this.resourceId,
+    threadId,
+  }: HarnessListAwaitingInputsOptions): Promise<HarnessAwaitingInput[]> {
+    if (resourceId !== this.resourceId) return [];
+
+    const workflowsStore = await this.config.storage?.getStore('workflows');
+    if (!workflowsStore) return [];
+
+    const listRuns = async (status: 'suspended' | 'waiting') =>
+      await workflowsStore.listWorkflowRuns({
+        workflowName: HARNESS_AGENTIC_LOOP_WORKFLOW_NAME,
+        resourceId,
+        status,
+        perPage: false,
+      });
+
+    const [suspended, waiting] = await Promise.all([listRuns('suspended'), listRuns('waiting')]);
+    const runs = [...suspended.runs, ...waiting.runs].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+    const inputs = new Map<string, HarnessAwaitingInput>();
+
+    for (const run of runs) {
+      const resumeLabels = this.getResumeLabelsFromWorkflowRun(run);
+      for (const id of Object.keys(resumeLabels)) {
+        if (inputs.has(id)) continue;
+
+        const input = this.getAwaitingInputFromWorkflowRun({ id, run });
+        if (input && (!threadId || input.threadId === threadId)) {
+          inputs.set(input.id, input);
+        }
+      }
+    }
+
+    return Array.from(inputs.values());
+  }
+
+  private getResumeLabelsFromWorkflowRun(run: WorkflowRun): WorkflowRunState['resumeLabels'] {
+    try {
+      const snapshot = typeof run.snapshot === 'string' ? (JSON.parse(run.snapshot) as WorkflowRunState) : run.snapshot;
+      return snapshot.resumeLabels ?? {};
+    } catch {
+      return {};
+    }
   }
 
   private async activateResumeThread(threadId: string): Promise<void> {

--- a/packages/core/src/harness/index.ts
+++ b/packages/core/src/harness/index.ts
@@ -19,6 +19,7 @@ export type {
   HarnessMessage,
   HarnessMessageContent,
   HarnessMode,
+  HarnessListAwaitingInputsOptions,
   HarnessOMConfig,
   HarnessQuestionAnswer,
   HarnessQuestionOption,

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -589,6 +589,9 @@ export type HarnessAwaitingInput =
       id: string;
       kind: 'question';
       durable: false;
+      modeId?: string;
+      threadId?: string;
+      resourceId?: string;
       questionId: string;
       question: string;
       options?: HarnessQuestionOption[];
@@ -598,6 +601,9 @@ export type HarnessAwaitingInput =
       id: string;
       kind: 'plan_approval';
       durable: false;
+      modeId?: string;
+      threadId?: string;
+      resourceId?: string;
       planId: string;
       title?: string;
       plan: string;
@@ -611,6 +617,11 @@ export interface HarnessWaitForAwaitingInputReadyOptions {
 
 export interface HarnessGetAwaitingInputOptions {
   id: string;
+}
+
+export interface HarnessListAwaitingInputsOptions {
+  resourceId?: string;
+  threadId?: string;
 }
 
 export interface HarnessResumeAwaitingInputOptions {

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -685,6 +685,9 @@ export interface HarnessDisplayState {
     toolCallId: string;
     toolName: string;
     args: unknown;
+    modeId?: string;
+    threadId?: string;
+    resourceId?: string;
   } | null;
 
   // ── Tool suspension ─────────────────────────────────────────────────
@@ -695,6 +698,9 @@ export interface HarnessDisplayState {
     args: unknown;
     suspendPayload: unknown;
     resumeSchema?: string;
+    modeId?: string;
+    threadId?: string;
+    resourceId?: string;
   } | null;
 
   // ── Interactive prompts ──────────────────────────────────────────────
@@ -704,6 +710,9 @@ export interface HarnessDisplayState {
     question: string;
     options?: HarnessQuestionOption[];
     selectionMode?: HarnessQuestionSelectionMode;
+    modeId?: string;
+    threadId?: string;
+    resourceId?: string;
   } | null;
 
   /** A plan awaiting user approval (null when none) */
@@ -711,6 +720,9 @@ export interface HarnessDisplayState {
     planId: string;
     title?: string;
     plan: string;
+    modeId?: string;
+    threadId?: string;
+    resourceId?: string;
   } | null;
 
   // ── Subagent tracking ────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #20.

## Summary

Adds harness.listAwaitingInputs({ resourceId?, threadId? }) so applications can enumerate pending Harness awaiting inputs without maintaining an external mirror.

The API returns durable tool approvals/suspensions from workflow storage and live-session-only questions/plan approvals from the current Harness display state. Results are scoped to the Harness resource, optionally filtered by thread, and deduplicated by awaiting-input id with the latest durable run first.

## Verification

- pnpm --filter @mastra/core test src/harness/harness-awaiting-input.test.ts
- pnpm --filter @mastra/core build:lib
- pnpm --filter @mastra/core lint
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a built‑in "to‑do" listing for Harness so you can ask the Harness instance what pending inputs/actions are waiting (scoped to the current resource and optionally a thread) instead of mirroring UI/state elsewhere.

## Overview
Adds a public API harness.listAwaitingInputs({ resourceId?, threadId? }) that returns pending Harness awaiting inputs (durable and live-session) scoped to the current resource by default and optionally filtered by thread. It merges durable awaiting inputs from workflow storage with live display-state items, deduplicates by awaiting-input id preferring the latest durable run, and enforces thread/resource scoping so callers cannot enumerate other threads’ pending inputs.

## Key Changes

### New API Method
- Harness.listAwaitingInputs(options?: HarnessListAwaitingInputsOptions): Promise<HarnessAwaitingInput[]>
  - Default resourceId = this.resourceId; optional threadId filter.
  - Returns tool approvals, tool suspensions, questions, and plan approvals with optional modeId/threadId/resourceId metadata when available.

### Implementation Details
- Combines two sources:
  1. Durable awaiting inputs: loaded from suspended/waiting agentic-loop workflow runs by parsing resume labels from stored run snapshots (tool approvals and suspensions).
  2. Live-session awaiting inputs: read from in-memory Harness displayState (questions and plan approvals).
- Deduplicates by awaiting-input id with preference for the latest durable run.
- displayState now persists modeId, threadId, and resourceId for pending items so live items are returned with consistent scoping.
- getLiveAwaitingInput was refactored to delegate to a new listLiveAwaitingInputs helper that supports resource/thread filtering.

### Types & Exports
- Added exported interface: HarnessListAwaitingInputsOptions { resourceId?: string; threadId?: string } and exported it via packages/core/src/harness/index.ts.
- HarnessAwaitingInput union variants for 'question' and 'plan_approval' now include optional modeId?, threadId?, resourceId?.
- HarnessDisplayState pending shapes extended to carry optional modeId/threadId/resourceId.
- Note: HarnessGetAwaitingInputOptions (with required id) remains present.

### Tests & Changelog
- .changeset entry added for @mastra/core (minor) documenting the new API.
- Tests updated/added in packages/core/src/harness/harness-awaiting-input.test.ts:
  - createSuspendedSnapshot accepts optional threadId/resourceId and tests verify durable awaiting inputs are discoverable and correctly scoped by resourceId and threadId.
  - Tests assert live-session-only entries (questions) are included and that unrelated harnesses return empty lists.
- Local test run in the provided environment failed to execute Vitest (node_modules missing / vitest not found), so tests could not be verified locally here. The PR still lists unit tests, build, and lint as verification steps.

## Files Changed (high level)
- Added: list-awaiting-inputs changeset (.changeset/list-awaiting-inputs.md)
- Modified: packages/core/src/harness/harness.ts (added method + helpers; displayState persistence)
- Modified: packages/core/src/harness/types.ts (type extensions, new options interface)
- Modified: packages/core/src/harness/index.ts (exported options type)
- Modified: packages/core/src/harness/harness-awaiting-input.test.ts (tests updated/added)

## Notes for reviewers
- Pay attention to the durable vs live-item merge/deduplication logic and the ordering preference for the latest durable run.
- Verify scoping enforcement so callers cannot enumerate awaiting inputs from other resources/threads.
- CI or a local environment with node_modules installed is needed to run the updated tests (vitest) and verify build/lint steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->