### PR TITLE
test(workflows): cover repeated sequential resume input

### DIFF
--- a/packages/core/src/workflows/sequential-resume-input.test.ts
+++ b/packages/core/src/workflows/sequential-resume-input.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { Mastra } from '../mastra';
+import { MockStore } from '../storage/mock';
+import { createStep, createWorkflow } from './workflow';
+
+describe('workflow resume: sequential step input preservation', () => {
+  it('keeps strict step input intact across suspend -> resume -> suspend -> resume', async () => {
+    const storage = new MockStore();
+    const sourceOutputSchema = z.object({
+      query: z.string(),
+      searchPlan: z.object({
+        queries: z.array(z.string()).min(1),
+        extractionGoals: z.array(z.string()).min(1),
+      }),
+      papers: z
+        .array(
+          z.object({
+            id: z.string(),
+            title: z.string(),
+            abstract: z.string(),
+          }),
+        )
+        .min(1),
+      budget: z.number(),
+    });
+    const reviewResumeSchema = z.object({
+      action: z.enum(['revise', 'approve']),
+      note: z.string(),
+    });
+
+    const produceLiterature = createStep({
+      id: 'produce-literature',
+      inputSchema: z.object({ topic: z.string() }),
+      outputSchema: sourceOutputSchema,
+      execute: async ({ inputData }) => ({
+        query: inputData.topic,
+        searchPlan: {
+          queries: [`${inputData.topic} benchmark`],
+          extractionGoals: ['quality', 'latency'],
+        },
+        papers: [
+          {
+            id: 'paper-1',
+            title: 'Benchmark Paper',
+            abstract: 'A useful abstract for the extraction schema step.',
+          },
+        ],
+        budget: 3,
+      }),
+    });
+
+    const observedInputs: Array<z.infer<typeof sourceOutputSchema>> = [];
+    const executeReview = vi.fn(async ({ inputData, resumeData, suspend }) => {
+      observedInputs.push(inputData);
+
+      if (!resumeData) {
+        await suspend({
+          prompt: 'Review generated schema',
+          seenQuery: inputData.query,
+        });
+      }
+
+      if (resumeData?.action === 'revise') {
+        await suspend({
+          prompt: 'Review revised schema',
+          seenQuery: inputData.query,
+        });
+      }
+
+      return {
+        ...inputData,
+        approved: true,
+        revisionNotes: resumeData ? [resumeData.note] : [],
+      };
+    });
+    const reviewSchema = createStep({
+      id: 'review-schema',
+      inputSchema: sourceOutputSchema,
+      outputSchema: sourceOutputSchema.extend({
+        approved: z.boolean(),
+        revisionNotes: z.array(z.string()),
+      }),
+      suspendSchema: z.object({
+        prompt: z.string(),
+        seenQuery: z.string(),
+      }),
+      resumeSchema: reviewResumeSchema,
+      execute: executeReview,
+    });
+
+    const workflow = createWorkflow({
+      id: 'sequential-second-resume-input-preservation',
+      inputSchema: z.object({ topic: z.string() }),
+      outputSchema: sourceOutputSchema.extend({
+        approved: z.boolean(),
+        revisionNotes: z.array(z.string()),
+      }),
+      steps: [produceLiterature, reviewSchema],
+    })
+      .then(produceLiterature)
+      .then(reviewSchema)
+      .commit();
+
+    new Mastra({
+      logger: false,
+      storage,
+      workflows: { 'sequential-second-resume-input-preservation': workflow },
+    });
+
+    const run = await workflow.createRun();
+    const started = await run.start({ inputData: { topic: 'workflow resume' } });
+    expect(started.status).toBe('suspended');
+
+    const afterRevision = await run.resume({
+      resumeData: { action: 'revise', note: 'add latency fields' },
+    });
+    expect(afterRevision.status).toBe('suspended');
+
+    const completed = await run.resume({
+      resumeData: { action: 'approve', note: 'looks good' },
+    });
+    expect(completed.status).toBe('success');
+    if (completed.status === 'success') {
+      expect(completed.result).toMatchObject({
+        query: 'workflow resume',
+        approved: true,
+        revisionNotes: ['looks good'],
+      });
+    }
+
+    expect(executeReview).toHaveBeenCalledTimes(3);
+    expect(observedInputs).toHaveLength(3);
+    for (const input of observedInputs) {
+      expect(input).toEqual({
+        query: 'workflow resume',
+        searchPlan: {
+          queries: ['workflow resume benchmark'],
+          extractionGoals: ['quality', 'latency'],
+        },
+        papers: [
+          {
+            id: 'paper-1',
+            title: 'Benchmark Paper',
+            abstract: 'A useful abstract for the extraction schema step.',
+          },
+        ],
+        budget: 3,
+      });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #50

## Summary

- adds a default-engine regression test for a sequential step that suspends, resumes, suspends again, and resumes a second time
- asserts the strict downstream step input remains the full upstream step output on every execution
- verifies the second resume completes successfully while resumeData only carries the latest response

## Verification

- pnpm turbo build --filter @mastra/core
- pnpm --filter @mastra/core test src/workflows/sequential-resume-input.test.ts src/workflows/foreach-suspend-payload.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a test to make sure that when a workflow pauses and restarts multiple times, the data being passed between steps stays the same each time—like making sure you get the same ingredients delivered to your kitchen every time you pause and resume cooking.

## Overview

Adds a regression test for sequential workflows with multiple suspend/resume cycles to ensure downstream step inputs remain consistent across repeated executions.

## Changes

**packages/core/src/workflows/sequential-resume-input.test.ts** (+152 lines)

Introduces a Vitest test case that validates input preservation across multiple suspend/resume cycles. The test:

- Defines a two-step workflow: a producer step generating structured output and a review step with a strict inputSchema
- The review step captures inputData on every execution and conditionally suspends based on resumeData and user actions (`revise` vs `approve`)
- Executes the workflow with a full lifecycle:
  - Initial execution suspends (first suspend)
  - Resume with `revise` action causes another suspension (resume + suspend)
  - Final resume with `approve` action completes the workflow (success)
- Verifies:
  - Review step executes exactly three times across all cycles
  - The strict inputData remains identical across all three executions
  - The workflow completes successfully after the final resume
  - Result fields are populated correctly

This test serves as regression coverage for issue #50, ensuring that downstream steps receiving strict inputSchema consistently receive the full upstream step output regardless of repeated suspend/resume operations, while resumeData correctly contains only the latest response.

## Testing

Verification commands:
- `pnpm turbo build --filter @mastra/core`
- `pnpm --filter @mastra/core test src/workflows/sequential-resume-input.test.ts src/workflows/foreach-suspend-payload.test.ts`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->