### PR TITLE
feat(harness): emit tool output denied chunks

### DIFF
--- a/.changeset/four-melons-jump.md
+++ b/.changeset/four-melons-jump.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'@mastra/ai-sdk': patch
+---
+
+Preserve declined tool approval metadata in Harness display state and emit native `tool-output-denied` chunks from the AI SDK harness adapter.

--- a/client-sdks/ai-sdk/src/harness.test.ts
+++ b/client-sdks/ai-sdk/src/harness.test.ts
@@ -475,6 +475,51 @@ describe('harnessToUIMessageStream', () => {
     });
   });
 
+  it('emits native AI SDK tool denied chunks once for declined approvals', async () => {
+    const state = createState({ isRunning: true });
+    state.activeTools.set('tool-1', {
+      name: 'read_file',
+      args: { path: 'secret.ts' },
+      status: 'error',
+      result: 'Declined by user',
+      isError: true,
+      denied: true,
+    });
+
+    const harness = new FakeHarness(state);
+    const reader = harnessToUIMessageStream(harness, {
+      include: ['tools'],
+      sendStart: false,
+    }).getReader();
+
+    expect(await readChunks(reader, 3)).toMatchObject([
+      {
+        type: 'tool-input-available',
+        toolCallId: 'tool-1',
+        toolName: 'read_file',
+        input: { path: 'secret.ts' },
+      },
+      { type: 'tool-output-denied', toolCallId: 'tool-1', reason: 'Declined by user' },
+      { type: 'data-mastra-harness-snapshot', data: { sequence: 1 } },
+    ]);
+
+    const repeated = createState({ isRunning: true });
+    repeated.activeTools.set('tool-1', {
+      name: 'read_file',
+      args: { path: 'secret.ts' },
+      status: 'error',
+      result: 'Declined by user',
+      isError: true,
+      denied: true,
+    });
+    harness.emit(repeated);
+
+    expect(await readChunk(reader)).toMatchObject({
+      type: 'data-mastra-harness-snapshot',
+      data: { sequence: 2 },
+    });
+  });
+
   it('supports delta mode with an initial snapshot and append-only changed-domain parts', async () => {
     const harness = new FakeHarness(
       createState({ isRunning: true, tokenUsage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 } }),

--- a/client-sdks/ai-sdk/src/harness.ts
+++ b/client-sdks/ai-sdk/src/harness.ts
@@ -135,6 +135,7 @@ type HarnessUITextChunk =
   | { type: 'tool-input-available'; toolCallId: string; toolName: string; input: unknown }
   | { type: 'tool-approval-request'; approvalId: string; toolCallId: string }
   | { type: 'tool-output-available'; toolCallId: string; output: unknown }
+  | { type: 'tool-output-denied'; toolCallId: string; reason?: string }
   | { type: 'tool-output-error'; toolCallId: string; errorText: string };
 
 export type HarnessUIMessageStreamChunk = HarnessUITextChunk | HarnessUIDataPart;
@@ -466,6 +467,18 @@ function emitNativeToolChunks(state: HarnessDisplayState, context: EmitContext):
     }
 
     if (!toolState.outputEmitted && tool.status === 'error') {
+      if (tool.denied) {
+        context.controller.enqueue({
+          type: 'tool-output-denied',
+          toolCallId,
+          reason: stringifyToolError(tool.result ?? tool.partialResult ?? 'Tool approval was declined'),
+        });
+        toolState.outputEmitted = true;
+        context.finalizedTools.add(toolCallId);
+        context.tools.delete(toolCallId);
+        continue;
+      }
+
       context.controller.enqueue({
         type: 'tool-output-error',
         toolCallId,

--- a/packages/core/src/harness/display-state.test.ts
+++ b/packages/core/src/harness/display-state.test.ts
@@ -288,6 +288,24 @@ describe('tool lifecycle', () => {
       expect(tool!.status).toBe('error');
       expect(tool!.isError).toBe(true);
     });
+
+    it('preserves denied metadata on declined approval tool_end', () => {
+      emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: {} });
+      emit(harness, { type: 'tool_end', toolCallId: 't1', result: 'declined by user', isError: true, denied: true });
+      const tool = harness.getDisplayState().activeTools.get('t1');
+      expect(tool!.status).toBe('error');
+      expect(tool!.isError).toBe(true);
+      expect(tool!.denied).toBe(true);
+    });
+
+    it('clears stale denied metadata when tool_start reuses an id', () => {
+      emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: {} });
+      emit(harness, { type: 'tool_end', toolCallId: 't1', result: 'declined by user', isError: true, denied: true });
+      emit(harness, { type: 'tool_start', toolCallId: 't1', toolName: 'read_file', args: { path: 'ok.ts' } });
+      const tool = harness.getDisplayState().activeTools.get('t1');
+      expect(tool!.status).toBe('running');
+      expect(tool!.denied).toBeUndefined();
+    });
   });
 
   describe('tool_update', () => {

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -284,6 +284,7 @@ export class Harness<TState = {}> {
   private tokenUsage: TokenUsage = createEmptyTokenUsage();
   private sessionGrantedCategories = new Set<string>();
   private sessionGrantedTools = new Set<string>();
+  private declinedToolCallIds = new Set<string>();
   private displayState: HarnessDisplayState = defaultDisplayState();
   #internalMastra: Mastra | undefined = undefined;
 
@@ -2051,18 +2052,21 @@ export class Harness<TState = {}> {
 
         case 'tool-result': {
           const toolResult = chunk.payload;
+          const isError = toolResult.isError ?? false;
+          const denied = this.consumeDeclinedToolCall(toolResult.toolCallId, isError);
           currentMessage.content.push({
             type: 'tool_result',
             id: toolResult.toolCallId,
             name: toolResult.toolName,
             result: getDisplayProjection(chunk.metadata, 'output-available', toolResult.result),
-            isError: toolResult.isError ?? false,
+            isError,
           });
           this.emit({
             type: 'tool_end',
             toolCallId: toolResult.toolCallId,
             result: getDisplayProjection(chunk.metadata, 'output-available', toolResult.result),
-            isError: toolResult.isError ?? false,
+            isError,
+            denied,
           });
           this.emit({ type: 'message_update', message: { ...currentMessage } });
           break;
@@ -2070,11 +2074,13 @@ export class Harness<TState = {}> {
 
         case 'tool-error': {
           const toolError = chunk.payload;
+          const denied = this.consumeDeclinedToolCall(toolError.toolCallId, true);
           this.emit({
             type: 'tool_end',
             toolCallId: toolError.toolCallId,
             result: getDisplayProjection(chunk.metadata, 'error', toolError.error),
             isError: true,
+            denied,
           });
           break;
         }
@@ -3391,17 +3397,34 @@ export class Harness<TState = {}> {
 
     const requestContext = await this.buildRequestContext(requestContextInput);
     const isYolo = (this.state as Record<string, unknown>).yolo === true;
-    const response = await agent.declineToolCall({
-      runId: this.currentRunId,
-      toolCallId,
-      requireToolApproval: !isYolo,
-      memory: this.currentThreadId ? { thread: this.currentThreadId, resource: this.resourceId } : undefined,
-      abortSignal: this.abortController.signal,
-      requestContext,
-      toolsets: await this.buildToolsets(requestContext),
-    });
+    if (toolCallId) {
+      this.declinedToolCallIds.add(toolCallId);
+    }
+    try {
+      const response = await agent.declineToolCall({
+        runId: this.currentRunId,
+        toolCallId,
+        requireToolApproval: !isYolo,
+        memory: this.currentThreadId ? { thread: this.currentThreadId, resource: this.resourceId } : undefined,
+        abortSignal: this.abortController.signal,
+        requestContext,
+        toolsets: await this.buildToolsets(requestContext),
+      });
 
-    return await this.processStream(response, requestContext);
+      return await this.processStream(response, requestContext);
+    } finally {
+      if (toolCallId) {
+        this.declinedToolCallIds.delete(toolCallId);
+      }
+    }
+  }
+
+  private consumeDeclinedToolCall(toolCallId: string | undefined, isError: boolean): boolean | undefined {
+    if (!toolCallId || !this.declinedToolCallIds.has(toolCallId)) {
+      return undefined;
+    }
+    this.declinedToolCallIds.delete(toolCallId);
+    return isError ? true : undefined;
   }
 
   private async handleToolResume({
@@ -3615,6 +3638,7 @@ export class Harness<TState = {}> {
           existingTool.name = event.toolName;
           existingTool.args = event.args;
           existingTool.status = 'running';
+          delete existingTool.denied;
         } else {
           ds.activeTools.set(event.toolCallId, {
             name: event.toolName,
@@ -3640,6 +3664,11 @@ export class Harness<TState = {}> {
           endedTool.status = event.isError ? 'error' : 'completed';
           endedTool.result = event.result;
           endedTool.isError = event.isError;
+          if (event.denied) {
+            endedTool.denied = true;
+          } else {
+            delete endedTool.denied;
+          }
         }
         // Track file modifications
         if (!event.isError) {

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -501,6 +501,7 @@ export interface ActiveToolState {
   partialResult?: string;
   result?: unknown;
   isError?: boolean;
+  denied?: boolean;
   shellOutput?: string;
 }
 
@@ -865,7 +866,7 @@ export type HarnessEvent =
       resumeSchema?: string;
     }
   | { type: 'tool_update'; toolCallId: string; partialResult: unknown }
-  | { type: 'tool_end'; toolCallId: string; result: unknown; isError: boolean }
+  | { type: 'tool_end'; toolCallId: string; result: unknown; isError: boolean; denied?: boolean }
   | { type: 'tool_input_start'; toolCallId: string; toolName: string }
   | { type: 'tool_input_delta'; toolCallId: string; argsTextDelta: string; toolName?: string }
   | { type: 'tool_input_end'; toolCallId: string }


### PR DESCRIPTION
## Summary
- track declined Harness tool approvals as semantic tool state metadata
- emit native AI SDK `tool-output-denied` chunks for declined approvals
- keep generic tool failures on `tool-output-error`

Fixes #43

## Verification
- pnpm --filter ./packages/core test:unit src/harness/display-state.test.ts
- pnpm --filter ./client-sdks/ai-sdk test src/harness.test.ts
- pnpm --filter ./packages/core check
- git diff --check
- coderabbit review --type uncommitted: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you ask an AI to use a tool but then deny its request to do so, the system now tells you "the tool was denied" instead of "the tool failed." This is helpful because apps can now distinguish between a tool that was actually broken versus one that the user said "no" to.

## Overview

This PR adds support for emitting a native `tool-output-denied` chunk type in the AI SDK's harness adapter, allowing downstream consumers to distinguish user-declined tool approvals from generic tool execution failures.

## Key Changes

**Type System**
- Extended `HarnessEvent` to include an optional `denied?: boolean` field on the `tool_end` event payload
- Added new chunk variant `{ type: 'tool-output-denied'; toolCallId: string; reason?: string }` to the `HarnessUIMessageStreamChunk` union

**Harness Core Logic** (`packages/core/src/harness/harness.ts`)
- Introduced tracking of declined tool call IDs across the stream-to-display pipeline
- Records declined tool call IDs when the harness receives a decline action, then marks subsequent `tool_end` events with a `denied` flag
- Clears the decline record after completion

**Display State Management** (`packages/core/src/harness/display-state.test.ts`)
- Display state now preserves `denied` metadata on tools with `status: 'error'` and `denied: true`
- Clears stale `denied` metadata when a tool ID is reused for a new `tool_start`

**AI SDK Adapter** (`client-sdks/ai-sdk/src/harness.ts`)
- Extended the native tool streaming logic to emit `tool-output-denied` chunks when a tool's status is `error` and `tool.denied` is true
- Enqueues the denied event with an optional reason derived from available tool result fields
- Skips the generic error emission path for denied tools

## Testing

New test cases verify:
- `harnessToUIMessageStream` emits `tool-output-denied` chunks exactly once when a tool is declined
- Subsequent re-emissions of the same denied state only produce new harness snapshots without duplicate `tool-output-denied` chunks
- Denial metadata is correctly preserved and cleared in the display state lifecycle

## Verification Status

- All unit tests pass for harness display state and AI SDK harness adapter
- Type checking completes successfully
- No trailing whitespace or linting issues
- No findings from code review

<!-- end of auto-generated comment: release notes by coderabbit.ai -->