### PR TITLE
memory: skip empty assistant messages

### DIFF
--- a/.changeset/memory-skip-empty-assistant.md
+++ b/.changeset/memory-skip-empty-assistant.md
@@ -1,0 +1,24 @@
+---
+'@mastra/core': minor
+'@mastra/memory': minor
+---
+
+Add an opt-in `skipEmptyAssistantMessages` memory option.
+
+When enabled, memory persistence skips assistant messages that have no
+meaningful output after normal working-memory cleanup. This prevents no-op
+assistant rows from aborted or failed turns from being replayed into future
+model context, while preserving messages that carry real text in
+`content.content` even when their `parts` array is empty.
+
+Usage:
+
+```ts
+import { Memory } from '@mastra/memory';
+
+const memory = new Memory({
+  options: {
+    skipEmptyAssistantMessages: true,
+  },
+});
+```

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -708,6 +708,7 @@ https://mastra.ai/en/docs/memory/overview`,
             lastMessages: typeof lastMessages === 'number' ? lastMessages : undefined,
             saveMessages: this.saveMessages.bind(this),
             deleteMessages: this.deleteMessages.bind(this),
+            skipEmptyAssistantMessages: effectiveConfig.skipEmptyAssistantMessages,
           }),
         );
       }
@@ -869,6 +870,7 @@ https://mastra.ai/en/docs/memory/overview`,
             lastMessages: typeof lastMessages === 'number' ? lastMessages : undefined,
             saveMessages: this.saveMessages.bind(this),
             deleteMessages: this.deleteMessages.bind(this),
+            skipEmptyAssistantMessages: effectiveConfig.skipEmptyAssistantMessages,
           }),
         );
       }

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -961,6 +961,23 @@ type BaseMemoryConfig = {
   filterIncompleteToolCalls?: boolean;
 
   /**
+   * Whether to skip assistant messages that contain no meaningful output when
+   * persisting memory.
+   *
+   * When true, assistant messages with blank `content.content` and no non-empty
+   * text/reasoning parts or other persistable content parts are not saved. This
+   * prevents aborted or failed no-op assistant rows from being replayed into
+   * later model context.
+   *
+   * Messages with non-empty `content.content` are still saved even if their
+   * `parts` array is empty. With this flag disabled, the existing empty-parts
+   * filtering behavior is unchanged.
+   *
+   * @default false
+   */
+  skipEmptyAssistantMessages?: boolean;
+
+  /**
    * Thread management configuration.
    * @deprecated The `threads` object is deprecated. Use top-level `generateTitle` instead of `threads.generateTitle`.
    */
@@ -1164,6 +1181,9 @@ export type SerializedMemoryConfig = {
 
     /** Semantic recall configuration */
     semanticRecall?: boolean | SemanticRecall;
+
+    /** Skip persisting no-op assistant messages */
+    skipEmptyAssistantMessages?: boolean;
 
     /** Title generation configuration (serialized form) */
     generateTitle?:

--- a/packages/core/src/processors/memory/message-history.test.ts
+++ b/packages/core/src/processors/memory/message-history.test.ts
@@ -1107,6 +1107,177 @@ describe('MessageHistory', () => {
       });
     });
 
