### PR TITLE
perf(core): make agent finish non-blocking

### DIFF
--- a/.changeset/agent-finish-latency.md
+++ b/.changeset/agent-finish-latency.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Reduce agent response latency by making post-finish persistence non-blocking and deduplicating repeated finish handling for the same run.

--- a/.changeset/fast-agents-finish.md
+++ b/.changeset/fast-agents-finish.md
@@ -1,6 +1,0 @@
----
-'@mastra/core': patch
-'@mastra/observability': patch
----
-
-Improve agent response latency by making post-finish persistence non-blocking, deduplicating concurrent finish handling by run id, and reducing model tracing stream overhead.

--- a/.changeset/fast-agents-finish.md
+++ b/.changeset/fast-agents-finish.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'@mastra/observability': patch
+---
+
+Improve agent response latency by making post-finish persistence non-blocking, deduplicating concurrent finish handling by run id, and reducing model tracing stream overhead.

--- a/.changeset/model-tracing-overhead.md
+++ b/.changeset/model-tracing-overhead.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Reduce model tracing stream overhead to improve streamed response performance.

--- a/observability/mastra/src/model-tracing.ts
+++ b/observability/mastra/src/model-tracing.ts
@@ -17,7 +17,7 @@ import type {
   TracingContext,
   UpdateSpanOptions,
 } from '@mastra/core/observability';
-import type { ChunkType, StepStartPayload, StepFinishPayload } from '@mastra/core/stream';
+import type { StepStartPayload, StepFinishPayload } from '@mastra/core/stream';
 
 import { extractUsageMetrics } from './usage';
 
@@ -525,157 +525,12 @@ export class ModelSpanTracker {
   }
 
   /**
-   * Check if there is currently an active chunk span
-   */
-  #hasActiveChunkSpan(): boolean {
-    return !!this.#currentChunkSpan;
-  }
-
-  /**
    * Get the current accumulator value
    */
   #getAccumulator(): Record<string, any> {
     return this.#accumulator;
   }
 
