### PR TITLE
feat(harness): add native regenerate

### DIFF
--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -6,7 +6,8 @@ import type { MastraMemory } from '../memory/memory';
 import type { StorageThreadType } from '../memory/types';
 import type { TracingContext, TracingOptions } from '../observability';
 import type { PromptToolWaterfall } from '../observability/prompt-tool-waterfall';
-import { RequestContext } from '../request-context';
+import { MASTRA_MEMORY_HISTORY_OVERRIDE_KEY, RequestContext } from '../request-context';
+import type { MastraMemoryHistoryOverride } from '../request-context';
 import { toStandardSchema } from '../schema';
 import type { StandardSchemaWithJSON } from '../schema';
 import type { MemoryStorage } from '../storage/domains/memory/base';
@@ -129,6 +130,12 @@ function addOptionalUsageField(
 
 function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function cloneRequestContext(requestContext?: RequestContext): RequestContext {
+  return requestContext
+    ? new RequestContext(requestContext.entries() as Iterable<readonly [string, unknown]>)
+    : new RequestContext();
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -1653,6 +1660,67 @@ export class Harness<TState = {}> {
           tracingOptions,
         });
       }
+    }
+  }
+
+  /**
+   * Regenerate a previous assistant message in the current thread.
+   *
+   * The Harness delegates target validation and branch cleanup to the
+   * MessageHistory processor by setting its internal regenerate history
+   * override, then reuses the normal empty-input stream path so display state,
+   * approvals, tool events, and token usage stay aligned with sendMessage().
+   */
+  async regenerate({
+    targetMessageId,
+    tracingContext,
+    tracingOptions,
+    requestContext: requestContextInput,
+  }: {
+    targetMessageId: string;
+    tracingContext?: TracingContext;
+    tracingOptions?: TracingOptions;
+    requestContext?: RequestContext;
+  }): Promise<void> {
+    if (!targetMessageId) {
+      throw new Error('targetMessageId is required for Harness regeneration');
+    }
+    if (!this.currentThreadId) {
+      throw new Error('Cannot regenerate without a current thread');
+    }
+    if (!this.config.storage) {
+      throw new Error('Storage is not configured on this Harness');
+    }
+    if (!this.config.memory) {
+      throw new Error('Memory is not configured on this Harness');
+    }
+
+    const requestContext = cloneRequestContext(requestContextInput);
+    requestContext.set(MASTRA_MEMORY_HISTORY_OVERRIDE_KEY, {
+      type: 'regenerate',
+      targetMessageId,
+    } satisfies MastraMemoryHistoryOverride);
+
+    let regenerateTargetError: Error | undefined;
+    const unsubscribe = this.subscribe(event => {
+      if (event.type === 'error' && /^Cannot regenerate (missing|non-assistant) message /.test(event.error.message)) {
+        regenerateTargetError = event.error;
+      }
+    });
+
+    try {
+      await this.sendMessage({
+        content: '',
+        tracingContext,
+        tracingOptions,
+        requestContext,
+      });
+    } finally {
+      unsubscribe();
+    }
+
+    if (regenerateTargetError) {
+      throw regenerateTargetError;
     }
   }
 

