### PR TITLE
feat(harness): expose subagent display names

### DIFF
--- a/.changeset/stale-boats-look.md
+++ b/.changeset/stale-boats-look.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Expose configured subagent display names on Harness active subagent state and retained subagent history.

--- a/packages/core/src/harness/display-state.test.ts
+++ b/packages/core/src/harness/display-state.test.ts
@@ -4,7 +4,7 @@ import { RequestContext } from '../request-context';
 import { InMemoryStore } from '../storage/mock';
 import { ChunkFrom } from '../stream/types';
 import { Harness } from './harness';
-import type { HarnessEvent } from './types';
+import type { HarnessEvent, HarnessSubagent } from './types';
 import { defaultDisplayState } from './types';
 
 function createHarness(storage?: InMemoryStore) {
@@ -18,6 +18,21 @@ function createHarness(storage?: InMemoryStore) {
     id: 'test-harness',
     storage: storage ?? new InMemoryStore(),
     modes: [{ id: 'default', name: 'Default', default: true, agent }],
+  });
+}
+
+function createHarnessWithSubagents(subagents: HarnessSubagent[]) {
+  const agent = new Agent({
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+
+  return new Harness({
+    id: 'test-harness',
+    storage: new InMemoryStore(),
+    modes: [{ id: 'default', name: 'Default', default: true, agent }],
+    subagents,
   });
 }
 
@@ -856,6 +871,7 @@ describe('subagent lifecycle', () => {
       type: 'subagent_start',
       toolCallId: 's1',
       agentType: 'explore',
+      displayName: 'Explore',
       task: 'Find usages of X',
       modelId: 'gpt-4o',
       forked: true,
@@ -863,10 +879,33 @@ describe('subagent lifecycle', () => {
     const sub = harness.getDisplayState().activeSubagents.get('s1');
     expect(sub).toBeDefined();
     expect(sub!.agentType).toBe('explore');
+    expect(sub!.displayName).toBe('Explore');
     expect(sub!.task).toBe('Find usages of X');
     expect(sub!.forked).toBe(true);
     expect(sub!.status).toBe('running');
     expect(sub!.toolCalls).toEqual([]);
+  });
+
+  it('resolves subagent displayName from configured subagents', () => {
+    const configuredHarness = createHarnessWithSubagents([
+      {
+        id: 'execute',
+        name: 'Execute',
+        description: 'Run execution tasks',
+        instructions: 'Execute the task.',
+      },
+    ]);
+
+    emit(configuredHarness, {
+      type: 'subagent_start',
+      toolCallId: 's1',
+      agentType: 'execute',
+      task: 'Run checks',
+      modelId: 'gpt-4o',
+    });
+
+    const sub = configuredHarness.getDisplayState().activeSubagents.get('s1');
+    expect(sub!.displayName).toBe('Execute');
   });
 
   it('appends text on subagent_text_delta', () => {
@@ -912,7 +951,14 @@ describe('subagent lifecycle', () => {
   });
 
   it('marks subagent as completed on subagent_end', () => {
-    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'execute', task: 't', modelId: 'm' });
+    emit(harness, {
+      type: 'subagent_start',
+      toolCallId: 's1',
+      agentType: 'execute',
+      displayName: 'Execute',
+      task: 't',
+      modelId: 'm',
+    });
     emit(harness, {
       type: 'subagent_end',
       toolCallId: 's1',
@@ -928,7 +974,14 @@ describe('subagent lifecycle', () => {
   });
 
   it('records completed subagent history on subagent_end', () => {
-    emit(harness, { type: 'subagent_start', toolCallId: 's1', agentType: 'execute', task: 't', modelId: 'm' });
+    emit(harness, {
+      type: 'subagent_start',
+      toolCallId: 's1',
+      agentType: 'execute',
+      displayName: 'Execute',
+      task: 't',
+      modelId: 'm',
+    });
     emit(harness, {
       type: 'subagent_tool_start',
       toolCallId: 's1',
@@ -952,6 +1005,7 @@ describe('subagent lifecycle', () => {
       expect.objectContaining({
         toolCallId: 's1',
         agentType: 'execute',
+        displayName: 'Execute',
         task: 't',
         modelId: 'm',
         status: 'completed',
@@ -962,6 +1016,7 @@ describe('subagent lifecycle', () => {
     );
     expect(ds.subagentHistory[0]!.endedAt).toBeInstanceOf(Date);
     expect(ds.subagentHistory[0]!.toolCalls).toEqual([{ name: 'read_file', isError: false }]);
+    expect(ds.subagentHistory[0]!.displayName).toBe('Execute');
   });
 
   it('marks subagent as error on failed subagent_end', () => {

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -1425,6 +1425,10 @@ export class Harness<TState = {}> {
     return typeof global === 'string' ? global : null;
   }
 
+  private getSubagentDisplayName(agentType: string): string | undefined {
+    return this.config.subagents?.find(subagent => subagent.id === agentType)?.name;
+  }
+
   async setSubagentModelId({ modelId, agentType }: { modelId: string; agentType?: string }): Promise<void> {
     const key = agentType ? `subagentModelId_${agentType}` : 'subagentModelId';
     void this.setState({ [key]: modelId } as unknown as Partial<TState>);
@@ -3754,8 +3758,8 @@ export class Harness<TState = {}> {
         break;
 
       // ── Subagent tracking ──────────────────────────────────────────────
-      case 'subagent_start':
-        ds.activeSubagents.set(event.toolCallId, {
+      case 'subagent_start': {
+        const subagentState: ActiveSubagentState = {
           agentType: event.agentType,
           task: event.task,
           modelId: event.modelId,
@@ -3763,8 +3767,14 @@ export class Harness<TState = {}> {
           toolCalls: [],
           textDelta: '',
           status: 'running',
-        });
+        };
+        const displayName = event.displayName ?? this.getSubagentDisplayName(event.agentType);
+        if (displayName) {
+          subagentState.displayName = displayName;
+        }
+        ds.activeSubagents.set(event.toolCallId, subagentState);
         break;
+      }
 
       case 'subagent_text_delta': {
         const sub = ds.activeSubagents.get(event.toolCallId);

--- a/packages/core/src/harness/tools.ts
+++ b/packages/core/src/harness/tools.ts
@@ -799,6 +799,7 @@ Use this tool when:
         type: 'subagent_start',
         toolCallId,
         agentType,
+        displayName: definition.name,
         task: displayTask,
         modelId: resolvedModelId,
         forked: runAsForked,

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -510,6 +510,7 @@ export interface ActiveToolState {
  */
 export interface ActiveSubagentState {
   agentType: string;
+  displayName?: string;
   task: string;
   modelId?: string;
   forked?: boolean;
@@ -985,7 +986,15 @@ export type HarnessEvent =
       plan: string;
     }
   | { type: 'plan_approved' }
-  | { type: 'subagent_start'; toolCallId: string; agentType: string; task: string; modelId: string; forked?: boolean }
+  | {
+      type: 'subagent_start';
+      toolCallId: string;
+      agentType: string;
+      task: string;
+      modelId: string;
+      forked?: boolean;
+      displayName?: string;
+    }
   | { type: 'subagent_text_delta'; toolCallId: string; agentType: string; textDelta: string }
   | {
       type: 'subagent_tool_start';


### PR DESCRIPTION
## Summary
- add optional `displayName` to Harness active subagent state
- populate it from configured subagent names during subagent starts
- retain display names in subagent history snapshots

Fixes #44

## Verification
- pnpm --filter ./packages/core test:unit src/harness/display-state.test.ts
- pnpm --filter ./packages/core test:unit src/harness/subagent-tool.test.ts
- pnpm --filter ./packages/core check
- git diff --check
- coderabbit review --type uncommitted: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes it so that when Harness (an AI agent coordination system) runs smaller subagents, it tells you their human-readable names—like "research-bot" or "data-analyzer"—instead of just giving you internal type codes. Now the UI doesn't have to figure out what each subagent is by looking up a manual mapping table; it gets the name directly.

## Changes Overview

The PR adds support for exposing configured subagent display names across Harness's active subagent state and history tracking. This allows UI consumers to directly use human-readable subagent names without maintaining separate mapping logic.

### Type System Updates

- **`ActiveSubagentState`**: Added optional `displayName?: string` field
- **`HarnessEvent['subagent_start']`**: Extended with optional `displayName?: string` payload field

### Implementation Details

- **`harness.ts`**: Introduced `getSubagentDisplayName()` helper that resolves display names from either the event payload or the configured subagent definitions, prioritizing the event-provided value
- **`tools.ts`**: Updated `createSubagentTool` to include `displayName: definition.name` in emitted `subagent_start` events
- **`display-state.test.ts`**: Added comprehensive test coverage including a `createHarnessWithSubagents()` helper for configurable test setups; verified that `displayName` is correctly resolved and persisted in both active subagents and subagent history entries

### Changeset

Added `@mastra/core` patch release documenting the new display name exposure capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->