### PR TITLE
feat(ai-sdk): emit harness plan approval requests

### DIFF
--- a/.changeset/harness-plan-approval-ui.md
+++ b/.changeset/harness-plan-approval-ui.md
@@ -1,0 +1,21 @@
+---
+'@mastra/ai-sdk': minor
+---
+
+Emit native Harness plan approval request data from `harnessToUIMessageStream`.
+
+When a Harness display state contains `pendingPlanApproval`, the AI SDK harness
+bridge now emits a `data-mastra-plan-approval-request` chunk with the approval
+id, plan id, title, and plan body. Tool approval behavior and the existing
+Harness snapshot/delta HITL data are unchanged.
+
+Usage:
+
+```ts
+for await (const chunk of harnessToUIMessageStream(harness, { include: ['hitl'] })) {
+  if (chunk.type === 'data-mastra-plan-approval-request') {
+    const { approvalId, planId, title, plan } = chunk.data;
+    renderPlanApproval({ approvalId, planId, title, plan });
+  }
+}
+```

--- a/client-sdks/ai-sdk/src/harness.test.ts
+++ b/client-sdks/ai-sdk/src/harness.test.ts
@@ -247,6 +247,70 @@ describe('harnessToUIMessageStream', () => {
     await reader.cancel();
   });
 
