### PR TITLE
feat(core): durably resume Harness questions and plans

### DIFF
--- a/.changeset/durable-question-plan-awaiting-inputs.md
+++ b/.changeset/durable-question-plan-awaiting-inputs.md
@@ -2,4 +2,9 @@
 '@mastra/core': patch
 ---
 
-Allow Harness `ask_user` questions and `submit_plan` approvals to be discovered and resumed through durable awaiting-input APIs.
+Harness now lets developers discover and resume durable `ask_user` questions and `submit_plan` approvals with `listAwaitingInputs()` and `resumeAwaitingInput()`.
+
+```ts
+const [input] = await harness.listAwaitingInputs();
+await harness.resumeAwaitingInput({ id: input.id, resumeData: 'Yes, continue' });
+```

--- a/.changeset/durable-question-plan-awaiting-inputs.md
+++ b/.changeset/durable-question-plan-awaiting-inputs.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Allow Harness `ask_user` questions and `submit_plan` approvals to be discovered and resumed through durable awaiting-input APIs.

--- a/packages/core/src/harness/ask-user-tool.test.ts
+++ b/packages/core/src/harness/ask-user-tool.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { RequestContext } from '../request-context';
 
-import { askUserTool } from './tools';
+import { askUserTool, submitPlanTool } from './tools';
 import type { HarnessEvent, HarnessQuestionAnswer, HarnessRequestContext } from './types';
 
 function createAskUserContext() {
@@ -102,5 +102,92 @@ describe('askUserTool', () => {
     });
 
     expect(emitEvent).not.toHaveBeenCalled();
+  });
+
+  it('uses durable suspension without a live question resolver', async () => {
+    const events: HarnessEvent[] = [];
+    const requestContext = new RequestContext();
+    const suspend = vi.fn(async () => undefined);
+    requestContext.set('harness', {
+      durableAwaitingInputs: true,
+      emitEvent: event => events.push(event),
+    } satisfies Partial<HarnessRequestContext>);
+
+    await expect(
+      (askUserTool as any).execute(
+        {
+          question: 'Pick any?',
+          options: [{ label: 'A' }, { label: 'B' }],
+          selectionMode: 'multi_select',
+        },
+        { requestContext, suspend, toolCallId: 'ask-call' },
+      ),
+    ).resolves.toEqual({
+      content: '[Question for user]: Pick any?',
+      isError: false,
+    });
+
+    expect(events[0]).toMatchObject({
+      type: 'ask_question',
+      question: 'Pick any?',
+      options: [{ label: 'A' }, { label: 'B' }],
+      selectionMode: 'multi_select',
+    });
+    expect(suspend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'question',
+        toolCallId: 'ask-call',
+        toolName: 'ask_user',
+        question: 'Pick any?',
+        options: [{ label: 'A' }, { label: 'B' }],
+        selectionMode: 'multi_select',
+      }),
+      expect.objectContaining({
+        resumeLabel: expect.stringMatching(/^q_/),
+        resumeSchema: expect.any(String),
+      }),
+    );
+  });
+
+  it('uses durable plan suspension without a live plan resolver', async () => {
+    const events: HarnessEvent[] = [];
+    const requestContext = new RequestContext();
+    const suspend = vi.fn(async () => undefined);
+    requestContext.set('harness', {
+      durableAwaitingInputs: true,
+      emitEvent: event => events.push(event),
+    } satisfies Partial<HarnessRequestContext>);
+
+    await expect(
+      (submitPlanTool as any).execute(
+        {
+          title: 'Plan',
+          plan: '# Plan',
+        },
+        { requestContext, suspend, toolCallId: 'plan-call' },
+      ),
+    ).resolves.toEqual({
+      content: '[Plan submitted for review]\n\nTitle: Plan\n\n# Plan',
+      isError: false,
+    });
+
+    expect(events[0]).toMatchObject({
+      type: 'plan_approval_required',
+      title: 'Plan',
+      plan: '# Plan',
+    });
+    expect(suspend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'plan_approval',
+        toolCallId: 'plan-call',
+        toolName: 'submit_plan',
+        title: 'Plan',
+        plan: '# Plan',
+      }),
+      expect.objectContaining({
+        resumeLabel: expect.stringMatching(/^plan_/),
+        resumeSchema: expect.any(String),
+      }),
+    );
   });
 });

--- a/packages/core/src/harness/harness-awaiting-input.test.ts
+++ b/packages/core/src/harness/harness-awaiting-input.test.ts
@@ -40,6 +40,72 @@ function createToolCallStream() {
   });
 }
 
