### PR TITLE
fix(memory): hoist media tool outputs into observer attachments

### DIFF
--- a/.changeset/huge-papers-rest.md
+++ b/.changeset/huge-papers-rest.md
@@ -2,6 +2,6 @@
 '@mastra/memory': patch
 ---
 
-Fixed an issue where tool results containing media content blocks (returned via `toModelOutput`) were stringified into the observational memory prompt as raw base64 text. The base64 data overflowed the observer's context, causing token-limit errors and degenerate output.
+Observers no longer receive raw base64 media in prompts. This prevents token overflows and broken responses when tool results include images or files.
 
-Image and file blocks (`image`, `image-data`, `image-url`, `file`, `file-data`, `file-url`, and `media`) inside tool results are now hoisted into the observer's input as proper attachments, the same way image and file message parts already are. The text body shows a placeholder like `[Image #1: image/png]` so the observer keeps positional context without seeing the bytes.
+Media from tool results is now sent as attachments. The prompt keeps a short placeholder like `[Image #1: image/png]`, so the observer still has positional context without seeing the raw bytes.

--- a/.changeset/huge-papers-rest.md
+++ b/.changeset/huge-papers-rest.md
@@ -1,0 +1,7 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed an issue where tool results containing media content blocks (returned via `toModelOutput`) were stringified into the observational memory prompt as raw base64 text. The base64 data overflowed the observer's context, causing token-limit errors and degenerate output.
+
+Image and file blocks (`image`, `image-data`, `image-url`, `file`, `file-data`, `file-url`, and `media`) inside tool results are now hoisted into the observer's input as proper attachments, the same way image and file message parts already are. The text body shows a placeholder like `[Image #1: image/png]` so the observer keeps positional context without seeing the bytes.

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -1508,6 +1508,104 @@ describe('Observer Agent Helpers', () => {
       expect(formatted).not.toContain('x'.repeat(200));
     });
 
