### PR TITLE
feat(core): defer harness auto approvals

### DIFF
--- a/.changeset/deferred-auto-approval.md
+++ b/.changeset/deferred-auto-approval.md
@@ -2,4 +2,13 @@
 '@mastra/core': patch
 ---
 
-Add an opt-in `deferredAutoApproval` Harness config option for auto-approved tool approvals.
+Add an opt-in `deferredAutoApproval` Harness config option for auto-approved and auto-denied tool approvals.
+
+```ts
+const harness = new Harness({
+  // ...
+  deferredAutoApproval: true,
+});
+```
+
+When enabled, Harness queues automatic approval and denial decisions until the current stream has finished, then resumes each pending tool approval in order. This helps apps avoid resuming before the awaiting-input state is ready. No migration is required; the default inline behavior is unchanged unless `deferredAutoApproval` is set.

--- a/.changeset/deferred-auto-approval.md
+++ b/.changeset/deferred-auto-approval.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Add an opt-in `deferredAutoApproval` Harness config option for auto-approved tool approvals.

--- a/packages/core/src/harness/harness-awaiting-input.test.ts
+++ b/packages/core/src/harness/harness-awaiting-input.test.ts
@@ -3,6 +3,7 @@ import z from 'zod';
 
 import { Agent } from '../agent';
 import { Mastra } from '../mastra';
+import { RequestContext } from '../request-context';
 import { InMemoryStore } from '../storage';
 import { MastraLanguageModelV2Mock } from '../test-utils/llm-mock';
 import { createTool } from '../tools';
@@ -66,6 +67,30 @@ async function* createHarnessTextFullStream(runId: string) {
   yield { type: 'text-start', runId, payload: { id: 'text-1' } };
   yield { type: 'text-delta', runId, payload: { id: 'text-1', text: 'Approved.' } };
   yield { type: 'text-end', runId, payload: { id: 'text-1' } };
+  yield { type: 'finish', runId, payload: { stepResult: { reason: 'stop' } } };
+}
+
+async function* createApprovalFullStream({
+  runId = 'approval-run',
+  toolCallIds = ['approval-call'],
+  afterApproval,
+}: {
+  runId?: string;
+  toolCallIds?: string[];
+  afterApproval?: () => Promise<void> | void;
+} = {}) {
+  for (const toolCallId of toolCallIds) {
+    yield {
+      type: 'tool-call-approval',
+      runId,
+      payload: {
+        toolCallId,
+        toolName: 'writeFile',
+        args: { path: 'README.md' },
+      },
+    };
+  }
+  await afterApproval?.();
   yield { type: 'finish', runId, payload: { stepResult: { reason: 'stop' } } };
 }
 