+function createAskUserToolCallStream({
+  question = 'Continue?',
+  options,
+  selectionMode,
+}: {
+  question?: string;
+  options?: Array<{ label: string; description?: string }>;
+  selectionMode?: 'single_select' | 'multi_select';
+} = {}) {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue({ type: 'stream-start', warnings: [] });
+      controller.enqueue({
+        type: 'response-metadata',
+        id: 'id-ask',
+        modelId: 'mock',
+        timestamp: new Date(0),
+      });
+      controller.enqueue({
+        type: 'tool-call',
+        toolCallId: 'ask-call',
+        toolName: 'ask_user',
+        input: JSON.stringify({
+          question,
+          ...(options ? { options } : {}),
+          ...(selectionMode ? { selectionMode } : {}),
+        }),
+        providerExecuted: false,
+      });
+      controller.enqueue({
+        type: 'finish',
+        finishReason: 'tool-calls',
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      });
+      controller.close();
+    },
+  });
+}
+
+function createSubmitPlanToolCallStream({ title = 'Implementation Plan', plan = '# Plan' } = {}) {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue({ type: 'stream-start', warnings: [] });
+      controller.enqueue({
+        type: 'response-metadata',
+        id: 'id-plan',
+        modelId: 'mock',
+        timestamp: new Date(0),
+      });
+      controller.enqueue({
+        type: 'tool-call',
+        toolCallId: 'plan-call',
+        toolName: 'submit_plan',
+        input: JSON.stringify({ title, plan }),
+        providerExecuted: false,
+      });
+      controller.enqueue({
+        type: 'finish',
+        finishReason: 'tool-calls',
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      });
+      controller.close();
+    },
+  });
+}
+
 function createTextStream() {
   return new ReadableStream({
     start(controller) {
@@ -220,6 +286,146 @@ describe('Harness awaiting input durability', () => {
       resumeData: { confirmed: true },
     });
     expect(repeated.status).toBe('already_resolved');
+  });
+
+  it('discovers a durable ask_user question and resumes it from a fresh harness', async () => {
+    const agent = new Agent({
+      id: 'durable-question-agent',
+      name: 'Durable Question Agent',
+      instructions: 'You ask questions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: (() => {
+          let callCount = 0;
+          return async () => {
+            callCount++;
+            return { stream: callCount === 1 ? createAskUserToolCallStream() : createTextStream() };
+          };
+        })(),
+      }),
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'durable-question-agent': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('durable-question-agent');
+
+    const firstHarness = new Harness({
+      id: 'durable-question-harness',
+      resourceId: 'question-resource',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await firstHarness.init();
+    await firstHarness.createThread();
+    await firstHarness.sendMessage({ content: 'Ask before continuing' });
+
+    const [question] = await firstHarness.listAwaitingInputs();
+    expect(question).toMatchObject({
+      kind: 'question',
+      durable: true,
+      runId: expect.any(String),
+      resourceId: 'question-resource',
+      questionId: expect.any(String),
+      question: 'Continue?',
+    });
+
+    const freshHarness = new Harness({
+      id: 'durable-question-harness',
+      resourceId: 'question-resource',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await freshHarness.init();
+
+    const result = await freshHarness.resumeAwaitingInput({
+      id: question!.id,
+      resumeData: 'Yes, continue',
+    });
+
+    expect(result.status).toBe('resumed');
+
+    const repeated = await freshHarness.resumeAwaitingInput({
+      id: question!.id,
+      resumeData: 'Yes, continue',
+    });
+    expect(repeated.status).toBe('already_resolved');
+  });
+
+  it('discovers a durable submit_plan approval and resumes approved from a fresh harness', async () => {
+    const agent = new Agent({
+      id: 'durable-plan-agent',
+      name: 'Durable Plan Agent',
+      instructions: 'You submit plans.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: (() => {
+          let callCount = 0;
+          return async () => {
+            callCount++;
+            return { stream: callCount === 1 ? createSubmitPlanToolCallStream() : createTextStream() };
+          };
+        })(),
+      }),
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'durable-plan-agent': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('durable-plan-agent');
+
+    const firstHarness = new Harness({
+      id: 'durable-plan-harness',
+      resourceId: 'plan-resource',
+      storage,
+      modes: [
+        { id: 'build', name: 'Build', default: true, agent: registeredAgent },
+        { id: 'plan', name: 'Plan', agent: registeredAgent },
+      ],
+      initialState: { yolo: true } as any,
+    });
+    await firstHarness.init();
+    await firstHarness.switchMode({ modeId: 'plan' });
+    await firstHarness.createThread();
+    await firstHarness.sendMessage({ content: 'Submit the plan' });
+
+    const [plan] = await firstHarness.listAwaitingInputs();
+    expect(plan).toMatchObject({
+      kind: 'plan_approval',
+      durable: true,
+      runId: expect.any(String),
+      modeId: 'plan',
+      resourceId: 'plan-resource',
+      planId: expect.any(String),
+      title: 'Implementation Plan',
+      plan: '# Plan',
+    });
+
+    const freshHarness = new Harness({
+      id: 'durable-plan-harness',
+      resourceId: 'plan-resource',
+      storage,
+      modes: [
+        { id: 'build', name: 'Build', default: true, agent: registeredAgent },
+        { id: 'plan', name: 'Plan', agent: registeredAgent },
+      ],
+      initialState: { yolo: true } as any,
+    });
+    await freshHarness.init();
+
+    const result = await freshHarness.resumeAwaitingInput({
+      id: plan!.id,
+      resumeData: { action: 'approved' },
+    });
+
+    expect(result.status).toBe('resumed');
+    expect(freshHarness.getCurrentModeId()).toBe('build');
   });
 
   it('resumes a durable tool approval by id from storage', async () => {

--- a/packages/core/src/harness/harness-awaiting-input.test.ts
+++ b/packages/core/src/harness/harness-awaiting-input.test.ts
@@ -298,7 +298,15 @@ describe('Harness awaiting input durability', () => {
           let callCount = 0;
           return async () => {
             callCount++;
-            return { stream: callCount === 1 ? createAskUserToolCallStream() : createTextStream() };
+            return {
+              stream:
+                callCount === 1
+                  ? createAskUserToolCallStream({
+                      options: [{ label: 'A' }, { label: 'B' }, { label: 'C' }],
+                      selectionMode: 'multi_select',
+                    })
+                  : createTextStream(),
+            };
           };
         })(),
       }),
@@ -329,9 +337,13 @@ describe('Harness awaiting input durability', () => {
       durable: true,
       runId: expect.any(String),
       resourceId: 'question-resource',
-      questionId: expect.any(String),
+      questionId: question!.id,
       question: 'Continue?',
+      options: [{ label: 'A' }, { label: 'B' }, { label: 'C' }],
+      selectionMode: 'multi_select',
     });
+    expect(question!.questionId).toMatch(/^q_/);
+    expect(question!.questionId).not.toBe('ask-call');
 
     const freshHarness = new Harness({
       id: 'durable-question-harness',
@@ -344,14 +356,14 @@ describe('Harness awaiting input durability', () => {
 
     const result = await freshHarness.resumeAwaitingInput({
       id: question!.id,
-      resumeData: 'Yes, continue',
+      resumeData: ['A', 'C'],
     });
 
     expect(result.status).toBe('resumed');
 
     const repeated = await freshHarness.resumeAwaitingInput({
       id: question!.id,
-      resumeData: 'Yes, continue',
+      resumeData: ['A', 'C'],
     });
     expect(repeated.status).toBe('already_resolved');
   });
@@ -402,10 +414,12 @@ describe('Harness awaiting input durability', () => {
       runId: expect.any(String),
       modeId: 'plan',
       resourceId: 'plan-resource',
-      planId: expect.any(String),
+      planId: plan!.id,
       title: 'Implementation Plan',
       plan: '# Plan',
     });
+    expect(plan!.planId).toMatch(/^plan_/);
+    expect(plan!.planId).not.toBe('plan-call');
 
     const freshHarness = new Harness({
       id: 'durable-plan-harness',
@@ -426,6 +440,150 @@ describe('Harness awaiting input durability', () => {
 
     expect(result.status).toBe('resumed');
     expect(freshHarness.getCurrentModeId()).toBe('build');
+
+    const repeated = await freshHarness.resumeAwaitingInput({
+      id: plan!.id,
+      resumeData: { action: 'approved' },
+    });
+    expect(repeated.status).toBe('already_resolved');
+  });
+
+  it('resumes a durable submit_plan rejection with feedback from a fresh harness', async () => {
+    const agent = new Agent({
+      id: 'durable-plan-rejection-agent',
+      name: 'Durable Plan Rejection Agent',
+      instructions: 'You submit plans.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: (() => {
+          let callCount = 0;
+          return async () => {
+            callCount++;
+            return { stream: callCount === 1 ? createSubmitPlanToolCallStream() : createTextStream() };
+          };
+        })(),
+      }),
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'durable-plan-rejection-agent': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('durable-plan-rejection-agent');
+
+    const firstHarness = new Harness({
+      id: 'durable-plan-rejection-harness',
+      resourceId: 'plan-rejection-resource',
+      storage,
+      modes: [
+        { id: 'build', name: 'Build', default: true, agent: registeredAgent },
+        { id: 'plan', name: 'Plan', agent: registeredAgent },
+      ],
+      initialState: { yolo: true } as any,
+    });
+    await firstHarness.init();
+    await firstHarness.switchMode({ modeId: 'plan' });
+    await firstHarness.createThread();
+    await firstHarness.sendMessage({ content: 'Submit the plan' });
+
+    const [plan] = await firstHarness.listAwaitingInputs();
+    expect(plan).toMatchObject({
+      kind: 'plan_approval',
+      durable: true,
+      runId: expect.any(String),
+      modeId: 'plan',
+      resourceId: 'plan-rejection-resource',
+      planId: plan!.id,
+      title: 'Implementation Plan',
+      plan: '# Plan',
+    });
+
+    const freshHarness = new Harness({
+      id: 'durable-plan-rejection-harness',
+      resourceId: 'plan-rejection-resource',
+      storage,
+      modes: [
+        { id: 'build', name: 'Build', default: true, agent: registeredAgent },
+        { id: 'plan', name: 'Plan', agent: registeredAgent },
+      ],
+      initialState: { yolo: true } as any,
+    });
+    await freshHarness.init();
+
+    const result = await freshHarness.resumeAwaitingInput({
+      id: plan!.id,
+      resumeData: { action: 'rejected', feedback: 'Add verification steps.' },
+    });
+
+    expect(result.status).toBe('resumed');
+    expect(freshHarness.getCurrentModeId()).toBe('plan');
+
+    const repeated = await freshHarness.resumeAwaitingInput({
+      id: plan!.id,
+      resumeData: { action: 'rejected', feedback: 'Add verification steps.' },
+    });
+    expect(repeated.status).toBe('already_resolved');
+  });
+
+  it('waits for a durable question snapshot before returning live_session_only', async () => {
+    const agent = new Agent({
+      id: 'durable-question-race-agent',
+      name: 'Durable Question Race Agent',
+      instructions: 'You ask questions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createTextStream() }),
+      }),
+    });
+    const harness = new Harness({
+      id: 'durable-question-race-harness',
+      resourceId: 'race-resource',
+      modes: [{ id: 'default', name: 'Default', default: true, agent }],
+    });
+    const liveQuestion = {
+      id: 'q-race',
+      kind: 'question' as const,
+      durable: false,
+      resourceId: 'race-resource',
+      questionId: 'q-race',
+      question: 'Continue?',
+    };
+    const durableQuestion = {
+      ...liveQuestion,
+      durable: true,
+      runId: 'race-run',
+    };
+    const message = {
+      id: 'race-message',
+      role: 'assistant' as const,
+      content: [{ type: 'text' as const, text: 'Resumed.' }],
+      createdAt: new Date(),
+    };
+
+    vi.spyOn(harness, 'getAwaitingInput').mockResolvedValueOnce(liveQuestion).mockResolvedValueOnce(durableQuestion);
+    const waitForAwaitingInputReady = vi.spyOn(harness, 'waitForAwaitingInputReady').mockResolvedValue(durableQuestion);
+    const handleToolResumeByRunId = vi.spyOn(harness as any, 'handleToolResumeByRunId').mockResolvedValue({ message });
+
+    const result = await harness.resumeAwaitingInput({
+      id: 'q-race',
+      resumeData: 'Yes',
+    });
+
+    expect(waitForAwaitingInputReady).toHaveBeenCalledWith({ id: 'q-race' });
+    expect(handleToolResumeByRunId).toHaveBeenCalledWith({
+      runId: 'race-run',
+      toolCallId: 'q-race',
+      resumeData: 'Yes',
+      requestContext: undefined,
+      threadId: undefined,
+      resourceId: 'race-resource',
+      requireToolApproval: undefined,
+    });
+    expect(result).toMatchObject({
+      status: 'resumed',
+      awaitingInput: durableQuestion,
+      message,
+    });
   });
 
   it('resumes a durable tool approval by id from storage', async () => {

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -41,6 +41,7 @@ import type {
   HarnessMessageContent,
   HarnessMode,
   HarnessQuestionAnswer,
+  HarnessQuestionOption,
   HarnessResumeAwaitingInputOptions,
   HarnessResumeAwaitingInputResult,
   HarnessRequestContext,
@@ -121,6 +122,36 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function readString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
+}
+
+function readQuestionAnswer(value: unknown): HarnessQuestionAnswer | undefined {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value) && value.every(item => typeof item === 'string')) return value;
+  if (isRecord(value)) return readQuestionAnswer(value.answer);
+  return undefined;
+}
+
+function readQuestionOptions(value: unknown): HarnessQuestionOption[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const options: HarnessQuestionOption[] = [];
+  for (const item of value) {
+    if (!isRecord(item) || typeof item.label !== 'string') return undefined;
+    options.push({
+      label: item.label,
+      ...(typeof item.description === 'string' ? { description: item.description } : {}),
+    });
+  }
+  return options;
+}
+
+function readPlanApprovalResponse(value: unknown): { action: 'approved' | 'rejected'; feedback?: string } | undefined {
+  if (!isRecord(value)) return undefined;
+  const action = value.action;
+  if (action !== 'approved' && action !== 'rejected') return undefined;
+  return {
+    action,
+    ...(typeof value.feedback === 'string' ? { feedback: value.feedback } : {}),
+  };
 }
 
 function getWorkflowInputState(snapshot: WorkflowRunState): Record<string, unknown> | undefined {
@@ -2517,13 +2548,7 @@ export class Harness<TState = {}> {
 
     while (true) {
       const awaitingInput = await this.getAwaitingInput({ id });
-      if (
-        awaitingInput &&
-        (awaitingInput.durable ||
-          awaitingInput.kind === 'question' ||
-          awaitingInput.kind === 'plan_approval' ||
-          Date.now() - startedAt >= timeoutMs)
-      ) {
+      if (awaitingInput && (awaitingInput.durable || Date.now() - startedAt >= timeoutMs)) {
         return awaitingInput;
       }
 
@@ -2589,12 +2614,20 @@ export class Harness<TState = {}> {
       };
     }
 
-    if (awaitingInput.kind === 'question' || awaitingInput.kind === 'plan_approval') {
-      return {
-        status: 'live_session_only',
-        awaitingInput,
-        message: `${awaitingInput.kind} awaiting inputs are live-session-only and cannot be durably resumed.`,
-      };
+    if (awaitingInput.kind === 'question' && !awaitingInput.durable) {
+      const answer = readQuestionAnswer(resumeData);
+      if (answer !== undefined && this.pendingQuestions.has(awaitingInput.questionId)) {
+        this.respondToQuestion({ questionId: awaitingInput.questionId, answer });
+        return { status: 'resumed', awaitingInput };
+      }
+    }
+
+    if (awaitingInput.kind === 'plan_approval' && !awaitingInput.durable) {
+      const response = readPlanApprovalResponse(resumeData);
+      if (response && this.pendingPlanApprovals.has(awaitingInput.planId)) {
+        await this.respondToPlanApproval({ planId: awaitingInput.planId, response });
+        return { status: 'resumed', awaitingInput };
+      }
     }
 
     if (!awaitingInput.durable || !awaitingInput.runId) {
@@ -2628,6 +2661,13 @@ export class Harness<TState = {}> {
       }
     }
 
+    if (awaitingInput.kind === 'plan_approval' && readPlanApprovalResponse(resumeData)?.action === 'approved') {
+      const defaultMode = this.config.modes.find(m => m.default) ?? this.config.modes[0];
+      if (defaultMode && defaultMode.id !== this.currentModeId) {
+        await this.switchMode({ modeId: defaultMode.id });
+      }
+    }
+
     this.emit({ type: 'agent_start' });
 
     try {
@@ -2644,12 +2684,18 @@ export class Harness<TState = {}> {
             })
           : await this.handleToolResumeByRunId({
               runId: awaitingInput.runId,
-              toolCallId: awaitingInput.toolCallId,
+              toolCallId:
+                awaitingInput.kind === 'question'
+                  ? awaitingInput.questionId
+                  : awaitingInput.kind === 'plan_approval'
+                    ? awaitingInput.planId
+                    : awaitingInput.toolCallId,
               resumeData,
               requestContext,
               threadId: awaitingInput.threadId,
               resourceId: awaitingInput.resourceId,
-              requireToolApproval: awaitingInput.requireToolApproval,
+              requireToolApproval:
+                awaitingInput.kind === 'tool_suspension' ? awaitingInput.requireToolApproval : undefined,
             });
 
       const reason = streamResult.suspended ? 'suspended' : 'complete';
@@ -2788,7 +2834,12 @@ export class Harness<TState = {}> {
     if (resolve) {
       this.pendingQuestions.delete(questionId);
       resolve(answer);
+      return;
     }
+
+    void this.resumeAwaitingInput({ id: questionId, resumeData: answer }).catch(error => {
+      this.emit({ type: 'error', error: error instanceof Error ? error : new Error(String(error)) });
+    });
   }
 
   /**
@@ -2818,7 +2869,10 @@ export class Harness<TState = {}> {
     response: { action: 'approved' | 'rejected'; feedback?: string };
   }): Promise<void> {
     const resolve = this.pendingPlanApprovals.get(planId);
-    if (!resolve) return;
+    if (!resolve) {
+      await this.resumeAwaitingInput({ id: planId, resumeData: response });
+      return;
+    }
 
     if (response.action === 'approved') {
       const defaultMode = this.config.modes.find(m => m.default) ?? this.config.modes[0];
@@ -3038,7 +3092,10 @@ export class Harness<TState = {}> {
       readString(harnessContext?.resourceId) ??
       readString(streamMemoryInfo?.resourceId) ??
       run.resourceId;
-    const payloadType = readString(suspendPayload.type);
+    const suspendedToolPayload = isRecord(suspendPayload.toolCallSuspended)
+      ? suspendPayload.toolCallSuspended
+      : undefined;
+    const payloadType = readString(suspendPayload.type) ?? readString(suspendedToolPayload?.type);
     const streamToolPayload = getStreamToolPayload(suspendPayload);
     const requireToolApproval = harnessState?.yolo !== true;
 
@@ -3063,6 +3120,52 @@ export class Harness<TState = {}> {
         args: approvalPayload.args,
         resumeSchema: readString(suspendPayload.resumeSchema),
         requireToolApproval,
+      };
+    }
+
+    if (payloadType === 'question') {
+      const questionPayload = suspendedToolPayload ?? suspendPayload;
+      const questionId = readString(questionPayload.questionId) ?? id;
+      const question = readString(questionPayload.question);
+      if (!question) return null;
+
+      return {
+        id,
+        kind: 'question',
+        durable: true,
+        runId: run.runId,
+        modeId,
+        threadId,
+        resourceId,
+        toolCallId: readString(questionPayload.toolCallId) ?? readString(streamToolPayload?.toolCallId),
+        questionId,
+        question,
+        options: readQuestionOptions(questionPayload.options),
+        selectionMode:
+          questionPayload.selectionMode === 'single_select' || questionPayload.selectionMode === 'multi_select'
+            ? questionPayload.selectionMode
+            : undefined,
+      };
+    }
+
+    if (payloadType === 'plan_approval') {
+      const planPayload = suspendedToolPayload ?? suspendPayload;
+      const planId = readString(planPayload.planId) ?? id;
+      const plan = readString(planPayload.plan);
+      if (!plan) return null;
+
+      return {
+        id,
+        kind: 'plan_approval',
+        durable: true,
+        runId: run.runId,
+        modeId,
+        threadId,
+        resourceId,
+        toolCallId: readString(planPayload.toolCallId) ?? readString(streamToolPayload?.toolCallId),
+        planId,
+        title: readString(planPayload.title),
+        plan,
       };
     }
 
@@ -3916,6 +4019,7 @@ export class Harness<TState = {}> {
       emitEvent: event => this.emit(event),
       registerQuestion: params => this.registerQuestion(params),
       registerPlanApproval: params => this.registerPlanApproval(params),
+      durableAwaitingInputs: Boolean(this.config.storage),
       getSubagentModelId: params => this.getSubagentModelId(params),
     };
 

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -2614,26 +2614,27 @@ export class Harness<TState = {}> {
       };
     }
 
-    if (awaitingInput.kind === 'question' && !awaitingInput.durable) {
-      const answer = readQuestionAnswer(resumeData);
-      if (answer !== undefined && this.pendingQuestions.has(awaitingInput.questionId)) {
-        this.respondToQuestion({ questionId: awaitingInput.questionId, answer });
-        return { status: 'resumed', awaitingInput };
-      }
-    }
-
-    if (awaitingInput.kind === 'plan_approval' && !awaitingInput.durable) {
-      const response = readPlanApprovalResponse(resumeData);
-      if (response && this.pendingPlanApprovals.has(awaitingInput.planId)) {
-        await this.respondToPlanApproval({ planId: awaitingInput.planId, response });
-        return { status: 'resumed', awaitingInput };
-      }
+    const liveResumeResult = await this.resumeLiveAwaitingInput(awaitingInput, resumeData);
+    if (liveResumeResult) {
+      return liveResumeResult;
     }
 
     if (!awaitingInput.durable || !awaitingInput.runId) {
+      const readyAwaitingInput = await this.waitForAwaitingInputReady({ id });
+      if (readyAwaitingInput && readyAwaitingInput !== awaitingInput) {
+        const readyLiveResumeResult = await this.resumeLiveAwaitingInput(readyAwaitingInput, resumeData);
+        if (readyLiveResumeResult) {
+          return readyLiveResumeResult;
+        }
+
+        if (readyAwaitingInput.durable && readyAwaitingInput.runId) {
+          return this.resumeAwaitingInput({ id, resumeData, requestContext });
+        }
+      }
+
       return {
         status: 'live_session_only',
-        awaitingInput,
+        awaitingInput: readyAwaitingInput ?? awaitingInput,
         message: `Awaiting input "${id}" is not backed by a durable workflow snapshot yet.`,
       };
     }
@@ -2725,6 +2726,29 @@ export class Harness<TState = {}> {
       this.emit({ type: 'agent_end', reason: 'error' });
       throw err;
     }
+  }
+
+  private async resumeLiveAwaitingInput(
+    awaitingInput: HarnessAwaitingInput,
+    resumeData: unknown,
+  ): Promise<HarnessResumeAwaitingInputResult | null> {
+    if (awaitingInput.kind === 'question' && !awaitingInput.durable) {
+      const answer = readQuestionAnswer(resumeData);
+      if (answer !== undefined && this.pendingQuestions.has(awaitingInput.questionId)) {
+        this.respondToQuestion({ questionId: awaitingInput.questionId, answer });
+        return { status: 'resumed', awaitingInput };
+      }
+    }
+
+    if (awaitingInput.kind === 'plan_approval' && !awaitingInput.durable) {
+      const response = readPlanApprovalResponse(resumeData);
+      if (response && this.pendingPlanApprovals.has(awaitingInput.planId)) {
+        await this.respondToPlanApproval({ planId: awaitingInput.planId, response });
+        return { status: 'resumed', awaitingInput };
+      }
+    }
+
+    return null;
   }
 
   /**
@@ -3095,7 +3119,7 @@ export class Harness<TState = {}> {
     const suspendedToolPayload = isRecord(suspendPayload.toolCallSuspended)
       ? suspendPayload.toolCallSuspended
       : undefined;
-    const payloadType = readString(suspendPayload.type) ?? readString(suspendedToolPayload?.type);
+    const payloadType = readString(suspendedToolPayload?.type) ?? readString(suspendPayload.type);
     const streamToolPayload = getStreamToolPayload(suspendPayload);
     const requireToolApproval = harnessState?.yolo !== true;
 

--- a/packages/core/src/harness/tools.ts
+++ b/packages/core/src/harness/tools.ts
@@ -30,6 +30,49 @@ function formatQuestionAnswer(answer: HarnessQuestionAnswer): string {
   return Array.isArray(answer) ? answer.join(', ') : answer;
 }
 
+function readQuestionAnswer(value: unknown): HarnessQuestionAnswer | undefined {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value) && value.every(item => typeof item === 'string')) return value;
+  if (value && typeof value === 'object' && 'answer' in value) {
+    return readQuestionAnswer((value as { answer?: unknown }).answer);
+  }
+  return undefined;
+}
+
+function readPlanApprovalResponse(value: unknown): { action: 'approved' | 'rejected'; feedback?: string } | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const response = value as { action?: unknown; feedback?: unknown };
+  if (response.action !== 'approved' && response.action !== 'rejected') return undefined;
+  return {
+    action: response.action,
+    ...(typeof response.feedback === 'string' ? { feedback: response.feedback } : {}),
+  };
+}
+
+function readToolResumeData(context: any): unknown {
+  return context?.agent?.resumeData ?? context?.workflow?.resumeData ?? context?.resumeData;
+}
+
+function readToolSuspend(context: any): ((payload: any, options?: any) => Promise<unknown>) | undefined {
+  return context?.suspend ?? context?.agent?.suspend ?? context?.workflow?.suspend;
+}
+
+function readToolCallId(context: any): string | undefined {
+  return context?.toolCallId ?? context?.agent?.toolCallId ?? context?.workflow?.toolCallId;
+}
+
+async function suspendForHarnessInput(
+  suspend: (payload: any, options?: any) => Promise<unknown>,
+  payload: Record<string, unknown>,
+  resumeLabel: string,
+  resumeSchema: Record<string, unknown>,
+): Promise<void> {
+  await suspend(payload, {
+    resumeLabel,
+    resumeSchema: JSON.stringify(resumeSchema),
+  });
+}
+
 /**
  * Built-in harness tool: ask the user a question and wait for their response.
  *
@@ -68,8 +111,14 @@ export const askUserTool = createTool({
   }),
   execute: async ({ question, options, selectionMode }, context) => {
     try {
+      const toolContext = context as any;
       const harnessCtx = context?.requestContext?.get('harness') as HarnessRequestContext | undefined;
       const resolvedSelectionMode = options?.length ? (selectionMode ?? 'single_select') : undefined;
+      const resumedAnswer = readQuestionAnswer(readToolResumeData(toolContext));
+
+      if (resumedAnswer !== undefined) {
+        return { content: `User answered: ${formatQuestionAnswer(resumedAnswer)}`, isError: false };
+      }
 
       if (selectionMode && !options?.length) {
         return {
@@ -88,6 +137,35 @@ export const askUserTool = createTool({
       }
 
       const questionId = `q_${++questionCounter}_${Date.now()}`;
+
+      const suspend = readToolSuspend(toolContext);
+      if (harnessCtx.durableAwaitingInputs && suspend) {
+        harnessCtx.emitEvent!({
+          type: 'ask_question',
+          questionId,
+          question,
+          options,
+          selectionMode: resolvedSelectionMode,
+        });
+        await suspendForHarnessInput(
+          suspend,
+          {
+            type: 'question',
+            toolCallId: readToolCallId(toolContext),
+            toolName: 'ask_user',
+            args: { question, options, selectionMode },
+            questionId,
+            question,
+            ...(options ? { options } : {}),
+            ...(resolvedSelectionMode ? { selectionMode: resolvedSelectionMode } : {}),
+          },
+          questionId,
+          {
+            anyOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+          },
+        );
+        return { content: `[Question for user]: ${question}`, isError: false };
+      }
 
       const answer = await new Promise<HarnessQuestionAnswer>((resolve, reject) => {
         const signal = harnessCtx.abortSignal;
@@ -141,7 +219,24 @@ export const submitPlanTool = createTool({
   }),
   execute: async ({ title, plan }, context) => {
     try {
+      const toolContext = context as any;
       const harnessCtx = context?.requestContext?.get('harness') as HarnessRequestContext | undefined;
+      const resumedResponse = readPlanApprovalResponse(readToolResumeData(toolContext));
+
+      if (resumedResponse) {
+        if (resumedResponse.action === 'approved') {
+          return {
+            content: 'Plan approved. Proceed with implementation following the approved plan.',
+            isError: false,
+          };
+        }
+
+        const feedback = resumedResponse.feedback ? `\n\nUser feedback: ${resumedResponse.feedback}` : '';
+        return {
+          content: `Plan was not approved. The user wants revisions.${feedback}\n\nPlease revise the plan based on the feedback and submit again with submit_plan.`,
+          isError: false,
+        };
+      }
 
       if (!harnessCtx?.emitEvent || !harnessCtx?.registerPlanApproval) {
         return {
@@ -151,6 +246,41 @@ export const submitPlanTool = createTool({
       }
 
       const planId = `plan_${++planCounter}_${Date.now()}`;
+
+      const suspend = readToolSuspend(toolContext);
+      if (harnessCtx.durableAwaitingInputs && suspend) {
+        harnessCtx.emitEvent!({
+          type: 'plan_approval_required',
+          planId,
+          title: title || 'Implementation Plan',
+          plan,
+        });
+        await suspendForHarnessInput(
+          suspend,
+          {
+            type: 'plan_approval',
+            toolCallId: readToolCallId(toolContext),
+            toolName: 'submit_plan',
+            args: { title, plan },
+            planId,
+            title: title || 'Implementation Plan',
+            plan,
+          },
+          planId,
+          {
+            type: 'object',
+            properties: {
+              action: { enum: ['approved', 'rejected'] },
+              feedback: { type: 'string' },
+            },
+            required: ['action'],
+          },
+        );
+        return {
+          content: `[Plan submitted for review]\n\nTitle: ${title || 'Implementation Plan'}\n\n${plan}`,
+          isError: false,
+        };
+      }
 
       const result = await new Promise<{ action: 'approved' | 'rejected'; feedback?: string }>((resolve, reject) => {
         const signal = harnessCtx.abortSignal;

--- a/packages/core/src/harness/tools.ts
+++ b/packages/core/src/harness/tools.ts
@@ -127,7 +127,10 @@ export const askUserTool = createTool({
         };
       }
 
-      if (!harnessCtx?.emitEvent || !harnessCtx?.registerQuestion) {
+      const suspend = readToolSuspend(toolContext);
+      const canSuspendDurably = Boolean(harnessCtx?.durableAwaitingInputs && harnessCtx?.emitEvent && suspend);
+
+      if (!harnessCtx?.emitEvent || (!harnessCtx?.registerQuestion && !canSuspendDurably)) {
         return {
           content: `[Question for user]: ${question}${
             options?.length ? '\nOptions: ' + options.map(o => o.label).join(', ') : ''
@@ -138,7 +141,6 @@ export const askUserTool = createTool({
 
       const questionId = `q_${++questionCounter}_${Date.now()}`;
 
-      const suspend = readToolSuspend(toolContext);
       if (harnessCtx.durableAwaitingInputs && suspend) {
         harnessCtx.emitEvent!({
           type: 'ask_question',
@@ -238,7 +240,10 @@ export const submitPlanTool = createTool({
         };
       }
 
-      if (!harnessCtx?.emitEvent || !harnessCtx?.registerPlanApproval) {
+      const suspend = readToolSuspend(toolContext);
+      const canSuspendDurably = Boolean(harnessCtx?.durableAwaitingInputs && harnessCtx?.emitEvent && suspend);
+
+      if (!harnessCtx?.emitEvent || (!harnessCtx?.registerPlanApproval && !canSuspendDurably)) {
         return {
           content: `[Plan submitted for review]\n\nTitle: ${title || 'Implementation Plan'}\n\n${plan}`,
           isError: false,
@@ -247,7 +252,6 @@ export const submitPlanTool = createTool({
 
       const planId = `plan_${++planCounter}_${Date.now()}`;
 
-      const suspend = readToolSuspend(toolContext);
       if (harnessCtx.durableAwaitingInputs && suspend) {
         harnessCtx.emitEvent!({
           type: 'plan_approval_required',

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -594,10 +594,12 @@ export type HarnessAwaitingInput =
   | {
       id: string;
       kind: 'question';
-      durable: false;
+      durable: boolean;
+      runId?: string;
       modeId?: string;
       threadId?: string;
       resourceId?: string;
+      toolCallId?: string;
       questionId: string;
       question: string;
       options?: HarnessQuestionOption[];
@@ -606,10 +608,12 @@ export type HarnessAwaitingInput =
   | {
       id: string;
       kind: 'plan_approval';
-      durable: false;
+      durable: boolean;
+      runId?: string;
       modeId?: string;
       threadId?: string;
       resourceId?: string;
+      toolCallId?: string;
       planId: string;
       title?: string;
       plan: string;
@@ -1139,6 +1143,9 @@ export interface HarnessRequestContext<TState = unknown> {
     planId: string;
     resolve: (result: { action: 'approved' | 'rejected'; feedback?: string }) => void;
   }) => void;
+
+  /** Whether built-in Harness tools can use durable workflow suspension for awaiting input */
+  durableAwaitingInputs?: boolean;
 
   /** Get the configured subagent model ID for a specific agent type */
   getSubagentModelId?: (params?: { agentType?: string }) => string | null;

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -619,15 +619,16 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
               // Flush messages before suspension to ensure they are persisted
               await flushMessagesBeforeSuspension();
 
+              const resumeLabel = options?.resumeLabel ?? inputData.toolCallId;
               return await suspend(
                 {
                   toolCallSuspended: suspendPayload,
                   __streamState: streamState.serialize(),
                   toolName: inputData.toolName,
-                  resumeLabel: options?.resumeLabel,
+                  resumeLabel,
                 },
                 {
-                  resumeLabel: inputData.toolCallId,
+                  resumeLabel,
                 },
               );
             }


### PR DESCRIPTION
## Summary
- make built-in ask_user and submit_plan use durable tool suspension when Harness storage is configured
- teach Harness awaiting-input discovery to decode durable question and plan_approval suspension payloads
- route resumeAwaitingInput for questions/plans through the existing agent.resumeStream path, while preserving live resolver fallback behavior
- allow custom suspend resume labels so built-in question/plan ids are the public awaiting-input ids

Fixes #30

## Verification
- pnpm --filter @mastra/core test src/harness/harness-awaiting-input.test.ts
- pnpm --filter @mastra/core test src/loop/workflows/agentic-execution/tool-call-step.test.ts
- pnpm --filter @mastra/core typecheck

## Claude review
Claude reviewed the issue before implementation and recommended reusing the existing durable tool suspension primitive instead of adding a new awaiting-input table. This PR follows that shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 - Explain Like I'm 5

When an AI assistant asks you a question or needs you to approve a plan, it used to forget about it if the system restarted. This PR makes those questions and approvals "sticky"—the system saves them to a database so they won't get lost, and users can finish answering them even after the system comes back online.

## Overview

This PR adds durable awaiting-input support to Harness for `ask_user` (questions) and `submit_plan` (plan approvals), enabling them to survive process restarts and be resumed through the existing `resumeAwaitingInput()` API when Harness storage is configured.

## Key Features

- **Durable question & plan approval suspension**: Built-in `ask_user` and `submit_plan` tools now use durable workflow suspension instead of live Promise-based resolvers when `durableAwaitingInputs` is enabled in the request context.
- **Discovery and resumption**: `listAwaitingInputs()` now discovers `question` and `plan_approval` awaiting inputs from durable workflow snapshots; `resumeAwaitingInput()` can resume them with typed responses.
- **Smart routing**: Resume requests for durable questions/plans are routed through `agent.resumeStream` while preserving the live-session in-memory fast path when a resolver is present.
- **Custom suspend/resume labels**: Introduced helpers to extract and manage `resumeLabel` and resume schemas, allowing built-in question/plan IDs to serve as public awaiting-input IDs.

## Implementation Details

**Types** (`harness/types.ts`):
- `HarnessAwaitingInput` now includes optional `toolCallId?: string` for `question` and `plan_approval` variants
- Added optional `durableAwaitingInputs?: boolean` flag to `HarnessRequestContext`

**Tools** (`harness/tools.ts`):
- `ask_user` and `submit_plan` now check for resumed answers/approvals first and return immediately if present
- When durable inputs are enabled and a suspend function exists, tools emit their respective events (`ask_question` or `plan_approval_required`) and suspend with serialized JSON schemas instead of waiting on live resolvers
- New helpers: `readToolResumeData()`, `readToolSuspend()`, `readToolCallId()`, `readQuestionAnswer()`, `readPlanApprovalResponse()`, and `suspendForHarnessInput()`

**Harness Core** (`harness/harness.ts`):
- Enhanced `resumeAwaitingInput()` to directly resolve live-session questions and plan approvals with proper validation and resolver invocation
- Updated `waitForAwaitingInputReady()` to handle durable awaiting inputs immediately
- Expanded `getAwaitingInputFromWorkflowRun()` to recognize and reconstruct `question` and `plan_approval` awaiting inputs from suspend payloads
- `respondToQuestion()` and `respondToPlanApproval()` now fall back to `resumeAwaitingInput()` when no live resolver is present
- Exposed `durableAwaitingInputs` flag to tools via `buildRequestContext()`

**Tool Call Suspension** (`loop/workflows/agentic-execution/tool-call-step.ts`):
- `resumeLabel` is now properly computed and used consistently in both the suspended payload and suspend options

## Testing

**New test coverage** (`harness-awaiting-input.test.ts`):
- Added 364 new lines of test code covering durable question discovery and resumption from a fresh Harness instance
- Added durable plan approval tests including approval, rejection (with optional feedback), and idempotency verification
- Added test for awaiting durable question snapshots before resolving to live-session behavior

**Enhanced existing tests** (`ask-user-tool.test.ts`):
- Added durable suspension behavior tests for both `ask_user` and `submit_plan` tools
- Verify correct event emission, suspend parameters, and resume schemas

## Verification

Unit tests in `harness-awaiting-input.test.ts` and `tool-call-step.test.ts` validate durable listing/resumption across Harness instance restarts while preserving live-session behavior for in-memory resolvers.

## Related

Fixes #30; follows Claude's recommendation to reuse the existing durable tool suspension primitive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->