### PR TITLE
[PF-166] Reserve Flow request context keys

### DIFF
--- a/.changeset/frank-pears-pay.md
+++ b/.changeset/frank-pears-pay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed server request context merging so client-provided context cannot set internal Mastra Flow keys.

--- a/packages/server/src/server/constants.ts
+++ b/packages/server/src/server/constants.ts
@@ -12,6 +12,8 @@ export const MASTRA_THREAD_ID_KEY = 'mastra__threadId';
 
 export const MASTRA_AUTH_TOKEN_KEY = 'mastra__authToken';
 
+export const MASTRA_FLOW_CONTEXT_KEY_PREFIX = 'mastra__flow';
+
 export const WORKSPACE_TOOLS_PREFIX = 'mastra_workspace' as const;
 
 export const WORKSPACE_TOOLS = {

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -9,7 +9,7 @@ import { z } from 'zod/v4';
 
 import type { InMemoryTaskStore } from '../a2a/store';
 import { coreAuthMiddleware } from '../auth/helpers';
-import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../constants';
+import { MASTRA_FLOW_CONTEXT_KEY_PREFIX, MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../constants';
 import { formatZodError } from '../handlers/error';
 import { normalizeRoutePath } from '../utils';
 import { generateOpenAPIDocument, convertCustomRoutesToOpenAPIPaths } from './openapi-utils';
@@ -327,12 +327,12 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
   }
 
   private static readonly RESERVED_CONTEXT_KEYS = new Set([MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY]);
-  private static readonly RESERVED_CONTEXT_KEY_PREFIXES = ['mastra.flow'];
+  private static readonly RESERVED_CONTEXT_KEY_PREFIXES = [MASTRA_FLOW_CONTEXT_KEY_PREFIX];
 
   private static isReservedContextKey(key: string): boolean {
     return (
       MastraServer.RESERVED_CONTEXT_KEYS.has(key) ||
-      MastraServer.RESERVED_CONTEXT_KEY_PREFIXES.some(prefix => key === prefix || key.startsWith(`${prefix}.`))
+      MastraServer.RESERVED_CONTEXT_KEY_PREFIXES.some(prefix => key === prefix || key.startsWith(prefix))
     );
   }
 

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -327,6 +327,14 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
   }
 
   private static readonly RESERVED_CONTEXT_KEYS = new Set([MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY]);
