### PR TITLE
Refactor to fix architecture redundancy in core

### DIFF
--- a/packages/core/src/agent/durable/durable-stream-until-idle.ts
+++ b/packages/core/src/agent/durable/durable-stream-until-idle.ts
@@ -1,3 +1,4 @@
+import { acquireStreamSlot, buildContinuationOpts, releaseStreamSlot, resolveStreamUntilIdleScope, TERMINAL_BG_CHUNKS } from "../shared/stream-until-idle";
 /**
  * Implementation of `DurableAgent.streamUntilIdle`. Mirrors the regular
  * agent's `stream-until-idle.ts` but adapted for durable execution:
@@ -17,7 +18,6 @@
  * 5. `maxIdleMs` fires only between turns when nothing is happening.
  */
 import type { BackgroundTaskManager } from '../../background-tasks/manager';
-import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY, RequestContext } from '../../request-context';
 import { deepMerge } from '../../utils';
 import type { MessageListInput } from '../message-list';
 
@@ -26,81 +26,6 @@ import type { DurableAgent, DurableAgentStreamOptions, DurableAgentStreamResult 
 export interface DurableStreamUntilIdleDeps {
   activeStreams: Map<string, () => void>;
   bgManager: BackgroundTaskManager | undefined;
-}
-
-const TERMINAL_BG_CHUNKS = new Set([
-  'background-task-completed',
-  'background-task-failed',
-  'background-task-cancelled',
-]);
-
-async function resolveScope(
-  agent: DurableAgent<any, any, any>,
-  mergedOptions: Record<string, any>,
-): Promise<{ threadId: string | undefined; resourceId: string | undefined; scopeKey: string | null } | null> {
-  const requestContext = (mergedOptions?.requestContext as RequestContext | undefined) ?? new RequestContext();
-  const memory = await agent.getMemory();
-  if (!memory) return null;
-
-  const threadIdFromContext = requestContext.get(MASTRA_THREAD_ID_KEY) as string | undefined;
-  const resourceIdFromContext = requestContext.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
-  const threadIdFromArgs =
-    typeof mergedOptions?.memory?.thread === 'string'
-      ? mergedOptions.memory.thread
-      : (mergedOptions?.memory?.thread as { id?: string } | undefined)?.id;
-
-  const threadId = threadIdFromContext ?? threadIdFromArgs;
-  const resourceId = resourceIdFromContext ?? (mergedOptions?.memory?.resource as string | undefined);
-  const scopeKey = threadId || resourceId ? `${threadId ?? ''}|${resourceId ?? ''}` : null;
-  return { threadId, resourceId, scopeKey };
-}
-
-function buildContinuationDirective(batch: Array<Record<string, unknown>>): string {
-  const entries = batch
-    .map(chunk => {
-      const payload = (chunk as { payload?: Record<string, unknown> }).payload ?? {};
-      return {
-        toolCallId: payload.toolCallId as string | undefined,
-        toolName: payload.toolName as string | undefined,
-      };
-    })
-    .filter(e => !!e.toolCallId);
-
-  const idList = entries.map(e => (e.toolName ? `${e.toolCallId} (${e.toolName})` : e.toolCallId)).join(', ');
-
-  return (
-    `Background task(s) you previously dispatched have completed. ` +
-    `Process ONLY these tool-call IDs (their results are now in the conversation): ${idList}. ` +
-    `IMPORTANT: Do NOT process any tool-call IDs that were not in the list, ` +
-    `and do NOT call the same tool again — the result is already available. ` +
-    `Use these result(s) to answer the user's original question.`
-  );
-}
-
-function buildContinuationOpts(
-  baseContinuationOpts: Record<string, any>,
-  callerContext: any[] | undefined,
-  batch: Array<Record<string, unknown>>,
-): Record<string, any> {
-  const directive = buildContinuationDirective(batch);
-  return {
-    ...baseContinuationOpts,
-    context: [...(callerContext ?? []), { role: 'user' as const, content: directive }],
-  };
-}
-
-function acquireStreamSlot(activeStreams: Map<string, () => void>, scopeKey: string | null, closer: () => void): void {
-  if (!scopeKey) return;
-  const priorClose = activeStreams.get(scopeKey);
-  priorClose?.();
-  activeStreams.set(scopeKey, closer);
-}
-
-function releaseStreamSlot(activeStreams: Map<string, () => void>, scopeKey: string | null, closer: () => void): void {
-  if (!scopeKey) return;
-  if (activeStreams.get(scopeKey) === closer) {
-    activeStreams.delete(scopeKey);
-  }
 }
 
 export async function runDurableStreamUntilIdle<OUTPUT = undefined>(
@@ -119,7 +44,7 @@ export async function runDurableStreamUntilIdle<OUTPUT = undefined>(
     (restStreamOptions ?? {}) as Record<string, unknown>,
   ) as Record<string, any>;
 
-  const scope = await resolveScope(agent, mergedOptions);
+  const scope = await resolveStreamUntilIdleScope(agent, mergedOptions);
 
   if (!deps.bgManager || !scope) {
     return (agent as any).stream(messages, restStreamOptions as any) as Promise<DurableAgentStreamResult<OUTPUT>>;

--- a/packages/core/src/agent/shared/stream-until-idle.ts
+++ b/packages/core/src/agent/shared/stream-until-idle.ts
@@ -1,0 +1,101 @@
+import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY, RequestContext } from '../../request-context';
+
+export interface ResolvedScope {
+  threadId: string | undefined;
+  resourceId: string | undefined;
+  scopeKey: string | null;
+}
+
+export const TERMINAL_BG_CHUNKS = new Set([
+  'background-task-completed',
+  'background-task-failed',
+  'background-task-cancelled',
+]);
+
+/**
+ * Resolve memory / thread / resource for this call, matching `#execute`
+ * semantics (RequestContext-scoped keys override caller-supplied memory
+ * args). Returns `null` when no memory backend is configured — caller
+ * falls through to a plain stream in that case.
+ */
+export async function resolveStreamUntilIdleScope(
+  agent: { getMemory: (options?: any) => Promise<any> },
+  mergedOptions: Record<string, any>,
+): Promise<ResolvedScope | null> {
+  const requestContext = (mergedOptions?.requestContext as RequestContext | undefined) ?? new RequestContext();
+  const memory = await agent.getMemory({ requestContext });
+  if (!memory) return null;
+
+  const threadIdFromContext = requestContext.get(MASTRA_THREAD_ID_KEY) as string | undefined;
+  const resourceIdFromContext = requestContext.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
+  const threadIdFromArgs =
+    typeof mergedOptions?.memory?.thread === 'string'
+      ? mergedOptions.memory.thread
+      : (mergedOptions?.memory?.thread as { id?: string } | undefined)?.id;
+
+  const threadId = threadIdFromContext ?? threadIdFromArgs;
+  const resourceId = resourceIdFromContext ?? (mergedOptions?.memory?.resource as string | undefined);
+
+  // Scope key = `threadId|resourceId`. Calls without either get null (no
+  // active-stream coordination — no way to meaningfully identify "the same
+  // conversation").
+  const scopeKey = threadId || resourceId ? `${threadId ?? ''}|${resourceId ?? ''}` : null;
+
+  return { threadId, resourceId, scopeKey };
+}
+
+/**
+ * Build the ephemeral user-prompt text that tells the LLM which tool-call
+ * IDs just completed. The directive stops the LLM from (a) re-processing
+ * results already handled on a prior continuation and (b) mimicking the
+ * prior assistant ack text ("I'm running it in the background") and
+ * re-dispatching the same tool.
+ */
+export function buildContinuationDirective(batch: Array<Record<string, unknown>>): string {
+  const entries = batch
+    .map(chunk => {
+      const payload = (chunk as { payload?: Record<string, unknown> }).payload ?? {};
+      return {
+        toolCallId: payload.toolCallId as string | undefined,
+        toolName: payload.toolName as string | undefined,
+      };
+    })
+    .filter(e => !!e.toolCallId);
+
+  const idList = entries.map(e => (e.toolName ? `${e.toolCallId} (${e.toolName})` : e.toolCallId)).join(', ');
+
+  return (
+    `Background task(s) you previously dispatched have completed. ` +
+    `Process ONLY these tool-call IDs (their results are now in the conversation): ${idList}. ` +
+    `IMPORTANT: Do NOT process any tool-call IDs that were not in the list, ` +
+    `and do NOT call the same tool again — the result is already available. ` +
+    `Use these result(s) to answer the user's original question.`
+  );
+}
+
+export function buildContinuationOpts(
+  baseContinuationOpts: Record<string, any>,
+  callerContext: any[] | undefined,
+  batch: Array<Record<string, unknown>>,
+): Record<string, any> {
+  const directive = buildContinuationDirective(batch);
+  return {
+    ...baseContinuationOpts,
+    context: [...(callerContext ?? []), { role: 'user' as const, content: directive }],
+  };
+}
+
+export function acquireStreamSlot(activeStreams: Map<string, () => void>, scopeKey: string | null, closer: () => void): void {
+  if (!scopeKey) return;
+  const priorClose = activeStreams.get(scopeKey);
+  priorClose?.();
+  activeStreams.set(scopeKey, closer);
+}
+
+export function releaseStreamSlot(activeStreams: Map<string, () => void>, scopeKey: string | null, closer: () => void): void {
+  if (!scopeKey) return;
+  // Only delete if it's still our stream
+  if (activeStreams.get(scopeKey) === closer) {
+    activeStreams.delete(scopeKey);
+  }
+}

--- a/packages/core/src/agent/stream-until-idle.ts
+++ b/packages/core/src/agent/stream-until-idle.ts
@@ -1,3 +1,4 @@
+import { acquireStreamSlot, buildContinuationOpts, releaseStreamSlot, resolveStreamUntilIdleScope, TERMINAL_BG_CHUNKS } from "./shared/stream-until-idle";
 /**
  * Implementation of `Agent.streamUntilIdle`. Extracted from `agent.ts` to
  * keep that file focused on the public Agent surface. `Agent.streamUntilIdle`
@@ -19,7 +20,6 @@
  *    active inner stream) so slow first-tokens don't close the stream.
  */
 import type { BackgroundTaskManager } from '../background-tasks/manager';
-import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY, RequestContext } from '../request-context';
 import type { MastraModelOutput } from '../stream/base/output';
 import { deepMerge } from '../utils';
 import type { Agent } from './agent';
@@ -44,130 +44,6 @@ export interface StreamUntilIdleDeps {
   bgManager: BackgroundTaskManager | undefined;
 }
 
-interface ResolvedScope {
-  threadId: string | undefined;
-  resourceId: string | undefined;
-  scopeKey: string | null;
-}
-
-const TERMINAL_BG_CHUNKS = new Set([
-  'background-task-completed',
-  'background-task-failed',
-  'background-task-cancelled',
-]);
-
-/**
- * Resolve memory / thread / resource for this call, matching `#execute`
- * semantics (RequestContext-scoped keys override caller-supplied memory
- * args). Returns `null` when no memory backend is configured — caller
- * falls through to a plain stream in that case.
- */
-async function resolveStreamUntilIdleScope(
-  agent: Agent<any, any, any, any>,
-  mergedOptions: Record<string, any>,
-): Promise<ResolvedScope | null> {
-  const requestContext = (mergedOptions?.requestContext as RequestContext | undefined) ?? new RequestContext();
-  const memory = await agent.getMemory({ requestContext });
-  if (!memory) return null;
-
-  const threadIdFromContext = requestContext.get(MASTRA_THREAD_ID_KEY) as string | undefined;
-  const resourceIdFromContext = requestContext.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
-  const threadIdFromArgs =
-    typeof mergedOptions?.memory?.thread === 'string'
-      ? mergedOptions.memory.thread
-      : (mergedOptions?.memory?.thread as { id?: string } | undefined)?.id;
-
-  const threadId = threadIdFromContext ?? threadIdFromArgs;
-  const resourceId = resourceIdFromContext ?? (mergedOptions?.memory?.resource as string | undefined);
-
-  // Scope key = `threadId|resourceId`. Calls without either get null (no
-  // active-stream coordination — no way to meaningfully identify "the same
-  // conversation").
-  const scopeKey = threadId || resourceId ? `${threadId ?? ''}|${resourceId ?? ''}` : null;
-
-  return { threadId, resourceId, scopeKey };
-}
-
-/**
- * Build the ephemeral user-prompt text that tells the LLM which tool-call
- * IDs just completed. The directive stops the LLM from (a) re-processing
- * results already handled on a prior continuation and (b) mimicking the
- * prior assistant ack text ("I'm running it in the background") and
- * re-dispatching the same tool.
- */
-function buildContinuationDirective(batch: Array<Record<string, unknown>>): string {
-  const entries = batch
-    .map(chunk => {
-      const payload = (chunk as { payload?: Record<string, unknown> }).payload ?? {};
-      return {
-        toolCallId: payload.toolCallId as string | undefined,
-        toolName: payload.toolName as string | undefined,
-      };
-    })
-    .filter(e => !!e.toolCallId);
-
-  const idList = entries.map(e => (e.toolName ? `${e.toolCallId} (${e.toolName})` : e.toolCallId)).join(', ');
-
-  return (
-    `Background task(s) you previously dispatched have completed. ` +
-    `Process ONLY these tool-call IDs (their results are now in the conversation): ${idList}. ` +
-    `IMPORTANT: Do NOT process any tool-call IDs that were not in the list, ` +
-    `and do NOT call the same tool again — the result is already available. ` +
-    `Use these result(s) to answer the user's original question.`
-  );
-}
-
-/**
- * Wrap the continuation directive into a stream-options object suitable for
- * a recursive `agent.stream([], ...)` call. `context` messages are visible
- * to the LLM but NOT persisted to memory, so the directive doesn't pollute
- * future turns.
- */
-function buildContinuationOpts(
-  baseContinuationOpts: Record<string, any>,
-  callerContext: any[] | undefined,
-  batch: Array<Record<string, unknown>>,
-): Record<string, any> {
-  const directive = buildContinuationDirective(batch);
-  return {
-    ...baseContinuationOpts,
-    context: [...(callerContext ?? []), { role: 'user' as const, content: directive }],
-  };
-}
-
-/**
- * Register `closer` as the active wrapper for `scopeKey`, aborting any
- * prior registered closer first. No-op for null scopes.
- */
-function acquireStreamSlot(activeStreams: Map<string, () => void>, scopeKey: string | null, closer: () => void): void {
-  if (!scopeKey) return;
-  const priorClose = activeStreams.get(scopeKey);
-  priorClose?.();
-  activeStreams.set(scopeKey, closer);
-}
-
-/**
- * Remove `closer` from the active streams map iff it's still the entry for
- * `scopeKey`. A later call that took over (and replaced the entry) will not
- * get its own entry deleted by a predecessor's delayed close.
- */
-function releaseStreamSlot(activeStreams: Map<string, () => void>, scopeKey: string | null, closer: () => void): void {
-  if (!scopeKey) return;
-  if (activeStreams.get(scopeKey) === closer) {
-    activeStreams.delete(scopeKey);
-  }
-}
-
-/**
- * Run `agent.streamUntilIdle`. See the module doc above for the high-level
- * flow. Returns a `MastraModelOutput` whose `fullStream` spans the initial
- * turn PLUS any continuations triggered by background task completions.
- *
- * Aggregate properties (`text`, `toolCalls`, `toolResults`, `finishReason`,
- * `messageList`, `getFullOutput()`) still resolve against the first turn's
- * internal buffer. Consumers who need an aggregated view should read
- * `fullStream` and accumulate, or follow up with `agent.generate(...)`.
- */
 export async function runStreamUntilIdle<OUTPUT>(
   agent: Agent<any, any, any, any>,
   messages: MessageListInput,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,3 +1,4 @@
+export { fetchWithRetry } from "./utils/fetchWithRetry";
 import { createHash } from 'node:crypto';
 import type { CoreMessage } from '@internal/ai-sdk-v4';
 import { jsonSchemaToZod } from '@mastra/schema-compat/json-to-zod';
@@ -699,38 +700,6 @@ export function parseFieldKey(key: string): FieldKey {
  * @param validateResponse Optional function to validate the response beyond HTTP status
  * @returns The fetch Response if successful
  */
-export async function fetchWithRetry(
-  url: string,
-  options: RequestInit = {},
-  maxRetries: number = 3,
-): Promise<Response> {
-  let retryCount = 0;
-  let lastError: Error | null = null;
-
-  while (retryCount < maxRetries) {
-    try {
-      const response = await fetch(url, options);
-
-      if (!response.ok) {
-        throw new Error(`Request failed with status: ${response.status} ${response.statusText}`);
-      }
-
-      return response;
-    } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error));
-      retryCount++;
-
-      if (retryCount >= maxRetries) {
-        break;
-      }
-
-      const delay = Math.min(1000 * Math.pow(2, retryCount), 10000);
-      await new Promise(resolve => setTimeout(resolve, delay));
-    }
-  }
-
-  throw lastError || new Error('Request failed after multiple retry attempts');
-}
 
 /**
  * Removes specific keys from an object.


### PR DESCRIPTION
I identified and refactored code redundancy and duplication. Specifically:
- **`fetchWithRetry`**: There were two implementations. One was moved to its own file (`packages/core/src/utils/fetchWithRetry.ts`), and `packages/core/src/utils.ts` now imports and re-exports it.
- **`stream-until-idle`**: Found extensive duplication between `packages/core/src/agent/stream-until-idle.ts` and `packages/core/src/agent/durable/durable-stream-until-idle.ts`. Created a shared utility file at `packages/core/src/agent/shared/stream-until-idle.ts` to house the common scope resolution and slot management functions, reducing overall codebase redundancy.

---
*PR created automatically by Jules for task [18063218570641534163](https://jules.google.com/task/18063218570641534163) started by @mbenhamd*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR cleans up repetitive code in the core package by moving duplicated utilities into shared files. It's like when you have the same recipe written in multiple notebooks—the PR consolidates them into one notebook that everyone can reference instead.

## Changes Overview

The refactor addresses code duplication across the core package by:
- Extracting `fetchWithRetry` into its own dedicated file
- Consolidating stream-until-idle utilities that were duplicated across regular and durable implementations into a shared module

## Files Modified

### `packages/core/src/utils/fetchWithRetry.ts` (new file)
New file containing the `fetchWithRetry` implementation, previously defined in `utils.ts`.

### `packages/core/src/utils.ts`
- Removed local `fetchWithRetry` implementation
- Now re-exports `fetchWithRetry` from `./utils/fetchWithRetry`
- **Changes**: +1/-32 lines

### `packages/core/src/agent/shared/stream-until-idle.ts` (new file)
New shared utility module consolidating stream-until-idle coordination logic. Exports:
- **`ResolvedScope` interface**: Contains `threadId`, `resourceId`, and `scopeKey`
- **`resolveStreamUntilIdleScope()`**: Determines thread/resource IDs from `RequestContext`, with fallback to `mergedOptions.memory`; returns `null` when no memory backend is available
- **`TERMINAL_BG_CHUNKS`**: Set of terminal background-task chunk types (`'background-task-completed'`, `'background-task-failed'`, `'background-task-cancelled'`)
- **`buildContinuationDirective()`**: Generates a user prompt instructing the LLM to process only specified tool-call IDs
- **`buildContinuationOpts()`**: Injects the continuation directive into continuation options
- **`acquireStreamSlot()` / `releaseStreamSlot()`**: Manage active streams using a `Map` keyed by `scopeKey`
- **Changes**: +101/-0 lines

### `packages/core/src/agent/stream-until-idle.ts`
- Imports shared utilities from `./shared/stream-until-idle` instead of defining locally
- Removed: scope resolution, continuation directive/options construction, and stream-slot bookkeeping implementations
- Retained: `runStreamUntilIdle` orchestration logic
- **Changes**: +1/-125 lines

### `packages/core/src/agent/durable/durable-stream-until-idle.ts`
- Updated to use shared stream-until-idle utilities via imports
- `resolveScope` calls replaced with `resolveStreamUntilIdleScope`
- Surrounding control flow (idle timer, continuation handling, background-task event processing, cleanup) unchanged
- **Changes**: +2/-77 lines

## Code Review Effort
Medium across all modified files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->