### PR TITLE
feat(harness): timestamp active display state

### DIFF
--- a/.changeset/witty-falcons-train.md
+++ b/.changeset/witty-falcons-train.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Add lifecycle timestamps to Harness active tool and subagent display state records.

--- a/client-sdks/ai-sdk/src/harness.test.ts
+++ b/client-sdks/ai-sdk/src/harness.test.ts
@@ -377,7 +377,12 @@ describe('harnessToUIMessageStream', () => {
 
   it('emits native AI SDK tool lifecycle chunks from display-state snapshots', async () => {
     const initial = createState({ isRunning: true });
-    initial.activeTools.set('tool-1', { name: 'write_file', args: {}, status: 'streaming_input' });
+    initial.activeTools.set('tool-1', {
+      name: 'write_file',
+      args: {},
+      status: 'streaming_input',
+      startedAt: new Date('2026-05-01T12:00:00.000Z'),
+    });
     initial.toolInputBuffers.set('tool-1', { toolName: 'write_file', text: '{"path"' });
 
     const harness = new FakeHarness(initial);
@@ -394,6 +399,7 @@ describe('harnessToUIMessageStream', () => {
       name: 'write_file',
       args: { path: 'src/app.ts', content: 'hello' },
       status: 'running',
+      startedAt: new Date('2026-05-01T12:00:00.000Z'),
     });
     harness.emit(running);
 
@@ -412,6 +418,8 @@ describe('harnessToUIMessageStream', () => {
       name: 'write_file',
       args: { path: 'src/app.ts', content: 'hello' },
       status: 'completed',
+      startedAt: new Date('2026-05-01T12:00:00.000Z'),
+      completedAt: new Date('2026-05-01T12:00:01.000Z'),
       result: { ok: true },
       isError: false,
     });
@@ -438,6 +446,8 @@ describe('harnessToUIMessageStream', () => {
       name: 'read_file',
       args: { path: 'missing.ts' },
       status: 'error',
+      startedAt: new Date('2026-05-01T12:00:00.000Z'),
+      completedAt: new Date('2026-05-01T12:00:01.000Z'),
       result: new Error('not found'),
       isError: true,
     });
@@ -464,6 +474,8 @@ describe('harnessToUIMessageStream', () => {
       name: 'read_file',
       args: { path: 'missing.ts' },
       status: 'error',
+      startedAt: new Date('2026-05-01T12:00:00.000Z'),
+      completedAt: new Date('2026-05-01T12:00:01.000Z'),
       result: new Error('not found'),
       isError: true,
     });
@@ -481,6 +493,8 @@ describe('harnessToUIMessageStream', () => {
       name: 'read_file',
       args: { path: 'secret.ts' },
       status: 'error',
+      startedAt: new Date('2026-05-01T12:00:00.000Z'),
+      completedAt: new Date('2026-05-01T12:00:01.000Z'),
       result: 'Declined by user',
       isError: true,
       denied: true,
@@ -508,6 +522,8 @@ describe('harnessToUIMessageStream', () => {
       name: 'read_file',
       args: { path: 'secret.ts' },
       status: 'error',
+      startedAt: new Date('2026-05-01T12:00:00.000Z'),
+      completedAt: new Date('2026-05-01T12:00:01.000Z'),
       result: 'Declined by user',
       isError: true,
       denied: true,
@@ -684,6 +700,7 @@ describe('harnessToUIMessageStream', () => {
         error: new Error('boom'),
       },
       status: 'running',
+      startedAt: new Date('2026-05-01T12:00:00.000Z'),
     });
     state.modifiedFiles.set('src/app.ts', {
       operations: ['write_file'],
@@ -710,6 +727,7 @@ describe('harnessToUIMessageStream', () => {
             count: '1',
             error: { name: 'Error', message: 'boom' },
           },
+          startedAt: '2026-05-01T12:00:00.000Z',
         },
       },
     });

--- a/packages/core/src/harness/display-state.test.ts
+++ b/packages/core/src/harness/display-state.test.ts
@@ -177,6 +177,7 @@ describe('agent lifecycle', () => {
 
     emit(harness, { type: 'agent_end', reason: 'aborted' });
     expect(harness.getDisplayState().activeTools.get('t1')?.status).toBe('error');
+    expect(harness.getDisplayState().activeTools.get('t1')?.completedAt).toBeInstanceOf(Date);
   });
 
   it('marks streaming_input tools as error on agent_end', () => {
@@ -185,6 +186,7 @@ describe('agent lifecycle', () => {
 
     emit(harness, { type: 'agent_end', reason: 'aborted' });
     expect(harness.getDisplayState().activeTools.get('t1')?.status).toBe('error');
+    expect(harness.getDisplayState().activeTools.get('t1')?.completedAt).toBeInstanceOf(Date);
   });
 
   it('does not change completed tools on agent_end', () => {
@@ -194,6 +196,7 @@ describe('agent lifecycle', () => {
 
     emit(harness, { type: 'agent_end', reason: 'complete' });
     expect(harness.getDisplayState().activeTools.get('t1')?.status).toBe('completed');
+    expect(harness.getDisplayState().activeTools.get('t1')?.completedAt).toBeInstanceOf(Date);
   });
 
   it('clears activeSubagents on agent_end', () => {
@@ -272,6 +275,8 @@ describe('tool lifecycle', () => {
       expect(tool!.name).toBe('read_file');
       expect(tool!.args).toEqual({ path: 'foo.ts' });
       expect(tool!.status).toBe('running');
+      expect(tool!.startedAt).toBeInstanceOf(Date);
+      expect(tool!.completedAt).toBeUndefined();
     });
 
     it('updates existing tool entry on tool_start (after tool_input_start)', () => {
@@ -285,6 +290,8 @@ describe('tool lifecycle', () => {
       const tool = harness.getDisplayState().activeTools.get('t1');
       expect(tool!.status).toBe('running');
       expect(tool!.args).toEqual({ path: 'x', content: 'y' });
+      expect(tool!.startedAt).toBeInstanceOf(Date);
+      expect(tool!.completedAt).toBeUndefined();
     });
 
     it('marks tool as completed on successful tool_end', () => {
@@ -294,6 +301,7 @@ describe('tool lifecycle', () => {
       expect(tool!.status).toBe('completed');
       expect(tool!.result).toBe('file contents');
       expect(tool!.isError).toBe(false);
+      expect(tool!.completedAt).toBeInstanceOf(Date);
     });
 
     it('marks tool as error on failed tool_end', () => {
@@ -302,6 +310,7 @@ describe('tool lifecycle', () => {
       const tool = harness.getDisplayState().activeTools.get('t1');
       expect(tool!.status).toBe('error');
       expect(tool!.isError).toBe(true);
+      expect(tool!.completedAt).toBeInstanceOf(Date);
     });
 
     it('preserves denied metadata on declined approval tool_end', () => {
@@ -320,6 +329,7 @@ describe('tool lifecycle', () => {
       const tool = harness.getDisplayState().activeTools.get('t1');
       expect(tool!.status).toBe('running');
       expect(tool!.denied).toBeUndefined();
+      expect(tool!.completedAt).toBeUndefined();
     });
   });
 
@@ -883,6 +893,8 @@ describe('subagent lifecycle', () => {
     expect(sub!.task).toBe('Find usages of X');
     expect(sub!.forked).toBe(true);
     expect(sub!.status).toBe('running');
+    expect(sub!.startedAt).toBeInstanceOf(Date);
+    expect(sub!.completedAt).toBeUndefined();
     expect(sub!.toolCalls).toEqual([]);
   });
 
@@ -971,6 +983,7 @@ describe('subagent lifecycle', () => {
     expect(sub.status).toBe('completed');
     expect(sub.durationMs).toBe(1234);
     expect(sub.result).toBe('done');
+    expect(sub.completedAt).toBeInstanceOf(Date);
   });
 
   it('records completed subagent history on subagent_end', () => {
@@ -1015,6 +1028,8 @@ describe('subagent lifecycle', () => {
       }),
     );
     expect(ds.subagentHistory[0]!.endedAt).toBeInstanceOf(Date);
+    expect(ds.subagentHistory[0]!.startedAt).toBeInstanceOf(Date);
+    expect(ds.subagentHistory[0]!.completedAt).toBeInstanceOf(Date);
     expect(ds.subagentHistory[0]!.toolCalls).toEqual([{ name: 'read_file', isError: false }]);
     expect(ds.subagentHistory[0]!.displayName).toBe('Execute');
   });
@@ -1122,6 +1137,7 @@ describe('subagent lifecycle', () => {
     const ds = harness.getDisplayState();
     expect(ds.activeSubagents.size).toBe(0);
     expect(ds.subagentHistory).toHaveLength(1);
+    expect(ds.subagentHistory[0]!.completedAt).toBeInstanceOf(Date);
     expect(ds.subagentHistory[0]).toEqual(
       expect.objectContaining({
         toolCallId: 's1',

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -3576,10 +3576,12 @@ export class Harness<TState = {}> {
         for (const [, tool] of ds.activeTools) {
           if (tool.status === 'running' || tool.status === 'streaming_input') {
             tool.status = 'error';
+            tool.completedAt = new Date();
           }
         }
         for (const [toolCallId, subagent] of ds.activeSubagents) {
           if (subagent.status === 'running') {
+            subagent.completedAt = new Date();
             ds.subagentHistory.push(
               createSubagentHistoryEntry({
                 toolCallId,
@@ -3614,11 +3616,16 @@ export class Harness<TState = {}> {
         const existing = ds.activeTools.get(event.toolCallId);
         if (existing) {
           existing.status = 'streaming_input';
+          if (existing.completedAt || !existing.startedAt) {
+            existing.startedAt = new Date();
+          }
+          delete existing.completedAt;
         } else {
           ds.activeTools.set(event.toolCallId, {
             name: event.toolName,
             args: {},
             status: 'streaming_input',
+            startedAt: new Date(),
           });
         }
         break;
@@ -3641,13 +3648,18 @@ export class Harness<TState = {}> {
         if (existingTool) {
           existingTool.name = event.toolName;
           existingTool.args = event.args;
+          if (existingTool.completedAt || !existingTool.startedAt) {
+            existingTool.startedAt = new Date();
+          }
           existingTool.status = 'running';
+          delete existingTool.completedAt;
           delete existingTool.denied;
         } else {
           ds.activeTools.set(event.toolCallId, {
             name: event.toolName,
             args: event.args,
             status: 'running',
+            startedAt: new Date(),
           });
         }
         break;
@@ -3668,6 +3680,7 @@ export class Harness<TState = {}> {
           endedTool.status = event.isError ? 'error' : 'completed';
           endedTool.result = event.result;
           endedTool.isError = event.isError;
+          endedTool.completedAt = new Date();
           if (event.denied) {
             endedTool.denied = true;
           } else {
@@ -3764,6 +3777,7 @@ export class Harness<TState = {}> {
           task: event.task,
           modelId: event.modelId,
           forked: event.forked,
+          startedAt: new Date(),
           toolCalls: [],
           textDelta: '',
           status: 'running',
@@ -3809,6 +3823,7 @@ export class Harness<TState = {}> {
           endedSub.status = event.isError ? 'error' : 'completed';
           endedSub.durationMs = event.durationMs;
           endedSub.result = event.result;
+          endedSub.completedAt = new Date();
           ds.subagentHistory.push(
             createSubagentHistoryEntry({
               toolCallId: event.toolCallId,

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -498,6 +498,8 @@ export interface ActiveToolState {
   name: string;
   args: unknown;
   status: 'streaming_input' | 'running' | 'completed' | 'error';
+  startedAt: Date;
+  completedAt?: Date;
   partialResult?: string;
   result?: unknown;
   isError?: boolean;
@@ -514,6 +516,8 @@ export interface ActiveSubagentState {
   task: string;
   modelId?: string;
   forked?: boolean;
+  startedAt: Date;
+  completedAt?: Date;
   toolCalls: Array<{ name: string; isError: boolean }>;
   textDelta: string;
   status: 'running' | 'completed' | 'error';


### PR DESCRIPTION
## Summary
- add `startedAt` / `completedAt` to Harness active tool state
- add `startedAt` / `completedAt` to Harness active subagent state and retained history
- verify AI SDK harness snapshots serialize timestamp fields through the existing JSON conversion path

Fixes #48

## Verification
- pnpm --filter ./packages/core test:unit src/harness/display-state.test.ts
- pnpm --filter ./client-sdks/ai-sdk test src/harness.test.ts
- pnpm --filter ./packages/core check
- git diff --check
- coderabbit review --type uncommitted: no findings

Claude CLI review was attempted with a 120s timeout but returned no output before timing out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR adds timestamps to track when tools and helper agents (subagents) start and finish running in the Harness system. Instead of keeping a separate list somewhere to remember "when did this tool start?", the timing information is now built directly into the state objects, making it easier for apps to show real-time activity and replay logs without extra work.

## Changes Overview

### Type Definitions (`packages/core/src/harness/types.ts`)
Added timestamp fields to the core state interfaces:
- **`ActiveToolState`**: Added `startedAt: Date` (required) and `completedAt?: Date` (optional)
- **`ActiveSubagentState`**: Added `startedAt: Date` (required) and `completedAt?: Date` (optional)

### Implementation (`packages/core/src/harness/harness.ts`)
Updated harness display-state management to populate timestamps during tool and subagent lifecycle:
- `startedAt` is set when a tool or subagent first becomes active (via `tool_input_start`/`tool_start` and `subagent_start` events)
- `completedAt` is cleared when a tool restarts or is re-triggered
- `completedAt` is set when tools complete successfully (`tool_end`), fail, or are marked as errored
- `completedAt` is set when subagents finish (`subagent_end`) or when the parent agent ends abruptly (forcing running tools/subagents to completion)

### Test Coverage
- **Display state tests** (`packages/core/src/harness/display-state.test.ts`): Validates timestamp transitions across tool and subagent lifecycle states, including edge cases like restart scenarios and abort cases
- **AI SDK harness tests** (`client-sdks/ai-sdk/src/harness.test.ts`): Confirms that timestamps serialize correctly through the JSON conversion path used by the AI SDK message stream

### Release Notes
- **Changeset** (`.changeset/witty-falcons-train.md`): Documents the feature as a patch release for `@mastra/core`

## Outcome
Framework-native lifecycle timestamps are now available on active tool and subagent state, enabling clients to render live activity indicators, persist complete timing data in replay logs, and handle reconnection snapshots without maintaining separate external timing maps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->