-  /**
-   * Handle text chunk spans (text-start/delta/end)
-   */
-  #handleTextChunk<OUTPUT>(chunk: ChunkType<OUTPUT>) {
-    switch (chunk.type) {
-      case 'text-start':
-        this.#startChunkSpan('text');
-        break;
-
-      case 'text-delta':
-        // Auto-create span if we receive text-delta without text-start
-        // (AI SDK streaming doesn't always emit wrapper events)
-        // Allow transition from any other chunk type
-        if (this.#currentChunkType !== 'text') {
-          this.#startChunkSpan('text');
-        }
-        this.#appendToAccumulator('text', chunk.payload.text);
-        break;
-
-      case 'text-end': {
-        this.#endChunkSpan();
-        break;
-      }
-    }
-  }
-
-  /**
-   * Handle reasoning chunk spans (reasoning-start/delta/end)
-   */
-  #handleReasoningChunk<OUTPUT>(chunk: ChunkType<OUTPUT>) {
-    switch (chunk.type) {
-      case 'reasoning-start':
-        this.#startChunkSpan('reasoning');
-        break;
-
-      case 'reasoning-delta':
-        // Auto-create span if we receive reasoning-delta without reasoning-start
-        // (AI SDK streaming doesn't always emit wrapper events)
-        // Allow transition from any other chunk type
-        if (this.#currentChunkType !== 'reasoning') {
-          this.#startChunkSpan('reasoning');
-        }
-        this.#appendToAccumulator('text', chunk.payload.text);
-        break;
-
-      case 'reasoning-end': {
-        this.#endChunkSpan();
-        break;
-      }
-    }
-  }
-
-  /**
-   * Handle tool call chunk spans (tool-call-input-streaming-start/delta/end, tool-call)
-   */
-  #handleToolCallChunk<OUTPUT>(chunk: ChunkType<OUTPUT>) {
-    switch (chunk.type) {
-      case 'tool-call-input-streaming-start':
-        this.#startChunkSpan('tool-call', {
-          toolName: chunk.payload.toolName,
-          toolCallId: chunk.payload.toolCallId,
-        });
-        break;
-
-      case 'tool-call-delta':
-        this.#appendToAccumulator('toolInput', chunk.payload.argsTextDelta);
-        break;
-
-      case 'tool-call-input-streaming-end':
-      case 'tool-call': {
-        // Build output with toolName, toolCallId, and parsed toolInput
-        const acc = this.#getAccumulator();
-        let toolInput;
-        try {
-          toolInput = acc.toolInput ? JSON.parse(acc.toolInput) : {};
-        } catch {
-          toolInput = acc.toolInput; // Keep as string if parsing fails
-        }
-        this.#endChunkSpan({
-          toolName: acc.toolName,
-          toolCallId: acc.toolCallId,
-          toolInput,
-        });
-        break;
-      }
-    }
-  }
-
-  /**
-   * Handle object chunk spans (object, object-result)
-   */
-  #handleObjectChunk<OUTPUT>(chunk: ChunkType<OUTPUT>) {
-    switch (chunk.type) {
-      case 'object':
-        // Start span on first partial object chunk (only if not already started)
-        // Multiple object chunks may arrive as the object is being generated
-        // Check specifically for object chunk type to allow transitioning from other types
-        if (this.#currentChunkType !== 'object') {
-          this.#startChunkSpan('object');
-        }
-        break;
-
-      case 'object-result':
-        // End the span with the final complete object as output
-        this.#endChunkSpan(chunk.object);
-        break;
-    }
-  }
-
-  /**
-   * Handle tool-call-approval chunks.
-   * Creates a span for approval requests so they can be seen in traces for debugging.
-   */
-  #handleToolApprovalChunk<OUTPUT>(chunk: ChunkType<OUTPUT>) {
-    if (chunk.type !== 'tool-call-approval') return;
-    const payload = chunk.payload;
-
-    // Auto-create step if we see a chunk before step-start
-    if (!this.#currentStepSpan) {
-      this.startStep();
-    }
-
-    // Create an event span for the approval request
-    // Using createEventSpan since approvals are point-in-time events (not time ranges)
-    const span = this.#currentStepSpan?.createEventSpan({
-      name: `chunk: 'tool-call-approval'`,
-      type: SpanType.MODEL_CHUNK,
-      attributes: {
-        chunkType: 'tool-call-approval',
-        sequenceNumber: this.#chunkSequence,
-      },
-      output: payload,
-    });
-
-    if (span) {
-      this.#chunkSequence++;
-    }
-  }
   /**
    * Wraps a stream with model tracing transform to track MODEL_STEP and MODEL_CHUNK spans.
    *
@@ -686,46 +541,80 @@ export class ModelSpanTracker {
     return stream.pipeThrough(
       new TransformStream({
         transform: (chunk, controller) => {
-          // Capture completion start time on first actual content (for time-to-first-token)
-          switch (chunk.type) {
-            case 'text-delta':
-            case 'tool-call-delta':
-            case 'reasoning-delta':
-              this.#captureCompletionStartTime();
-              break;
+          const chunkType = chunk.type;
+
+          if (chunkType === 'text-delta' || chunkType === 'tool-call-delta' || chunkType === 'reasoning-delta') {
+            this.#captureCompletionStartTime();
           }
 
           controller.enqueue(chunk);
 
-          // Handle chunk span tracking based on chunk type
-          switch (chunk.type) {
-            case 'text-start':
+          // Handle chunk span tracking after enqueue so tracing work does not delay downstream consumers.
+          switch (chunkType) {
             case 'text-delta':
+              if (this.#currentChunkType !== 'text') {
+                this.#startChunkSpan('text');
+              }
+              this.#appendToAccumulator('text', chunk.payload.text);
+              break;
+            case 'text-start':
+              if (this.#currentChunkType !== 'text') {
+                this.#startChunkSpan('text');
+              }
+              break;
             case 'text-end':
-              this.#handleTextChunk(chunk);
+              this.#endChunkSpan();
               break;
 
-            case 'tool-call-input-streaming-start':
             case 'tool-call-delta':
-            case 'tool-call-input-streaming-end':
-            case 'tool-call':
-              this.#handleToolCallChunk(chunk);
+              this.#appendToAccumulator('toolInput', chunk.payload.argsTextDelta);
               break;
+            case 'tool-call-input-streaming-start':
+              this.#startChunkSpan('tool-call', {
+                toolName: chunk.payload.toolName,
+                toolCallId: chunk.payload.toolCallId,
+              });
+              break;
+            case 'tool-call-input-streaming-end':
+            case 'tool-call': {
+              const acc = this.#getAccumulator();
+              let toolInput;
+              try {
+                toolInput = acc.toolInput ? JSON.parse(acc.toolInput) : {};
+              } catch {
+                toolInput = acc.toolInput;
+              }
+              this.#endChunkSpan({
+                toolName: acc.toolName,
+                toolCallId: acc.toolCallId,
+                toolInput,
+              });
+              break;
+            }
 
-            case 'reasoning-start':
             case 'reasoning-delta':
+              if (this.#currentChunkType !== 'reasoning') {
+                this.#startChunkSpan('reasoning');
+              }
+              this.#appendToAccumulator('text', chunk.payload.text);
+              break;
+            case 'reasoning-start':
+              this.#startChunkSpan('reasoning');
+              break;
             case 'reasoning-end':
-              this.#handleReasoningChunk(chunk);
+              this.#endChunkSpan();
               break;
 
             case 'object':
+              if (this.#currentChunkType !== 'object') {
+                this.#startChunkSpan('object');
+              }
+              break;
             case 'object-result':
-              this.#handleObjectChunk(chunk);
+              this.#endChunkSpan(chunk.object);
               break;
 
             case 'step-start':
-              // If step already started (via startStep()), just update with payload data
-              // Otherwise start a new step (for backwards compatibility)
               if (this.#currentStepSpan) {
                 this.updateStep(chunk.payload);
               } else {
@@ -735,48 +624,51 @@ export class ModelSpanTracker {
 
             case 'step-finish':
               if (this.#deferStepClose) {
-                // Durable mode: save payload for later, don't close the step
                 this.#pendingStepFinishPayload = chunk.payload;
               } else {
-                // Normal mode: close the step immediately
                 this.#endStepSpan(chunk.payload);
               }
               break;
 
-            // Infrastructure chunks - skip creating spans for these
-            // They are either redundant, metadata-only, or error/control flow
-            case 'raw': // Redundant raw data
-            case 'start': // Stream start marker
-            case 'finish': // Stream finish marker (step-finish already captures this)
-            case 'response-metadata': // Response metadata (not semantic content)
-            case 'source': // Source references (metadata)
-            case 'file': // Binary file data (too large/not semantic)
-            case 'error': // Error handling
-            case 'abort': // Abort signal
-            case 'tripwire': // Processor rejection
-            case 'watch': // Internal watch event
-            case 'tool-error': // Tool error handling
-            case 'tool-call-suspended': // Suspension (not content)
-            case 'reasoning-signature': // Signature metadata
-            case 'redacted-reasoning': // Redacted content metadata
-            case 'step-output': // Step output wrapper (content is nested)
-              // Don't create spans for these chunks
+            case 'tool-call-approval':
+              if (!this.#currentStepSpan) {
+                this.startStep();
+              }
+              const span = this.#currentStepSpan?.createEventSpan({
+                name: `chunk: 'tool-call-approval'`,
+                type: SpanType.MODEL_CHUNK,
+                attributes: {
+                  chunkType: 'tool-call-approval',
+                  sequenceNumber: this.#chunkSequence,
+                },
+                output: chunk.payload,
+              });
+              if (span) {
+                this.#chunkSequence++;
+              }
               break;
 
-            case 'tool-call-approval': // Approval request - create span for debugging
-              this.#handleToolApprovalChunk(chunk);
-              break;
-
+            // Infrastructure chunks are either redundant, metadata-only, or control flow.
+            case 'raw':
+            case 'start':
+            case 'finish':
+            case 'response-metadata':
+            case 'source':
+            case 'file':
+            case 'error':
+            case 'abort':
+            case 'tripwire':
+            case 'watch':
+            case 'tool-error':
+            case 'tool-call-suspended':
+            case 'reasoning-signature':
+            case 'redacted-reasoning':
+            case 'step-output':
             case 'tool-output':
-              // tool-output chunks are streaming progress from tools (e.g., sub-agents)
-              // No span created - the final tool-result event captures the result
               break;
 
             case 'tool-result': {
-              // tool-result is always a point-in-time event span
-              // (tool execution duration is captured by the parent tool_call span)
               const {
-                // Metadata - tool call context (unique to tool-result chunks)
                 toolCallId,
                 toolName,
                 isError,
@@ -802,9 +694,6 @@ export class ModelSpanTracker {
               break;
             }
 
-            // Default: skip creating spans for unrecognized chunk types
-            // All semantic content chunks should be explicitly handled above
-            // Unknown chunks are likely infrastructure or custom chunks that don't need tracing
             default:
               // No span created - reduces trace noise
               break;

--- a/packages/core/src/agent/__tests__/execute-on-finish-single-flight.test.ts
+++ b/packages/core/src/agent/__tests__/execute-on-finish-single-flight.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RequestContext } from '../../request-context';
+import { Agent } from '../agent';
+import { MessageList } from '../message-list';
+import { MockLanguageModelV2 } from './mock-model';
+
+function createMockModel() {
+  return new MockLanguageModelV2({
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+    }),
+  });
+}
+
+describe('Agent#executeOnFinish single-flight', () => {
+  let agent: Agent;
+  let handles: ReturnType<Agent['__testHandles']>;
+  let listScorersSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    agent = new Agent({
+      id: 'test-single-flight-agent',
+      name: 'Test Single Flight Agent',
+      instructions: 'test',
+      model: createMockModel() as any,
+    });
+
+    handles = agent.__testHandles();
+    listScorersSpy = vi.spyOn(agent, 'listScorers').mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const createAgentSpan = () =>
+    ({
+      end: vi.fn(),
+      error: vi.fn(),
+    }) as any;
+
+  const createMinimalOptions = (runId: string, agentSpan = createAgentSpan()) => ({
+    runId,
+    result: {
+      text: 'test',
+      object: undefined,
+      files: [],
+      toolResults: [],
+      toolCalls: [],
+      usage: { totalTokens: 0 },
+      totalUsage: { totalTokens: 0 },
+      steps: [],
+      response: {
+        id: `${runId}-response`,
+        messages: [],
+        dbMessages: [],
+      },
+    } as any,
+    thread: null,
+    readOnlyMemory: true,
+    threadId: 'thread-1',
+    resourceId: 'resource-1',
+    requestContext: new RequestContext(),
+    agentSpan,
+    memoryConfig: undefined,
+    outputText: 'test',
+    messageList: new MessageList(),
+    threadExists: false,
+    structuredOutput: false,
+  });
+
+  it('only runs finish side effects once for concurrent calls with the same runId', async () => {
+    const runId = 'run-1-single-flight';
+    const agentSpan = createAgentSpan();
+    const options = createMinimalOptions(runId, agentSpan);
+
+    const [result1, result2] = await Promise.all([handles.executeOnFinish(options), handles.executeOnFinish(options)]);
+
+    expect(result1).toBeUndefined();
+    expect(result2).toBeUndefined();
+    expect(listScorersSpy).toHaveBeenCalledTimes(1);
+    expect(agentSpan.end).toHaveBeenCalledTimes(1);
+    expect(handles.inProgressRunIds.has(runId)).toBe(false);
+    expect(handles.completedRunIds.has(runId)).toBe(true);
+  });
+
+  it('waits for the in-flight execution before the second call returns', async () => {
+    const runId = 'run-2-wait-same';
+    const agentSpan = createAgentSpan();
+    const options = createMinimalOptions(runId, agentSpan);
+    let scorerLookupCompleted = false;
+
+    listScorersSpy.mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+      scorerLookupCompleted = true;
+      return {};
+    });
+
+    const [result1, result2] = await Promise.all([handles.executeOnFinish(options), handles.executeOnFinish(options)]);
+
+    expect(result1).toBeUndefined();
+    expect(result2).toBeUndefined();
+    expect(scorerLookupCompleted).toBe(true);
+    expect(listScorersSpy).toHaveBeenCalledTimes(1);
+    expect(agentSpan.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates an in-flight execution error to all callers', async () => {
+    const runId = 'run-3-error-propagation';
+    const options = createMinimalOptions(runId);
+    const invalidOptions = {
+      ...options,
+      result: {
+        ...options.result,
+        steps: undefined,
+      },
+    } as any;
+
+    const [promise1, promise2] = await Promise.allSettled([
+      handles.executeOnFinish(invalidOptions),
+      handles.executeOnFinish(invalidOptions),
+    ]);
+
+    expect(promise1.status).toBe('rejected');
+    expect(promise2.status).toBe('rejected');
+    expect(handles.inProgressRunIds.has(runId)).toBe(false);
+    expect(handles.completedRunIds.has(runId)).toBe(false);
+  });
+
+  it('allows retry after the first execution failed', async () => {
+    const runId = 'run-4-retry-after-failure';
+    const options = createMinimalOptions(runId);
+    const invalidOptions = {
+      ...options,
+      result: {
+        ...options.result,
+        steps: undefined,
+      },
+    } as any;
+
+    await expect(handles.executeOnFinish(invalidOptions)).rejects.toThrow();
+    expect(handles.completedRunIds.has(runId)).toBe(false);
+
+    await expect(handles.executeOnFinish(options)).resolves.toBeUndefined();
+
+    expect(listScorersSpy).toHaveBeenCalledTimes(1);
+    expect(handles.completedRunIds.has(runId)).toBe(true);
+  });
+
+  it('tracks different runIds independently', async () => {
+    const runIdA = 'run-5a-independent';
+    const runIdB = 'run-5b-independent';
+
+    await Promise.all([
+      handles.executeOnFinish(createMinimalOptions(runIdA)),
+      handles.executeOnFinish(createMinimalOptions(runIdB)),
+    ]);
+
+    expect(listScorersSpy).toHaveBeenCalledTimes(2);
+    expect(handles.completedRunIds.has(runIdA)).toBe(true);
+    expect(handles.completedRunIds.has(runIdB)).toBe(true);
+  });
+
+  it('skips side effects for an already completed runId', async () => {
+    const runId = 'run-6-skip-completed';
+    const agentSpan = createAgentSpan();
+    const options = createMinimalOptions(runId, agentSpan);
+
+    await handles.executeOnFinish(options);
+    expect(listScorersSpy).toHaveBeenCalledTimes(1);
+    expect(agentSpan.end).toHaveBeenCalledTimes(1);
+
+    await handles.executeOnFinish(options);
+    expect(listScorersSpy).toHaveBeenCalledTimes(1);
+    expect(agentSpan.end).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/agent/__tests__/execute-on-finish-single-flight.test.ts
+++ b/packages/core/src/agent/__tests__/execute-on-finish-single-flight.test.ts
@@ -153,6 +153,32 @@ describe('Agent#executeOnFinish single-flight', () => {
     expect(handles.completedRunIds.has(runId)).toBe(true);
   });
 
+  it('does not append duplicate response messages when retrying after a partial finish failure', async () => {
+    const runId = 'run-4b-retry-after-partial-failure';
+    const agentSpan = createAgentSpan();
+    const options = createMinimalOptions(runId, agentSpan);
+    options.result.response.dbMessages = [
+      {
+        id: 'assistant-response-1',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'hello' }],
+      },
+    ] as any;
+    agentSpan.end.mockImplementationOnce(() => {
+      throw new Error('span export failed after message append');
+    });
+
+    await expect(handles.executeOnFinish(options)).rejects.toThrow('span export failed after message append');
+    expect(handles.completedRunIds.has(runId)).toBe(false);
+    expect(options.messageList.get.all.db().filter(message => message.id === 'assistant-response-1')).toHaveLength(1);
+
+    await expect(handles.executeOnFinish(options)).resolves.toBeUndefined();
+
+    expect(options.messageList.get.all.db().filter(message => message.id === 'assistant-response-1')).toHaveLength(1);
+    expect(agentSpan.end).toHaveBeenCalledTimes(2);
+    expect(handles.completedRunIds.has(runId)).toBe(true);
+  });
+
   it('tracks different runIds independently', async () => {
     const runIdA = 'run-5a-independent';
     const runIdB = 'run-5b-independent';

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -5329,6 +5329,30 @@ export class Agent<
     updateAgeOnGet: true,
   });
 
+  /**
+   * Tracks response messages already appended during finish processing. This
+   * prevents a retry after a partial finish failure from mutating the shared
+   * MessageList twice.
+   * @internal
+   */
+  #finishResponseAddedRunIds = new TTLCache<string, boolean>({
+    max: 1000,
+    ttl: 5 * 60 * 1000,
+    updateAgeOnGet: true,
+  });
+
+  /**
+   * Tracks title generation already scheduled during finish processing. Title
+   * generation is intentionally fire-and-forget, so retries must not schedule it
+   * again for the same run.
+   * @internal
+   */
+  #titleGenerationScheduledRunIds = new TTLCache<string, boolean>({
+    max: 1000,
+    ttl: 5 * 60 * 1000,
+    updateAgeOnGet: true,
+  });
+
   async #executeOnFinish({
     result,
     readOnlyMemory,
