### PR TITLE
PF-175: Add Tool Gate substrate

### DIFF
--- a/.changeset/slow-poems-jump.md
+++ b/.changeset/slow-poems-jump.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Prepared Mastra for experimental runtime tool access policies. This lays internal groundwork for controlling tool visibility, tool calls, and dynamic tool loading in a future release, but no enforcement is active yet.

--- a/packages/core/src/tools/tool-gate.test.ts
+++ b/packages/core/src/tools/tool-gate.test.ts
@@ -1,0 +1,397 @@
+import { describe, expect, it } from 'vitest';
+import { RequestContext } from '../request-context';
+import {
+  appendToolGateDecision,
+  clearToolGateRuntimeState,
+  createProviderToolGateSubject,
+  createToolGateDecisionRecord,
+  createToolGateSubject,
+  evaluateToolGatePolicy,
+  getToolGateRuntimeState,
+  hydrateToolGateRuntimeState,
+  serializeToolGateRuntimeState,
+  setToolGateRuntimeState,
+} from './tool-gate';
+import type { CoreTool } from './types';
+
+describe('tool gate subjects', () => {
+  it('keeps local tool source information explicit', () => {
+    const subject = createToolGateSubject({
+      boundary: 'model-input',
+      toolName: 'agent-researcher',
+      tool: {
+        id: 'agent-researcher',
+        description: 'Delegate research',
+      },
+      source: {
+        source: 'agent',
+        primitiveId: 'researcher',
+      },
+    });
+
+    expect(subject).toMatchObject({
+      boundary: 'model-input',
+      toolName: 'agent-researcher',
+      toolId: 'agent-researcher',
+      description: 'Delegate research',
+      source: {
+        source: 'agent',
+        primitiveId: 'researcher',
+      },
+    });
+  });
+
+  it('captures provider tool ids without treating them like function tools', () => {
+    const subject = createProviderToolGateSubject({
+      boundary: 'tool-call',
+      toolName: 'web_search',
+      tool: {
+        id: 'openai.web_search',
+        name: 'web_search',
+        description: 'Search the web',
+        args: { search_context_size: 'medium' },
+      } as Partial<CoreTool> & { id: string; name: string; args: Record<string, unknown> },
+    });
+
+    expect(subject).toMatchObject({
+      boundary: 'tool-call',
+      toolName: 'web_search',
+      toolId: 'openai.web_search',
+      source: {
+        source: 'provider',
+        providerToolId: 'openai.web_search',
+        providerName: 'openai',
+        modelFacingName: 'web_search',
+      },
+      provider: {
+        id: 'openai.web_search',
+        args: { search_context_size: 'medium' },
+      },
+    });
+  });
+
+  it('preserves MCP metadata separately from the source', () => {
+    const subject = createToolGateSubject({
+      boundary: 'dynamic-load',
+      toolName: 'list_files',
+      tool: {
+        id: 'list_files',
+        mcpMetadata: {
+          serverName: 'filesystem',
+          serverVersion: '1.0.0',
+        },
+        mcp: {
+          toolType: 'agent',
+          annotations: {
+            readOnlyHint: true,
+            destructiveHint: false,
+          },
+        },
+      },
+      source: {
+        source: 'mcp',
+        serverName: 'filesystem',
+        serverVersion: '1.0.0',
+        toolType: 'agent',
+      },
+    });
+
+    expect(subject).toMatchObject({
+      source: {
+        source: 'mcp',
+        serverName: 'filesystem',
+        serverVersion: '1.0.0',
+        toolType: 'agent',
+      },
+      mcp: {
+        metadata: {
+          serverName: 'filesystem',
+          serverVersion: '1.0.0',
+        },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+        },
+      },
+    });
+  });
+});
+
+describe('tool gate runtime state', () => {
+  it('evaluates policies into auditable decision records', async () => {
+    const subject = createToolGateSubject({
+      boundary: 'tool-call',
+      toolName: 'sendEmail',
+      source: { source: 'client' },
+    });
+
+    const record = await evaluateToolGatePolicy({
+      policy: {
+        id: 'workspace-policy',
+        evaluate: evaluation => ({
+          effect: 'requireApproval',
+          reason: `${evaluation.subject.toolName} crosses a workspace boundary`,
+          ruleId: 'external-write',
+        }),
+      },
+      evaluation: {
+        subject,
+        runId: 'run-1',
+        threadId: 'thread-1',
+        resourceId: 'resource-1',
+        toolCallId: 'tool-call-1',
+      },
+      evaluatedAt: '2026-05-06T00:00:00.000Z',
+    });
+
+    expect(record).toMatchObject({
+      effect: 'requireApproval',
+      reason: 'sendEmail crosses a workspace boundary',
+      ruleId: 'external-write',
+      policyId: 'workspace-policy',
+      runId: 'run-1',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      toolCallId: 'tool-call-1',
+      evaluatedAt: '2026-05-06T00:00:00.000Z',
+      subject,
+    });
+  });
+
+  it('stores gate state outside public RequestContext entries and JSON', () => {
+    const requestContext = new RequestContext([['publicKey', 'publicValue']]);
+    const subject = createToolGateSubject({
+      boundary: 'model-input',
+      toolName: 'deleteUser',
+      source: { source: 'assigned' },
+    });
+
+    setToolGateRuntimeState(requestContext, {
+      policy: {
+        id: 'tenant-policy',
+        evaluate: () => ({ effect: 'deny', reason: 'tenant rule' }),
+      },
+      decisions: [
+        createToolGateDecisionRecord({
+          subject,
+          policyId: 'tenant-policy',
+          decision: {
+            effect: 'deny',
+            reason: 'tenant rule',
+            ruleId: 'no-delete-user',
+          },
+          evaluatedAt: '2026-05-06T00:00:00.000Z',
+        }),
+      ],
+    });
+
+    expect(requestContext.all).toEqual({ publicKey: 'publicValue' });
+    expect(Object.fromEntries(requestContext.entries())).toEqual({ publicKey: 'publicValue' });
+    expect(requestContext.toJSON()).toEqual({ publicKey: 'publicValue' });
+    expect(getToolGateRuntimeState(requestContext)?.policy?.id).toBe('tenant-policy');
+  });
+
+  it('does not expose stored state by reference', () => {
+    const requestContext = new RequestContext();
+    const subject = createToolGateSubject({
+      boundary: 'tool-call',
+      toolName: 'sendEmail',
+      source: { source: 'client' },
+    });
+    const metadata = { nested: { value: 'original' } };
+
+    setToolGateRuntimeState(requestContext, {
+      decisions: [
+        createToolGateDecisionRecord({
+          subject,
+          decision: { effect: 'allow', reason: 'safe client tool', metadata },
+          evaluatedAt: '2026-05-06T00:00:00.000Z',
+        }),
+      ],
+    });
+
+    const firstRead = getToolGateRuntimeState(requestContext);
+    (firstRead?.decisions?.[0]?.metadata?.nested as { value: string }).value = 'mutated';
+    firstRead?.decisions?.push(
+      createToolGateDecisionRecord({
+        subject,
+        decision: { effect: 'deny', reason: 'mutated copy' },
+      }),
+    );
+
+    expect(getToolGateRuntimeState(requestContext)?.decisions).toHaveLength(1);
+    expect(getToolGateRuntimeState(requestContext)?.decisions?.[0]?.metadata).toEqual(metadata);
+  });
+
+  it('appends decisions without exposing state through RequestContext', () => {
+    const requestContext = new RequestContext();
+    const subject = createToolGateSubject({
+      boundary: 'dynamic-search',
+      toolName: 'searchIssues',
+      source: {
+        source: 'dynamic',
+        catalogName: 'github',
+      },
+    });
+
+    appendToolGateDecision(
+      requestContext,
+      createToolGateDecisionRecord({
+        subject,
+        decision: { effect: 'requireApproval', reason: 'external write capability' },
+        toolCallId: 'tool-call-1',
+        evaluatedAt: '2026-05-06T00:00:00.000Z',
+      }),
+    );
+
+    expect(requestContext.size()).toBe(0);
+    expect(getToolGateRuntimeState(requestContext)?.decisions?.[0]).toMatchObject({
+      effect: 'requireApproval',
+      toolCallId: 'tool-call-1',
+    });
+
+    clearToolGateRuntimeState(requestContext);
+    expect(getToolGateRuntimeState(requestContext)).toBeUndefined();
+  });
+});
+
+describe('tool gate durable state shape', () => {
+  it('serializes only durable-safe policy identity and decisions', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const providerArgs = {
+      kept: { nested: 'arg' },
+      droppedNested: { fn: () => true },
+      droppedCircular: circular,
+    };
+    const subject = createProviderToolGateSubject({
+      boundary: 'tool-call',
+      toolName: 'web_search',
+      tool: {
+        id: 'openai.web_search',
+        args: providerArgs,
+      } as Partial<CoreTool> & { id: string; args: Record<string, unknown> },
+    });
+
+    const serialized = serializeToolGateRuntimeState({
+      policy: {
+        id: 'workspace-policy',
+        evaluate: () => ({ effect: 'allow', reason: 'test policy' }),
+      },
+      policyRevision: 'rev-1',
+      resumeRule: 'narrow-on-resume',
+      decisions: [
+        createToolGateDecisionRecord({
+          subject,
+          decision: {
+            effect: 'allow',
+            reason: 'workflow allowed',
+            metadata: {
+              kept: { nested: true, droppedNestedFunction: () => true },
+              droppedFunction: () => true,
+              droppedSymbol: Symbol('tool-gate'),
+              droppedCircular: circular,
+            },
+          },
+          evaluatedAt: '2026-05-06T00:00:00.000Z',
+        }),
+      ],
+    });
+
+    expect(serialized).toEqual({
+      policyId: 'workspace-policy',
+      policyRevision: 'rev-1',
+      resumeRule: 'narrow-on-resume',
+      decisions: [
+        expect.objectContaining({
+          effect: 'allow',
+          reason: 'workflow allowed',
+          metadata: {
+            kept: { nested: true },
+          },
+          subject: {
+            ...subject,
+            provider: {
+              id: 'openai.web_search',
+              args: {
+                kept: { nested: 'arg' },
+              },
+            },
+          },
+        }),
+      ],
+    });
+    providerArgs.kept.nested = 'mutated';
+    expect(serialized?.decisions?.[0]?.subject.provider?.args).toEqual({
+      kept: { nested: 'arg' },
+    });
+    expect(JSON.stringify(serialized)).toContain('workspace-policy');
+    expect(serialized).not.toHaveProperty('policy');
+  });
+
+  it('preserves durable policy identity when hydrating without an evaluator', () => {
+    const runtimeState = hydrateToolGateRuntimeState({
+      serialized: {
+        policyId: 'workspace-policy',
+        policyRevision: 'rev-1',
+      },
+    });
+
+    expect(runtimeState).toMatchObject({
+      policyId: 'workspace-policy',
+      policyRevision: 'rev-1',
+    });
+    expect(serializeToolGateRuntimeState(runtimeState)).toMatchObject({
+      policyId: 'workspace-policy',
+      policyRevision: 'rev-1',
+    });
+  });
+
+  it('hydrates serialized decisions with a re-provided evaluator', () => {
+    const runtimeState = hydrateToolGateRuntimeState({
+      serialized: {
+        policyId: 'workspace-policy',
+        policyRevision: 'rev-1',
+        resumeRule: 'original-policy-only',
+        decisions: [],
+      },
+      policy: {
+        id: 'workspace-policy',
+        evaluate: () => ({ effect: 'deny', reason: 'rehydrated policy' }),
+      },
+    });
+
+    expect(runtimeState).toMatchObject({
+      policy: {
+        id: 'workspace-policy',
+      },
+      policyRevision: 'rev-1',
+      resumeRule: 'original-policy-only',
+      decisions: [],
+    });
+    expect(
+      runtimeState?.policy?.evaluate({
+        subject: createToolGateSubject({ boundary: 'tool-call', toolName: 'x', source: { source: 'unknown' } }),
+      }),
+    ).toEqual({
+      effect: 'deny',
+      reason: 'rehydrated policy',
+    });
+  });
+
+  it('rejects hydration with an unrelated policy id', () => {
+    expect(() =>
+      hydrateToolGateRuntimeState({
+        serialized: {
+          policyId: 'original-policy',
+        },
+        policy: {
+          id: 'other-policy',
+          evaluate: () => ({ effect: 'allow', reason: 'wrong policy' }),
+        },
+      }),
+    ).toThrow(
+      'Tool Gate policyId mismatch: serialized policyId "original-policy" does not match provided policy id "other-policy".',
+    );
+  });
+});

