### PR TITLE
fix(client-js): batch streamed client tool calls

### DIFF
--- a/client-sdks/client-js/src/resources/agent.test.ts
+++ b/client-sdks/client-js/src/resources/agent.test.ts
@@ -23,6 +23,23 @@ class TestAgent extends Agent {
   }
 }
 
+async function waitForAssertion(assertion: () => void, timeoutMs = 1000) {
+  const startedAt = Date.now();
+  let lastError: unknown;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+  }
+
+  throw lastError;
+}
+
 describe('Agent.stream', () => {
   const mockClientOptions = {
     baseUrl: 'http://localhost:4111',
@@ -674,6 +691,133 @@ describe('Agent Client Methods', () => {
       expect.objectContaining({
         headers: expect.objectContaining(clientOptions.headers),
       }),
+    );
+  });
+});
+
+describe('Agent legacy stream client tools', () => {
+  const mockClientOptions: ClientOptions = {
+    baseUrl: 'https://api.test.com',
+  };
+
+  function emptyStreamResponse() {
+    return new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.close();
+        },
+      }),
+      { status: 200 },
+    );
+  }
+
+  it('executes parallel client tool calls from one streamed step before recursing', async () => {
+    const agent = new Agent(mockClientOptions, 'test-agent-id');
+    const mockRequest = vi.fn(async () => emptyStreamResponse());
+    agent['request'] = mockRequest as (typeof agent)['request'];
+
+    const weatherInvocation = {
+      state: 'call',
+      toolCallId: 'call_weather',
+      toolName: 'weatherTool',
+      args: { location: 'NYC' },
+    };
+    const newsInvocation = {
+      state: 'call',
+      toolCallId: 'call_news',
+      toolName: 'newsTool',
+      args: { topic: 'weather' },
+    };
+    const firstMessage = {
+      id: 'message-1',
+      role: 'assistant',
+      content: '',
+      parts: [
+        { type: 'tool-invocation', toolInvocation: weatherInvocation },
+        { type: 'tool-invocation', toolInvocation: newsInvocation },
+      ],
+      toolInvocations: [weatherInvocation, newsInvocation],
+    };
+
+    let processCallCount = 0;
+    (agent as any).processChatResponse = vi.fn(async ({ update, onFinish }: any) => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+      processCallCount++;
+
+      if (processCallCount === 1) {
+        update({ message: firstMessage, data: undefined, replaceLastMessage: false });
+        await onFinish?.({ finishReason: 'tool-calls', message: firstMessage, usage: '' });
+        return;
+      }
+
+      const finalMessage = {
+        id: 'message-2',
+        role: 'assistant',
+        content: 'Done',
+        parts: [],
+      };
+      update({ message: finalMessage, data: undefined, replaceLastMessage: false });
+      await onFinish?.({ finishReason: 'stop', message: finalMessage, usage: '' });
+    });
+
+    const weatherExecuteSpy = vi.fn(async () => ({ temperature: 72 }));
+    const newsExecuteSpy = vi.fn(async () => ({ headlines: ['Sunny tomorrow'] }));
+    const writtenChunks: string[] = [];
+    const writable = new WritableStream<Uint8Array>({
+      write(chunk) {
+        writtenChunks.push(new TextDecoder().decode(chunk));
+      },
+    });
+
+    await (agent as any).processStreamResponseLegacy(
+      {
+        messages: [],
+        clientTools: {
+          weatherTool: { execute: weatherExecuteSpy },
+          newsTool: { execute: newsExecuteSpy },
+        },
+      },
+      writable,
+    );
+
+    await waitForAssertion(() => {
+      expect(mockRequest).toHaveBeenCalledTimes(2);
+    });
+
+    expect(weatherExecuteSpy).toHaveBeenCalledTimes(1);
+    expect(newsExecuteSpy).toHaveBeenCalledTimes(1);
+
+    const toolResultParts = writtenChunks
+      .join('')
+      .split('\n')
+      .filter(line => line.startsWith('a:'))
+      .map(line => JSON.parse(line.slice(2)));
+    expect(toolResultParts).toEqual(
+      expect.arrayContaining([
+        { toolCallId: 'call_weather', result: { temperature: 72 } },
+        { toolCallId: 'call_news', result: { headlines: ['Sunny tomorrow'] } },
+      ]),
+    );
+
+    const recursiveBody = mockRequest.mock.calls[1][1].body;
+    const assistantMessage = recursiveBody.messages.find((message: any) => Array.isArray(message.parts));
+    const toolInvocations = assistantMessage.parts
+      .filter((part: any) => part.type === 'tool-invocation')
+      .map((part: any) => part.toolInvocation);
+
+    expect(toolInvocations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          toolCallId: 'call_weather',
+          state: 'result',
+          result: { temperature: 72 },
+        }),
+        expect.objectContaining({
+          toolCallId: 'call_news',
+          state: 'result',
+          result: { headlines: ['Sunny tomorrow'] },
+        }),
+      ]),
     );
   });
 });

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -65,6 +65,41 @@ type ToolCallRespondFn<OUTPUT> = (
   },
 ) => Promise<FullOutput<OUTPUT>>;
 