+    it('should skip empty assistant messages when configured', async () => {
+      const mockStorage = {
+        saveMessages: vi.fn().mockResolvedValue(undefined),
+        getThreadById: vi.fn().mockResolvedValue({
+          id: 'thread-1',
+          title: 'Test Thread',
+          metadata: {},
+        }),
+        listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        updateThread: vi.fn().mockResolvedValue(undefined),
+      } as unknown as MemoryStorage;
+      const processor = new MessageHistory({ storage: mockStorage, skipEmptyAssistantMessages: true });
+      const messages: MastraDBMessage[] = [
+        {
+          id: 'empty-assistant',
+          role: 'assistant',
+          content: { format: 2, parts: [{ type: 'text', text: '   ' }] },
+          createdAt: new Date(),
+        },
+        {
+          id: 'real-assistant',
+          role: 'assistant',
+          content: { format: 2, parts: [{ type: 'text', text: 'Useful answer' }] },
+          createdAt: new Date(),
+        },
+        {
+          id: 'reasoning-assistant',
+          role: 'assistant',
+          content: {
+            format: 2,
+            parts: [{ type: 'reasoning', reasoning: '', details: [{ type: 'text', text: 'Useful reasoning' }] }],
+          },
+          createdAt: new Date(),
+        },
+        {
+          id: 'tool-assistant',
+          role: 'assistant',
+          content: {
+            format: 2,
+            parts: [
+              {
+                type: 'tool-invocation',
+                toolInvocation: { state: 'call', toolName: 'lookup', toolCallId: 'call-1', args: {} },
+              },
+            ],
+          },
+          createdAt: new Date(),
+        },
+        {
+          id: 'step-only-assistant',
+          role: 'assistant',
+          content: { format: 2, parts: [{ type: 'step-start' }] },
+          createdAt: new Date(),
+        },
+      ];
+
+      await processor.persistMessages({
+        messages,
+        threadId: 'thread-1',
+      });
+
+      expect(mockStorage.saveMessages).toHaveBeenCalledWith({
+        messages: [
+          expect.objectContaining({ id: 'real-assistant' }),
+          expect.objectContaining({ id: 'reasoning-assistant' }),
+          expect.objectContaining({ id: 'tool-assistant' }),
+        ],
+      });
+    });
+
+    it('should preserve assistant messages with content text and empty parts when skipping empty assistant messages', async () => {
+      const mockStorage = {
+        saveMessages: vi.fn().mockResolvedValue(undefined),
+        getThreadById: vi.fn().mockResolvedValue({
+          id: 'thread-1',
+          title: 'Test Thread',
+          metadata: {},
+        }),
+        listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        updateThread: vi.fn().mockResolvedValue(undefined),
+      } as unknown as MemoryStorage;
+      const processor = new MessageHistory({ storage: mockStorage, skipEmptyAssistantMessages: true });
+      const response: MastraDBMessage = {
+        id: 'assistant-content-text',
+        role: 'assistant',
+        content: {
+          format: 2,
+          content: 'Useful answer',
+          parts: [],
+        },
+        createdAt: new Date(),
+      };
+
+      await processor.persistMessages({
+        messages: [response],
+        threadId: 'thread-1',
+      });
+
+      expect(mockStorage.saveMessages).toHaveBeenCalledWith({
+        messages: [expect.objectContaining({ id: 'assistant-content-text' })],
+      });
+    });
+
+    it('should keep default empty-parts filtering unchanged when skipEmptyAssistantMessages is not configured', async () => {
+      const mockStorage = {
+        saveMessages: vi.fn().mockResolvedValue(undefined),
+        getThreadById: vi.fn().mockResolvedValue({
+          id: 'thread-1',
+          title: 'Test Thread',
+          metadata: {},
+        }),
+        listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        updateThread: vi.fn().mockResolvedValue(undefined),
+      } as unknown as MemoryStorage;
+      const processor = new MessageHistory({ storage: mockStorage });
+      const response: MastraDBMessage = {
+        id: 'assistant-content-text',
+        role: 'assistant',
+        content: {
+          format: 2,
+          content: 'Useful answer',
+          parts: [],
+        },
+        createdAt: new Date(),
+      };
+
+      await processor.persistMessages({
+        messages: [response],
+        threadId: 'thread-1',
+      });
+
+      expect(mockStorage.saveMessages).not.toHaveBeenCalled();
+    });
+
+    it('should honor skipEmptyAssistantMessages from runtime memory config', async () => {
+      const mockStorage = {
+        saveMessages: vi.fn().mockResolvedValue(undefined),
+        getThreadById: vi.fn().mockResolvedValue({
+          id: 'thread-1',
+          title: 'Test Thread',
+          metadata: {},
+        }),
+        listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0 }),
+        updateThread: vi.fn().mockResolvedValue(undefined),
+      } as unknown as MemoryStorage;
+      const processor = new MessageHistory({ storage: mockStorage });
+      const response: MastraDBMessage = {
+        id: 'empty-assistant',
+        role: 'assistant',
+        content: { format: 2, parts: [{ type: 'text', text: '   ' }] },
+        createdAt: new Date(),
+      };
+      const messageList = new MessageList().add(response, 'response');
+      const requestContext = createRuntimeContextWithMemory('thread-1');
+      requestContext.set('MastraMemory', {
+        thread: { id: 'thread-1' },
+        memoryConfig: { skipEmptyAssistantMessages: true },
+      } as MemoryRuntimeContext);
+
+      await processor.processOutputResult({
+        messageList,
+        messages: [response],
+        abort: ((reason?: string) => {
+          throw new Error(reason || 'Aborted');
+        }) as (reason?: string) => never,
+        requestContext,
+      });
+
+      expect(mockStorage.saveMessages).not.toHaveBeenCalled();
+    });
+
     it('should preserve existing message IDs', async () => {
       const mockStorage = {
         saveMessages: vi.fn().mockResolvedValue(undefined),

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -16,6 +16,7 @@ export interface MessageHistoryOptions {
   lastMessages?: number;
   saveMessages?: (args: { messages: MastraDBMessage[] }) => Promise<{ messages: MastraDBMessage[] }>;
   deleteMessages?: (messageIds: string[], observabilityContext?: Partial<ObservabilityContext>) => Promise<void>;
+  skipEmptyAssistantMessages?: boolean;
 }
 
 type RegenerateState = {
@@ -26,6 +27,76 @@ type RegenerateState = {
 type MemoryHistoryOverride = MastraMemoryHistoryOverride;
 
 const INCOMPLETE_RESPONSE_STATUSES = new Set(['partial', 'aborted', 'cancelled', 'canceled']);
+
+function isEmptyAssistantMessage(message: MastraDBMessage): boolean {
+  if (message.role !== 'assistant') {
+    return false;
+  }
+
+  if (typeof (message.content as unknown) === 'string') {
+    return (message.content as unknown as string).trim().length === 0;
+  }
+
+  const content = message.content;
+  if (typeof content?.content === 'string' && content.content.trim().length > 0) {
+    return false;
+  }
+
+  if (!Array.isArray(content?.parts) || content.parts.length === 0) {
+    return true;
+  }
+
+  return !content.parts.some(part => isMeaningfulAssistantPart(part));
+}
+
+function isMeaningfulAssistantPart(part: unknown): boolean {
+  if (!part || typeof part !== 'object') {
+    return false;
+  }
+
+  const record = part as Record<string, unknown>;
+  const type = record.type;
+
+  if (type === 'text') {
+    return typeof record.text === 'string' && record.text.trim().length > 0;
+  }
+
+  if (type === 'reasoning') {
+    return (
+      hasNonEmptyString(record.text) ||
+      hasNonEmptyString(record.reasoning) ||
+      hasMeaningfulReasoningDetails(record.details)
+    );
+  }
+
+  if (type === 'thinking') {
+    return typeof record.thinking === 'string' && record.thinking.trim().length > 0;
+  }
+
+  if (type === 'step-start' || type === 'step-end') {
+    return false;
+  }
+
+  return true;
+}
+
+function hasNonEmptyString(value: unknown): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function hasMeaningfulReasoningDetails(details: unknown): boolean {
+  return (
+    Array.isArray(details) &&
+    details.some(detail => {
+      if (!detail || typeof detail !== 'object') {
+        return false;
+      }
+
+      const record = detail as Record<string, unknown>;
+      return hasNonEmptyString(record.text) || hasNonEmptyString(record.data);
+    })
+  );
+}
 
 /**
  * Hybrid processor that handles both retrieval and persistence of message history.
@@ -42,12 +113,14 @@ export class MessageHistory implements Processor {
   private lastMessages?: number;
   private saveMessages?: MessageHistoryOptions['saveMessages'];
   private deleteMessages?: MessageHistoryOptions['deleteMessages'];
+  private skipEmptyAssistantMessages: boolean;
 
   constructor(options: MessageHistoryOptions) {
     this.storage = options.storage;
     this.lastMessages = options.lastMessages;
     this.saveMessages = options.saveMessages;
     this.deleteMessages = options.deleteMessages;
+    this.skipEmptyAssistantMessages = options.skipEmptyAssistantMessages ?? false;
   }
 
   /**
@@ -312,7 +385,10 @@ export class MessageHistory implements Processor {
    */
   private filterMessagesForPersistence(
     messages: MastraDBMessage[],
-    { includeIncompleteAssistantMessages = false }: { includeIncompleteAssistantMessages?: boolean } = {},
+    {
+      includeIncompleteAssistantMessages = false,
+      skipEmptyAssistantMessages = false,
+    }: { includeIncompleteAssistantMessages?: boolean; skipEmptyAssistantMessages?: boolean } = {},
   ): MastraDBMessage[] {
     return messages
       .map(m => {
@@ -354,10 +430,20 @@ export class MessageHistory implements Processor {
             })
             .filter((p): p is NonNullable<typeof p> => Boolean(p));
 
-          // If all parts were filtered out, skip the whole message
+          // If all parts were filtered out, skip the whole message only when
+          // it has no fallback text content left.
           if (newMessage.content.parts.length === 0) {
-            return null;
+            const hasContentText =
+              typeof newMessage.content.content === 'string' && newMessage.content.content.trim().length > 0;
+
+            if (!skipEmptyAssistantMessages || !hasContentText) {
+              return null;
+            }
           }
+        }
+
+        if (skipEmptyAssistantMessages && isEmptyAssistantMessage(newMessage)) {
+          return null;
         }
 
         return newMessage;
@@ -382,6 +468,7 @@ export class MessageHistory implements Processor {
     // Check if readOnly from memoryConfig
     const memoryContext = parseMemoryRequestContext(requestContext);
     const readOnly = memoryContext?.memoryConfig?.readOnly;
+    const skipEmptyAssistantMessages = memoryContext?.memoryConfig?.skipEmptyAssistantMessages === true;
 
     if (!context || readOnly) {
       return messageList;
@@ -408,6 +495,7 @@ export class MessageHistory implements Processor {
         threadId,
         resourceId,
         includeIncompleteAssistantMessages: override?.type === 'server-history',
+        skipEmptyAssistantMessages,
       });
 
       const regenerateState = args.state?.regenerate as RegenerateState | undefined;
@@ -453,14 +541,18 @@ export class MessageHistory implements Processor {
     threadId: string;
     resourceId?: string;
     includeIncompleteAssistantMessages?: boolean;
+    skipEmptyAssistantMessages?: boolean;
   }): Promise<MastraDBMessage[]> {
-    const { messages, threadId, resourceId, includeIncompleteAssistantMessages } = args;
+    const { messages, threadId, resourceId, includeIncompleteAssistantMessages, skipEmptyAssistantMessages } = args;
 
     if (messages.length === 0) {
       return [];
     }
 
-    const filtered = this.filterMessagesForPersistence(messages, { includeIncompleteAssistantMessages });
+    const filtered = this.filterMessagesForPersistence(messages, {
+      includeIncompleteAssistantMessages,
+      skipEmptyAssistantMessages: this.skipEmptyAssistantMessages || skipEmptyAssistantMessages === true,
+    });
 
     if (filtered.length === 0) {
       return [];

--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -271,6 +271,255 @@ describe('Memory', () => {
       expect(recalled.messages.map(message => message.content)).toEqual([messages[0].content, messages[1].content]);
     });
 
+    it('should skip empty assistant messages when configured', async () => {
+      const threadId = 'thread-skip-empty-assistant';
+      const resourceId = 'resource-skip-empty-assistant';
+      const configuredMemory = new Memory({
+        storage: new InMemoryStore(),
+        options: {
+          skipEmptyAssistantMessages: true,
+        },
+      });
+
+      await configuredMemory.createThread({
+        threadId,
+        resourceId,
+      });
+
+      const result = await configuredMemory.saveMessages({
+        messages: [
+          {
+            id: 'empty-assistant',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            createdAt: new Date('2024-01-01T10:00:00Z'),
+            content: {
+              format: 2,
+              content: '',
+              experimental_attachments: [],
+              parts: [{ type: 'text', text: '   ' }],
+            },
+          },
+          {
+            id: 'real-assistant',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            createdAt: new Date('2024-01-01T10:01:00Z'),
+            content: {
+              format: 2,
+              content: '',
+              experimental_attachments: [],
+              parts: [{ type: 'text', text: 'Useful answer' }],
+            },
+          },
+          {
+            id: 'reasoning-assistant',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            createdAt: new Date('2024-01-01T10:02:00Z'),
+            content: {
+              format: 2,
+              content: '',
+              experimental_attachments: [],
+              parts: [{ type: 'reasoning', reasoning: '', details: [{ type: 'text', text: 'Useful reasoning' }] }],
+            },
+          },
+          {
+            id: 'tool-assistant',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            createdAt: new Date('2024-01-01T10:03:00Z'),
+            content: {
+              format: 2,
+              content: '',
+              experimental_attachments: [],
+              parts: [
+                {
+                  type: 'tool-invocation',
+                  toolInvocation: { state: 'call', toolName: 'lookup', toolCallId: 'call-1', args: {} },
+                },
+              ],
+            },
+          },
+          {
+            id: 'step-only-assistant',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            createdAt: new Date('2024-01-01T10:04:00Z'),
+            content: {
+              format: 2,
+              content: '',
+              experimental_attachments: [],
+              parts: [{ type: 'step-start' }],
+            },
+          },
+        ],
+      });
+
+      expect(result.messages.map(message => message.id)).toEqual([
+        'real-assistant',
+        'reasoning-assistant',
+        'tool-assistant',
+      ]);
+
+      const recalled = await configuredMemory.recall({
+        threadId,
+        resourceId,
+        perPage: false,
+      });
+      expect(recalled.messages.map(message => message.id)).toEqual([
+        'real-assistant',
+        'reasoning-assistant',
+        'tool-assistant',
+      ]);
+    });
+
+    it('should keep assistant messages with content text and empty parts when configured to skip empty assistant messages', async () => {
+      const threadId = 'thread-keep-content-text';
+      const resourceId = 'resource-keep-content-text';
+      const configuredMemory = new Memory({
+        storage: new InMemoryStore(),
+        options: {
+          skipEmptyAssistantMessages: true,
+        },
+      });
+
+      await configuredMemory.createThread({
+        threadId,
+        resourceId,
+      });
+
+      const result = await configuredMemory.saveMessages({
+        messages: [
+          {
+            id: 'assistant-content-text',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            createdAt: new Date('2024-01-01T10:00:00Z'),
+            content: {
+              format: 2,
+              content: 'Useful answer from content.content',
+              experimental_attachments: [],
+              parts: [],
+            },
+          },
+        ],
+      });
+
+      expect(result.messages.map(message => message.id)).toEqual(['assistant-content-text']);
+
+      const recalled = await configuredMemory.recall({
+        threadId,
+        resourceId,
+        perPage: false,
+      });
+      expect(recalled.messages.map(message => message.id)).toEqual(['assistant-content-text']);
+    });
+
+    it('should return without saving when all messages are empty assistants', async () => {
+      const threadId = 'thread-all-empty-assistant';
+      const resourceId = 'resource-all-empty-assistant';
+      const storage = new InMemoryStore();
+      const configuredMemory = new Memory({
+        storage,
+        options: {
+          skipEmptyAssistantMessages: true,
+        },
+      });
+
+      await configuredMemory.createThread({
+        threadId,
+        resourceId,
+      });
+      const memoryStore = await storage.getStore('memory');
+      expect(memoryStore).toBeDefined();
+      const saveMessagesSpy = vi.spyOn(memoryStore!, 'saveMessages');
+      saveMessagesSpy.mockClear();
+
+      const result = await configuredMemory.saveMessages({
+        messages: [
+          {
+            id: 'empty-assistant',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            createdAt: new Date('2024-01-01T10:00:00Z'),
+            content: {
+              format: 2,
+              content: '',
+              experimental_attachments: [],
+              parts: [{ type: 'text', text: '   ' }],
+            },
+          },
+        ],
+      });
+
+      expect(result.messages).toEqual([]);
+      expect(saveMessagesSpy).not.toHaveBeenCalled();
+    });
+
+    it('should honor per-call skipEmptyAssistantMessages memory config', async () => {
+      const threadId = 'thread-runtime-skip-empty-assistant';
+      const resourceId = 'resource-runtime-skip-empty-assistant';
+      const configuredMemory = new Memory({
+        storage: new InMemoryStore(),
+      });
+
+      await configuredMemory.createThread({
+        threadId,
+        resourceId,
+      });
+
+      const result = await configuredMemory.saveMessages({
+        memoryConfig: {
+          skipEmptyAssistantMessages: true,
+        },
+        messages: [
+          {
+            id: 'empty-assistant',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            createdAt: new Date('2024-01-01T10:00:00Z'),
+            content: {
+              format: 2,
+              content: '',
+              experimental_attachments: [],
+              parts: [{ type: 'text', text: '   ' }],
+            },
+          },
+          {
+            id: 'real-assistant',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            createdAt: new Date('2024-01-01T10:01:00Z'),
+            content: {
+              format: 2,
+              content: '',
+              experimental_attachments: [],
+              parts: [{ type: 'text', text: 'Useful answer' }],
+            },
+          },
+        ],
+      });
+
+      expect(result.messages.map(message => message.id)).toEqual(['real-assistant']);
+
+      const recalled = await configuredMemory.recall({
+        threadId,
+        resourceId,
+        perPage: false,
+      });
+      expect(recalled.messages.map(message => message.id)).toEqual(['real-assistant']);
+    });
+
     it('should preserve the original createdAt when saving the same message id again', async () => {
       const threadId = 'thread-save-duplicate';
       const resourceId = 'resource-save-duplicate';

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -72,6 +72,7 @@ type MemoryObservationalMemoryOptions = Omit<ObservationalMemoryOptions, 'model'
 
 type MemoryOptions = Omit<MemoryConfigInternal, 'observationalMemory'> & {
   observationalMemory?: boolean | MemoryObservationalMemoryOptions;
+  skipEmptyAssistantMessages?: boolean;
 };
 
 type MemoryConstructorConfig = Omit<SharedMemoryConfig, 'options'> & {
@@ -80,6 +81,7 @@ type MemoryConstructorConfig = Omit<SharedMemoryConfig, 'options'> & {
 
 type RuntimeMemoryConfig = Omit<MemoryConfig, 'observationalMemory'> & {
   observationalMemory?: boolean | MemoryObservationalMemoryOptions;
+  skipEmptyAssistantMessages?: boolean;
 };
 
 type NormalizedObservationalMemoryConfig = MemoryObservationalMemoryOptions & {
@@ -97,6 +99,10 @@ type NormalizedObservationalMemoryConfig = MemoryObservationalMemoryOptions & {
  * with packages/core/src/memory/working-memory-utils.ts and
  * packages/core/src/memory/system-reminders.ts. Those source files also carry
  * compatibility notes that point back here.
+ *
+ * The empty-assistant helpers below follow the same rule: keep them in sync
+ * with packages/core/src/processors/memory/message-history.ts rather than
+ * importing new runtime helpers from @mastra/core.
  */
 const WORKING_MEMORY_START_TAG = '<working_memory>';
 const WORKING_MEMORY_END_TAG = '</working_memory>';
@@ -104,6 +110,75 @@ const LEGACY_SYSTEM_REMINDER_METADATA_KEY = 'dynamicAgentsMdReminder';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+/*
+ * Compatibility note: the following empty-message detection helpers are
+ * intentionally copied from packages/core/src/processors/memory/message-history.ts.
+ * Keep both implementations in sync when changing this logic.
+ */
+function isEmptyAssistantMessage(message: MastraDBMessage): boolean {
+  if (message.role !== 'assistant') {
+    return false;
+  }
+
+  if (typeof (message.content as unknown) === 'string') {
+    return (message.content as unknown as string).trim().length === 0;
+  }
+
+  const content = message.content;
+  if (typeof content?.content === 'string' && content.content.trim().length > 0) {
+    return false;
+  }
+
+  if (!Array.isArray(content?.parts) || content.parts.length === 0) {
+    return true;
+  }
+
+  return !content.parts.some(part => isMeaningfulAssistantPart(part));
+}
+
+function isMeaningfulAssistantPart(part: unknown): boolean {
+  if (!isRecord(part)) {
+    return false;
+  }
+
+  if (part.type === 'text') {
+    return typeof part.text === 'string' && part.text.trim().length > 0;
+  }
+
+  if (part.type === 'reasoning') {
+    return (
+      hasNonEmptyString(part.text) || hasNonEmptyString(part.reasoning) || hasMeaningfulReasoningDetails(part.details)
+    );
+  }
+
+  if (part.type === 'thinking') {
+    return typeof part.thinking === 'string' && part.thinking.trim().length > 0;
+  }
+
+  if (part.type === 'step-start' || part.type === 'step-end') {
+    return false;
+  }
+
+  return true;
+}
+
+function hasNonEmptyString(value: unknown): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function hasMeaningfulReasoningDetails(details: unknown): boolean {
+  return (
+    Array.isArray(details) &&
+    details.some(detail => {
+      if (!isRecord(detail)) {
+        return false;
+      }
+
+      return hasNonEmptyString(detail.text) || hasNonEmptyString(detail.data);
+    })
+  );
 }
 
 export function extractWorkingMemoryTags(text: string): string[] | null {
@@ -1014,14 +1089,27 @@ ${workingMemory}`;
     });
 
     try {
+      const config = this.getMergedThreadConfig(memoryConfig);
+
       // Then strip working memory tags from all messages
       const updatedMessages = messages
         .map(m => {
           return this.updateMessageToHideWorkingMemoryV2(m);
         })
-        .filter((m): m is MastraDBMessage => Boolean(m));
+        .filter((m): m is MastraDBMessage => Boolean(m))
+        .filter(message => !config.skipEmptyAssistantMessages || !isEmptyAssistantMessage(message));
 
-      const config = this.getMergedThreadConfig(memoryConfig);
+      if (updatedMessages.length === 0) {
+        const saveResult = { messages: [] };
+        span?.end({
+          output: { success: true },
+          attributes: {
+            messageCount: 0,
+            semanticRecallEnabled: Boolean(config.semanticRecall),
+          },
+        });
+        return saveResult;
+      }
 
       // Convert messages to MastraDBMessage format if needed
       const dbMessages = new MessageList({


### PR DESCRIPTION
## Summary
- Add opt-in `skipEmptyAssistantMessages` to memory config.
- Thread the option into core `MessageHistory` input/output processors.
- Filter assistant messages with no meaningful text/reasoning/parts in both `@mastra/core` message-history persistence and `@mastra/memory` direct `saveMessages`.
- Preserve assistant messages that carry real `content.content` even when `parts` is empty, and keep default empty-parts behavior unchanged when the flag is off.
- Treat step-boundary-only assistant rows as empty while preserving tool/reasoning/text assistant messages.

Fixes #26

## Why
Aborted or failed runs can leave blank assistant rows in memory. When replayed, those rows add noise to future model context. PapersFlow currently removes these with an app-level sanitizer; this PR makes the behavior a framework-native opt-in while preserving backward compatibility.

## Claude review
Asked Claude to review the diff before opening the PR and again against the submitted PR diff.

First pass found blocking gaps around reasoning-part shape, accidental default empty-parts behavior change, and missing tool-only/reasoning/runtime-config tests. Those were addressed. Final submitted-diff review reported no blocking findings. I also addressed its cheap quality notes by documenting fallback `content.content` behavior, treating step-only assistant rows as empty, testing that edge case, adding Memory-layer tests for all-empty early return and per-call runtime config, and removing an unnecessary cast.

The only remaining Claude concern is duplicated empty-assistant helper logic between core and memory. This is intentional for now because `@mastra/memory` has a broad `@mastra/core` peer range and already avoids importing newer core runtime helpers for compatibility; the local compatibility comment now calls that out.

## CodeRabbit
Addressed the actionable CodeRabbit items by adding `skipEmptyAssistantMessages` to `SerializedMemoryConfig.options` and adding a changeset usage example. The duplicate-helper note is non-actionable for this PR because of the package peer-compatibility constraint above.

## Verification
- `pnpm --filter @mastra/core test src/processors/memory/message-history.test.ts`
- `pnpm --filter @mastra/memory exec vitest run src/index.test.ts`
- `pnpm --filter @mastra/core exec eslint src/memory/types.ts src/memory/memory.ts src/processors/memory/message-history.ts src/processors/memory/message-history.test.ts`
- `pnpm --filter @mastra/memory exec eslint src/index.ts src/index.test.ts`
- `pnpm --filter @mastra/core build:lib`
- `pnpm --filter @mastra/memory build:lib` after rebuilding core types
- `git diff --check`

Known unrelated local broad-script failures:
- Full `pnpm --filter @mastra/core lint` currently fails on existing harness import-order/duplicate-import lint in files this PR does not touch.
- Broad `@mastra/memory` test scripts hit unrelated integration/OM fixture failures; the targeted `src/index.test.ts` vitest run passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds an optional setting to prevent the system from saving empty AI responses to memory. When turned on, if an AI assistant gives a response with no actual content, it won't be saved, which prevents that empty message from being replayed in future conversations. The default behavior stays the same unless you specifically turn this feature on.

---

## Overview

Implements a new opt-in memory configuration flag `skipEmptyAssistantMessages` that, when enabled, prevents empty assistant messages from being persisted to memory. This addresses the issue where no-op assistant responses (messages with no meaningful text or reasoning content) were being stored and could be replayed in future conversations.

The implementation maintains backward compatibility by defaulting to `false`, leaving existing behavior unchanged unless explicitly enabled.

---

## Changes by Component

### Memory Configuration Types
Added `skipEmptyAssistantMessages?: boolean` option to:
- `MemoryConfig` and `MemoryConfigInternal` in `packages/core/src/memory/types.ts`
- `SerializedMemoryConfig` for serialization/transport
- `MemoryOptions` and `RuntimeMemoryConfig` in `packages/memory/src/index.ts`

### Core Memory Integration
Updated `MastraMemory` in `packages/core/src/memory/memory.ts` to forward the `skipEmptyAssistantMessages` config into both the `MessageHistory` input and output processors.

### Message History Processor
Enhanced `MessageHistory` in `packages/core/src/processors/memory/message-history.ts` with:
- `skipEmptyAssistantMessages?: boolean` option in `MessageHistoryOptions`
- Helper logic to detect empty assistant messages by examining both string `content` and structured `parts` (text, reasoning, thinking)
- Filtering during persistence that omits empty assistant messages when the flag is enabled
- Support for per-call override via `persistMessages` method parameter
- Runtime config forwarding from `processOutputResult` via `memoryContext`

Assistant messages are considered non-empty if they contain: non-whitespace string content in `content.content`, or meaningful parts like `text`, `reasoning`/`thinking` with non-empty values, or `tool-invocation` entries. Step-boundary markers (`step-start`/`step-end`) alone don't constitute meaningful content.

### Memory Package Updates
Modified `saveMessages` in `packages/memory/src/index.ts` to:
- Accept and merge thread-specific config earlier in the pipeline
- Filter out empty assistant messages when `skipEmptyAssistantMessages` is enabled
- Return early with empty results if filtering removes all messages, preventing unnecessary downstream storage calls
- Maintain working-memory tag stripping as before

Includes duplicated empty-detection helper logic intentionally scoped for peer-compatibility.

### Test Coverage
Added comprehensive tests in:
- `packages/core/src/processors/memory/message-history.test.ts` covering:
  - Filtering behavior when `skipEmptyAssistantMessages: true`
  - Preservation of non-empty assistant variants (content with empty parts, reasoning, tool-invocation, step markers)
  - Default behavior when flag is not set
  - Runtime config via `requestContext` and `memoryContext`
  - `processOutputResult` behavior preventing `saveMessages` calls for empty results

- `packages/memory/src/index.test.ts` covering:
  - Per-call config via `memoryConfig`
  - Filtering of empty assistants and step-only messages
  - Preservation of meaningful content (reasoning, tool-invocation, content.content)
  - Early return and no-op storage calls when all messages filtered
  - Impact on subsequent `recall` operations

### Documentation
Added Changesets entry documenting the new memory option for both `@mastra/core` and `@mastra/memory` (marked as `minor`).

---

## Key Behaviors

- **Default**: `skipEmptyAssistantMessages` defaults to `false`; existing behavior unchanged
- **When enabled**: Assistant messages with both blank `content.content` (after trimming) and no meaningful `parts` are excluded from persistence
- **Content preservation**: Assistant messages with non-empty `content.content` are saved even if `parts` is empty
- **Scope**: Only affects assistant messages; user and tool messages are unaffected
- **Backward compatibility**: No breaking changes; behavior opt-in only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->