### PR TITLE
test(harness): cover regenerate branch cleanup

### DIFF
--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -6,6 +6,7 @@ import type { MastraMemory } from '../memory/memory';
 import type { StorageThreadType } from '../memory/types';
 import type { TracingContext, TracingOptions } from '../observability';
 import type { PromptToolWaterfall } from '../observability/prompt-tool-waterfall';
+import { RegenerateTargetError } from '../processors/memory/message-history';
 import { MASTRA_MEMORY_HISTORY_OVERRIDE_KEY, RequestContext } from '../request-context';
 import type { MastraMemoryHistoryOverride } from '../request-context';
 import { toStandardSchema } from '../schema';
@@ -1703,7 +1704,11 @@ export class Harness<TState = {}> {
 
     let regenerateTargetError: Error | undefined;
     const unsubscribe = this.subscribe(event => {
-      if (event.type === 'error' && /^Cannot regenerate (missing|non-assistant) message /.test(event.error.message)) {
+      if (
+        event.type === 'error' &&
+        event.error instanceof RegenerateTargetError &&
+        event.error.targetMessageId === targetMessageId
+      ) {
         regenerateTargetError = event.error;
       }
     });

--- a/packages/core/src/harness/regenerate.test.ts
+++ b/packages/core/src/harness/regenerate.test.ts
@@ -1,6 +1,9 @@
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { describe, expect, it, vi } from 'vitest';
 
 import { Agent } from '../agent';
+import { MockMemory } from '../memory/mock';
+import { RegenerateTargetError } from '../processors/memory/message-history';
 import { MASTRA_MEMORY_HISTORY_OVERRIDE_KEY, RequestContext } from '../request-context';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
@@ -31,18 +34,39 @@ async function* replacementStream() {
   };
 }
 
-function createHarness() {
+function createReplacementModel() {
+  return new MockLanguageModelV2({
+    doStream: async () => ({
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Replacement answer' },
+        { type: 'text-end', id: 'text-1' },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
+        },
+      ]),
+      rawCall: { rawPrompt: [], rawSettings: {} },
+      warnings: [],
+    }),
+  });
+}
+
+function createHarness({ model = { provider: 'openai', name: 'gpt-4o' } as any } = {}) {
+  const storage = new InMemoryStore();
   const agent = new Agent({
     id: 'regenerate-agent',
     name: 'Regenerate Agent',
     instructions: 'Answer.',
-    model: { provider: 'openai', name: 'gpt-4o' },
+    model,
   });
-  const storage = new InMemoryStore();
   const harness = new Harness({
     id: 'regenerate-harness',
     storage,
-    memory: {} as any,
+    memory: new MockMemory({ storage }),
     modes: [{ id: 'default', name: 'Default', default: true, agent }],
   });
 
@@ -56,6 +80,7 @@ async function saveMessage(args: {
   id: string;
   role: 'user' | 'assistant';
   text: string;
+  createdAt?: Date;
 }) {
   const memoryStorage = await args.storage.getStore('memory');
   await memoryStorage.saveMessages({
@@ -66,7 +91,7 @@ async function saveMessage(args: {
         threadId: args.threadId,
         resourceId: args.resourceId,
         content: { format: 2, parts: [{ type: 'text', text: args.text }] },
-        createdAt: new Date(),
+        createdAt: args.createdAt ?? new Date(),
       },
     ],
   });
@@ -115,6 +140,74 @@ describe('Harness.regenerate', () => {
     expect(harness.getCurrentRunId()).toBe('run-regenerate');
   });
 
+  it('deletes the regenerated branch after the replacement response is persisted', async () => {
+    const { harness, storage } = createHarness({ model: createReplacementModel() });
+
+    await harness.init();
+    const thread = await harness.createThread();
+    const resourceId = 'regenerate-harness';
+    await saveMessage({
+      storage,
+      threadId: thread.id,
+      resourceId,
+      id: 'user-1',
+      role: 'user',
+      text: 'Original question',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    await saveMessage({
+      storage,
+      threadId: thread.id,
+      resourceId,
+      id: 'assistant-1',
+      role: 'assistant',
+      text: 'Original answer',
+      createdAt: new Date('2026-01-01T00:00:01.000Z'),
+    });
+    await saveMessage({
+      storage,
+      threadId: thread.id,
+      resourceId,
+      id: 'user-2',
+      role: 'user',
+      text: 'Follow-up question',
+      createdAt: new Date('2026-01-01T00:00:02.000Z'),
+    });
+    await saveMessage({
+      storage,
+      threadId: thread.id,
+      resourceId,
+      id: 'assistant-2',
+      role: 'assistant',
+      text: 'Follow-up answer',
+      createdAt: new Date('2026-01-01T00:00:03.000Z'),
+    });
+
+    await harness.regenerate({ targetMessageId: 'assistant-1' });
+
+    const memoryStorage = await storage.getStore('memory');
+    const { messages } = await memoryStorage.listMessages({
+      threadId: thread.id,
+      resourceId,
+      perPage: false,
+      orderBy: { field: 'createdAt', direction: 'ASC' },
+    });
+    const messageIds = messages.map(message => message.id);
+
+    expect(messageIds).toContain('user-1');
+    expect(messageIds).not.toContain('assistant-1');
+    expect(messageIds).not.toContain('user-2');
+    expect(messageIds).not.toContain('assistant-2');
+    expect(
+      messages.some(
+        message =>
+          message.role === 'assistant' &&
+          message.id !== 'assistant-1' &&
+          message.content.parts?.some(part => part.type === 'text' && part.text === 'Replacement answer'),
+      ),
+    ).toBe(true);
+  });
+
   it('requires a target assistant message id', async () => {
     const { harness } = createHarness();
     await harness.init();
@@ -140,8 +233,8 @@ describe('Harness.regenerate', () => {
     await harness.createThread();
     const stream = vi
       .fn()
-      .mockRejectedValueOnce(new Error('Cannot regenerate missing message "missing-assistant"'))
-      .mockRejectedValueOnce(new Error('Cannot regenerate non-assistant message "user-1"'));
+      .mockRejectedValueOnce(new RegenerateTargetError('missing', 'missing-assistant'))
+      .mockRejectedValueOnce(new RegenerateTargetError('non-assistant', 'user-1'));
     (agent as any).stream = stream;
 
     await expect(harness.regenerate({ targetMessageId: 'missing-assistant' })).rejects.toThrow(
@@ -152,6 +245,15 @@ describe('Harness.regenerate', () => {
       'Cannot regenerate non-assistant message "user-1"',
     );
     expect(stream).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not capture regenerate validation errors for a different target', async () => {
+    const { agent, harness } = createHarness();
+    await harness.init();
+    await harness.createThread();
+    (agent as any).stream = vi.fn().mockRejectedValueOnce(new Error('Cannot regenerate missing message "other"'));
+
+    await expect(harness.regenerate({ targetMessageId: 'assistant-1' })).resolves.toBeUndefined();
   });
 
   it('requires storage and memory so MessageHistory can validate and clean up the regenerated branch', async () => {

--- a/packages/core/src/processors/memory/message-history.ts
+++ b/packages/core/src/processors/memory/message-history.ts
@@ -28,6 +28,16 @@ type MemoryHistoryOverride = MastraMemoryHistoryOverride;
 
 const INCOMPLETE_RESPONSE_STATUSES = new Set(['partial', 'aborted', 'cancelled', 'canceled']);
 
+export class RegenerateTargetError extends Error {
+  constructor(
+    public readonly kind: 'missing' | 'non-assistant',
+    public readonly targetMessageId: string,
+  ) {
+    super(`Cannot regenerate ${kind} message "${targetMessageId}"`);
+    this.name = 'RegenerateTargetError';
+  }
+}
+
 function isEmptyAssistantMessage(message: MastraDBMessage): boolean {
   if (message.role !== 'assistant') {
     return false;
@@ -238,12 +248,12 @@ export class MessageHistory implements Processor {
     const storedMessages = result.messages.filter((msg: MastraDBMessage) => msg.role !== 'system');
     const targetIndex = storedMessages.findIndex(message => message.id === override.targetMessageId);
     if (targetIndex === -1) {
-      throw new Error(`Cannot regenerate missing message "${override.targetMessageId}"`);
+      throw new RegenerateTargetError('missing', override.targetMessageId);
     }
 
     const targetMessage = storedMessages[targetIndex]!;
     if (targetMessage.role !== 'assistant') {
-      throw new Error(`Cannot regenerate non-assistant message "${override.targetMessageId}"`);
+      throw new RegenerateTargetError('non-assistant', override.targetMessageId);
     }
 
     const branchMessages = storedMessages.slice(targetIndex);


### PR DESCRIPTION
## Summary
- add a typed RegenerateTargetError so Harness only rethrows regenerate validation errors for the active target
- cover Harness.regenerate branch cleanup through the real Agent.stream + MockMemory path
- add regression coverage that unrelated regenerate-looking errors are not captured by the active regenerate call

## Verification
- pnpm build:core
- pnpm --filter @mastra/core exec vitest run src/harness/regenerate.test.ts
- pnpm --filter @mastra/core exec vitest run src/processors/memory/message-history.test.ts
- pnpm --filter @mastra/core build:lib

Follow-up to #55. Fixes #53.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR makes it easier for the code to tell when a message regeneration fails by creating a specific error type instead of using generic errors. It also adds comprehensive tests to verify that when you regenerate an AI response, old draft messages get properly deleted and the new response is saved correctly.

## Overview
Introduces a typed `RegenerateTargetError` class to distinguish regeneration validation failures from other errors, and adds test coverage verifying that Harness.regenerate() correctly handles branch cleanup, error cases, and request context preservation.

## Changes

### `RegenerateTargetError` - New Error Type
A new exported error class was introduced in the memory processor to represent regeneration target validation failures with structured information:
- `kind`: Either `'missing'` (target message not found) or `'non-assistant'` (target is not an assistant message)
- `targetMessageId`: The ID of the message that failed validation

This replaces generic `Error` messages with a specific, typed error that callers can reliably match against.

### Harness Regenerate Error Detection
The `Harness.regenerate()` method now detects regeneration failures by matching emitted error events against the `RegenerateTargetError` type and `targetMessageId`, replacing the previous message-regex-based approach. This is more reliable and type-safe.

### Test Coverage Expansion
Test suite enhancements include:
- A new `createReplacementModel()` helper that simulates deterministic LLM streaming responses with proper start/finish events and token usage
- Configurable `model` parameter in the harness factory for test flexibility
- New `createdAt` option in `saveMessage` for better timestamp control in tests
- **Branch cleanup verification**: Tests now confirm that after `harness.regenerate()`, the regenerated branch messages and follow-ups are properly deleted from memory while the replacement response is persisted
- **Error regression testing**: New test verifies that regenerate-like validation errors for unrelated targets are not captured by the active regenerate call (resolves `undefined` as expected)
- Adjusted error-path tests to use `RegenerateTargetError` instead of generic `Error` stubs

## Impact
These changes complete the regenerate feature implementation by:
- Providing reliable error handling that distinguishes regeneration validation failures from other errors
- Verifying through tests that the memory branch cleanup behavior works correctly (removing draft messages after regeneration success)
- Ensuring the regenerate call doesn't capture unrelated validation errors
- Maintaining consistency with SDK chat-route regenerate semantics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->