+function getPendingToolInvocations(message?: UIMessage): ToolInvocation[] {
+  return (message?.parts ?? [])
+    .filter((part): part is ToolInvocationUIPart => part.type === 'tool-invocation')
+    .map(part => part.toolInvocation)
+    .filter(
+      (toolInvocation): toolInvocation is ToolInvocation => toolInvocation != null && toolInvocation.state !== 'result',
+    );
+}
+
+function cloneUIMessage(message: UIMessage): UIMessage {
+  return JSON.parse(JSON.stringify(message));
+}
+
+function applyToolInvocationResult(lastMessage: UIMessage | undefined, toolCall: ToolInvocation, result: unknown) {
+  const toolInvocationPart = lastMessage?.parts?.find(
+    part => part.type === 'tool-invocation' && part.toolInvocation?.toolCallId === toolCall.toolCallId,
+  ) as ToolInvocationUIPart | undefined;
+
+  if (toolInvocationPart) {
+    toolInvocationPart.toolInvocation = {
+      ...toolInvocationPart.toolInvocation,
+      state: 'result',
+      result,
+    } as ToolInvocation;
+  }
+
+  const toolInvocation = lastMessage?.toolInvocations?.find(
+    toolInvocation => toolInvocation.toolCallId === toolCall.toolCallId,
+  ) as ToolInvocation | undefined;
+
+  if (toolInvocation) {
+    Object.assign(toolInvocation as any, { state: 'result', result });
+  }
+}
+
 async function executeToolCallAndRespond<OUTPUT>({
   response,
   params,
@@ -1346,7 +1381,6 @@ export class Agent extends BaseResource {
     }
 
     try {
-      let toolCalls: ToolInvocation[] = [];
       let messages: UIMessage[] = [];
 
       // Use tee() to split the stream into two branches
@@ -1398,16 +1432,14 @@ export class Agent extends BaseResource {
         },
         onFinish: async ({ finishReason, message }) => {
           if (finishReason === 'tool-calls') {
-            const toolCall = [...(message?.parts ?? [])]
-              .reverse()
-              .find(part => part.type === 'tool-invocation')?.toolInvocation;
-            if (toolCall) {
-              toolCalls.push(toolCall);
-            }
-
             let shouldExecuteClientTool = false;
+            const pendingToolCalls = getPendingToolInvocations(message);
+            const lastMessageRaw = messages[messages.length - 1];
+            const lastMessage: UIMessage | undefined =
+              lastMessageRaw != null ? cloneUIMessage(lastMessageRaw) : undefined;
+
             // Handle tool calls if needed
-            for (const toolCall of toolCalls) {
+            for (const toolCall of pendingToolCalls) {
               const clientTool = processedParams.clientTools?.[toolCall.toolName] as Tool;
               if (clientTool && clientTool.execute) {
                 shouldExecuteClientTool = true;
@@ -1425,58 +1457,36 @@ export class Agent extends BaseResource {
                   },
                 });
 
-                const lastMessageRaw = messages[messages.length - 1];
-                const lastMessage: UIMessage | undefined =
-                  lastMessageRaw != null ? JSON.parse(JSON.stringify(lastMessageRaw)) : undefined;
+                applyToolInvocationResult(lastMessage, toolCall, result);
+              }
+            }
 
-                const toolInvocationPart = lastMessage?.parts?.find(
-                  part => part.type === 'tool-invocation' && part.toolInvocation?.toolCallId === toolCall.toolCallId,
-                ) as ToolInvocationUIPart | undefined;
+            if (shouldExecuteClientTool) {
+              // Build updated messages for the recursive call
+              // When threadId is present, server has memory - don't re-include original messages to avoid storage duplicates
+              // When no threadId (stateless), include full conversation history for context
+              const newMessages =
+                lastMessage != null ? [...messages.filter(m => m.id !== lastMessage.id), lastMessage] : [...messages];
 
-                if (toolInvocationPart) {
-                  toolInvocationPart.toolInvocation = {
-                    ...toolInvocationPart.toolInvocation,
-                    state: 'result',
-                    result,
-                  };
-                }
+              const updatedMessages = threadId
+                ? newMessages
+                : [...(Array.isArray(processedParams.messages) ? processedParams.messages : []), ...newMessages];
 
-                const toolInvocation = lastMessage?.toolInvocations?.find(
-                  toolInvocation => toolInvocation.toolCallId === toolCall.toolCallId,
-                ) as ToolInvocation | undefined;
+              // Recursively call stream with updated messages
+              // This will wait for the recursive stream to complete before continuing.
+              const continuationRoute = route === 'stream-until-idle' ? route : 'stream';
 
-                if (toolInvocation) {
-                  toolInvocation.state = 'result';
-                  // @ts-expect-error - result property exists when state is 'result'
-                  toolInvocation.result = result;
-                }
-
-                // Build updated messages for the recursive call
-                // When threadId is present, server has memory - don't re-include original messages to avoid storage duplicates
-                // When no threadId (stateless), include full conversation history for context
-                const newMessages =
-                  lastMessage != null ? [...messages.filter(m => m.id !== lastMessage.id), lastMessage] : [...messages];
-
-                const updatedMessages = threadId
-                  ? newMessages
-                  : [...(Array.isArray(processedParams.messages) ? processedParams.messages : []), ...newMessages];
-
-                // Recursively call stream with updated messages
-                // This will wait for the recursive stream to complete before continuing.
-                // Forward `route` so stream-until-idle (and future non-default routes)
-                // stay on the same endpoint across client-tool continuations.
-                try {
-                  await this.processStreamResponse(
-                    {
-                      ...processedParams,
-                      messages: updatedMessages,
-                    },
-                    controller,
-                    route,
-                  );
-                } catch (error) {
-                  console.error('Error processing recursive stream response:', error);
-                }
+              try {
+                await this.processStreamResponse(
+                  {
+                    ...processedParams,
+                    messages: updatedMessages,
+                  },
+                  controller,
+                  continuationRoute,
+                );
+              } catch (error) {
+                console.error('Error processing recursive stream response:', error);
               }
             }
 
@@ -2197,7 +2207,6 @@ export class Agent extends BaseResource {
     }
 
     try {
-      let toolCalls: ToolInvocation[] = [];
       let messages: UIMessage[] = [];
 
       // Use tee() to split the stream into two branches
@@ -2226,17 +2235,17 @@ export class Agent extends BaseResource {
         },
         onFinish: async ({ finishReason, message }) => {
           if (finishReason === 'tool-calls') {
-            const toolCall = [...(message?.parts ?? [])]
-              .reverse()
-              .find(part => part.type === 'tool-invocation')?.toolInvocation;
-            if (toolCall) {
-              toolCalls.push(toolCall);
-            }
+            const pendingToolCalls = getPendingToolInvocations(message);
+            const lastMessageRaw = messages[messages.length - 1];
+            const lastMessage: UIMessage | undefined =
+              lastMessageRaw != null ? cloneUIMessage(lastMessageRaw) : undefined;
+            let shouldExecuteClientTool = false;
 
             // Handle tool calls if needed
-            for (const toolCall of toolCalls) {
+            for (const toolCall of pendingToolCalls) {
               const clientTool = processedParams.clientTools?.[toolCall.toolName] as Tool;
               if (clientTool && clientTool.execute) {
+                shouldExecuteClientTool = true;
                 const result = await clientTool.execute(toolCall?.args, {
                   requestContext: processedParams.requestContext as RequestContext,
                   // TODO: Pass proper tracing context when client-js supports tracing
@@ -2251,29 +2260,7 @@ export class Agent extends BaseResource {
                   },
                 });
 
-                const lastMessage: UIMessage = JSON.parse(JSON.stringify(messages[messages.length - 1]));
-
-                const toolInvocationPart = lastMessage?.parts?.find(
-                  part => part.type === 'tool-invocation' && part.toolInvocation?.toolCallId === toolCall.toolCallId,
-                ) as ToolInvocationUIPart | undefined;
-
-                if (toolInvocationPart) {
-                  toolInvocationPart.toolInvocation = {
-                    ...toolInvocationPart.toolInvocation,
-                    state: 'result',
-                    result,
-                  };
-                }
-
-                const toolInvocation = lastMessage?.toolInvocations?.find(
-                  toolInvocation => toolInvocation.toolCallId === toolCall.toolCallId,
-                ) as ToolInvocation | undefined;
-
-                if (toolInvocation) {
-                  toolInvocation.state = 'result';
-                  // @ts-expect-error - result property exists when state is 'result'
-                  toolInvocation.result = result;
-                }
+                applyToolInvocationResult(lastMessage, toolCall, result);
 
                 // write the tool result part to the stream
                 const writer = writable.getWriter();
@@ -2292,26 +2279,29 @@ export class Agent extends BaseResource {
                 } finally {
                   writer.releaseLock();
                 }
-
-                // Build updated messages for the recursive call
-                // When threadId is present, server has memory - don't re-include original messages to avoid storage duplicates
-                // When no threadId (stateless), include full conversation history for context
-                const newMessages = [...messages.filter(m => m.id !== lastMessage.id), lastMessage];
-                const updatedMessages = threadId
-                  ? newMessages
-                  : [...(Array.isArray(processedParams.messages) ? processedParams.messages : []), ...newMessages];
-
-                // Recursively call stream with updated messages
-                this.processStreamResponseLegacy(
-                  {
-                    ...processedParams,
-                    messages: updatedMessages,
-                  },
-                  writable,
-                ).catch(error => {
-                  console.error('Error processing stream response:', error);
-                });
               }
+            }
+
+            if (shouldExecuteClientTool) {
+              // Build updated messages for the recursive call
+              // When threadId is present, server has memory - don't re-include original messages to avoid storage duplicates
+              // When no threadId (stateless), include full conversation history for context
+              const newMessages =
+                lastMessage != null ? [...messages.filter(m => m.id !== lastMessage.id), lastMessage] : [...messages];
+              const updatedMessages = threadId
+                ? newMessages
+                : [...(Array.isArray(processedParams.messages) ? processedParams.messages : []), ...newMessages];
+
+              // Recursively call stream with updated messages
+              this.processStreamResponseLegacy(
+                {
+                  ...processedParams,
+                  messages: updatedMessages,
+                },
+                writable,
+              ).catch(error => {
+                console.error('Error processing stream response:', error);
+              });
             }
           } else {
             setTimeout(() => {

--- a/client-sdks/client-js/src/resources/agent.vnext.test.ts
+++ b/client-sdks/client-js/src/resources/agent.vnext.test.ts
@@ -343,6 +343,89 @@ describe('Agent vNext', () => {
     expect(global.fetch).toHaveBeenCalledTimes(3);
   });
 
+  it('stream: executes parallel client tool calls from one streamed step before recursing', async () => {
+    const firstCycle = [
+      { type: 'step-start', payload: { messageId: 'm1' } },
+      {
+        type: 'tool-call',
+        payload: { toolCallId: 'call_weather', toolName: 'weatherTool', args: { location: 'NYC' } },
+      },
+      {
+        type: 'tool-call',
+        payload: { toolCallId: 'call_news', toolName: 'newsTool', args: { topic: 'weather' } },
+      },
+      { type: 'step-finish', payload: { stepResult: { isContinued: false } } },
+      { type: 'finish', payload: { stepResult: { reason: 'tool-calls' }, usage: { totalTokens: 2 } } },
+    ];
+
+    const secondCycle = [
+      { type: 'step-start', payload: { messageId: 'm2' } },
+      { type: 'text-delta', payload: { text: 'Here is the combined update' } },
+      { type: 'step-finish', payload: { stepResult: { isContinued: false } } },
+      { type: 'finish', payload: { stepResult: { reason: 'stop' }, usage: { totalTokens: 8 } } },
+    ];
+
+    (global.fetch as any)
+      .mockResolvedValueOnce(sseResponse(firstCycle))
+      .mockResolvedValueOnce(sseResponse(secondCycle));
+
+    const weatherExecuteSpy = vi.fn(async () => ({ temperature: 72 }));
+    const newsExecuteSpy = vi.fn(async () => ({ headlines: ['Sunny tomorrow'] }));
+
+    const weatherTool = createTool({
+      id: 'weatherTool',
+      description: 'Get weather',
+      inputSchema: z.object({ location: z.string() }),
+      outputSchema: z.object({ temperature: z.number() }),
+      execute: weatherExecuteSpy,
+    });
+
+    const newsTool = createTool({
+      id: 'newsTool',
+      description: 'Get news',
+      inputSchema: z.object({ topic: z.string() }),
+      outputSchema: z.object({ headlines: z.array(z.string()) }),
+      execute: newsExecuteSpy,
+    });
+
+    const resp = await agent.stream('Give me weather and news', {
+      clientTools: { weatherTool, newsTool },
+    });
+
+    await resp.processDataStream({
+      onChunk: async () => {},
+    });
+
+    expect(weatherExecuteSpy).toHaveBeenCalledTimes(1);
+    expect(newsExecuteSpy).toHaveBeenCalledTimes(1);
+
+    const streamCalls = (global.fetch as any).mock.calls.filter((call: any[]) =>
+      (call?.[0] as string).includes('/stream'),
+    );
+    expect(streamCalls).toHaveLength(2);
+
+    const recursiveRequestBody = JSON.parse(streamCalls[1][1].body);
+    const assistantMessage = recursiveRequestBody.messages.find((message: any) => Array.isArray(message.parts));
+    const toolInvocations = assistantMessage.parts
+      .filter((part: any) => part.type === 'tool-invocation')
+      .map((part: any) => part.toolInvocation);
+
+    expect(toolInvocations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          toolCallId: 'call_weather',
+          state: 'result',
+          result: { temperature: 72 },
+        }),
+        expect.objectContaining({
+          toolCallId: 'call_news',
+          state: 'result',
+          result: { headlines: ['Sunny tomorrow'] },
+        }),
+      ]),
+    );
+  });
+
   it('stream: step execution when client tool is present without an execute function', async () => {
     const toolCallId = 'call_1';
 


### PR DESCRIPTION
## Summary

Fixes #38.

This updates the client-js stream continuation path so a single streamed `tool-calls` step can execute every pending client-side tool invocation before continuing the agent.

Changes:

- collect all pending tool invocations from the assistant message instead of only the last one;
- apply every matching client tool result to the cloned assistant message;
- recurse/continue once with the complete updated message;
- keep legacy stream result chunk emission for each executed tool;
- continue one-shot routes through `stream` after client tool execution, while preserving `stream-until-idle` continuation.

## Tests

- `pnpm --filter @mastra/client-js test:unit src/resources/agent.vnext.test.ts src/resources/agent.test.ts`
- `pnpm --filter @mastra/client-js build:lib`
- `pnpm --filter @mastra/client-js lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The PR fixes a bug where the AI assistant's streaming feature could only execute one tool at a time when multiple tools needed to be used. Now it's smart enough to collect all the tools that need to run together, execute them all in parallel, and then tell the assistant about all the results at once before continuing.

## Overview

This PR addresses issue #38 by refactoring the stream continuation behavior in `@mastra/client-js` to handle multiple pending client tool invocations within a single assistant message step. Previously, when an assistant streamed a step containing multiple `tool-invocation` parts, only the last one would be executed. The fix ensures all matching client tools are collected, executed in batch, and the agent continues with a single request containing all results.

## Changes

### Core Implementation (`agent.ts`)

Introduced three helper utilities to streamline tool-call handling:
- **`getPendingToolInvocations`**: Collects all pending tool invocations (where `state: "call"`) from an assistant message
- **`cloneUIMessage`**: Clones UI messages to avoid mutating the original state
- **`applyToolInvocationResult`**: Applies a tool execution result back into the message by updating the matching tool invocation's state to `"result"` and storing the result payload

Updated both stream implementations:

**vNext (`processStreamResponse_vNext`)**: 
- Refactored to batch all pending tool invocations before recursion
- Sets `continuationRoute` to preserve `'stream-until-idle'` when already in that mode; otherwise defaults to `'stream'`
- Wrapped recursive streaming call in try/catch with error logging
- Ensures one-shot routes continue through `stream` while preserving the behavior of `stream-until-idle` routes

**Legacy (`processStreamResponseLegacy`)**:
- Refactored to use `applyToolInvocationResult` helper instead of manual mutations
- Collects all pending tools and triggers recursion once after all results are applied
- Maintains existing behavior of emitting stream result chunks for each executed tool

### Test Coverage

**Legacy stream test (`agent.test.ts`)**:
- Added `waitForAssertion` helper utility for retrying assertions with timeout
- New test suite `Agent legacy stream client tools` validating that when a streamed step returns multiple `tool-invocation` parts, all client tools are executed in parallel and results are sent back in a single recursive request with correct `toolCallId` and `result` payloads

**vNext stream test (`agent.vnext.test.ts`)**:
- New test verifying that a single streamed step with multiple `tool-call` events results in all corresponding client tools executing once
- Asserts the recursive `/stream` request includes both tool results in the assistant message's `tool-invocation` parts with matching `toolCallId` values

## Impact

- **Fixes**: Agent now correctly handles multiple client tool invocations within one assistant step by executing them all before continuing
- **Batching**: Tool results are collected and sent in a single continuation request instead of partial continuations
- **Backward Compatibility**: Preserves legacy streaming behavior including per-tool result chunk emission
- **Route Preservation**: Maintains proper routing behavior (`stream` vs `stream-until-idle`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->