### PR TITLE
fix(core): normalize nested provider usage for Harness

### DIFF
--- a/.changeset/nested-provider-usage.md
+++ b/.changeset/nested-provider-usage.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Normalize nested and provider-native token usage shapes into canonical `LanguageModelUsage` before Harness token accounting.
+`@mastra/core` now reports consistent Harness prompt, completion, reasoning, and cache token counts across providers.

--- a/.changeset/nested-provider-usage.md
+++ b/.changeset/nested-provider-usage.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Normalize nested and provider-native token usage shapes into canonical `LanguageModelUsage` before Harness token accounting.

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -10,6 +10,8 @@ import { toStandardSchema } from '../schema';
 import type { StandardSchemaWithJSON } from '../schema';
 import type { MemoryStorage } from '../storage/domains/memory/base';
 import type { ObservationalMemoryRecord, WorkflowRun } from '../storage/types';
+import type { LanguageModelUsage } from '../stream/types';
+import { normalizeLanguageModelUsage } from '../stream/usage-normalization';
 import { getProjectedToolPayload, hasProjectedToolPayload } from '../tools/payload-projection';
 import type { ToolPayloadProjectionPhase } from '../tools/types';
 import { safeStringify } from '../utils';
@@ -87,18 +89,24 @@ function createEmptyTokenUsage(): TokenUsage {
   return { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
 }
 
-function getUsageNumber(usage: Record<string, unknown>, key: string): number | undefined {
-  const value = usage[key];
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return value;
+function toHarnessTokenUsage(usage: LanguageModelUsage): TokenUsage {
+  const promptTokens = usage.inputTokens ?? 0;
+  const completionTokens = usage.outputTokens ?? 0;
+  const normalized: TokenUsage = {
+    promptTokens,
+    completionTokens,
+    totalTokens: usage.totalTokens ?? promptTokens + completionTokens,
+  };
+
+  addOptionalUsageField(normalized, 'reasoningTokens', usage.reasoningTokens);
+  addOptionalUsageField(normalized, 'cachedInputTokens', usage.cachedInputTokens);
+  addOptionalUsageField(normalized, 'cacheCreationInputTokens', usage.cacheCreationInputTokens);
+
+  if (usage.raw !== undefined) {
+    normalized.raw = usage.raw;
   }
-  if (typeof value === 'string' && value.trim() !== '') {
-    const numericValue = Number(value);
-    if (Number.isFinite(numericValue)) {
-      return numericValue;
-    }
-  }
-  return undefined;
+
+  return normalized;
 }
 
 function addOptionalUsageField(
@@ -2124,31 +2132,11 @@ export class Harness<TState = {}> {
         case 'step-finish': {
           const usage = chunk.payload?.output?.usage;
           if (usage) {
-            const usageRecord = usage as Record<string, unknown>;
-            const promptTokens =
-              getUsageNumber(usageRecord, 'promptTokens') ?? getUsageNumber(usageRecord, 'inputTokens') ?? 0;
-            const completionTokens =
-              getUsageNumber(usageRecord, 'completionTokens') ?? getUsageNumber(usageRecord, 'outputTokens') ?? 0;
-            const totalTokens = getUsageNumber(usageRecord, 'totalTokens') ?? promptTokens + completionTokens;
-            const stepUsage: TokenUsage = {
-              promptTokens,
-              completionTokens,
-              totalTokens,
-            };
-            addOptionalUsageField(stepUsage, 'reasoningTokens', getUsageNumber(usageRecord, 'reasoningTokens'));
-            addOptionalUsageField(stepUsage, 'cachedInputTokens', getUsageNumber(usageRecord, 'cachedInputTokens'));
-            addOptionalUsageField(
-              stepUsage,
-              'cacheCreationInputTokens',
-              getUsageNumber(usageRecord, 'cacheCreationInputTokens'),
-            );
-            if (usageRecord.raw !== undefined) {
-              stepUsage.raw = usageRecord.raw;
-            }
+            const stepUsage = toHarnessTokenUsage(normalizeLanguageModelUsage(usage));
 
-            this.tokenUsage.promptTokens += promptTokens;
-            this.tokenUsage.completionTokens += completionTokens;
-            this.tokenUsage.totalTokens += totalTokens;
+            this.tokenUsage.promptTokens += stepUsage.promptTokens;
+            this.tokenUsage.completionTokens += stepUsage.completionTokens;
+            this.tokenUsage.totalTokens += stepUsage.totalTokens;
             addOptionalUsageField(this.tokenUsage, 'reasoningTokens', stepUsage.reasoningTokens);
             addOptionalUsageField(this.tokenUsage, 'cachedInputTokens', stepUsage.cachedInputTokens);
             addOptionalUsageField(this.tokenUsage, 'cacheCreationInputTokens', stepUsage.cacheCreationInputTokens);

--- a/packages/core/src/harness/token-usage.test.ts
+++ b/packages/core/src/harness/token-usage.test.ts
@@ -106,6 +106,100 @@ describe('step-finish token usage extraction', () => {
     });
   });
 
+  it('normalizes AI SDK nested output token details', async () => {
+    const usage = {
+      inputTokens: 100,
+      outputTokens: 50,
+      outputTokenDetails: { reasoningTokens: 30 },
+    };
+    const events: HarnessEvent[] = [];
+    harness.subscribe(event => events.push(event));
+
+    await (harness as any).processStream({ fullStream: mockStream(usage) });
+
+    const expectedUsage = {
+      promptTokens: 100,
+      completionTokens: 50,
+      totalTokens: 150,
+      reasoningTokens: 30,
+      raw: usage,
+    };
+    expect(harness.getTokenUsage()).toEqual(expectedUsage);
+    expect(harness.getDisplayState().tokenUsage).toEqual(expectedUsage);
+    expect(events.find(event => event.type === 'usage_update')).toEqual({
+      type: 'usage_update',
+      usage: expectedUsage,
+    });
+  });
+
+  it('normalizes OpenAI-style snake_case usage details', async () => {
+    const usage = {
+      prompt_tokens: 100,
+      completion_tokens: 50,
+      total_tokens: 150,
+      prompt_tokens_details: { cached_tokens: 25 },
+      completion_tokens_details: { reasoning_tokens: 30 },
+    };
+
+    await (harness as any).processStream({ fullStream: mockStream(usage) });
+
+    expect(harness.getTokenUsage()).toEqual({
+      promptTokens: 100,
+      completionTokens: 50,
+      totalTokens: 150,
+      reasoningTokens: 30,
+      cachedInputTokens: 25,
+      raw: usage,
+    });
+  });
+
+  it('normalizes Gemini-style usageMetadata fields', async () => {
+    const usage = {
+      usageMetadata: {
+        promptTokenCount: 100,
+        candidatesTokenCount: 50,
+        thoughtsTokenCount: 30,
+        totalTokenCount: 180,
+      },
+    };
+
+    await (harness as any).processStream({ fullStream: mockStream(usage) });
+
+    expect(harness.getTokenUsage()).toEqual({
+      promptTokens: 100,
+      completionTokens: 50,
+      totalTokens: 180,
+      reasoningTokens: 30,
+      raw: usage,
+    });
+  });
+
+  it('normalizes nested v3 usage with cache counters', async () => {
+    const usage = {
+      inputTokens: {
+        total: 100,
+        cacheRead: 25,
+        cacheWrite: 5,
+      },
+      outputTokens: {
+        total: 50,
+        reasoning: 30,
+      },
+    };
+
+    await (harness as any).processStream({ fullStream: mockStream(usage) });
+
+    expect(harness.getTokenUsage()).toEqual({
+      promptTokens: 100,
+      completionTokens: 50,
+      totalTokens: 150,
+      reasoningTokens: 30,
+      cachedInputTokens: 25,
+      cacheCreationInputTokens: 5,
+      raw: usage,
+    });
+  });
+
   it('persists richer token usage in thread metadata', async () => {
     const storage = new InMemoryStore();
     harness = createHarness(storage);

--- a/packages/core/src/stream/aisdk/v5/transform.ts
+++ b/packages/core/src/stream/aisdk/v5/transform.ts
@@ -4,11 +4,12 @@ import type {
   LanguageModelV2Usage,
   SharedV2ProviderMetadata,
 } from '@ai-sdk/provider-v5';
-import type { LanguageModelV3FinishReason, LanguageModelV3Usage } from '@ai-sdk/provider-v6';
+import type { LanguageModelV3FinishReason } from '@ai-sdk/provider-v6';
 import type { ModelMessage, ObjectStreamPart, TextStreamPart, ToolSet } from '@internal/ai-sdk-v5';
 import type { AIV5ResponseMessage } from '../../../agent/message-list';
-import type { ChunkType, LanguageModelUsage } from '../../types';
+import type { ChunkType } from '../../types';
 import { ChunkFrom } from '../../types';
+import { normalizeLanguageModelUsage } from '../../usage-normalization';
 import { DefaultGeneratedFile, DefaultGeneratedFileWithType } from './file';
 
 /**
@@ -321,7 +322,7 @@ export function convertFullStreamChunkToMastra(value: StreamPart, ctx: { runId: 
           },
           output: {
             // Normalize usage to handle both V2 (flat) and V3 (nested) formats
-            usage: normalizeUsage(value.usage),
+            usage: normalizeLanguageModelUsage(value.usage),
           },
           metadata: {
             providerMetadata: value.providerMetadata,
@@ -573,70 +574,6 @@ export function convertMastraChunkToAISDKv5<OUTPUT = undefined>({
       }
       return;
   }
-}
-
-/**
- * Type guard to check if usage is in V3 format (nested objects)
- */
-function isV3Usage(usage: unknown): usage is LanguageModelV3Usage {
-  if (!usage || typeof usage !== 'object') return false;
-  const u = usage as Record<string, unknown>;
-  return (
-    typeof u.inputTokens === 'object' &&
-    u.inputTokens !== null &&
-    'total' in (u.inputTokens as object) &&
-    typeof u.outputTokens === 'object' &&
-    u.outputTokens !== null &&
-    'total' in (u.outputTokens as object)
-  );
-}
-
-/**
- * Normalizes usage from either V2 (flat) or V3 (nested) format to Mastra's flat format.
- * V2 format: { inputTokens: number, outputTokens: number, totalTokens?: number }
- * V3 format: { inputTokens: { total, noCache, cacheRead, cacheWrite }, outputTokens: { total, text, reasoning } }
- *
- * The original usage data is preserved in the `raw` field for advanced use cases.
- */
-function normalizeUsage(usage: LanguageModelV2Usage | LanguageModelV3Usage | undefined): LanguageModelUsage {
-  if (!usage) {
-    return {
-      inputTokens: undefined,
-      outputTokens: undefined,
-      totalTokens: undefined,
-      reasoningTokens: undefined,
-      cachedInputTokens: undefined,
-      cacheCreationInputTokens: undefined,
-      raw: undefined,
-    };
-  }
-
-  if (isV3Usage(usage)) {
-    // V3 format - extract from nested structure
-    const inputTokens = usage.inputTokens.total;
-    const outputTokens = usage.outputTokens.total;
-    return {
-      inputTokens,
-      outputTokens,
-      totalTokens: (inputTokens ?? 0) + (outputTokens ?? 0),
-      reasoningTokens: usage.outputTokens.reasoning,
-      cachedInputTokens: usage.inputTokens.cacheRead,
-      cacheCreationInputTokens: usage.inputTokens.cacheWrite,
-      raw: usage,
-    };
-  }
-
-  // V2 format - already flat
-  const v2Usage = usage as LanguageModelV2Usage;
-  return {
-    inputTokens: v2Usage.inputTokens,
-    outputTokens: v2Usage.outputTokens,
-    totalTokens: v2Usage.totalTokens ?? (v2Usage.inputTokens ?? 0) + (v2Usage.outputTokens ?? 0),
-    reasoningTokens: (v2Usage as { reasoningTokens?: number }).reasoningTokens,
-    cachedInputTokens: (v2Usage as { cachedInputTokens?: number }).cachedInputTokens,
-    cacheCreationInputTokens: (v2Usage as { cacheCreationInputTokens?: number }).cacheCreationInputTokens,
-    raw: usage,
-  };
 }
 
 /**

--- a/packages/core/src/stream/usage-normalization.test.ts
+++ b/packages/core/src/stream/usage-normalization.test.ts
@@ -168,4 +168,16 @@ describe('normalizeLanguageModelUsage', () => {
       raw: undefined,
     });
   });
+
+  it('does not coerce unknown object usage totals to zero', () => {
+    expect(normalizeLanguageModelUsage({})).toEqual({
+      inputTokens: undefined,
+      outputTokens: undefined,
+      totalTokens: undefined,
+      reasoningTokens: undefined,
+      cachedInputTokens: undefined,
+      cacheCreationInputTokens: undefined,
+      raw: undefined,
+    });
+  });
 });

--- a/packages/core/src/stream/usage-normalization.test.ts
+++ b/packages/core/src/stream/usage-normalization.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeLanguageModelUsage } from './usage-normalization';
+
+describe('normalizeLanguageModelUsage', () => {
+  it('normalizes canonical flat usage', () => {
+    const usage = {
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 170,
+      reasoningTokens: 20,
+      cachedInputTokens: 15,
+      cacheCreationInputTokens: 5,
+      raw: { provider: 'test' },
+    };
+
+    expect(normalizeLanguageModelUsage(usage)).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 170,
+      reasoningTokens: 20,
+      cachedInputTokens: 15,
+      cacheCreationInputTokens: 5,
+      raw: { provider: 'test' },
+    });
+  });
+
+  it('normalizes legacy v4 prompt/completion usage', () => {
+    const usage = { promptTokens: 100, completionTokens: 50, totalTokens: 150 };
+
+    expect(normalizeLanguageModelUsage(usage)).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 150,
+      reasoningTokens: undefined,
+      cachedInputTokens: undefined,
+      cacheCreationInputTokens: undefined,
+      raw: usage,
+    });
+  });
+
+  it('normalizes AI SDK v6 nested usage', () => {
+    const usage = {
+      inputTokens: {
+        total: 100,
+        cacheRead: 25,
+        cacheWrite: 5,
+      },
+      outputTokens: {
+        total: 50,
+        reasoning: 30,
+      },
+    };
+
+    expect(normalizeLanguageModelUsage(usage)).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 150,
+      reasoningTokens: 30,
+      cachedInputTokens: 25,
+      cacheCreationInputTokens: 5,
+      raw: usage,
+    });
+  });
+
+  it('normalizes OpenAI-style snake_case usage', () => {
+    const usage = {
+      prompt_tokens: 100,
+      completion_tokens: 50,
+      total_tokens: 190,
+      prompt_tokens_details: { cached_tokens: 25 },
+      completion_tokens_details: { reasoning_tokens: 40 },
+    };
+
+    expect(normalizeLanguageModelUsage(usage)).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 190,
+      reasoningTokens: 40,
+      cachedInputTokens: 25,
+      cacheCreationInputTokens: undefined,
+      raw: usage,
+    });
+  });
+
+  it('normalizes Gemini usageMetadata fields', () => {
+    const usage = {
+      usageMetadata: {
+        promptTokenCount: 100,
+        candidatesTokenCount: 50,
+        thoughtsTokenCount: 30,
+        totalTokenCount: 180,
+      },
+    };
+
+    expect(normalizeLanguageModelUsage(usage)).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 180,
+      reasoningTokens: 30,
+      cachedInputTokens: undefined,
+      cacheCreationInputTokens: undefined,
+      raw: usage,
+    });
+  });
+
+  it('prefers canonical top-level fields over legacy and provider fallbacks', () => {
+    const usage = {
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 175,
+      reasoningTokens: 25,
+      cachedInputTokens: 12,
+      cacheCreationInputTokens: 6,
+      promptTokens: 999,
+      completionTokens: 888,
+      total_tokens: 777,
+      outputTokenDetails: { reasoningTokens: 666 },
+      prompt_tokens_details: { cached_tokens: 555 },
+      cache_creation_input_tokens: 444,
+    };
+
+    expect(normalizeLanguageModelUsage(usage)).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 175,
+      reasoningTokens: 25,
+      cachedInputTokens: 12,
+      cacheCreationInputTokens: 6,
+      raw: usage,
+    });
+  });
+
+  it('preserves provider total over recomputed totals', () => {
+    expect(normalizeLanguageModelUsage({ inputTokens: 100, outputTokens: 50, totalTokens: 250 })).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 250,
+    });
+  });
+
+  it('falls back to input plus output when total is omitted', () => {
+    expect(normalizeLanguageModelUsage({ inputTokens: 100, outputTokens: 50 })).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 150,
+    });
+  });
+
+  it('preserves explicit raw for canonical usage', () => {
+    const raw = { provider: 'raw-provider' };
+
+    expect(normalizeLanguageModelUsage({ inputTokens: 100, outputTokens: 50, raw })).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 150,
+      raw,
+    });
+  });
+
+  it('returns empty usage for missing input', () => {
+    expect(normalizeLanguageModelUsage(undefined)).toEqual({
+      inputTokens: undefined,
+      outputTokens: undefined,
+      totalTokens: undefined,
+      reasoningTokens: undefined,
+      cachedInputTokens: undefined,
+      cacheCreationInputTokens: undefined,
+      raw: undefined,
+    });
+  });
+});

--- a/packages/core/src/stream/usage-normalization.ts
+++ b/packages/core/src/stream/usage-normalization.ts
@@ -107,13 +107,15 @@ export function normalizeLanguageModelUsage(usage: unknown): LanguageModelUsage 
     ['outputTokens', 'total'],
     ['usageMetadata', 'candidatesTokenCount'],
   ]);
+  const explicitTotalTokens = getFirstUsageNumber(usage, [
+    ['totalTokens'],
+    ['total_tokens'],
+    ['totalTokenCount'],
+    ['usageMetadata', 'totalTokenCount'],
+  ]);
   const totalTokens =
-    getFirstUsageNumber(usage, [
-      ['totalTokens'],
-      ['total_tokens'],
-      ['totalTokenCount'],
-      ['usageMetadata', 'totalTokenCount'],
-    ]) ?? (inputTokens ?? 0) + (outputTokens ?? 0);
+    explicitTotalTokens ??
+    (inputTokens !== undefined || outputTokens !== undefined ? (inputTokens ?? 0) + (outputTokens ?? 0) : undefined);
 
   const normalized: LanguageModelUsage = {
     inputTokens,

--- a/packages/core/src/stream/usage-normalization.ts
+++ b/packages/core/src/stream/usage-normalization.ts
@@ -1,0 +1,148 @@
+import type { LanguageModelUsage } from './types';
+
+type UsagePath = readonly string[];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readUsageNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const numericValue = Number(value);
+    if (Number.isFinite(numericValue)) {
+      return numericValue;
+    }
+  }
+  return undefined;
+}
+
+function getUsageNumber(usage: Record<string, unknown>, key: string): number | undefined {
+  return readUsageNumber(usage[key]);
+}
+
+function getNestedUsageNumber(usage: Record<string, unknown>, path: UsagePath): number | undefined {
+  let current: unknown = usage;
+  for (const key of path) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[key];
+  }
+  return readUsageNumber(current);
+}
+
+function getFirstUsageNumber(usage: Record<string, unknown>, paths: readonly UsagePath[]): number | undefined {
+  for (const path of paths) {
+    const [firstKey] = path;
+    if (!firstKey) {
+      continue;
+    }
+    const value = path.length === 1 ? getUsageNumber(usage, firstKey) : getNestedUsageNumber(usage, path);
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function hasProviderNativeUsageShape(usage: Record<string, unknown>): boolean {
+  return (
+    isRecord(usage.inputTokens) ||
+    isRecord(usage.outputTokens) ||
+    usage.promptTokens !== undefined ||
+    usage.completionTokens !== undefined ||
+    usage.prompt_tokens !== undefined ||
+    usage.completion_tokens !== undefined ||
+    usage.total_tokens !== undefined ||
+    usage.input_token_count !== undefined ||
+    usage.output_token_count !== undefined ||
+    usage.promptTokenCount !== undefined ||
+    usage.candidatesTokenCount !== undefined ||
+    usage.reasoning_tokens !== undefined ||
+    usage.cache_read_input_tokens !== undefined ||
+    usage.cache_creation_input_tokens !== undefined ||
+    usage.outputTokenDetails !== undefined ||
+    usage.prompt_tokens_details !== undefined ||
+    usage.completion_tokens_details !== undefined ||
+    usage.output_tokens_details !== undefined ||
+    usage.input_tokens_details !== undefined ||
+    usage.usageMetadata !== undefined
+  );
+}
+
+export function normalizeLanguageModelUsage(usage: unknown): LanguageModelUsage {
+  if (!isRecord(usage)) {
+    return {
+      inputTokens: undefined,
+      outputTokens: undefined,
+      totalTokens: undefined,
+      reasoningTokens: undefined,
+      cachedInputTokens: undefined,
+      cacheCreationInputTokens: undefined,
+      raw: undefined,
+    };
+  }
+
+  const inputTokens = getFirstUsageNumber(usage, [
+    ['inputTokens'],
+    ['promptTokens'],
+    ['prompt_tokens'],
+    ['input_token_count'],
+    ['inputTokenCount'],
+    ['promptTokenCount'],
+    ['inputTokens', 'total'],
+    ['usageMetadata', 'promptTokenCount'],
+  ]);
+  const outputTokens = getFirstUsageNumber(usage, [
+    ['outputTokens'],
+    ['completionTokens'],
+    ['completion_tokens'],
+    ['output_tokens'],
+    ['output_token_count'],
+    ['outputTokenCount'],
+    ['candidatesTokenCount'],
+    ['outputTokens', 'total'],
+    ['usageMetadata', 'candidatesTokenCount'],
+  ]);
+  const totalTokens =
+    getFirstUsageNumber(usage, [
+      ['totalTokens'],
+      ['total_tokens'],
+      ['totalTokenCount'],
+      ['usageMetadata', 'totalTokenCount'],
+    ]) ?? (inputTokens ?? 0) + (outputTokens ?? 0);
+
+  const normalized: LanguageModelUsage = {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    reasoningTokens: getFirstUsageNumber(usage, [
+      ['reasoningTokens'],
+      ['outputTokenDetails', 'reasoningTokens'],
+      ['outputTokens', 'reasoning'],
+      ['completion_tokens_details', 'reasoning_tokens'],
+      ['output_tokens_details', 'reasoning_tokens'],
+      ['reasoning_tokens'],
+      ['thoughtsTokenCount'],
+      ['usageMetadata', 'thoughtsTokenCount'],
+    ]),
+    cachedInputTokens: getFirstUsageNumber(usage, [
+      ['cachedInputTokens'],
+      ['inputTokens', 'cacheRead'],
+      ['input_tokens_details', 'cached_tokens'],
+      ['prompt_tokens_details', 'cached_tokens'],
+      ['cache_read_input_tokens'],
+    ]),
+    cacheCreationInputTokens: getFirstUsageNumber(usage, [
+      ['cacheCreationInputTokens'],
+      ['inputTokens', 'cacheWrite'],
+      ['cache_creation_input_tokens'],
+    ]),
+    raw: usage.raw !== undefined ? usage.raw : hasProviderNativeUsageShape(usage) ? usage : undefined,
+  };
+
+  return normalized;
+}


### PR DESCRIPTION
## Summary
- add shared internal normalizeLanguageModelUsage helper for canonical LanguageModelUsage extraction
- reuse it from the AI SDK v5 stream transform instead of the private transform-local normalizer
- keep Harness as a thin adapter from canonical LanguageModelUsage to Harness TokenUsage
- cover canonical, legacy, AI SDK nested, OpenAI-style, Gemini-style, precedence, total fallback, and raw preservation cases

Fixes #31

## Verification
- pnpm --filter @mastra/core test src/stream/usage-normalization.test.ts src/harness/token-usage.test.ts
- pnpm --filter @mastra/core test src/stream/aisdk/v5/transform.test.ts
- pnpm --filter @mastra/core typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

Different AI providers report token counts in many different shapes. This PR adds one shared converter that turns all those shapes into a single standard form so Harness can reliably count, display, emit, and persist tokens the same way for every provider.

## Overview

Introduce a centralized normalization helper that maps provider- and SDK-specific nested/legacy token-usage shapes into a canonical LanguageModelUsage and reuse it across Harness and the AI SDK v5 stream transform, preserving raw data when appropriate and keeping Harness a thin adapter that maps the canonical usage into Harness TokenUsage fields.

## Key Changes

- New shared normalizer
  - packages/core/src/stream/usage-normalization.ts
    - Added export normalizeLanguageModelUsage(usage: unknown): LanguageModelUsage.
    - Safely reads numeric counts from many candidate fields and nested paths (canonical, legacy v4, AI SDK nested, OpenAI snake_case, Gemini usageMetadata, etc.).
    - Computes totalTokens from explicit total or inputTokens + outputTokens when available.
    - Extracts reasoningTokens, cachedInputTokens, cacheCreationInputTokens from provider-specific locations.
    - Preserves usage.raw when explicitly provided or when the input matches a provider-native usage shape; otherwise raw is undefined.
    - Non-record inputs yield all normalized fields undefined.

- Harness integration
  - packages/core/src/harness/harness.ts
    - Replaced fragile per-file number extraction with normalizeLanguageModelUsage + toHarnessTokenUsage (thin adapter).
    - toHarnessTokenUsage maps LanguageModelUsage → Harness TokenUsage fields: promptTokens, completionTokens, totalTokens, optional reasoning/cached/cache-creation fields, and raw when present.
    - Cumulative token merging preserves existing top-level behavior and accumulates optional fields only when provided.

- AI SDK v5 transform consolidation
  - packages/core/src/stream/aisdk/v5/transform.ts
    - Removed local normalizeUsage/isV3Usage logic and now delegates finish usage normalization to shared normalizeLanguageModelUsage.

- Tests
  - packages/core/src/stream/usage-normalization.test.ts
    - Comprehensive tests for canonical, legacy, AI SDK nested, OpenAI-style, Gemini-style, precedence rules, total-fallback behavior, raw preservation, undefined/empty inputs.
  - packages/core/src/harness/token-usage.test.ts
    - Harness-level tests validating normalized mapping for AI SDK nested fields, OpenAI snake_case with cached token details, Gemini usageMetadata, nested v3 shapes; assertions include getTokenUsage(), displayed tokenUsage state, persisted thread metadata, and emitted usage_update.
  - AI SDK v5 transform tests updated to use the shared normalizer.
  - Typecheck added/ran as part of verification.

- Changeset
  - .changeset/nested-provider-usage.md: patch-level notes documenting standardized token accounting.

- Commit intent
  - Commit "fix(core): preserve unknown usage totals" indicates unknown/unrecognized total fields are preserved rather than discarded during normalization.

## Behavior & Compatibility Notes

- Canonical top-level fields take precedence; legacy/provider-derived fallbacks used only when canonical fields missing.
- totalTokens is preserved if explicitly present; otherwise computed from input + output when either exists.
- raw is preserved when provided or when the input looks like a provider-native usage object; arbitrary non-record inputs do not coerce to zeros.
- Harness remains a thin adapter that accumulates and emits canonical tokenUsage consistently across providers.

## Related Issues

- Fixes #31: normalizes nested provider/AI-SDK usage shapes into canonical TokenUsage fields so Harness emits and persists promptTokens, completionTokens, totalTokens, reasoningTokens, cachedInputTokens, cacheCreationInputTokens, and raw.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->