--- a/packages/core/src/harness/regenerate.test.ts
+++ b/packages/core/src/harness/regenerate.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { Agent } from '../agent';
+import { MASTRA_MEMORY_HISTORY_OVERRIDE_KEY, RequestContext } from '../request-context';
+import { InMemoryStore } from '../storage/mock';
+import { Harness } from './harness';
+import type { HarnessEvent } from './types';
+
+async function* replacementStream() {
+  yield {
+    type: 'text-start',
+    runId: 'run-regenerate',
+    from: 'AGENT',
+    payload: { id: 'text-1' },
+  };
+  yield {
+    type: 'text-delta',
+    runId: 'run-regenerate',
+    from: 'AGENT',
+    payload: { id: 'text-1', text: 'Replacement answer' },
+  };
+  yield {
+    type: 'finish',
+    runId: 'run-regenerate',
+    from: 'AGENT',
+    payload: {
+      stepResult: { reason: 'stop' },
+      output: { usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 } },
+      metadata: {},
+    },
+  };
+}
+
+function createHarness() {
+  const agent = new Agent({
+    id: 'regenerate-agent',
+    name: 'Regenerate Agent',
+    instructions: 'Answer.',
+    model: { provider: 'openai', name: 'gpt-4o' },
+  });
+  const storage = new InMemoryStore();
+  const harness = new Harness({
+    id: 'regenerate-harness',
+    storage,
+    memory: {} as any,
+    modes: [{ id: 'default', name: 'Default', default: true, agent }],
+  });
+
+  return { agent, harness, storage };
+}
+
+async function saveMessage(args: {
+  storage: InMemoryStore;
+  threadId: string;
+  resourceId?: string;
+  id: string;
+  role: 'user' | 'assistant';
+  text: string;
+}) {
+  const memoryStorage = await args.storage.getStore('memory');
+  await memoryStorage.saveMessages({
+    messages: [
+      {
+        id: args.id,
+        role: args.role,
+        threadId: args.threadId,
+        resourceId: args.resourceId,
+        content: { format: 2, parts: [{ type: 'text', text: args.text }] },
+        createdAt: new Date(),
+      },
+    ],
+  });
+}
+
+describe('Harness.regenerate', () => {
+  it('sets the regenerate memory override and streams through the normal Harness event path', async () => {
+    const { agent, harness, storage } = createHarness();
+    const events: HarnessEvent[] = [];
+    harness.subscribe(event => events.push(event));
+
+    await harness.init();
+    const thread = await harness.createThread();
+    await saveMessage({
+      storage,
+      threadId: thread.id,
+      resourceId: 'regenerate-harness',
+      id: 'assistant-1',
+      role: 'assistant',
+      text: 'Original answer',
+    });
+
+    const stream = vi.fn(async () => ({ fullStream: replacementStream() }));
+    (agent as any).stream = stream;
+
+    const requestContext = new RequestContext();
+    requestContext.set('custom', 'value');
+
+    await harness.regenerate({ targetMessageId: 'assistant-1', requestContext });
+
+    expect(stream).toHaveBeenCalledTimes(1);
+    const [input, options] = stream.mock.calls[0]!;
+    expect(input).toEqual([]);
+    expect(options.memory).toEqual({ thread: thread.id, resource: 'regenerate-harness' });
+    expect(options.requestContext.get('custom')).toBe('value');
+    expect(options.requestContext.get(MASTRA_MEMORY_HISTORY_OVERRIDE_KEY)).toEqual({
+      type: 'regenerate',
+      targetMessageId: 'assistant-1',
+    });
+    expect(requestContext.has(MASTRA_MEMORY_HISTORY_OVERRIDE_KEY)).toBe(false);
+
+    expect(events.map(event => event.type)).toEqual(
+      expect.arrayContaining(['agent_start', 'message_start', 'message_update', 'message_end', 'agent_end']),
+    );
+    expect(events.find(event => event.type === 'agent_end')).toEqual({ type: 'agent_end', reason: 'complete' });
+    expect(harness.getCurrentRunId()).toBe('run-regenerate');
+  });
+
+  it('requires a target assistant message id', async () => {
+    const { harness } = createHarness();
+    await harness.init();
+    await harness.createThread();
+
+    await expect(harness.regenerate({ targetMessageId: '' })).rejects.toThrow(
+      'targetMessageId is required for Harness regeneration',
+    );
+  });
+
+  it('requires an existing current thread', async () => {
+    const { harness } = createHarness();
+    await harness.init();
+
+    await expect(harness.regenerate({ targetMessageId: 'assistant-1' })).rejects.toThrow(
+      'Cannot regenerate without a current thread',
+    );
+  });
+
+  it('rejects target validation errors surfaced by MessageHistory', async () => {
+    const { agent, harness } = createHarness();
+    await harness.init();
+    await harness.createThread();
+    const stream = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Cannot regenerate missing message "missing-assistant"'))
+      .mockRejectedValueOnce(new Error('Cannot regenerate non-assistant message "user-1"'));
+    (agent as any).stream = stream;
+
+    await expect(harness.regenerate({ targetMessageId: 'missing-assistant' })).rejects.toThrow(
+      'Cannot regenerate missing message "missing-assistant"',
+    );
+
+    await expect(harness.regenerate({ targetMessageId: 'user-1' })).rejects.toThrow(
+      'Cannot regenerate non-assistant message "user-1"',
+    );
+    expect(stream).toHaveBeenCalledTimes(2);
+  });
+
+  it('requires storage and memory so MessageHistory can validate and clean up the regenerated branch', async () => {
+    const agent = new Agent({
+      id: 'regenerate-agent',
+      name: 'Regenerate Agent',
+      instructions: 'Answer.',
+      model: { provider: 'openai', name: 'gpt-4o' },
+    });
+    const harnessWithoutStorage = new Harness({
+      id: 'regenerate-harness',
+      memory: {} as any,
+      modes: [{ id: 'default', name: 'Default', default: true, agent }],
+    });
+    (harnessWithoutStorage as any).currentThreadId = 'thread-1';
+
+    await expect(harnessWithoutStorage.regenerate({ targetMessageId: 'assistant-1' })).rejects.toThrow(
+      'Storage is not configured on this Harness',
+    );
+
+    const harnessWithoutMemory = new Harness({
+      id: 'regenerate-harness',
+      storage: new InMemoryStore(),
+      modes: [{ id: 'default', name: 'Default', default: true, agent }],
+    });
+    await harnessWithoutMemory.init();
+    await harnessWithoutMemory.createThread();
+
+    await expect(harnessWithoutMemory.regenerate({ targetMessageId: 'assistant-1' })).rejects.toThrow(
+      'Memory is not configured on this Harness',
+    );
+  });
+});