--- a/packages/core/src/tools/tool-gate.ts
+++ b/packages/core/src/tools/tool-gate.ts
@@ -1,0 +1,416 @@
+import type { RequestContext } from '../request-context';
+import type { CoreTool, MCPToolProperties, McpMetadata } from './types';
+
+export type ToolGateBoundary = 'model-input' | 'tool-call' | 'dynamic-search' | 'dynamic-load';
+
+export type ToolGateSource =
+  | { source: 'assigned' }
+  | { source: 'client' }
+  | { source: 'toolset'; toolsetName?: string }
+  | { source: 'dynamic'; catalogName?: string; loaded?: boolean }
+  | { source: 'provider'; providerToolId: string; providerName?: string; modelFacingName?: string }
+  | { source: 'mcp'; serverName?: string; serverVersion?: string; toolType?: MCPToolProperties['toolType'] }
+  | { source: 'agent'; primitiveId: string }
+  | { source: 'workflow'; primitiveId: string }
+  | { source: 'memory' }
+  | { source: 'workspace' }
+  | { source: 'skill'; skillId?: string }
+  | { source: 'browser' }
+  | { source: 'channel'; channelId?: string }
+  | { source: 'unknown' };
+
+export type ToolGateSubject = {
+  boundary: ToolGateBoundary;
+  toolName: string;
+  toolId?: string;
+  description?: string;
+  source: ToolGateSource;
+  mcp?: {
+    metadata?: McpMetadata;
+    annotations?: MCPToolProperties['annotations'];
+  };
+  provider?: {
+    id: string;
+    args?: Record<string, unknown>;
+  };
+};
+
+export type ToolGateEffect = 'allow' | 'deny' | 'requireApproval';
+
+export type ToolGateDecision = {
+  effect: ToolGateEffect;
+  reason: string;
+  ruleId?: string;
+  message?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type ToolGateDecisionRecord = ToolGateDecision & {
+  subject: ToolGateSubject;
+  policyId?: string;
+  runId?: string;
+  threadId?: string;
+  resourceId?: string;
+  toolCallId?: string;
+  evaluatedAt: string;
+};
+
+export type ToolGateEvaluation = {
+  subject: ToolGateSubject;
+  requestContext?: RequestContext;
+  args?: unknown;
+  runId?: string;
+  threadId?: string;
+  resourceId?: string;
+  toolCallId?: string;
+};
+
+export type ToolGateEvaluator = (evaluation: ToolGateEvaluation) => ToolGateDecision | Promise<ToolGateDecision>;
+
+export type ToolGatePolicy = {
+  id: string;
+  description?: string;
+  evaluate: ToolGateEvaluator;
+};
+
+export type ToolGateResumeRule = 'original-policy-only' | 'narrow-on-resume';
+
+export type ToolGateSerializableState = {
+  policyId?: string;
+  policyRevision?: string;
+  resumeRule?: ToolGateResumeRule;
+  decisions?: ToolGateDecisionRecord[];
+};
+
+export type ToolGateRuntimeState = {
+  policyId?: string;
+  policy?: ToolGatePolicy;
+  policyRevision?: string;
+  resumeRule?: ToolGateResumeRule;
+  decisions?: ToolGateDecisionRecord[];
+};
+
+const toolGateRuntimeState = new WeakMap<RequestContext, ToolGateRuntimeState>();
+
+function copyToolGateRecord(record: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  if (!record) return undefined;
+
+  const copied: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    copied[key] = copyToolGateValue(value);
+  }
+
+  return copied;
+}
+
+function copyToolGateValue(value: unknown, seen = new WeakMap<object, unknown>()): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (seen.has(value)) return seen.get(value);
+
+  if (Array.isArray(value)) {
+    const copied: unknown[] = [];
+    seen.set(value, copied);
+    for (const item of value) {
+      copied.push(copyToolGateValue(item, seen));
+    }
+    return copied;
+  }
+
+  const copied: Record<string, unknown> = {};
+  seen.set(value, copied);
+  for (const [key, item] of Object.entries(value)) {
+    copied[key] = copyToolGateValue(item, seen);
+  }
+
+  return copied;
+}
+
+function copyDecisionRecord(record: ToolGateDecisionRecord): ToolGateDecisionRecord {
+  return {
+    ...record,
+    subject: {
+      ...record.subject,
+      source: { ...record.subject.source },
+      mcp: record.subject.mcp
+        ? {
+            metadata: record.subject.mcp.metadata ? { ...record.subject.mcp.metadata } : undefined,
+            annotations: record.subject.mcp.annotations ? { ...record.subject.mcp.annotations } : undefined,
+          }
+        : undefined,
+      provider: record.subject.provider
+        ? {
+            ...record.subject.provider,
+            args: copyToolGateRecord(record.subject.provider.args),
+          }
+        : undefined,
+    },
+    metadata: copyToolGateRecord(record.metadata),
+  };
+}
+
+function copySerializableRecord(record: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  if (!record) return undefined;
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    const copied = copySerializableToolGateValue(value);
+    if (copied !== undefined) {
+      result[key] = copied;
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function copySerializableToolGateValue(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : undefined;
+  if (value === undefined || typeof value === 'function' || typeof value === 'symbol') return undefined;
+  if (typeof value !== 'object') return undefined;
+  if (seen.has(value)) return undefined;
+
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    const result = value.map(item => {
+      const copied = copySerializableToolGateValue(item, seen);
+      return copied === undefined ? null : copied;
+    });
+    seen.delete(value);
+    return result;
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    const copied = copySerializableToolGateValue(item, seen);
+    if (copied !== undefined) {
+      result[key] = copied;
+    }
+  }
+
+  seen.delete(value);
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function copySerializableDecisionRecord(record: ToolGateDecisionRecord): ToolGateDecisionRecord {
+  const copied = copyDecisionRecord(record);
+
+  return {
+    ...copied,
+    metadata: copySerializableRecord(copied.metadata),
+    subject: {
+      ...copied.subject,
+      provider: copied.subject.provider
+        ? {
+            ...copied.subject.provider,
+            args: copySerializableRecord(copied.subject.provider.args),
+          }
+        : undefined,
+    },
+  };
+}
+
+function providerNameFromId(providerToolId: string): string | undefined {
+  const [providerName] = providerToolId.split('.');
+  return providerName || undefined;
+}
+
+function modelFacingNameFromProviderId(providerToolId: string): string | undefined {
+  const [, ...nameParts] = providerToolId.split('.');
+  return nameParts.length > 0 ? nameParts.join('.') : undefined;
+}
+
+export function createToolGateSubject({
+  boundary,
+  toolName,
+  tool,
+  source,
+}: {
+  boundary: ToolGateBoundary;
+  toolName: string;
+  tool?: Partial<CoreTool> & { mcpMetadata?: McpMetadata };
+  source: ToolGateSource;
+}): ToolGateSubject {
+  const toolId = typeof tool?.id === 'string' ? tool.id : undefined;
+  const provider =
+    source.source === 'provider'
+      ? {
+          id: source.providerToolId,
+          args:
+            tool && 'args' in tool && typeof tool.args === 'object' && tool.args !== null
+              ? ({ ...(tool.args as Record<string, unknown>) } as Record<string, unknown>)
+              : undefined,
+        }
+      : undefined;
+
+  return {
+    boundary,
+    toolName,
+    toolId,
+    description: typeof tool?.description === 'string' ? tool.description : undefined,
+    source,
+    ...(tool?.mcp || tool?.mcpMetadata
+      ? {
+          mcp: {
+            metadata: tool.mcpMetadata,
+            annotations: tool.mcp?.annotations,
+          },
+        }
+      : {}),
+    ...(provider ? { provider } : {}),
+  };
+}
+
+export function createProviderToolGateSubject({
+  boundary,
+  toolName,
+  tool,
+}: {
+  boundary: ToolGateBoundary;
+  toolName: string;
+  tool: Partial<CoreTool> & { id: string };
+}): ToolGateSubject {
+  const providerToolId = tool.id;
+  const providerToolName = 'name' in tool && typeof tool.name === 'string' ? tool.name : undefined;
+
+  return createToolGateSubject({
+    boundary,
+    toolName,
+    tool,
+    source: {
+      source: 'provider',
+      providerToolId,
+      providerName: providerNameFromId(providerToolId),
+      modelFacingName: providerToolName ?? modelFacingNameFromProviderId(providerToolId),
+    },
+  });
+}
+
+export function createToolGateDecisionRecord({
+  decision,
+  subject,
+  policyId,
+  runId,
+  threadId,
+  resourceId,
+  toolCallId,
+  evaluatedAt = new Date().toISOString(),
+}: {
+  decision: ToolGateDecision;
+  subject: ToolGateSubject;
+  policyId?: string;
+  runId?: string;
+  threadId?: string;
+  resourceId?: string;
+  toolCallId?: string;
+  evaluatedAt?: string;
+}): ToolGateDecisionRecord {
+  return {
+    ...decision,
+    subject,
+    policyId,
+    runId,
+    threadId,
+    resourceId,
+    toolCallId,
+    evaluatedAt,
+  };
+}
+
+export async function evaluateToolGatePolicy({
+  policy,
+  evaluation,
+  evaluatedAt,
+}: {
+  policy: ToolGatePolicy;
+  evaluation: ToolGateEvaluation;
+  evaluatedAt?: string;
+}): Promise<ToolGateDecisionRecord> {
+  const decision = await policy.evaluate(evaluation);
+
+  return createToolGateDecisionRecord({
+    decision,
+    subject: evaluation.subject,
+    policyId: policy.id,
+    runId: evaluation.runId,
+    threadId: evaluation.threadId,
+    resourceId: evaluation.resourceId,
+    toolCallId: evaluation.toolCallId,
+    evaluatedAt,
+  });
+}
+
+export function setToolGateRuntimeState(requestContext: RequestContext, state: ToolGateRuntimeState): void {
+  if (state.policyId && state.policy?.id && state.policyId !== state.policy.id) {
+    throw new Error(
+      `Tool Gate policyId mismatch: state policyId "${state.policyId}" does not match policy id "${state.policy.id}".`,
+    );
+  }
+
+  toolGateRuntimeState.set(requestContext, {
+    ...state,
+    policyId: state.policy?.id ?? state.policyId,
+    decisions: state.decisions?.map(copyDecisionRecord),
+  });
+}
+
+export function getToolGateRuntimeState(requestContext: RequestContext): ToolGateRuntimeState | undefined {
+  const state = toolGateRuntimeState.get(requestContext);
+  if (!state) return undefined;
+
+  return {
+    ...state,
+    decisions: state.decisions?.map(copyDecisionRecord),
+  };
+}
+
+export function clearToolGateRuntimeState(requestContext: RequestContext): void {
+  toolGateRuntimeState.delete(requestContext);
+}
+
+export function appendToolGateDecision(requestContext: RequestContext, record: ToolGateDecisionRecord): void {
+  const state = toolGateRuntimeState.get(requestContext) ?? {};
+  const decisions = state.decisions ? [...state.decisions, copyDecisionRecord(record)] : [copyDecisionRecord(record)];
+
+  toolGateRuntimeState.set(requestContext, {
+    ...state,
+    decisions,
+  });
+}
+
+export function serializeToolGateRuntimeState(
+  state: ToolGateRuntimeState | undefined,
+): ToolGateSerializableState | undefined {
+  if (!state) return undefined;
+  const policyId = state.policy?.id ?? state.policyId;
+
+  return {
+    policyId,
+    policyRevision: state.policyRevision,
+    resumeRule: state.resumeRule,
+    decisions: state.decisions?.map(copySerializableDecisionRecord),
+  };
+}
+
+export function hydrateToolGateRuntimeState({
+  serialized,
+  policy,
+}: {
+  serialized?: ToolGateSerializableState;
+  policy?: ToolGatePolicy;
+}): ToolGateRuntimeState | undefined {
+  if (!serialized && !policy) return undefined;
+  if (serialized?.policyId && policy?.id && serialized.policyId !== policy.id) {
+    throw new Error(
+      `Tool Gate policyId mismatch: serialized policyId "${serialized.policyId}" does not match provided policy id "${policy.id}".`,
+    );
+  }
+
+  return {
+    policyId: serialized?.policyId ?? policy?.id,
+    policy,
+    policyRevision: serialized?.policyRevision,
+    resumeRule: serialized?.resumeRule,
+    decisions: serialized?.decisions?.map(copyDecisionRecord),
+  };
+}


### PR DESCRIPTION
## Summary
- add internal Tool Gate subject, decision, evaluator, and runtime-state primitives
- keep Tool Gate state outside public RequestContext entries/all/toJSON
- add durable-safe serialization and hydration shape for later resume parity work
- add focused unit tests and an @mastra/core changeset

## Design
This intentionally avoids a generic RuntimePolicy normalizer. The substrate models Mastra tool boundaries explicitly through ToolSubject, ToolGateDecision, and local source metadata. No enforcement path is wired in this PR.

## Tests
- pnpm --filter ./packages/core test -- src/tools/tool-gate.test.ts
- pnpm --filter ./packages/core check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds an internal "safety checkpoint" for tools in Mastra that records whether a tool call should be allowed, denied, or needs approval, and saves audit-ready decision records—nothing is blocked yet, enforcement comes later.

## Overview
Introduces a Tool Gate subsystem that models tool boundaries, sources, evaluation results, and per-request runtime state to prepare Mastra for runtime tool-access policies and future resume parity; no enforcement path is implemented in this PR.

## Key Changes

### New Types and Models
- Boundaries: `model-input | tool-call | dynamic-search | dynamic-load`.
- Sources: Rich union (`assigned`, `client`, `toolset`, `dynamic`, `provider`, `mcp`, `agent`, `workflow`, `memory`, `workspace`, `skill`, `browser`, `channel`, `unknown`).
- Subject: `ToolGateSubject` describing boundary, tool metadata, source, and optional MCP/provider context.
- Decision & Record: `ToolGateDecision` (`allow | deny | requireApproval`) and `ToolGateDecisionRecord` (adds subject, policy/run/thread/resource/toolCall IDs, evaluatedAt).
- Policy & Evaluator: `ToolGatePolicy` and `ToolGateEvaluator` (async evaluation function).
- Resume Rules: `original-policy-only | narrow-on-resume`.
- Serializable & Runtime State shapes: `ToolGateSerializableState` and `ToolGateRuntimeState`.

### Runtime State Management
- Per-request runtime state stored in a WeakMap keyed by RequestContext (`toolGateRuntimeState`), intentionally excluded from RequestContext public entries/all/toJSON.
- API: `setToolGateRuntimeState`, `getToolGateRuntimeState`, `clearToolGateRuntimeState`, `appendToolGateDecision`.
- Deep-copy helpers (e.g., copy of decision records) to prevent external mutation and avoid leaking internal references.

### Durability & Serialization
- `serializeToolGateRuntimeState` exports durable fields (policyId, policyRevision, resumeRule, decisions) but not the evaluator function.
- `hydrateToolGateRuntimeState` reconstructs runtime state from serialized data and accepts an optional policy evaluator to re-provision behavior for resume scenarios; includes compatibility checks (policyId/revision).

### Factories & Utilities
- `createToolGateSubject` and `createProviderToolGateSubject` for building subjects (provider helpers extract provider name and model-facing name from IDs).
- `createToolGateDecisionRecord` to wrap decisions into auditable records.
- `evaluateToolGatePolicy` to run a policy evaluator and produce a decision record (with full context and timestamps).
- Helper functions for safe copying and serialization.

## Tests
- New comprehensive unit tests (packages/core/src/tools/tool-gate.test.ts) covering:
  - Subject creation for local, provider, and MCP-sourced tools.
  - Policy evaluation producing auditable decision records with contextual IDs and timestamps.
  - Isolation of runtime state from RequestContext public surfaces.
  - Immutability of stored state (mutating returned copies doesn't affect stored state).
  - Serialization/hydration round-trips with optional re-provisioning of policy evaluators.

## Design Notes
- Intentionally avoids a generic RuntimePolicy normalizer; models Mastra tool boundaries and local source metadata explicitly.
- No enforcement wiring in this change; this PR provides primitives and durable-safe shapes to enable enforcement and resume-parity work later.

## Additional
- Adds a changeset patch for @mastra/core describing the experimental runtime tool-access primitives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->