@@ -517,5 +542,152 @@ describe('Harness awaiting input durability', () => {
 
     await expect(harness.listAwaitingInputs()).resolves.toEqual([]);
     await expect(harness.getAwaitingInput({ id: 'q-1' })).resolves.toBeNull();
+  });
+
+  it('keeps auto-approved tool approvals inline by default', async () => {
+    let streamDrained = false;
+    const agent = new Agent({
+      id: 'inline-auto-approval-agent',
+      name: 'Inline Auto Approval Agent',
+      instructions: 'You write files.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createTextStream() }),
+      }),
+    });
+    const harness = new Harness({
+      id: 'inline-auto-approval-harness',
+      initialState: { yolo: true } as any,
+      modes: [{ id: 'default', name: 'Default', default: true, agent }],
+    });
+    const approvedMessage = {
+      id: 'approved-message',
+      role: 'assistant' as const,
+      content: [{ type: 'text' as const, text: 'Approved.' }],
+      createdAt: new Date(),
+    };
+    const handleToolApprove = vi.fn(async () => {
+      expect(streamDrained).toBe(false);
+      return { message: approvedMessage };
+    });
+    (harness as any).handleToolApprove = handleToolApprove;
+
+    const result = await (harness as any).processStream(
+      {
+        fullStream: createApprovalFullStream({
+          afterApproval: () => {
+            streamDrained = true;
+          },
+        }),
+      },
+      new RequestContext(),
+    );
+
+    expect(result.message).toBe(approvedMessage);
+    expect(handleToolApprove).toHaveBeenCalledWith({
+      toolCallId: 'approval-call',
+      requestContext: expect.any(RequestContext),
+    });
+    expect(streamDrained).toBe(false);
+  });
+
+  it('defers auto-approved tool approvals until the stream drains when configured', async () => {
+    let releaseStream: (() => void) | undefined;
+    const afterApproval = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          releaseStream = resolve;
+        }),
+    );
+    const agent = new Agent({
+      id: 'deferred-auto-approval-agent',
+      name: 'Deferred Auto Approval Agent',
+      instructions: 'You write files.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createTextStream() }),
+      }),
+    });
+    const harness = new Harness({
+      id: 'deferred-auto-approval-harness',
+      initialState: { yolo: true } as any,
+      deferredAutoApproval: true,
+      modes: [{ id: 'default', name: 'Default', default: true, agent }],
+    });
+    const approvedMessage = {
+      id: 'deferred-approved-message',
+      role: 'assistant' as const,
+      content: [{ type: 'text' as const, text: 'Approved after drain.' }],
+      createdAt: new Date(),
+    };
+    const handleToolApprove = vi.fn(async () => ({ message: approvedMessage }));
+    const waitForAwaitingInputReady = vi.spyOn(harness, 'waitForAwaitingInputReady').mockResolvedValue(null);
+    (harness as any).handleToolApprove = handleToolApprove;
+
+    const resultPromise = (harness as any).processStream(
+      { fullStream: createApprovalFullStream({ afterApproval }) },
+      new RequestContext(),
+    );
+
+    await vi.waitFor(() => expect(afterApproval).toHaveBeenCalled());
+    expect(handleToolApprove).not.toHaveBeenCalled();
+
+    releaseStream?.();
+    await expect(resultPromise).resolves.toMatchObject({ message: approvedMessage });
+    expect(waitForAwaitingInputReady).toHaveBeenCalledWith({ id: 'approval-call' });
+    expect(handleToolApprove).toHaveBeenCalledWith({
+      toolCallId: 'approval-call',
+      requestContext: expect.any(RequestContext),
+    });
+    expect(waitForAwaitingInputReady.mock.invocationCallOrder[0]!).toBeLessThan(
+      handleToolApprove.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it('replays all deferred auto-approved tool approvals sequentially', async () => {
+    const agent = new Agent({
+      id: 'deferred-auto-approval-queue-agent',
+      name: 'Deferred Auto Approval Queue Agent',
+      instructions: 'You write files.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createTextStream() }),
+      }),
+    });
+    const harness = new Harness({
+      id: 'deferred-auto-approval-queue-harness',
+      initialState: { yolo: true } as any,
+      deferredAutoApproval: true,
+      modes: [{ id: 'default', name: 'Default', default: true, agent }],
+    });
+    const approvedMessage = {
+      id: 'deferred-approved-message',
+      role: 'assistant' as const,
+      content: [{ type: 'text' as const, text: 'Approved after drain.' }],
+      createdAt: new Date(),
+    };
+    const handleToolApprove = vi.fn(async () => ({ message: approvedMessage }));
+    const waitForAwaitingInputReady = vi.spyOn(harness, 'waitForAwaitingInputReady').mockResolvedValue(null);
+    (harness as any).handleToolApprove = handleToolApprove;
+
+    await expect(
+      (harness as any).processStream(
+        { fullStream: createApprovalFullStream({ toolCallIds: ['approval-call-1', 'approval-call-2'] }) },
+        new RequestContext(),
+      ),
+    ).resolves.toMatchObject({ message: approvedMessage });
+
+    expect(waitForAwaitingInputReady).toHaveBeenNthCalledWith(1, { id: 'approval-call-1' });
+    expect(waitForAwaitingInputReady).toHaveBeenNthCalledWith(2, { id: 'approval-call-2' });
+    expect(handleToolApprove).toHaveBeenNthCalledWith(1, {
+      toolCallId: 'approval-call-1',
+      requestContext: expect.any(RequestContext),
+    });
+    expect(handleToolApprove).toHaveBeenNthCalledWith(2, {
+      toolCallId: 'approval-call-2',
+      requestContext: expect.any(RequestContext),
+    });
+    const [wait1, wait2] = waitForAwaitingInputReady.mock.invocationCallOrder;
+    const [approve1, approve2] = handleToolApprove.mock.invocationCallOrder;
+    expect(wait1!).toBeLessThan(approve1!);
+    expect(approve1!).toBeLessThan(wait2!);
+    expect(wait2!).toBeLessThan(approve2!);
   });
 });