@@ -5462,8 +5486,22 @@ export class Agent<
       ];
     }
 
-    if (responseMessages?.length) {
-      messageList.add(responseMessages, 'response');
+    if (responseMessages?.length && !this.#finishResponseAddedRunIds.has(runId)) {
+      const existingMessageIds = new Set(
+        messageList.get.all
+          .db()
+          .map(message => message.id)
+          .filter((id): id is string => typeof id === 'string' && id.length > 0),
+      );
+      const newResponseMessages = responseMessages.filter(message => {
+        const id = (message as { id?: unknown }).id;
+        return !(typeof id === 'string' && existingMessageIds.has(id));
+      });
+
+      if (newResponseMessages.length > 0) {
+        messageList.add(newResponseMessages, 'response');
+      }
+      this.#finishResponseAddedRunIds.set(runId, true);
     }
 
     if (memory && resourceId && thread && !readOnlyMemory) {
@@ -5503,10 +5541,16 @@ export class Agent<
         const messages = messageList.get.all.core();
         const requiredMessages = minMessages ?? 1;
 
-        if (shouldGenerate && !thread.title && messages.length >= requiredMessages) {
+        if (
+          shouldGenerate &&
+          !thread.title &&
+          messages.length >= requiredMessages &&
+          !this.#titleGenerationScheduledRunIds.has(runId)
+        ) {
           const userMessage = this.getMostRecentUserMessage(uiMessages);
 
           if (userMessage) {
+            this.#titleGenerationScheduledRunIds.set(runId, true);
             void this.genTitle(userMessage, requestContext, observabilityContext, titleModel, titleInstructions).then(
               async title => {
                 if (title) {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import type { TextPart, UIMessage } from '@internal/ai-sdk-v4';
 import type { ModelMessage } from '@internal/ai-sdk-v5';
+import { TTLCache } from '@isaacs/ttlcache';
 import { wrapSchemaWithNullTransform } from '@mastra/schema-compat';
 import type { StandardSchemaWithJSON } from '@mastra/schema-compat/schema';
 import type { JSONSchema7 } from 'json-schema';
@@ -5311,10 +5312,85 @@ export class Agent<
   }
 
   /**
+   * Tracks in-progress runIds for single-flight: concurrent calls for the same runId
+   * await the same Promise instead of duplicating finish side effects.
+   * @internal
+   */
+  #inProgressRunIds = new Map<string, Promise<void>>();
+
+  /**
+   * Bounded cache for completed runIds. Entries expire after 5 minutes to avoid
+   * unbounded memory growth while still suppressing duplicate finish calls.
+   * @internal
+   */
+  #completedRunIds = new TTLCache<string, boolean>({
+    max: 1000,
+    ttl: 5 * 60 * 1000,
+    updateAgeOnGet: true,
+  });
+
+  async #executeOnFinish({
+    result,
+    readOnlyMemory,
+    thread: threadAfter,
+    threadId,
+    resourceId,
+    memoryConfig,
+    outputText,
+    requestContext,
+    agentSpan,
+    runId,
+    messageList,
+    threadExists,
+    structuredOutput = false,
+    overrideScorers,
+  }: AgentExecuteOnFinishOptions) {
+    if (this.#completedRunIds.has(runId)) {
+      this.logger.debug('Skipping executeOnFinish - already completed for runId', { runId, threadId });
+      return;
+    }
+
+    const existingInProgress = this.#inProgressRunIds.get(runId);
+    if (existingInProgress) {
+      this.logger.debug('Waiting for in-progress executeOnFinish for runId', { runId, threadId });
+      await existingInProgress;
+      return;
+    }
+
+    const executionPromise = this.#executeOnFinishCore({
+      result,
+      readOnlyMemory,
+      thread: threadAfter,
+      threadId,
+      resourceId,
+      memoryConfig,
+      outputText,
+      requestContext,
+      agentSpan,
+      runId,
+      messageList,
+      threadExists,
+      structuredOutput,
+      overrideScorers,
+    })
+      .then(() => {
+        this.#completedRunIds.set(runId, true);
+        this.#inProgressRunIds.delete(runId);
+      })
+      .catch(error => {
+        this.#inProgressRunIds.delete(runId);
+        throw error;
+      });
+
+    this.#inProgressRunIds.set(runId, executionPromise);
+    await executionPromise;
+  }
+
+  /**
    * Handles post-execution tasks including memory persistence and title generation.
    * @internal
    */
-  async #executeOnFinish({
+  async #executeOnFinishCore({
     result,
     readOnlyMemory,
     thread: threadAfter,
@@ -5503,6 +5579,21 @@ export class Agent<
           }
         : {}),
     });