### PR DESCRIPTION
Fixes #53

## Summary
- add `Harness.regenerate({ targetMessageId, requestContext, tracingContext, tracingOptions })`
- reuse the existing empty-input Harness stream path so display state, approvals, tool events, token usage, and persistence stay aligned with `sendMessage`
- clone caller `RequestContext` before setting the internal regenerate memory-history override
- surface MessageHistory regenerate target validation errors as `regenerate()` rejections without duplicating target lookup logic

## Tests
- `pnpm --filter @mastra/core exec vitest run src/harness/regenerate.test.ts`
- `pnpm --filter @mastra/core build:lib`
- `coderabbit review --type uncommitted --plain`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
Imagine you're chatting with an AI and it gives you an answer you don't like. Instead of being stuck with it, you can now ask it to "do over" and generate a new answer to your previous message. This PR adds that ability to Harness, an AI conversation tool, by reusing the same streaming system that normally sends messages so everything else (like keeping track of tokens used, approvals, and memory) works the same way.

## Changes Overview
This PR adds native regenerate support to Harness by introducing a new `Harness.regenerate()` method that allows streaming replacement assistant responses for previously sent messages.

## Key Features
- **New `regenerate()` Method**: Accepts `targetMessageId`, `requestContext`, `tracingContext`, and `tracingOptions` to regenerate an assistant message by ID
- **Memory-History Override**: Sets `MASTRA_MEMORY_HISTORY_OVERRIDE_KEY` with `{ type: 'regenerate', targetMessageId }` to signal the memory system to target the specified message for replacement
- **Reuses Existing Stream Path**: Leverages the normal empty-input Harness stream flow so display state, approvals, tool events, token usage, and persistence remain consistent with `sendMessage()`
- **RequestContext Cloning**: Clones the provided `requestContext` before applying the regenerate override, preventing mutation of caller's context
- **Error Surfacing**: Detects "cannot regenerate …" failures from message history validation and surfaces them as regenerate() rejections without duplicating target lookup logic

## Implementation Details
The `regenerate()` method validates required configuration (active thread, configured storage, and memory), creates a safe copy of the `RequestContext`, applies the memory-history override, triggers the normal agent flow via `sendMessage()` with empty content, and temporarily subscribes to harness errors to capture and rethrow regeneration-target validation failures.

## Testing
New comprehensive test suite verifies:
- Regeneration sets the override key correctly and forwards request context and memory targeting to the agent stream
- Override key is not left in the provided `requestContext` after the operation
- Expected `HarnessEvent` types are emitted with proper `agent_end` reason
- Missing or invalid `targetMessageId` values are rejected with clear error messages
- Missing current thread is rejected appropriately
- Validation errors from message history (including call count limits) are properly propagated
- Required harness configuration (storage and memory) is enforced

## Files Changed
- `packages/core/src/harness/harness.ts`: Added `regenerate()` method (+69/-1)
- `packages/core/src/harness/regenerate.test.ts`: New test suite (+187/-0)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->