### PR TITLE
feat(harness): expose prompt waterfall display state

### DIFF
--- a/.changeset/hungry-rivers-watch.md
+++ b/.changeset/hungry-rivers-watch.md
@@ -1,0 +1,18 @@
+---
+'@mastra/core': patch
+'@mastra/ai-sdk': patch
+---
+
+Expose finalized prompt/tool waterfall data through Harness display state and
+the Harness AI SDK snapshot stream. Harness consumers can now read
+`promptWaterfall` from `getDisplayState()` and from the `observability` snapshot
+domain instead of needing separate telemetry wrappers.
+
+```ts
+const state = harness.getDisplayState();
+console.log(state.promptWaterfall);
+
+const stream = harnessToUIMessageStream(harness, { include: ['observability'] });
+const snapshot = await stream.getReader().read();
+console.log(snapshot.value?.data?.domains?.observability?.promptWaterfall);
+```

--- a/client-sdks/ai-sdk/src/harness.test.ts
+++ b/client-sdks/ai-sdk/src/harness.test.ts
@@ -199,6 +199,36 @@ describe('harnessToUIMessageStream', () => {
     expect(chunks[3]).toEqual({ type: 'finish' });
   });
 
+  it('emits prompt waterfall in the observability snapshot domain', async () => {
+    const promptWaterfall = {
+      runId: 'run-1',
+      status: 'finished',
+      stepCount: 1,
+      phases: [],
+    };
+    const harness = new FakeHarness(createState({ isRunning: true, promptWaterfall: promptWaterfall as any }));
+    const reader = harnessToUIMessageStream(harness, { include: ['observability'], sendStart: false }).getReader();
+
+    const snapshot = expectSnapshot(await readChunk(reader));
+    expect(snapshot.data.domains).toEqual({
+      observability: {
+        promptWaterfall,
+      },
+    });
+  });
+
+  it('emits null prompt waterfall when observability domain is included before finalization', async () => {
+    const harness = new FakeHarness(createState({ isRunning: true }));
+    const reader = harnessToUIMessageStream(harness, { include: ['observability'], sendStart: false }).getReader();
+
+    const snapshot = expectSnapshot(await readChunk(reader));
+    expect(snapshot.data.domains).toEqual({
+      observability: {
+        promptWaterfall: null,
+      },
+    });
+  });
+
   it('emits native AI SDK approval requests once from pending HITL approval state', async () => {
     const state = createState({
       isRunning: true,

--- a/client-sdks/ai-sdk/src/harness.ts
+++ b/client-sdks/ai-sdk/src/harness.ts
@@ -17,7 +17,8 @@ export type HarnessUIStreamDomain =
   | 'tasks'
   | 'om'
   | 'files'
-  | 'subagents';
+  | 'subagents'
+  | 'observability';
 
 export type HarnessUIStreamMode = 'snapshot' | 'delta';
 
@@ -67,6 +68,7 @@ export interface HarnessUISnapshotData {
     om?: JsonValue;
     files?: JsonValue;
     subagents?: JsonValue;
+    observability?: JsonValue;
   };
 }
 
@@ -594,6 +596,12 @@ function createSnapshotData(
     domains.subagents = {
       active: mapToRecord(state.activeSubagents),
       history: toJsonValue(stateWithHistory.subagentHistory) ?? [],
+    };
+  }
+
+  if (include.has('observability')) {
+    domains.observability = {
+      promptWaterfall: toJsonValue(state.promptWaterfall) ?? null,
     };
   }
 

--- a/packages/core/src/harness/display-state.test.ts
+++ b/packages/core/src/harness/display-state.test.ts
@@ -42,6 +42,7 @@ describe('defaultDisplayState', () => {
     expect(ds.activeSubagents).toBeInstanceOf(Map);
     expect(ds.activeSubagents.size).toBe(0);
     expect(ds.subagentHistory).toEqual([]);
+    expect(ds.promptWaterfall).toBeUndefined();
     expect(ds.omProgress.status).toBe('idle');
     expect(ds.omProgress.pendingTokens).toBe(0);
     expect(ds.omProgress.threshold).toBe(30000);
@@ -422,6 +423,101 @@ describe('tool lifecycle', () => {
         result: { displayName: 'Acme' },
       }),
     );
+  });
+
+  it('stores finalized prompt waterfall from processed stream response', async () => {
+    const events: HarnessEvent[] = [];
+    harness.subscribe(event => events.push(event));
+    const promptWaterfall = {
+      runId: 'run-1',
+      status: 'finished',
+      stepCount: 1,
+      phases: [],
+    };
+
+    await (harness as any).processStream(
+      {
+        promptWaterfall,
+        fullStream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({
+              type: 'text-start',
+              runId: 'run-1',
+              from: ChunkFrom.AGENT,
+              payload: { id: 'text-1' },
+            });
+            controller.enqueue({
+              type: 'text-delta',
+              runId: 'run-1',
+              from: ChunkFrom.AGENT,
+              payload: { id: 'text-1', text: 'Done' },
+            });
+            controller.close();
+          },
+        }),
+      },
+      new RequestContext(),
+    );
+
+    expect(harness.getDisplayState().promptWaterfall).toBe(promptWaterfall);
+    expect(events.filter(event => event.type === 'prompt_waterfall_update')).toEqual([
+      { type: 'prompt_waterfall_update', promptWaterfall },
+    ]);
+  });
+
+  it('clears prompt waterfall when thread display state resets', () => {
+    const promptWaterfall = {
+      runId: 'run-1',
+      status: 'finished',
+      stepCount: 1,
+      phases: [],
+    } as any;
+
+    emit(harness, { type: 'prompt_waterfall_update', promptWaterfall });
+    expect(harness.getDisplayState().promptWaterfall).toBe(promptWaterfall);
+
+    emit(harness, { type: 'thread_changed', threadId: 'thread-2', previousThreadId: 'thread-1' });
+    expect(harness.getDisplayState().promptWaterfall).toBeUndefined();
+  });
+
+  it('clears prompt waterfall when a new agent run starts', () => {
+    const promptWaterfall = {
+      runId: 'run-1',
+      status: 'finished',
+      stepCount: 1,
+      phases: [],
+    } as any;
+
+    emit(harness, { type: 'prompt_waterfall_update', promptWaterfall });
+    expect(harness.getDisplayState().promptWaterfall).toBe(promptWaterfall);
+
+    emit(harness, { type: 'agent_start' });
+    expect(harness.getDisplayState().promptWaterfall).toBeUndefined();
+  });
+
+  it('does not emit prompt waterfall update when stream response has none', async () => {
+    const events: HarnessEvent[] = [];
+    harness.subscribe(event => events.push(event));
+
+    await (harness as any).processStream(
+      {
+        fullStream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({
+              type: 'text-start',
+              runId: 'run-1',
+              from: ChunkFrom.AGENT,
+              payload: { id: 'text-1' },
+            });
+            controller.close();
+          },
+        }),
+      },
+      new RequestContext(),
+    );
+
+    expect(events.some(event => event.type === 'prompt_waterfall_update')).toBe(false);
+    expect(harness.getDisplayState().promptWaterfall).toBeUndefined();
   });
 
   it('preserves explicit null display projections', async () => {

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -5,6 +5,7 @@ import { Mastra } from '../mastra';
 import type { MastraMemory } from '../memory/memory';
 import type { StorageThreadType } from '../memory/types';
 import type { TracingContext, TracingOptions } from '../observability';
+import type { PromptToolWaterfall } from '../observability/prompt-tool-waterfall';
 import { RequestContext } from '../request-context';
 import { toStandardSchema } from '../schema';
 import type { StandardSchemaWithJSON } from '../schema';
@@ -85,6 +86,12 @@ function createSubagentHistoryEntry({
   }
   return entry;
 }
+
+type HarnessStreamResponse = {
+  fullStream: AsyncIterable<any>;
+  traceId?: string;
+  promptWaterfall?: PromptToolWaterfall;
+};
 
 function createEmptyTokenUsage(): TokenUsage {
   return { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
@@ -1907,7 +1914,7 @@ export class Harness<TState = {}> {
    * Process a stream response (shared between sendMessage and tool approval).
    */
   private async processStream(
-    response: { fullStream: AsyncIterable<any>; traceId?: string },
+    response: HarnessStreamResponse,
     requestContext: RequestContext,
   ): Promise<{ message: HarnessMessage; suspended?: boolean }> {
     if (response.traceId) {
@@ -1923,6 +1930,12 @@ export class Harness<TState = {}> {
       role: 'assistant',
       content: [],
       createdAt: new Date(),
+    };
+
+    const emitPromptWaterfallIfAvailable = () => {
+      if (response.promptWaterfall) {
+        this.emit({ type: 'prompt_waterfall_update', promptWaterfall: response.promptWaterfall });
+      }
     };
 
     let isSuspended = false;
@@ -2085,6 +2098,7 @@ export class Harness<TState = {}> {
 
             const result = await this.handleToolApprove({ toolCallId, requestContext });
             currentMessage = result.message;
+            emitPromptWaterfallIfAvailable();
             return result;
           }
 
@@ -2097,6 +2111,7 @@ export class Harness<TState = {}> {
 
             const result = await this.handleToolDecline({ toolCallId, requestContext });
             currentMessage = result.message;
+            emitPromptWaterfallIfAvailable();
             return result;
           }
 
@@ -2116,6 +2131,7 @@ export class Harness<TState = {}> {
               requestContext: approval.requestContext ?? requestContext,
             });
             currentMessage = result.message;
+            emitPromptWaterfallIfAvailable();
             return result;
           } else {
             const result = await this.handleToolDecline({
@@ -2123,6 +2139,7 @@ export class Harness<TState = {}> {
               requestContext: approval.requestContext ?? requestContext,
             });
             currentMessage = result.message;
+            emitPromptWaterfallIfAvailable();
             return result;
           }
         }
@@ -2304,6 +2321,7 @@ export class Harness<TState = {}> {
             }
 
             abortForOmFailure({ operationType, stage: 'run', error });
+            emitPromptWaterfallIfAvailable();
             return { message: currentMessage };
           }
           break;
@@ -2349,6 +2367,7 @@ export class Harness<TState = {}> {
             });
 
             abortForOmFailure({ operationType, stage: 'buffering', error });
+            emitPromptWaterfallIfAvailable();
             return { message: currentMessage };
           }
           break;
@@ -2428,6 +2447,7 @@ export class Harness<TState = {}> {
       }
     }
 
+    emitPromptWaterfallIfAvailable();
     this.emit({ type: 'message_end', message: currentMessage });
 
     let deferredResult: { message: HarnessMessage; suspended?: boolean } | undefined;
@@ -2752,6 +2772,7 @@ export class Harness<TState = {}> {
     this.displayState.pendingPlanApproval = null;
     this.displayState.activeSubagents = new Map();
     this.displayState.subagentHistory = [];
+    this.displayState.promptWaterfall = undefined;
     this.displayState.currentMessage = null;
     this.displayState.modifiedFiles = new Map();
     this.displayState.tasks = [];
@@ -3510,6 +3531,7 @@ export class Harness<TState = {}> {
         ds.activeTools = new Map();
         ds.toolInputBuffers = new Map();
         ds.subagentHistory = [];
+        ds.promptWaterfall = undefined;
         ds.currentMessage = null;
         ds.pendingApproval = null;
         ds.pendingSuspension = null;
@@ -3869,6 +3891,10 @@ export class Harness<TState = {}> {
       // ── Token usage ────────────────────────────────────────────────────
       case 'usage_update':
         ds.tokenUsage = { ...this.tokenUsage };
+        break;
+
+      case 'prompt_waterfall_update':
+        ds.promptWaterfall = event.promptWaterfall;
         break;
 
       // ── Tasks ──────────────────────────────────────────────────────────

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -4,6 +4,7 @@ import type { MastraBrowser } from '../browser/browser';
 import type { MastraLanguageModel } from '../llm/model/shared.types';
 import type { LoopOptions } from '../loop/types';
 import type { MastraMemory } from '../memory/memory';
+import type { PromptToolWaterfall } from '../observability/prompt-tool-waterfall';
 import type { ObservabilityEntrypoint } from '../observability/types/core';
 import type { RequestContext } from '../request-context';
 import type { PublicSchema } from '../schema';
@@ -742,6 +743,10 @@ export interface HarnessDisplayState {
   /** Terminal subagent executions retained after they leave activeSubagents */
   subagentHistory: HarnessSubagentHistoryEntry[];
 
+  // ── Observability ────────────────────────────────────────────────────
+  /** Latest finalized prompt/tool waterfall for the current run */
+  promptWaterfall?: PromptToolWaterfall;
+
   // ── Observational Memory ─────────────────────────────────────────────
   /** Full OM progress state (status, tokens, thresholds, buffered) */
   omProgress: OMProgressState;
@@ -788,6 +793,7 @@ export function defaultDisplayState(): HarnessDisplayState {
     pendingPlanApproval: null,
     activeSubagents: new Map(),
     subagentHistory: [],
+    promptWaterfall: undefined,
     omProgress: defaultOMProgressState(),
     bufferingMessages: false,
     bufferingObservations: false,
@@ -865,6 +871,7 @@ export type HarnessEvent =
   | { type: 'tool_input_end'; toolCallId: string }
   | { type: 'shell_output'; toolCallId: string; output: string; stream: 'stdout' | 'stderr' }
   | { type: 'usage_update'; usage: TokenUsage }
+  | { type: 'prompt_waterfall_update'; promptWaterfall: PromptToolWaterfall }
   | { type: 'info'; message: string }
   | { type: 'error'; error: Error; errorType?: string; retryable?: boolean; retryDelay?: number }
   | { type: 'follow_up_queued'; count: number }


### PR DESCRIPTION
## Summary
- expose finalized promptToolWaterfall data on Harness display state
- add an opt-in AI SDK observability snapshot domain for promptWaterfall
- cover display-state persistence, reset behavior, and AI SDK snapshot emission

Fixes #42

## Verification
- pnpm --filter ./packages/core test:unit src/harness/display-state.test.ts
- pnpm --filter ./client-sdks/ai-sdk test src/harness.test.ts
- pnpm --filter ./packages/core check
- git diff --check
- Claude review: no blockers after follow-up fixes
- CodeRabbit CLI first pass findings fixed; GitHub CodeRabbit app should review this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR gives Harness users the ability to see detailed information about how prompts and tools were used in an agent, which was previously only available to direct agent callers. It's like opening a window so external users can see the same behind-the-scenes activity log that was previously only visible from inside.

## Summary of Changes

This PR exposes finalized prompt/tool waterfall data via Harness display state and the Harness AI SDK snapshot stream, allowing consumers to access the same level of visibility into agent execution that direct agent callers have.

### Core Changes

**Type Definitions** (`packages/core/src/harness/types.ts`)
- `HarnessDisplayState` now includes an optional `promptWaterfall?: PromptToolWaterfall` field
- `HarnessEvent` union extended with new `prompt_waterfall_update` event type carrying the finalized waterfall data
- `defaultDisplayState()` initializes `promptWaterfall` as `undefined`

**Harness Implementation** (`packages/core/src/harness/harness.ts`)
- `processStream()` now accepts and propagates optional `promptWaterfall` from agent stream responses
- Defined `emitPromptWaterfallIfAvailable()` helper that emits `prompt_waterfall_update` events at completion points (after tool approval/decline, after observational-memory buffering, during error handling, and before stream end)
- Display state machine resets `promptWaterfall` when starting/initializing thread/agent sessions

**AI SDK Integration** (`client-sdks/ai-sdk/src/harness.ts`)
- Extended `HarnessUIStreamDomain` union to include `'observability'` domain
- Updated `HarnessUISnapshotData.domains` to include optional `observability?: JsonValue`
- Modified snapshot serialization to conditionally populate `domains.observability` with the processed `state.promptWaterfall` when `observability` is included in the request

### Testing

**Display State Tests** (`packages/core/src/harness/display-state.test.ts`)
- Verified `defaultDisplayState()` initializes `promptWaterfall` as `undefined`
- Added coverage for `Harness.processStream()` behavior: ensures provided waterfall is stored and triggers `prompt_waterfall_update` events
- Validates waterfall is cleared on thread reset and when new agent run starts
- Confirms no event is emitted when stream response lacks waterfall data

**AI SDK Tests** (`client-sdks/ai-sdk/src/harness.test.ts`)
- New test cases validate `harnessToUIMessageStream` correctly emits `promptWaterfall` within `domains.observability`
- Verifies `promptWaterfall` is emitted as `null` when stream is included before finalization

### Related References
Fixes issue #42, which requested that Harness consumers receive the same finalized prompt/tool waterfall visibility as direct agent callers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->