--- a/packages/core/src/harness/harness-awaiting-input.test.ts
+++ b/packages/core/src/harness/harness-awaiting-input.test.ts
@@ -690,4 +690,48 @@ describe('Harness awaiting input durability', () => {
     expect(approve1!).toBeLessThan(wait2!);
     expect(wait2!).toBeLessThan(approve2!);
   });
+
+  it('replays all deferred auto-approved tool approvals sequentially', async () => {
+    const agent = new Agent({
+      id: 'deferred-auto-approval-queue-agent',
+      name: 'Deferred Auto Approval Queue Agent',
+      instructions: 'You write files.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createTextStream() }),
+      }),
+    });
+    const harness = new Harness({
+      id: 'deferred-auto-approval-queue-harness',
+      initialState: { yolo: true } as any,
+      deferredAutoApproval: true,
+      modes: [{ id: 'default', name: 'Default', default: true, agent }],
+    });
+    const approvedMessage = {
+      id: 'deferred-approved-message',
+      role: 'assistant' as const,
+      content: [{ type: 'text' as const, text: 'Approved after drain.' }],
+      createdAt: new Date(),
+    };
+    const handleToolApprove = vi.fn(async () => ({ message: approvedMessage }));
+    const waitForAwaitingInputReady = vi.spyOn(harness, 'waitForAwaitingInputReady').mockResolvedValue(null);
+    (harness as any).handleToolApprove = handleToolApprove;
+
+    await expect(
+      (harness as any).processStream(
+        { fullStream: createApprovalFullStream({ toolCallIds: ['approval-call-1', 'approval-call-2'] }) },
+        new RequestContext(),
+      ),
+    ).resolves.toMatchObject({ message: approvedMessage });
+
+    expect(waitForAwaitingInputReady).toHaveBeenNthCalledWith(1, { id: 'approval-call-1' });
+    expect(waitForAwaitingInputReady).toHaveBeenNthCalledWith(2, { id: 'approval-call-2' });
+    expect(handleToolApprove).toHaveBeenNthCalledWith(1, {
+      toolCallId: 'approval-call-1',
+      requestContext: expect.any(RequestContext),
+    });
+    expect(handleToolApprove).toHaveBeenNthCalledWith(2, {
+      toolCallId: 'approval-call-2',
+      requestContext: expect.any(RequestContext),
+    });
+  });
 });

--- a/packages/core/src/harness/harness-awaiting-input.test.ts
+++ b/packages/core/src/harness/harness-awaiting-input.test.ts
@@ -690,48 +690,4 @@ describe('Harness awaiting input durability', () => {
     expect(approve1!).toBeLessThan(wait2!);
     expect(wait2!).toBeLessThan(approve2!);
   });