+  it('emits native plan approval request data once from pending HITL plan state', async () => {
+    const state = createState({
+      isRunning: true,
+      pendingPlanApproval: {
+        planId: 'plan-1',
+        title: 'Implementation Plan',
+        plan: '# Plan\n\n1. Build it.',
+      },
+    });
+    const harness = new FakeHarness(state);
+    harness.currentRunId = 'run-123';
+    const reader = harnessToUIMessageStream(harness, { include: ['hitl'], sendStart: false }).getReader();
+
+    expect(await readChunks(reader, 2)).toMatchObject([
+      {
+        type: 'data-mastra-plan-approval-request',
+        id: 'run-123::plan-1',
+        data: {
+          approvalId: 'run-123::plan-1',
+          planId: 'plan-1',
+          title: 'Implementation Plan',
+          plan: '# Plan\n\n1. Build it.',
+        },
+      },
+      { type: 'data-mastra-harness-snapshot', data: { sequence: 1 } },
+    ]);
+
+    harness.emit(state);
+    expect(await readChunk(reader)).toMatchObject({
+      type: 'data-mastra-harness-snapshot',
+      data: { sequence: 2 },
+    });
+
+    harness.emit(createState({ isRunning: true }));
+    expect(await readChunk(reader)).toMatchObject({
+      type: 'data-mastra-harness-snapshot',
+      data: { sequence: 3 },
+    });
+
+    harness.emit(
+      createState({
+        isRunning: true,
+        pendingPlanApproval: {
+          planId: 'plan-1',
+          title: 'Implementation Plan',
+          plan: '# Plan\n\n1. Build it.',
+        },
+      }),
+    );
+    expect(await readChunks(reader, 2)).toMatchObject([
+      {
+        type: 'data-mastra-plan-approval-request',
+        id: 'run-123::plan-1',
+        data: {
+          approvalId: 'run-123::plan-1',
+          planId: 'plan-1',
+        },
+      },
+      { type: 'data-mastra-harness-snapshot', data: { sequence: 4 } },
+    ]);
+
+    await reader.cancel();
+  });
+
   it('represents HITL state appearing and clearing in replacing snapshots', async () => {
     const harness = new FakeHarness(createState({ isRunning: true }));
     const reader = harnessToUIMessageStream(harness, { include: ['hitl'], sendStart: false }).getReader();

--- a/client-sdks/ai-sdk/src/harness.ts
+++ b/client-sdks/ai-sdk/src/harness.ts
@@ -102,7 +102,22 @@ export type HarnessUIErrorDataPart = {
   };
 };
 
-export type HarnessUIDataPart = HarnessUISnapshotDataPart | HarnessUIDeltaDataPart | HarnessUIErrorDataPart;
+export type HarnessUIPlanApprovalRequestDataPart = {
+  type: 'data-mastra-plan-approval-request';
+  id: string;
+  data: {
+    approvalId: string;
+    planId: string;
+    title?: string;
+    plan: string;
+  };
+};
+
+export type HarnessUIDataPart =
+  | HarnessUISnapshotDataPart
+  | HarnessUIDeltaDataPart
+  | HarnessUIErrorDataPart
+  | HarnessUIPlanApprovalRequestDataPart;
 
 type HarnessUITextChunk =
   | { type: 'start'; messageId?: string }
@@ -160,6 +175,7 @@ type EmitContext = {
   tools: Map<string, NativeToolStreamState>;
   finalizedTools: Set<string>;
   emittedApprovalKey: string | null;
+  emittedPlanApprovalKey: string | null;
   lastSnapshot: HarnessUISnapshotData | null;
   sequence: number;
   sendStart: boolean;
@@ -197,6 +213,7 @@ export function harnessToUIMessageStream(
         tools: new Map(),
         finalizedTools: new Set(),
         emittedApprovalKey: null,
+        emittedPlanApprovalKey: null,
         lastSnapshot: null,
         sequence: 0,
         sendStart,
@@ -300,6 +317,10 @@ function emitDisplayState(state: HarnessDisplayState, context: EmitContext): voi
 
   if (context.include.has('tools') || context.include.has('hitl')) {
     emitNativeToolApprovalRequest(state, context);
+  }
+
+  if (context.include.has('hitl')) {
+    emitNativePlanApprovalRequest(state, context);
   }
 
   context.sequence += 1;
@@ -488,8 +509,34 @@ function emitNativeToolApprovalRequest(state: HarnessDisplayState, context: Emit
   context.emittedApprovalKey = approvalKey;
 }
 
-function createApprovalId(runId: string | null, toolCallId: string): string {
-  return runId ? `${runId}${APPROVAL_ID_SEPARATOR}${toolCallId}` : toolCallId;
+function emitNativePlanApprovalRequest(state: HarnessDisplayState, context: EmitContext): void {
+  const approval = state.pendingPlanApproval;
+  if (!approval) {
+    context.emittedPlanApprovalKey = null;
+    return;
+  }
+
+  const approvalId = createApprovalId(context.getCurrentRunId(), approval.planId);
+  const approvalKey = `${approvalId}:${approval.planId}`;
+  if (context.emittedPlanApprovalKey === approvalKey) {
+    return;
+  }
+
+  context.controller.enqueue({
+    type: 'data-mastra-plan-approval-request',
+    id: approvalId,
+    data: {
+      approvalId,
+      planId: approval.planId,
+      ...(approval.title ? { title: approval.title } : {}),
+      plan: approval.plan,
+    },
+  });
+  context.emittedPlanApprovalKey = approvalKey;
+}
+
+function createApprovalId(runId: string | null, awaitingInputId: string): string {
+  return runId ? `${runId}${APPROVAL_ID_SEPARATOR}${awaitingInputId}` : awaitingInputId;
 }
 
 function createSnapshotData(


### PR DESCRIPTION
Fixes #24

## Summary

- Adds a typed `data-mastra-plan-approval-request` chunk to `harnessToUIMessageStream`.
- Emits the chunk once per pending Harness plan approval with `{ approvalId, planId, title, plan }`.
- Keeps native tool approval chunks and existing Harness snapshot/delta HITL data unchanged.

## Verification

- `pnpm --filter @mastra/ai-sdk test src/harness.test.ts`
- `pnpm --filter @mastra/ai-sdk lint`
- `pnpm --filter @mastra/ai-sdk build:lib`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When the harness needs a human to OK a generated plan, the SDK now sends a clear, typed "please approve this plan" message with the plan contents so UIs can show it and users can approve/reject directly—no guessing or faking tool calls.

---

## Overview

Adds native plan-approval request chunks to the harness → UI message stream when a Harness display state contains `pendingPlanApproval`. This provides { approvalId, planId, title, plan } so UI clients can render and respond to plan approvals without synthesizing tool approvals. Tool-approval behavior and existing snapshot/delta HITL data remain unchanged.

---

## Changes

### API / Types
- Added exported type `HarnessUIPlanApprovalRequestDataPart` (discriminator `data-mastra-plan-approval-request`) with payload:
  - approvalId: string
  - planId: string
  - title?: string
  - plan: string
- Extended `HarnessUIDataPart` union to include `HarnessUIPlanApprovalRequestDataPart`.

### Implementation
- Emit logic:
  - Introduced `emittedPlanApprovalKey` in emit context to deduplicate emissions.
  - Added `emitNativePlanApprovalRequest` behavior inside `emitDisplayState` (only when `include` contains `hitl` and `state.pendingPlanApproval` is present).
  - Refactored `createApprovalId` usage to accept a generic awaiting-input identifier used for plan approvals (so no synthetic `toolCallId` needed).
- Existing harness snapshot/delta HITL domains and native tool approval chunks are preserved and unchanged.

### Tests
- Added Vitest coverage in `client-sdks/ai-sdk/src/harness.test.ts` verifying:
  - A `data-mastra-plan-approval-request` is emitted exactly once when `pendingPlanApproval` first appears for a given run/plan.
  - Re-emitting the same state does not duplicate the plan-approval request (only snapshots follow).
  - Clearing and later reintroducing `pendingPlanApproval` emits a new plan-approval request.
  - Payload includes expected fields (id, approvalId, planId, title, plan).
  - Native tool approval behavior and snapshot emission remain intact.

### Docs / Release
- `.changeset/harness-plan-approval-ui.md`: documents the change and bumps `@mastra/ai-sdk` to a minor release.

---

## Compatibility / Acceptance Criteria Mapping

- Emits a native plan approval request chunk when display state has `pendingPlanApproval` (satisfies emission requirement).
- Includes { approvalId, planId, title, plan } so UIs can render plan content without synthesizing tool calls.
- Deduplication logic ensures exactly one request per run/plan pair; re-introduction of pending approval emits a new request.
- No synthetic `toolCallId` is required; native tool approval chunks and behavior are unchanged.
- Preserves existing Harness snapshot/delta HITL data for backward compatibility.

--- 

## Verification (from changeset)
Recommended verification: run tests, lint, build the library, and run `git diff --check`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->