+  }
+
+  /**
+   * @internal Test hook for focused single-flight coverage.
+   */
+  __testHandles(): {
+    executeOnFinish: (options: AgentExecuteOnFinishOptions) => Promise<void>;
+    inProgressRunIds: Map<string, Promise<void>>;
+    completedRunIds: TTLCache<string, boolean>;
+  } {
+    return {
+      executeOnFinish: this.#executeOnFinish.bind(this),
+      inProgressRunIds: this.#inProgressRunIds,
+      completedRunIds: this.#completedRunIds,
+    };
   }
 
   /**

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -279,15 +279,23 @@ export function createMapResultsStep<OUTPUT = undefined>({
           // The LLM response may have continued after the caller disconnected,
           // and we should not persist a partial or full response for an aborted request.
           const aborted = options.abortSignal?.aborted;
+          const runOnFinishCallback = () =>
+            options?.onFinish?.({
+              ...payload,
+              runId,
+              messages: messageList.get.response.aiV5.model(),
+              usage: payload.usage,
+              totalUsage: payload.totalUsage,
+            });
 
           if (!aborted) {
-            try {
-              const outputText = messageList.get.all
-                .core()
-                .map(m => m.content)
-                .join('\n');
+            const outputText = messageList.get.all
+              .core()
+              .map(m => m.content)
+              .join('\n');
 
-              await capabilities.executeOnFinish({
+            const executeFinish = () =>
+              capabilities.executeOnFinish({
                 result: payload,
                 outputText,
                 thread: result.thread,
@@ -296,45 +304,62 @@ export function createMapResultsStep<OUTPUT = undefined>({
                 resourceId,
                 memoryConfig,
                 requestContext,
-                agentSpan: agentSpan,
+                agentSpan,
                 runId,
                 messageList,
                 threadExists: memoryData.threadExists,
                 structuredOutput: !!options.structuredOutput?.schema,
                 overrideScorers: options.scorers,
               });
-            } catch (e) {
-              capabilities.logger.error('Error saving memory on finish', {
-                error: e,
-                runId,
-              });
 
-              const spanError =
-                e instanceof Error
-                  ? e
-                  : new MastraError(
-                      {
-                        id: 'AGENT_ON_FINISH_ERROR',
-                        domain: ErrorDomain.AGENT,
-                        category: ErrorCategory.SYSTEM,
-                        details: { runId },
-                      },
-                      e,
-                    );
+            void (async () => {
+              try {
+                await executeFinish();
+              } catch (e) {
+                capabilities.logger.error('Error saving memory on finish (first attempt)', {
+                  error: e,
+                  runId,
+                });
 
-              agentSpan?.error({ error: spanError, endSpan: true });
-            }
+                try {
+                  await executeFinish();
+                } catch (retryError) {
+                  capabilities.logger.error('Error saving memory on finish (retry failed)', {
+                    error: retryError,
+                    runId,
+                  });
+
+                  const spanError =
+                    retryError instanceof Error
+                      ? retryError
+                      : new MastraError(
+                          {
+                            id: 'AGENT_ON_FINISH_ERROR',
+                            domain: ErrorDomain.AGENT,
+                            category: ErrorCategory.SYSTEM,
+                            details: { runId },
+                          },
+                          retryError,
+                        );
+
+                  agentSpan?.error({ error: spanError, endSpan: true });
+                  return;
+                }
+              }
+
+              try {
+                await runOnFinishCallback();
+              } catch (onFinishError) {
+                capabilities.logger.error('Error in onFinish callback', {
+                  error: onFinishError,
+                  runId,
+                });
+              }
+            })();
           } else {
             agentSpan?.end();
+            await runOnFinishCallback();
           }
-
-          await options?.onFinish?.({
-            ...payload,
-            runId,
-            messages: messageList.get.response.aiV5.model(),
-            usage: payload.usage,
-            totalUsage: payload.totalUsage,
-          });
         },
         onStepFinish: result.onStepFinish,
         onChunk: options.onChunk,

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -289,10 +289,15 @@ export function createMapResultsStep<OUTPUT = undefined>({
             });
 
           if (!aborted) {
-            const outputText = messageList.get.all
-              .core()
-              .map(m => m.content)
-              .join('\n');
+            const outputText =
+              typeof payload.text === 'string' && payload.text.length > 0
+                ? payload.text
+                : payload.object !== undefined
+                  ? (JSON.stringify(payload.object) ?? String(payload.object))
+                  : messageList.get.all
+                      .core()
+                      .map(m => m.content)
+                      .join('\n');
 
             const executeFinish = () =>
               capabilities.executeOnFinish({
@@ -343,17 +348,16 @@ export function createMapResultsStep<OUTPUT = undefined>({
                         );
 
                   agentSpan?.error({ error: spanError, endSpan: true });
-                  return;
                 }
-              }
-
-              try {
-                await runOnFinishCallback();
-              } catch (onFinishError) {
-                capabilities.logger.error('Error in onFinish callback', {
-                  error: onFinishError,
-                  runId,
-                });
+              } finally {
+                try {
+                  await runOnFinishCallback();
+                } catch (onFinishError) {
+                  capabilities.logger.error('Error in onFinish callback', {
+                    error: onFinishError,
+                    runId,
+                  });
+                }
               }
             })();
           } else {

--- a/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/map-results-step.ts
@@ -362,7 +362,14 @@ export function createMapResultsStep<OUTPUT = undefined>({
             })();
           } else {
             agentSpan?.end();
-            await runOnFinishCallback();
+            try {
+              await runOnFinishCallback();
+            } catch (onFinishError) {
+              capabilities.logger.error('Error in onFinish callback', {
+                error: onFinishError,
+                runId,
+              });
+            }
           }
         },
         onStepFinish: result.onStepFinish,


### PR DESCRIPTION
Fixes #28

## Summary
- Port the relevant performance idea from upstream mastra-ai/mastra#16013 without pulling the unrelated upstream branch history.
- Move agent finish persistence/scoring/title work off the stream finish path while preserving user `onFinish` ordering after framework finish work.
- Deduplicate concurrent `executeOnFinish` calls per Agent instance/run id with a bounded TTL cache.
- Reduce model tracing overhead by enqueuing stream chunks before heavier span work, while still capturing time-to-first-token before enqueue.
- Remove now-dead chunk handler helpers after inlining the tracing switch.

## Notes
- This is local per-Agent single-flight, not cross-process durable idempotency.
- The first finish failure is logged and retried once in the background; only final retry failure closes the agent span as an error.
- Claude review found issues in the first port; this revision addresses the onFinish ordering, detached timer retry, span lifecycle, explicit tracing skip cases, sequence increment guard, and dead tracing helper cleanup. A second Claude review attempt timed out with no output.

## Verification
- `pnpm --filter @mastra/core test src/agent/__tests__/execute-on-finish-single-flight.test.ts`
- `pnpm --filter @mastra/core typecheck`
- `pnpm --filter @mastra/core build:lib`
- `pnpm --filter @mastra/observability build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes agent responses arrive faster by sending the final streamed answer immediately and doing slow cleanup work (saving memory, scoring, generating titles, tracing) in the background, while ensuring those background steps still run correctly and only once per run.

## Changes

### Agent finish processing made non-blocking
- Moves post-execution side effects (persistence, scoring, title generation, span lifecycle) off the critical stream finish path so they don't block the final streamed chunk.
- Executes finish work asynchronously (unawaited) for successful finishes; aborted requests still await finish callbacks and end spans immediately.
- Ensures user `onFinish` is invoked in the proper order relative to framework finish work and that user callback errors are caught and logged (do not propagate).

### Single-flight deduplication and guards
- Adds per-Agent, bounded TTL single-flight deduplication for finish handling:
  - `#inProgressRunIds` coordinates in-flight executions.
  - `#completedRunIds` (TTLCache, 5-minute TTL, max 1000) records completed runIds to skip duplicate work.
- Adds TTL-backed guards to prevent duplicate finish-side effects within a run:
  - `#finishResponseAddedRunIds` guards response-message appends.
  - `#titleGenerationScheduledRunIds` guards title scheduling.
- Exposes `__testHandles()` test hook to inspect `executeOnFinish`, `inProgressRunIds`, and `completedRunIds`.

### Retry and span failure behavior
- On first finish failure: log the failure and schedule a single background retry (detached timer); only the final retry failure closes the agent span as an error.
- First/intermediate failures do not block the stream or cause immediate span error closure.
- Adds guards so retries/duplicates do not produce duplicated persistence side effects.

### Model tracing overhead reduction
- Refactors ModelSpanTracker streaming logic: inlines chunk-type handling in wrapStream() via a switch, removes now-dead chunk handler helpers, captures time-to-first-token before enqueue, and skips infrastructure/control-flow chunks to reduce per-chunk tracing overhead while preserving important event spans.

### map-results-step behavior
- Derives output text sensibly from payload/message contents.
- Runs memory persistence with a first-attempt + conditional retry strategy; invokes user `onFinish` from inside the background flow (finally) and logs user callback errors.
- For aborted requests, ends spans immediately and awaits callbacks (no persistence).

### Tests and changesets
- Adds Vitest suite verifying single-flight behavior, retry semantics, idempotency, and that partial-finish failures don't duplicate persisted responses.
- Adds changesets documenting reduced agent finish latency and reduced model tracing overhead.

## Notable internal API change
- Public test helper added: `Agent.__testHandles()` returning `{ executeOnFinish, inProgressRunIds, completedRunIds }`.

## Impact
- Users receive streamed agent responses faster because finish-time side effects no longer block the final chunk.
- Concurrent finish calls for the same runId are deduplicated locally per-Agent to avoid duplicated persistence and scoring.
- Tracing overhead during streaming is reduced while preserving key timing spans.
- Robustness improved via a single retry on first failure and careful span lifecycle handling.

## Misc / Fixes
- Adds guard for aborted `onFinish` callbacks to avoid running them after aborts (commit: fix(core): guard aborted onFinish callback).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->