### PR TITLE
feat(ai-sdk): support pre-run harness UI stream attachment

### DIFF
--- a/client-sdks/ai-sdk/README.md
+++ b/client-sdks/ai-sdk/README.md
@@ -310,3 +310,5 @@ export async function GET() {
 ```
 
 The adapter reads the initial state from `harness.getDisplayState()` and then subscribes with `harness.subscribeDisplayState()`. It emits assistant text, reasoning, and native AI SDK tool lifecycle chunks when available, plus a stable `data-mastra-harness-snapshot` baseline. In `delta` mode, later display-state changes are emitted as append-only `data-mastra-harness-delta` parts that replace changed fields or domains.
+
+If the response stream must be created before the Harness turn starts, pass `waitForRun: true`. The adapter will subscribe while the Harness is idle and begin emitting when the first running display state arrives. `waitForRunTimeoutMs` can be used to fail deterministically when no run starts.

--- a/client-sdks/ai-sdk/src/harness.test.ts
+++ b/client-sdks/ai-sdk/src/harness.test.ts
@@ -1,6 +1,6 @@
 import { defaultDisplayState } from '@mastra/core/harness';
 import type { HarnessDisplayState, HarnessDisplayStateListener, HarnessMessage } from '@mastra/core/harness';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { harnessToUIMessageStream } from './harness';
 import type { HarnessUIMessageStreamChunk, HarnessUISnapshotDataPart } from './harness';
@@ -840,6 +840,109 @@ describe('harnessToUIMessageStream', () => {
     await reader.cancel();
 
     expect(harness.unsubscribed).toBe(true);
+  });
+
+  it('keeps default idle attachment behavior unchanged', async () => {
+    const harness = new FakeHarness(createState({ isRunning: false }));
+    const reader = harnessToUIMessageStream(harness, {
+      include: ['usage'],
+      sendStart: false,
+      sendFinish: false,
+    }).getReader();
+
+    const snapshot = expectSnapshot(await readChunk(reader));
+    expect(snapshot.data).toMatchObject({ sequence: 1, isRunning: false });
+
+    const done = await reader.read();
+    expect(done.done).toBe(true);
+    expect(harness.subscribeCalls).toBe(0);
+  });
+
+  it('waits for the first running display state when waitForRun is enabled', async () => {
+    const harness = new FakeHarness(createState({ isRunning: false }));
+    const reader = harnessToUIMessageStream(harness, {
+      include: ['text'],
+      waitForRun: true,
+    }).getReader();
+
+    expect(harness.subscribeCalls).toBe(1);
+
+    harness.emit(createState({ isRunning: true, message: { id: 'm1', text: 'Hello' } }));
+
+    const started = await readChunks(reader, 4);
+    expect(started).toMatchObject([
+      { type: 'start', messageId: 'm1' },
+      { type: 'text-start', id: 'm1:text' },
+      { type: 'text-delta', id: 'm1:text', delta: 'Hello' },
+      { type: 'data-mastra-harness-snapshot', data: { sequence: 1, isRunning: true } },
+    ]);
+
+    harness.emit(createState({ isRunning: false, message: { id: 'm1', text: 'Hello' } }));
+
+    const terminal = await readChunks(reader, 3);
+    expect(terminal).toMatchObject([
+      { type: 'data-mastra-harness-snapshot', data: { sequence: 2, isRunning: false } },
+      { type: 'text-end', id: 'm1:text' },
+      { type: 'finish' },
+    ]);
+
+    const done = await reader.read();
+    expect(done.done).toBe(true);
+    expect(harness.unsubscribed).toBe(true);
+  });
+
+  it('starts immediately when waitForRun is enabled and the initial state is already running', async () => {
+    vi.useFakeTimers();
+    try {
+      const harness = new FakeHarness(createState({ isRunning: true, message: { id: 'm1', text: 'Hello' } }));
+      const reader = harnessToUIMessageStream(harness, {
+        include: ['text'],
+        waitForRun: true,
+        waitForRunTimeoutMs: 1,
+      }).getReader();
+
+      expect(harness.subscribeCalls).toBe(1);
+      const started = await readChunks(reader, 4);
+      expect(started).toMatchObject([
+        { type: 'start', messageId: 'm1' },
+        { type: 'text-start', id: 'm1:text' },
+        { type: 'text-delta', id: 'm1:text', delta: 'Hello' },
+        { type: 'data-mastra-harness-snapshot', data: { sequence: 1, isRunning: true } },
+      ]);
+
+      await vi.advanceTimersByTimeAsync(5);
+      harness.emit(createState({ isRunning: true, message: { id: 'm1', text: 'Hello again' } }));
+
+      const update = await readChunks(reader, 2);
+      expect(update).toMatchObject([
+        { type: 'text-delta', id: 'm1:text', delta: ' again' },
+        { type: 'data-mastra-harness-snapshot', data: { sequence: 2, isRunning: true } },
+      ]);
+
+      await reader.cancel();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('errors deterministically when waitForRun times out', async () => {
+    vi.useFakeTimers();
+    try {
+      const harness = new FakeHarness(createState({ isRunning: false }));
+      const reader = harnessToUIMessageStream(harness, {
+        waitForRun: true,
+        waitForRunTimeoutMs: 1,
+      }).getReader();
+      const read = reader.read();
+      const rejection = expect(read).rejects.toThrow('Harness did not start running within 1ms');
+
+      await vi.advanceTimersByTimeAsync(1);
+
+      await rejection;
+      expect(harness.unsubscribed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('includes terminal subagent history when the Harness display state provides it', async () => {

--- a/client-sdks/ai-sdk/src/harness.ts
+++ b/client-sdks/ai-sdk/src/harness.ts
@@ -27,6 +27,8 @@ export interface HarnessToUIMessageStreamOptions {
   include?: readonly HarnessUIStreamDomain[];
   windowMs?: number;
   maxWaitMs?: number;
+  waitForRun?: boolean;
+  waitForRunTimeoutMs?: number;
   messageId?: string | ((state: HarnessDisplayState) => string);
   sendStart?: boolean;
   sendFinish?: boolean;
@@ -197,11 +199,14 @@ export function harnessToUIMessageStream(
   const include = new Set(options.include ?? DEFAULT_DOMAINS);
   const windowMs = options.windowMs ?? 250;
   const maxWaitMs = options.maxWaitMs ?? 500;
+  const waitForRun = options.waitForRun ?? false;
+  const waitForRunTimeoutMs = options.waitForRunTimeoutMs;
   const sendStart = options.sendStart ?? true;
   const sendFinish = options.sendFinish ?? true;
   const resolveMessageId = createMessageIdResolver(options.messageId);
 
   let unsubscribe: (() => void) | undefined;
+  let waitForRunTimer: ReturnType<typeof setTimeout> | undefined;
   let closed = false;
 
   return new ReadableStream<HarnessUIMessageStreamChunk>({
@@ -230,6 +235,10 @@ export function harnessToUIMessageStream(
           return;
         }
         closed = true;
+        if (waitForRunTimer) {
+          clearTimeout(waitForRunTimer);
+          waitForRunTimer = undefined;
+        }
         unsubscribe?.();
         controller.close();
       };
@@ -239,6 +248,10 @@ export function harnessToUIMessageStream(
           return;
         }
         closed = true;
+        if (waitForRunTimer) {
+          clearTimeout(waitForRunTimer);
+          waitForRunTimer = undefined;
+        }
         unsubscribe?.();
         controller.error(error);
       };
@@ -249,6 +262,15 @@ export function harnessToUIMessageStream(
         }
 
         try {
+          if (waitForRun && !context.started && !state.isRunning) {
+            return;
+          }
+
+          if (waitForRunTimer) {
+            clearTimeout(waitForRunTimer);
+            waitForRunTimer = undefined;
+          }
+
           emitDisplayState(state, context);
 
           if (!state.isRunning) {
@@ -264,7 +286,20 @@ export function harnessToUIMessageStream(
         }
       };
 
-      emit(harness.getDisplayState() as HarnessDisplayState);
+      if (waitForRun) {
+        if (waitForRunTimeoutMs !== undefined) {
+          waitForRunTimer = setTimeout(() => {
+            failStream(new Error(`Harness did not start running within ${waitForRunTimeoutMs}ms`));
+          }, waitForRunTimeoutMs);
+        }
+        // Subscribe before reading the snapshot so a run that starts during attachment is not missed.
+        unsubscribe = harness.subscribeDisplayState(emit, { windowMs, maxWaitMs });
+        emit(harness.getDisplayState() as HarnessDisplayState);
+        return;
+      }
+
+      const initialState = harness.getDisplayState() as HarnessDisplayState;
+      emit(initialState);
 
       if (!closed) {
         unsubscribe = harness.subscribeDisplayState(emit, { windowMs, maxWaitMs });
@@ -273,6 +308,10 @@ export function harnessToUIMessageStream(
 
     cancel() {
       closed = true;
+      if (waitForRunTimer) {
+        clearTimeout(waitForRunTimer);
+        waitForRunTimer = undefined;
+      }
       unsubscribe?.();
     },
   });


### PR DESCRIPTION
Fixes #52

## Summary
- add `waitForRun` and `waitForRunTimeoutMs` options to `harnessToUIMessageStream`
- keep default idle attachment behavior unchanged
- subscribe before reading the initial snapshot when pre-run attachment is enabled so a run start is not missed
- document the new option in the AI SDK harness README

## Tests
- `pnpm --filter @mastra/ai-sdk exec vitest run src/harness.test.ts`
- `pnpm --filter @mastra/ai-sdk build:lib`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR solves a timing problem where you want to set up a stream to show the AI execution before the Harness actually starts running. Previously, if you tried to connect the UI stream while the Harness was sitting idle waiting for a command, the stream would immediately close. Now you can tell it to "wait for the run to start" before closing, letting you build and attach the stream ahead of time.

## Overview

This PR adds pre-run UI stream attachment support to the AI SDK harness adapter, fixing issue #52. It introduces new options (`waitForRun` and `waitForRunTimeoutMs`) to allow callers to subscribe to the harness-to-UI message stream before execution begins, while maintaining backwards compatibility with the default idle-attachment behavior.

## Changes

### Documentation (README.md)
- Added documentation for `waitForRun` option, explaining that when the response stream must be created before the Harness run starts, callers can pass `waitForRun: true` to enable pre-run subscription
- Documented `waitForRunTimeoutMs` for enforcing deterministic failure when no run starts

### Implementation (harness.ts)
- Added two new optional fields to `HarnessToUIMessageStreamOptions`:
  - `waitForRun?: boolean` - enables pre-run subscription behavior
  - `waitForRunTimeoutMs?: number` - timeout for waiting for run to start
- Updated stream creation logic: when `waitForRun` is enabled, defers emitting subsequent display state updates until the harness enters a running state (`state.isRunning`)
- Modified `start()` method to conditionally subscribe and emit initial snapshot before returning when pre-run mode is enabled
- Added timeout timer management for cleanup on stream close/failure/cancellation

### Tests (harness.test.ts)
- Added three new test cases covering:
  1. Preservation of default idle behavior when `sendStart`/`sendFinish` are disabled
  2. Waiting for first running display state before emitting chunks when `waitForRun` is enabled
  3. Timeout behavior verification using fake timers, ensuring immediate start when already running and deterministic stream error when timeout elapses

## Test Results
- 28 tests passed in suite run
- AI SDK build successful (tsup build command)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->