+    it('should replace image-data tool-result blocks with attachment placeholders', () => {
+      const base64 = 'A'.repeat(2000);
+      const msg = createTestMessage('ignored', 'assistant');
+      msg.content = {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-1',
+              toolName: 'screenshot',
+              args: { url: 'https://example.com' },
+              result: {},
+            },
+            providerMetadata: {
+              mastra: {
+                modelOutput: {
+                  type: 'content',
+                  value: [
+                    { type: 'text', text: 'Captured screenshot of the homepage.' },
+                    { type: 'image-data', data: base64, mediaType: 'image/png' },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      } as any;
+
+      const formatted = formatMessagesForObserver([msg]);
+      expect(formatted).toContain('Tool Result screenshot');
+      expect(formatted).toContain('Captured screenshot of the homepage.');
+      expect(formatted).toContain('[Image #1: image/png]');
+      expect(formatted).not.toContain(base64);
+    });
+
+    it('should replace legacy image tool-result blocks with attachment placeholders', () => {
+      const base64 = 'C'.repeat(2000);
+      const msg = createTestMessage('ignored', 'assistant');
+      msg.content = {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-legacy-image',
+              toolName: 'read_file',
+              args: { path: 'figures/result.png' },
+              result: {},
+            },
+            providerMetadata: {
+              mastra: {
+                modelOutput: {
+                  type: 'content',
+                  value: [
+                    { type: 'text', text: 'Image read: figures/result.png' },
+                    { type: 'image', data: base64, mimeType: 'image/png' },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      } as any;
+
+      const formatted = formatMessagesForObserver([msg]);
+      expect(formatted).toContain('Tool Result read_file');
+      expect(formatted).toContain('Image read: figures/result.png');
+      expect(formatted).toContain('[Image #1: image/png]');
+      expect(formatted).not.toContain(base64);
+    });
+
+    it('should leave non-content tool-result outputs unchanged', () => {
+      const msg = createTestMessage('ignored', 'assistant');
+      msg.content = {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-2',
+              toolName: 'getWeather',
+              args: { city: 'NYC' },
+              result: { temperature: 72, conditions: 'sunny' },
+            },
+          },
+        ],
+      } as any;
+
+      const formatted = formatMessagesForObserver([msg]);
+      expect(formatted).toContain('Tool Result getWeather');
+      expect(formatted).toContain('"temperature": 72');
+      expect(formatted).toContain('"conditions": "sunny"');
+    });
+
     // Regression test for https://github.com/mastra-ai/mastra/issues/15573
     // Anthropic rejects bodies containing lone UTF-16 surrogates with
     // `The request body is not valid JSON: no low surrogate in string`.
@@ -1600,6 +1698,104 @@ describe('Observer Agent Helpers', () => {
       expect(content[2]).toMatchObject({ type: 'image', image: 'https://example.com/reference-board.png' });
       expect(content[3]).toMatchObject({ type: 'image', image: 'https://example.com/annotated-photo.jpg' });
       expect(content).not.toContainEqual(expect.objectContaining({ image: 'https://example.com/floorplan.pdf' }));
+    });
+
+    it('should hoist image-data tool-result blocks into observer input attachments', () => {
+      const base64 = 'B'.repeat(1500);
+      const msg = createTestMessage('ignored', 'assistant');
+      msg.content = {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-1',
+              toolName: 'screenshot',
+              args: { url: 'https://example.com' },
+              result: {},
+            },
+            providerMetadata: {
+              mastra: {
+                modelOutput: {
+                  type: 'content',
+                  value: [
+                    { type: 'text', text: 'Captured.' },
+                    { type: 'image-data', data: base64, mediaType: 'image/png' },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      } as any;
+
+      const historyMessage = buildObserverHistoryMessage([msg]);
+      const content = historyMessage.content as any[];
+
+      const textParts = content.filter(part => part.type === 'text');
+      const imageParts = content.filter(part => part.type === 'image');
+
+      expect(imageParts).toHaveLength(1);
+      expect(imageParts[0]).toMatchObject({
+        type: 'image',
+        image: `data:image/png;base64,${base64}`,
+        mimeType: 'image/png',
+      });
+
+      const joinedText = textParts.map(part => part.text).join('\n');
+      expect(joinedText).toContain('Tool Result screenshot');
+      expect(joinedText).toContain('[Image #1: image/png]');
+      expect(joinedText).not.toContain(base64);
+    });
+
+    it('should hoist legacy image tool-result blocks into observer input attachments', () => {
+      const base64 = 'D'.repeat(1500);
+      const msg = createTestMessage('ignored', 'assistant');
+      msg.content = {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-legacy-image',
+              toolName: 'read_file',
+              args: { path: 'figures/result.png' },
+              result: {},
+            },
+            providerMetadata: {
+              mastra: {
+                modelOutput: {
+                  type: 'content',
+                  value: [
+                    { type: 'text', text: 'Image read.' },
+                    { type: 'image', data: base64, mimeType: 'image/png' },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      } as any;
+
+      const historyMessage = buildObserverHistoryMessage([msg]);
+      const content = historyMessage.content as any[];
+
+      const textParts = content.filter(part => part.type === 'text');
+      const imageParts = content.filter(part => part.type === 'image');
+
+      expect(imageParts).toHaveLength(1);
+      expect(imageParts[0]).toMatchObject({
+        type: 'image',
+        image: `data:image/png;base64,${base64}`,
+        mimeType: 'image/png',
+      });
+
+      const joinedText = textParts.map(part => part.text).join('\n');
+      expect(joinedText).toContain('Tool Result read_file');
+      expect(joinedText).toContain('[Image #1: image/png]');
+      expect(joinedText).not.toContain(base64);
     });
 
     it('should reuse part-level date grouping without message separators', () => {

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -1582,6 +1582,79 @@ describe('Observer Agent Helpers', () => {
       expect(formatted).not.toContain(base64);
     });
 
+    it('should replace URL, file, and generic media tool-result blocks with attachment placeholders', () => {
+      const pdfBase64 = 'P'.repeat(2000);
+      const imageBase64 = 'I'.repeat(2000);
+      const imageUrl = 'https://example.com/screenshots/page.png';
+      const fileUrl = 'https://example.com/files/report.csv';
+      const msg = createTestMessage('ignored', 'assistant');
+      msg.content = {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-media',
+              toolName: 'read_assets',
+              args: {},
+              result: {},
+            },
+            providerMetadata: {
+              mastra: {
+                modelOutput: {
+                  type: 'content',
+                  value: [
+                    { type: 'text', text: 'Collected assets.' },
+                    { type: 'image-url', url: imageUrl, mediaType: 'image/png' },
+                    { type: 'file-data', data: pdfBase64, mediaType: 'application/pdf', filename: 'paper.pdf' },
+                    { type: 'file-url', url: fileUrl, mediaType: 'text/csv', filename: 'report.csv' },
+                    { type: 'media', data: imageBase64, mediaType: 'image/jpeg' },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      } as any;
+
+      const formatted = formatMessagesForObserver([msg]);
+      expect(formatted).toContain('Tool Result read_assets');
+      expect(formatted).toContain('Collected assets.');
+      expect(formatted).toContain('[Image #1: page.png]');
+      expect(formatted).toContain('[File #1: paper.pdf]');
+      expect(formatted).toContain('[File #2: report.csv]');
+      expect(formatted).toContain('[Image #2: image/jpeg]');
+      expect(formatted).not.toContain(pdfBase64);
+      expect(formatted).not.toContain(imageBase64);
+      expect(formatted).not.toContain(imageUrl);
+      expect(formatted).not.toContain(fileUrl);
+    });
+
+    it('should redact media blocks when formatting tool results for token counting', () => {
+      const imageBase64 = 'G'.repeat(2000);
+      const pdfBase64 = 'H'.repeat(2000);
+      const formatted = formatToolResultForObserver({
+        type: 'content',
+        value: [
+          { type: 'text', text: 'Collected assets.' },
+          { type: 'image-data', data: `data:image/png;base64,${imageBase64}`, mediaType: 'image/png' },
+          { type: 'file-data', data: pdfBase64, mediaType: 'application/pdf', filename: 'paper.pdf' },
+          { type: 'image-file-id', id: 'img_123' },
+          { type: 'file-id', id: 'file_456' },
+        ],
+      });
+
+      expect(formatted).toContain('Collected assets.');
+      expect(formatted).toContain('[Image: image/png]');
+      expect(formatted).toContain('[File: paper.pdf]');
+      expect(formatted).toContain('[Image: img_123]');
+      expect(formatted).toContain('[File: file_456]');
+      expect(formatted).not.toContain(imageBase64);
+      expect(formatted).not.toContain(pdfBase64);
+      expect(formatted).not.toContain('data:image/png;base64');
+    });
+
     it('should leave non-content tool-result outputs unchanged', () => {
       const msg = createTestMessage('ignored', 'assistant');
       msg.content = {
@@ -1796,6 +1869,87 @@ describe('Observer Agent Helpers', () => {
       expect(joinedText).toContain('Tool Result read_file');
       expect(joinedText).toContain('[Image #1: image/png]');
       expect(joinedText).not.toContain(base64);
+    });
+
+    it('should hoist URL, file, and generic media tool-result blocks into observer input attachments', () => {
+      const pdfBase64 = 'E'.repeat(1500);
+      const dataUriImage = `data:image/jpeg;base64,${'F'.repeat(1500)}`;
+      const imageUrl = 'https://example.com/screenshots/page.png';
+      const fileUrl = 'https://example.com/files/report.csv';
+      const msg = createTestMessage('ignored', 'assistant');
+      msg.content = {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-media',
+              toolName: 'read_assets',
+              args: {},
+              result: {},
+            },
+            providerMetadata: {
+              mastra: {
+                modelOutput: {
+                  type: 'content',
+                  value: [
+                    { type: 'text', text: 'Collected assets.' },
+                    { type: 'image-url', url: imageUrl, mediaType: 'image/png' },
+                    { type: 'file-data', data: pdfBase64, mediaType: 'application/pdf', filename: 'paper.pdf' },
+                    { type: 'file-url', url: fileUrl, mediaType: 'text/csv', filename: 'report.csv' },
+                    { type: 'media', data: dataUriImage, mediaType: 'image/jpeg' },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      } as any;
+
+      const historyMessage = buildObserverHistoryMessage([msg]);
+      const content = historyMessage.content as any[];
+
+      const textParts = content.filter(part => part.type === 'text');
+      const imageParts = content.filter(part => part.type === 'image');
+      const fileParts = content.filter(part => part.type === 'file');
+
+      expect(imageParts).toHaveLength(2);
+      expect(imageParts[0]).toMatchObject({
+        type: 'image',
+        image: imageUrl,
+        mimeType: 'image/png',
+      });
+      expect(imageParts[1]).toMatchObject({
+        type: 'image',
+        image: dataUriImage,
+        mimeType: 'image/jpeg',
+      });
+
+      expect(fileParts).toHaveLength(2);
+      expect(fileParts[0]).toMatchObject({
+        type: 'file',
+        data: `data:application/pdf;base64,${pdfBase64}`,
+        mimeType: 'application/pdf',
+        filename: 'paper.pdf',
+      });
+      expect(fileParts[1]).toMatchObject({
+        type: 'file',
+        data: fileUrl,
+        mimeType: 'text/csv',
+        filename: 'report.csv',
+      });
+
+      const joinedText = textParts.map(part => part.text).join('\n');
+      expect(joinedText).toContain('Tool Result read_assets');
+      expect(joinedText).toContain('[Image #1: page.png]');
+      expect(joinedText).toContain('[File #1: paper.pdf]');
+      expect(joinedText).toContain('[File #2: report.csv]');
+      expect(joinedText).toContain('[Image #2: image/jpeg]');
+      expect(joinedText).not.toContain(pdfBase64);
+      expect(joinedText).not.toContain(dataUriImage);
+      expect(joinedText).not.toContain(imageUrl);
+      expect(joinedText).not.toContain(fileUrl);
     });
 
     it('should reuse part-level date grouping without message separators', () => {

--- a/packages/memory/src/processors/observational-memory/observer-agent.ts
+++ b/packages/memory/src/processors/observational-memory/observer-agent.ts
@@ -695,6 +695,14 @@ function formatObserverAttachmentPlaceholder(part: ObserverAttachmentPart, count
   return label ? `[${attachmentType} #${attachmentId}: ${label}]` : `[${attachmentType} #${attachmentId}]`;
 }
 
+function ensureDataUri(data: string, mediaType?: string): string {
+  if (!mediaType || data.startsWith('data:')) {
+    return data;
+  }
+
+  return `data:${mediaType};base64,${data}`;
+}
+
 function mapToolResultBlockToAttachment(block: unknown): ObserverAttachmentPart | undefined {
   if (!block || typeof block !== 'object') {
     return undefined;
@@ -718,15 +726,13 @@ function mapToolResultBlockToAttachment(block: unknown): ObserverAttachmentPart 
 
     const data = record.data;
     if (typeof data !== 'string') return undefined;
-    const imageData = mediaType ? `data:${mediaType};base64,${data}` : data;
-    return { type: 'image', image: imageData, mimeType: mediaType };
+    return { type: 'image', image: ensureDataUri(data, mediaType), mimeType: mediaType };
   }
 
   if (type === 'image-data') {
     const data = record.data;
     if (typeof data !== 'string') return undefined;
-    const image = mediaType ? `data:${mediaType};base64,${data}` : data;
-    return { type: 'image', image, mimeType: mediaType };
+    return { type: 'image', image: ensureDataUri(data, mediaType), mimeType: mediaType };
   }
 
   if (type === 'image-url') {
@@ -738,7 +744,7 @@ function mapToolResultBlockToAttachment(block: unknown): ObserverAttachmentPart 
   if (type === 'media') {
     const data = record.data;
     if (typeof data !== 'string' || !mediaType) return undefined;
-    const dataUri = `data:${mediaType};base64,${data}`;
+    const dataUri = ensureDataUri(data, mediaType);
     if (mediaType.toLowerCase().startsWith('image/')) {
       return { type: 'image', image: dataUri, mimeType: mediaType };
     }
@@ -748,15 +754,13 @@ function mapToolResultBlockToAttachment(block: unknown): ObserverAttachmentPart 
   if (type === 'file-data') {
     const data = record.data;
     if (typeof data !== 'string') return undefined;
-    const dataUri = mediaType ? `data:${mediaType};base64,${data}` : data;
-    return { type: 'file', data: dataUri, mimeType: mediaType, filename };
+    return { type: 'file', data: ensureDataUri(data, mediaType), mimeType: mediaType, filename };
   }
 
   if (type === 'file') {
     const data = record.data;
     if (typeof data !== 'string') return undefined;
-    const fileData = mediaType && !data.startsWith('data:') ? `data:${mediaType};base64,${data}` : data;
-    return { type: 'file', data: fileData, mimeType: mediaType, filename };
+    return { type: 'file', data: ensureDataUri(data, mediaType), mimeType: mediaType, filename };
   }
 
   if (type === 'file-url') {
@@ -790,7 +794,7 @@ function extractToolResultAttachments(
 
     attachments.push(toObserverInputAttachmentPart(attachment));
     const placeholder = formatObserverAttachmentPlaceholder(attachment, counter);
-    return { type: (block as { type?: unknown }).type, placeholder };
+    return { type: 'text', text: placeholder };
   });
 
   if (attachments.length === 0) {

--- a/packages/memory/src/processors/observational-memory/observer-agent.ts
+++ b/packages/memory/src/processors/observational-memory/observer-agent.ts
@@ -695,6 +695,111 @@ function formatObserverAttachmentPlaceholder(part: ObserverAttachmentPart, count
   return label ? `[${attachmentType} #${attachmentId}: ${label}]` : `[${attachmentType} #${attachmentId}]`;
 }
 
+function mapToolResultBlockToAttachment(block: unknown): ObserverAttachmentPart | undefined {
+  if (!block || typeof block !== 'object') {
+    return undefined;
+  }
+
+  const record = block as Record<string, unknown>;
+  const type = record.type;
+  const mediaType =
+    typeof record.mediaType === 'string'
+      ? record.mediaType
+      : typeof record.mimeType === 'string'
+        ? record.mimeType
+        : undefined;
+  const filename = typeof record.filename === 'string' ? record.filename : undefined;
+
+  if (type === 'image') {
+    const image = record.image;
+    if (typeof image === 'string') {
+      return { type: 'image', image, mimeType: mediaType };
+    }
+
+    const data = record.data;
+    if (typeof data !== 'string') return undefined;
+    const imageData = mediaType ? `data:${mediaType};base64,${data}` : data;
+    return { type: 'image', image: imageData, mimeType: mediaType };
+  }
+
+  if (type === 'image-data') {
+    const data = record.data;
+    if (typeof data !== 'string') return undefined;
+    const image = mediaType ? `data:${mediaType};base64,${data}` : data;
+    return { type: 'image', image, mimeType: mediaType };
+  }
+
+  if (type === 'image-url') {
+    const url = record.url;
+    if (typeof url !== 'string') return undefined;
+    return { type: 'image', image: url, mimeType: mediaType };
+  }
+
+  if (type === 'media') {
+    const data = record.data;
+    if (typeof data !== 'string' || !mediaType) return undefined;
+    const dataUri = `data:${mediaType};base64,${data}`;
+    if (mediaType.toLowerCase().startsWith('image/')) {
+      return { type: 'image', image: dataUri, mimeType: mediaType };
+    }
+    return { type: 'file', data: dataUri, mimeType: mediaType };
+  }
+
+  if (type === 'file-data') {
+    const data = record.data;
+    if (typeof data !== 'string') return undefined;
+    const dataUri = mediaType ? `data:${mediaType};base64,${data}` : data;
+    return { type: 'file', data: dataUri, mimeType: mediaType, filename };
+  }
+
+  if (type === 'file') {
+    const data = record.data;
+    if (typeof data !== 'string') return undefined;
+    const fileData = mediaType && !data.startsWith('data:') ? `data:${mediaType};base64,${data}` : data;
+    return { type: 'file', data: fileData, mimeType: mediaType, filename };
+  }
+
+  if (type === 'file-url') {
+    const url = record.url;
+    if (typeof url !== 'string') return undefined;
+    return { type: 'file', data: url, mimeType: mediaType, filename };
+  }
+
+  return undefined;
+}
+
+function extractToolResultAttachments(
+  result: unknown,
+  counter: ObserverAttachmentCounter,
+): { residual: unknown; attachments: ObserverInputAttachmentPart[] } {
+  if (!result || typeof result !== 'object') {
+    return { residual: result, attachments: [] };
+  }
+
+  const record = result as Record<string, unknown>;
+  if (record.type !== 'content' || !Array.isArray(record.value)) {
+    return { residual: result, attachments: [] };
+  }
+
+  const attachments: ObserverInputAttachmentPart[] = [];
+  const newValue = (record.value as unknown[]).map(block => {
+    const attachment = mapToolResultBlockToAttachment(block);
+    if (!attachment) {
+      return block;
+    }
+
+    attachments.push(toObserverInputAttachmentPart(attachment));
+    const placeholder = formatObserverAttachmentPlaceholder(attachment, counter);
+    return { type: (block as { type?: unknown }).type, placeholder };
+  });
+
+  if (attachments.length === 0) {
+    return { residual: result, attachments };
+  }
+
+  return { residual: { ...record, value: newValue }, attachments };
+}
+
 function formatObserverPartLine(title: string, body: string, time: string, previousTime?: string): string {
   const timeLabel = time && time !== previousTime ? `(${time})` : '';
 
@@ -823,9 +928,16 @@ function formatObserverMessage(
             part as { providerMetadata?: Record<string, any> },
             inv.result,
           );
+          const { residual, attachments: extractedAttachments } = extractToolResultAttachments(
+            resultForObserver,
+            counter,
+          );
+          if (extractedAttachments.length > 0) {
+            attachments.push(...extractedAttachments);
+          }
           pushLine(
             `Tool Result ${inv.toolName}`,
-            maybeTruncate(formatToolResultForObserver(resultForObserver, { maxTokens: maxToolResultTokens }), maxLen),
+            maybeTruncate(formatToolResultForObserver(residual, { maxTokens: maxToolResultTokens }), maxLen),
             partCreatedAt,
           );
           return;

--- a/packages/memory/src/processors/observational-memory/tool-result-helpers.ts
+++ b/packages/memory/src/processors/observational-memory/tool-result-helpers.ts
@@ -11,6 +11,64 @@ function isObjectLike(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+function getStringProperty(record: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim()) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function resolveMediaBlockLabel(record: Record<string, unknown>): string | undefined {
+  const filename = getStringProperty(record, 'filename');
+  if (filename) {
+    return filename;
+  }
+
+  const asset = getStringProperty(record, 'url');
+  if (asset) {
+    try {
+      const url = new URL(asset);
+      const basename = url.pathname.split('/').filter(Boolean).pop();
+      if (basename) {
+        return decodeURIComponent(basename);
+      }
+    } catch {
+      // Fall through to mediaType, mimeType, or id.
+    }
+  }
+
+  return getStringProperty(record, 'mediaType', 'mimeType', 'id');
+}
+
+function formatMediaBlockPlaceholder(record: Record<string, unknown>): string | undefined {
+  const type = record.type;
+  const mediaType = getStringProperty(record, 'mediaType', 'mimeType');
+  const isImage =
+    type === 'image' ||
+    type === 'image-data' ||
+    type === 'image-url' ||
+    type === 'image-file-id' ||
+    (type === 'media' && mediaType?.toLowerCase().startsWith('image/'));
+  const isFile =
+    type === 'file' ||
+    type === 'file-data' ||
+    type === 'file-url' ||
+    type === 'file-id' ||
+    (type === 'media' && !isImage);
+
+  if (!isImage && !isFile) {
+    return undefined;
+  }
+
+  const label = resolveMediaBlockLabel(record);
+  const attachmentType = isImage ? 'Image' : 'File';
+  return label ? `[${attachmentType}: ${label}]` : `[${attachmentType}]`;
+}
+
 function sanitizeToolResultValue(value: unknown, seen: WeakMap<object, unknown> = new WeakMap()): unknown {
   if (!isObjectLike(value)) {
     return value;
@@ -27,6 +85,11 @@ function sanitizeToolResultValue(value: unknown, seen: WeakMap<object, unknown> 
       sanitizedArray.push(sanitizeToolResultValue(item, seen));
     }
     return sanitizedArray;
+  }
+
+  const mediaPlaceholder = formatMediaBlockPlaceholder(value);
+  if (mediaPlaceholder) {
+    return { type: 'text', text: mediaPlaceholder };
   }
 
   const sanitizedObject: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary

Fixes #40.

Observational memory now treats media blocks inside content-shaped tool outputs like normal observer attachments instead of serializing raw payloads into observer text. The observer text keeps positional placeholders, while image/file data moves to structured attachment parts.

Covered attachment block shapes:
- image / image-data / image-url
- file / file-data / file-url
- media

The shared observer tool-result formatter also redacts media blocks before token counting, including image-file-id and file-id placeholders, so base64 payloads do not inflate observational-memory budgets. Non-content tool results and unknown/custom content blocks remain unchanged.

## Why

Tools can store model-facing output under provider metadata. When that output contains base64 image or file data, stringifying it into the observer prompt wastes context and can make the observer fail or produce poor observations. Attachments are the right abstraction because the observer already supports image/file parts that way.

## Verification

- pnpm --filter ./packages/memory test:unit src/processors/observational-memory/__tests__/observational-memory.test.ts
- pnpm --filter ./packages/memory check
- git diff --check
- coderabbit review --type uncommitted --base fork/main --agent
- Claude review: no blockers after token-counting redaction update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

When tools return images or files as giant text blobs, they make the AI's memory prompts huge and slow. This PR pulls those images/files out into proper attachments and leaves a small placeholder like "[Image: cat.png]" in the text so the observer still knows where they belong without carrying the raw bytes.

## Overview

Observational memory now hoists media/file blocks from content-shaped tool results into structured observer attachments and replaces them in the serialized observer text with compact positional placeholders. This prevents raw base64/URL payloads from inflating observer prompts and token counts while preserving positional context.

## Problem

Tool results with embedded media (legacy and newer block shapes) were being stringified into the observer prompt, embedding base64 or long URLs and risking token-limit overflows and degraded observations.

## Solution

- Detects and normalizes media/file blocks in tool-result content arrays into attachment parts and replaces them with text placeholders.
- Placeholders use the form "[Image: <label>]" or "[File: <label>]" where label is resolved from filename, URL basename, mediaType/mimeType, or id.
- Extracted attachment types include: image, image-data, image-url, image-file-id, media (image/* or other), file, file-data, file-url, file-id, and related legacy variants.
- When processing tool-invocation results (inv.state === 'result'), the observer-agent appends extracted attachments to message.attachments and renders only the placeholder-rewritten residual tool-result text via formatToolResultForObserver.
- Non-content tool results and unknown/custom blocks remain serialized unchanged.

## Key changes

- .changeset/huge-papers-rest.md — release note describing the fix.
- packages/memory/src/processors/observational-memory/tool-result-helpers.ts — added:
  - formatMediaBlockPlaceholder(resolve label and choose Image/File).
  - sanitizeToolResultValue that replaces detected media blocks with `{ type: 'text', text: <placeholder> }`.
  - stringify/truncation flow unchanged but now operates on sanitized/residual result.
- packages/memory/src/processors/observational-memory/observer-agent.ts — added logic to:
  - resolve tool-result value, extract normalized attachments from content arrays, rewrite content with placeholders, append attachments to message.attachments, and render residual text via formatToolResultForObserver.
- packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts — new/expanded unit tests verifying:
  - media hoisting into attachments,
  - placeholders appear in observer text,
  - raw base64/URLs are not present in the observer text,
  - buildObserverHistoryMessage includes media as structured attachments.

## Verification

- Unit tests for observational-memory updated/added to cover multimodal tool results.
- Recommended checks: run the observational-memory unit tests, package checks, git diff --check, and code review tooling as noted in the project.

## Related

Fixes issue #40.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->