-
-  it('replays all deferred auto-approved tool approvals sequentially', async () => {
-    const agent = new Agent({
-      id: 'deferred-auto-approval-queue-agent',
-      name: 'Deferred Auto Approval Queue Agent',
-      instructions: 'You write files.',
-      model: new MastraLanguageModelV2Mock({
-        doStream: async () => ({ stream: createTextStream() }),
-      }),
-    });
-    const harness = new Harness({
-      id: 'deferred-auto-approval-queue-harness',
-      initialState: { yolo: true } as any,
-      deferredAutoApproval: true,
-      modes: [{ id: 'default', name: 'Default', default: true, agent }],
-    });
-    const approvedMessage = {
-      id: 'deferred-approved-message',
-      role: 'assistant' as const,
-      content: [{ type: 'text' as const, text: 'Approved after drain.' }],
-      createdAt: new Date(),
-    };
-    const handleToolApprove = vi.fn(async () => ({ message: approvedMessage }));
-    const waitForAwaitingInputReady = vi.spyOn(harness, 'waitForAwaitingInputReady').mockResolvedValue(null);
-    (harness as any).handleToolApprove = handleToolApprove;
-
-    await expect(
-      (harness as any).processStream(
-        { fullStream: createApprovalFullStream({ toolCallIds: ['approval-call-1', 'approval-call-2'] }) },
-        new RequestContext(),
-      ),
-    ).resolves.toMatchObject({ message: approvedMessage });
-
-    expect(waitForAwaitingInputReady).toHaveBeenNthCalledWith(1, { id: 'approval-call-1' });
-    expect(waitForAwaitingInputReady).toHaveBeenNthCalledWith(2, { id: 'approval-call-2' });
-    expect(handleToolApprove).toHaveBeenNthCalledWith(1, {
-      toolCallId: 'approval-call-1',
-      requestContext: expect.any(RequestContext),
-    });
-    expect(handleToolApprove).toHaveBeenNthCalledWith(2, {
-      toolCallId: 'approval-call-2',
-      requestContext: expect.any(RequestContext),
-    });
-  });
 });

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1874,6 +1874,11 @@ export class Harness<TState = {}> {
     if (response.traceId) {
       this.currentTraceId = response.traceId;
     }
+    const deferredAutoApprovals: Array<{
+      decision: 'approve' | 'decline';
+      toolCallId: string;
+      requestContext: RequestContext;
+    }> = [];
     let currentMessage: HarnessMessage = {
       id: this.generateId(),
       role: 'assistant',
@@ -2033,12 +2038,24 @@ export class Harness<TState = {}> {
           const policy = this.resolveToolApproval(toolName);
 
           if (policy === 'allow') {
+            if (this.config.deferredAutoApproval) {
+              deferredAutoApprovals.push({ decision: 'approve', toolCallId, requestContext });
+              isSuspended = true;
+              break;
+            }
+
             const result = await this.handleToolApprove({ toolCallId, requestContext });
             currentMessage = result.message;
             return result;
           }
 
           if (policy === 'deny') {
+            if (this.config.deferredAutoApproval) {
+              deferredAutoApprovals.push({ decision: 'decline', toolCallId, requestContext });
+              isSuspended = true;
+              break;
+            }
+
             const result = await this.handleToolDecline({ toolCallId, requestContext });
             currentMessage = result.message;
             return result;
@@ -2393,6 +2410,24 @@ export class Harness<TState = {}> {
     }
 
     this.emit({ type: 'message_end', message: currentMessage });
+
+    const deferredAutoApproval = deferredAutoApprovals[0];
+    if (deferredAutoApproval) {
+      await this.waitForAwaitingInputReady({ id: deferredAutoApproval.toolCallId });
+
+      if (deferredAutoApproval.decision === 'approve') {
+        return await this.handleToolApprove({
+          toolCallId: deferredAutoApproval.toolCallId,
+          requestContext: deferredAutoApproval.requestContext,
+        });
+      }
+
+      return await this.handleToolDecline({
+        toolCallId: deferredAutoApproval.toolCallId,
+        requestContext: deferredAutoApproval.requestContext,
+      });
+    }
+
     return { message: currentMessage, suspended: isSuspended || undefined };
   }
 

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -2411,22 +2411,25 @@ export class Harness<TState = {}> {
 
     this.emit({ type: 'message_end', message: currentMessage });
 
-    const deferredAutoApproval = deferredAutoApprovals[0];
-    if (deferredAutoApproval) {
+    let deferredResult: { message: HarnessMessage; suspended?: boolean } | undefined;
+    for (const deferredAutoApproval of deferredAutoApprovals) {
       await this.waitForAwaitingInputReady({ id: deferredAutoApproval.toolCallId });
 
       if (deferredAutoApproval.decision === 'approve') {
-        return await this.handleToolApprove({
+        deferredResult = await this.handleToolApprove({
           toolCallId: deferredAutoApproval.toolCallId,
           requestContext: deferredAutoApproval.requestContext,
         });
+        continue;
       }
 
-      return await this.handleToolDecline({
+      deferredResult = await this.handleToolDecline({
         toolCallId: deferredAutoApproval.toolCallId,
         requestContext: deferredAutoApproval.requestContext,
       });
     }
+
+    if (deferredResult) return deferredResult;
 
     return { message: currentMessage, suspended: isSuspended || undefined };
   }

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -277,6 +277,12 @@ export interface HarnessConfig<TState = {}> {
   };
 
   /**
+   * Defer auto-approved or auto-denied tool approvals until the current stream
+   * has drained, so durable suspension state can be persisted before resume.
+   */
+  deferredAutoApproval?: boolean;
+
+  /**
    * Observability entrypoint for tracing, scoring, and feedback.
    * When provided, the internal Mastra instance is configured with this
    * observability backend so that agent runs produce trace spans.


### PR DESCRIPTION
Fixes #22.

## Summary

Adds an opt-in Harness config option, deferredAutoApproval, for auto-approved or auto-denied tool approvals.

When enabled, processStream queues allow/deny approval decisions, drains the current stream first, waits for the awaiting input to become visible, and then resumes through the existing handleToolApprove or handleToolDecline path. The default inline behavior is unchanged.

## Verification

- pnpm --filter @mastra/core test src/harness/harness-awaiting-input.test.ts
- pnpm --filter @mastra/core build:lib
- pnpm --filter @mastra/core lint
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This adds an optional switch so the system can wait to apply automatic "approve" or "deny" decisions for tool calls until after the workflow's suspension snapshot is safely saved, preventing races where approvals ran too early and later couldn't be found.

## Overview

Adds an opt-in Harness config option deferredAutoApproval that, when enabled, defers auto-resolved tool-call approval/denial decisions until after the current process stream finishes and the awaiting-input suspension snapshot is durable/visible. While the stream runs, allow/deny decisions are queued rather than applied inline; after the stream drains, the queued decisions are replayed deterministically in order. Default inline behavior remains unchanged unless the option is explicitly enabled.

## Changes

### Configuration
- Added optional deferredAutoApproval?: boolean to HarnessConfig in packages/core/src/harness/types.ts.

### Implementation
- Modified processStream() in packages/core/src/harness/harness.ts to:
  - When an approval policy resolves to allow/deny and this.config.deferredAutoApproval is true, enqueue the decision (toolCallId + requestContext) in a deferredAutoApprovals queue and set isSuspended = true instead of immediately calling handleToolApprove/handleToolDecline.
  - After the stream finishes, iterate the full deferredAutoApprovals queue sequentially; for each entry wait for the corresponding durable awaiting input via waitForAwaitingInputReady and then call handleToolApprove or handleToolDecline, returning the last produced result if any.
  - Preserve the existing inline approval path when deferredAutoApproval is not set.
- Import ordering adjusted at top of file (no behavioral change).

### Testing
- Added createApprovalFullStream helper and new tests in packages/core/src/harness/harness-awaiting-input.test.ts:
  - Confirms default inline behavior (handleToolApprove called during processStream and receives RequestContext).
  - Confirms deferred behavior: approvals are queued, waitForAwaitingInputReady is invoked after stream drains, and handleToolApprove/handleToolDecline are deferred until after durability.
  - Adds regression test asserting multiple deferred approvals are replayed sequentially in order and strict sequencing assertions (wait1 < approve1 < wait2 < approve2), addressing a prior bug where only the first queued decision was replayed.

### Release metadata
- Added .changeset/deferred-auto-approval.md describing an opt-in patch release for @mastra/core and documenting the new option and behavior.

## Backward Compatibility

Opt-in only: existing inline auto-approval semantics remain the default. Enabling deferredAutoApproval: true explicitly changes approval timing to avoid suspension-durability races.

## Notes / Misc
- Commit 209fc56784 fixed replay to iterate the full queued decision list and expanded changeset/docs.
- Commit e4e901eff4 added invocation-order assertions and strict sequencing tests for multi-approval replay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->