+  private static readonly RESERVED_CONTEXT_KEY_PREFIXES = ['mastra.flow'];
+
+  private static isReservedContextKey(key: string): boolean {
+    return (
+      MastraServer.RESERVED_CONTEXT_KEYS.has(key) ||
+      MastraServer.RESERVED_CONTEXT_KEY_PREFIXES.some(prefix => key === prefix || key.startsWith(`${prefix}.`))
+    );
+  }
 
   protected mergeRequestContext({
     paramsRequestContext,
@@ -338,13 +346,13 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     const requestContext = new RequestContext();
     if (bodyRequestContext) {
       for (const [key, value] of Object.entries(bodyRequestContext)) {
-        if (MastraServer.RESERVED_CONTEXT_KEYS.has(key)) continue;
+        if (MastraServer.isReservedContextKey(key)) continue;
         requestContext.set(key, value);
       }
     }
     if (paramsRequestContext) {
       for (const [key, value] of Object.entries(paramsRequestContext)) {
-        if (MastraServer.RESERVED_CONTEXT_KEYS.has(key)) continue;
+        if (MastraServer.isReservedContextKey(key)) continue;
         requestContext.set(key, value);
       }
     }

--- a/packages/server/src/server/server-adapter/request-context.test.ts
+++ b/packages/server/src/server/server-adapter/request-context.test.ts
@@ -1,0 +1,65 @@
+import { Mastra } from '@mastra/core/mastra';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../constants';
+import { MastraServer } from './index';
+
+class TestMastraServer extends MastraServer<any, any, any> {
+  stream = vi.fn();
+  getParams = vi.fn();
+  sendResponse = vi.fn();
+  registerRoute = vi.fn();
+  registerContextMiddleware = vi.fn();
+  registerAuthMiddleware = vi.fn();
+  registerHttpLoggingMiddleware = vi.fn();
+
+  mergeContextForTest(args: Parameters<MastraServer<any, any, any>['mergeRequestContext']>[0]) {
+    return this.mergeRequestContext(args);
+  }
+}
+
+function createServer() {
+  return new TestMastraServer({ app: {}, mastra: new Mastra({}) });
+}
+
+describe('server request context merge', () => {
+  it('filters reserved context keys from client-provided body and query context', () => {
+    const server = createServer();
+
+    const requestContext = server.mergeContextForTest({
+      bodyRequestContext: {
+        [MASTRA_RESOURCE_ID_KEY]: 'body-resource',
+        [MASTRA_THREAD_ID_KEY]: 'body-thread',
+        'mastra.flow': { capabilities: ['root-forged'] },
+        'mastra.flow.state': { capabilities: ['forged'] },
+        'mastra.flow.policy': { allowedTools: ['forged-tool'] },
+        'app.locale': 'en',
+      },
+      paramsRequestContext: {
+        [MASTRA_RESOURCE_ID_KEY]: 'query-resource',
+        [MASTRA_THREAD_ID_KEY]: 'query-thread',
+        'mastra.flow.state': { capabilities: ['query-forged'] },
+        'app.locale': 'fr',
+      },
+    });
+
+    expect(requestContext.get(MASTRA_RESOURCE_ID_KEY)).toBeUndefined();
+    expect(requestContext.get(MASTRA_THREAD_ID_KEY)).toBeUndefined();
+    expect(requestContext.get('mastra.flow')).toBeUndefined();
+    expect(requestContext.get('mastra.flow.state')).toBeUndefined();
+    expect(requestContext.get('mastra.flow.policy')).toBeUndefined();
+    expect(requestContext.get('app.locale')).toBe('fr');
+  });
+
+  it('only reserves the mastra.flow namespace segment', () => {
+    const server = createServer();
+
+    const requestContext = server.mergeContextForTest({
+      bodyRequestContext: {
+        'mastra.flowState': 'app-owned',
+      },
+    });
+
+    expect(requestContext.get('mastra.flowState')).toBe('app-owned');
+  });
+});

--- a/packages/server/src/server/server-adapter/request-context.test.ts
+++ b/packages/server/src/server/server-adapter/request-context.test.ts
@@ -1,7 +1,7 @@
 import { Mastra } from '@mastra/core/mastra';
 import { describe, expect, it, vi } from 'vitest';
 
-import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../constants';
+import { MASTRA_FLOW_CONTEXT_KEY_PREFIX, MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../constants';
 import { MastraServer } from './index';
 
 class TestMastraServer extends MastraServer<any, any, any> {
@@ -30,36 +30,38 @@ describe('server request context merge', () => {
       bodyRequestContext: {
         [MASTRA_RESOURCE_ID_KEY]: 'body-resource',
         [MASTRA_THREAD_ID_KEY]: 'body-thread',
-        'mastra.flow': { capabilities: ['root-forged'] },
-        'mastra.flow.state': { capabilities: ['forged'] },
-        'mastra.flow.policy': { allowedTools: ['forged-tool'] },
+        [MASTRA_FLOW_CONTEXT_KEY_PREFIX]: { capabilities: ['root-forged'] },
+        mastra__flowState: { capabilities: ['forged'] },
+        mastra__flowPolicy: { allowedTools: ['forged-tool'] },
         'app.locale': 'en',
       },
       paramsRequestContext: {
         [MASTRA_RESOURCE_ID_KEY]: 'query-resource',
         [MASTRA_THREAD_ID_KEY]: 'query-thread',
-        'mastra.flow.state': { capabilities: ['query-forged'] },
+        mastra__flowState: { capabilities: ['query-forged'] },
         'app.locale': 'fr',
       },
     });
 
     expect(requestContext.get(MASTRA_RESOURCE_ID_KEY)).toBeUndefined();
     expect(requestContext.get(MASTRA_THREAD_ID_KEY)).toBeUndefined();
-    expect(requestContext.get('mastra.flow')).toBeUndefined();
-    expect(requestContext.get('mastra.flow.state')).toBeUndefined();
-    expect(requestContext.get('mastra.flow.policy')).toBeUndefined();
+    expect(requestContext.get(MASTRA_FLOW_CONTEXT_KEY_PREFIX)).toBeUndefined();
+    expect(requestContext.get('mastra__flowState')).toBeUndefined();
+    expect(requestContext.get('mastra__flowPolicy')).toBeUndefined();
     expect(requestContext.get('app.locale')).toBe('fr');
   });
 
-  it('only reserves the mastra.flow namespace segment', () => {
+  it('preserves non-internal application flow keys', () => {
     const server = createServer();
 
     const requestContext = server.mergeContextForTest({
       bodyRequestContext: {
-        'mastra.flowState': 'app-owned',
+        'app.flowState': 'app-owned',
+        'mastra.flowState': 'dotted-app-owned',
       },
     });
 
-    expect(requestContext.get('mastra.flowState')).toBe('app-owned');
+    expect(requestContext.get('app.flowState')).toBe('app-owned');
+    expect(requestContext.get('mastra.flowState')).toBe('dotted-app-owned');
   });
 });


### PR DESCRIPTION
## Summary
- Reserve the internal `mastra.flow` request-context namespace during server body/query context merging
- Keep existing app-owned keys such as `mastra.flowState` pass-through compatible
- Add focused server-adapter tests for reserved body/query request context filtering
- Add an `@mastra/server` patch changeset

## Why
Future Flow Signals runtime helpers may read `mastra.flow.state` for capabilities, evidence, and decisions. Client-provided request context must not be able to forge those internal values before processors start trusting them.

## Verification
- `pnpm --filter ./packages/server test src/server/server-adapter/request-context.test.ts`
- `pnpm --filter ./packages/server lint -- src/server/server-adapter/index.ts src/server/server-adapter/request-context.test.ts`
- `pnpm build:server`

Linear: PF-166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR prevents clients from faking internal Mastra Flow values in request contexts by reserving an internal key namespace (mastra__flow.*) and blocking those keys when merging client-provided context. Tests ensure legitimate app keys stay untouched.

## Changes
- **Reserved context namespace protection**: Added `MASTRA_FLOW_CONTEXT_KEY_PREFIX = 'mastra__flow'`, `RESERVED_CONTEXT_KEY_PREFIXES`, and an `isReservedContextKey()` helper to treat keys that equal or start with reserved prefixes as internal.
- **Request context merging**: Updated `mergeRequestContext()` in `MastraServer` to use `isReservedContextKey()` so client-supplied keys matching reserved exact names or reserved prefixes are filtered out when merging `bodyRequestContext` and `paramsRequestContext`.
- **Test coverage**: New Vitest suite (`request-context.test.ts`) verifies:
  - Reserved keys (resource/thread IDs, `mastra__flow*`, and internal flow keys like `mastra__flowState`/`mastra__flowPolicy`) are removed from merged context.
  - Non-reserved application keys (e.g., `app.locale`, `app.flowState`, `mastra.flowState`) are preserved.
- **Changeset**: Updated `.changeset` for `@mastra/server` (patch) documenting the fix.

## Rationale
Future Flow Signals runtime helpers will read internal flow state/capabilities from mastra flow keys; preventing client-supplied tampering ensures those internal values remain trustworthy before server processors run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->