### PR TITLE
PF-176: Enforce Tool Gate for agent runs

### DIFF
--- a/.changeset/young-webs-type.md
+++ b/.changeset/young-webs-type.md
@@ -3,3 +3,15 @@
 ---
 
 Added experimental Tool Gate enforcement for non-durable agent runs. Tool Gate policies can now filter model-visible tools and require approval or reject server-side tool calls at runtime.
+
+```ts
+await agent.stream('Review this PR', {
+  toolGatePolicy: {
+    id: 'workspace-policy',
+    evaluate: ({ subject }) =>
+      subject.boundary === 'tool-call'
+        ? { effect: 'requireApproval', reason: 'External actions need approval' }
+        : { effect: 'allow', reason: 'Allowed' },
+  },
+});
+```

--- a/.changeset/young-webs-type.md
+++ b/.changeset/young-webs-type.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added experimental Tool Gate enforcement for non-durable agent runs. Tool Gate policies can now filter model-visible tools and require approval or reject server-side tool calls at runtime.

--- a/packages/core/src/agent/__tests__/active-tools-enforcement.test.ts
+++ b/packages/core/src/agent/__tests__/active-tools-enforcement.test.ts
@@ -1,7 +1,9 @@
-import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
+import { RequestContext } from '../../request-context';
 import { createTool } from '../../tools';
+import { getToolGateRuntimeState } from '../../tools/tool-gate';
 import { Agent } from '../agent';
 
 /**
@@ -219,5 +221,215 @@ describe('activeTools enforcement at execution time', () => {
 
     expect(tool1Execute).toHaveBeenCalledOnce();
     expect(tool2Execute).toHaveBeenCalledOnce();
+  });
+
+  it('filters denied tool gate tools after prepareStep before calling the model', async () => {
+    const requestContext = new RequestContext();
+    const seenModelTools: string[][] = [];
+
+    const mockModel = new MockLanguageModelV2({
+      doGenerate: async ({ tools }: any) => {
+        seenModelTools.push(Array.isArray(tools) ? tools.map(tool => tool.name) : Object.keys(tools ?? {}));
+
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          text: 'Done.',
+          content: [{ type: 'text' as const, text: 'Done.' }],
+          warnings: [],
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'You are a helpful assistant.',
+      model: mockModel,
+      tools: {
+        allowedTool: createTool({
+          id: 'allowedTool',
+          description: 'An allowed tool',
+          inputSchema: z.object({ value: z.string() }),
+          execute: vi.fn(),
+        }),
+        hiddenTool: createTool({
+          id: 'hiddenTool',
+          description: 'A denied tool',
+          inputSchema: z.object({ value: z.string() }),
+          execute: vi.fn(),
+        }),
+      },
+    });
+
+    await agent.generate('Hello', {
+      requestContext,
+      maxSteps: 1,
+      prepareStep: ({ tools }) => ({
+        tools,
+        activeTools: ['allowedTool', 'hiddenTool'],
+      }),
+      toolGatePolicy: {
+        id: 'test-tool-gate',
+        evaluate: ({ subject }) =>
+          subject.toolName === 'hiddenTool'
+            ? { effect: 'deny', reason: 'hidden tool is disabled' }
+            : { effect: 'allow', reason: 'tool is allowed' },
+      },
+    });
+
+    expect(seenModelTools[0]).toContain('allowedTool');
+    expect(seenModelTools[0]).not.toContain('hiddenTool');
+    expect(getToolGateRuntimeState(requestContext)?.decisions).toEqual([
+      expect.objectContaining({
+        effect: 'allow',
+        subject: expect.objectContaining({ boundary: 'model-input', toolName: 'allowedTool' }),
+      }),
+      expect.objectContaining({
+        effect: 'deny',
+        subject: expect.objectContaining({ boundary: 'model-input', toolName: 'hiddenTool' }),
+      }),
+    ]);
+  });
+
+  it('does not reuse a call-site tool gate policy on later calls with the same requestContext', async () => {
+    const requestContext = new RequestContext();
+    const seenModelTools: string[][] = [];
+
+    const mockModel = new MockLanguageModelV2({
+      doGenerate: async ({ tools }: any) => {
+        seenModelTools.push(Array.isArray(tools) ? tools.map(tool => tool.name) : Object.keys(tools ?? {}));
+
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          text: 'Done.',
+          content: [{ type: 'text' as const, text: 'Done.' }],
+          warnings: [],
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'You are a helpful assistant.',
+      model: mockModel,
+      tools: {
+        allowedTool: createTool({
+          id: 'allowedTool',
+          description: 'An allowed tool',
+          inputSchema: z.object({ value: z.string() }),
+          execute: vi.fn(),
+        }),
+        hiddenTool: createTool({
+          id: 'hiddenTool',
+          description: 'A denied tool',
+          inputSchema: z.object({ value: z.string() }),
+          execute: vi.fn(),
+        }),
+      },
+    });
+
+    const prepareStep = ({ tools }: any) => ({
+      tools,
+      activeTools: ['allowedTool', 'hiddenTool'],
+    });
+
+    await agent.generate('Hello', {
+      requestContext,
+      maxSteps: 1,
+      prepareStep,
+      toolGatePolicy: {
+        id: 'test-tool-gate',
+        evaluate: ({ subject }) =>
+          subject.toolName === 'hiddenTool'
+            ? { effect: 'deny', reason: 'hidden tool is disabled' }
+            : { effect: 'allow', reason: 'tool is allowed' },
+      },
+    });
+
+    await agent.generate('Hello again', {
+      requestContext,
+      maxSteps: 1,
+      prepareStep,
+    });
+
+    expect(seenModelTools[0]).toContain('allowedTool');
+    expect(seenModelTools[0]).not.toContain('hiddenTool');
+    expect(seenModelTools[1]).toContain('allowedTool');
+    expect(seenModelTools[1]).toContain('hiddenTool');
+    expect(getToolGateRuntimeState(requestContext)?.policy).toBeUndefined();
+  });
+
+  it('does not run streaming input hooks before a tool-call policy decision', async () => {
+    const onInputStart = vi.fn();
+    const onInputDelta = vi.fn();
+    const onInputAvailable = vi.fn();
+
+    const mockModel = new MockLanguageModelV2({
+      doStream: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'response-id', modelId: 'mock-model', timestamp: new Date(0) },
+          { type: 'tool-input-start', id: 'gate-call-id', toolName: 'gateTool' },
+          { type: 'tool-input-delta', id: 'gate-call-id', delta: '{"action"' },
+          { type: 'tool-input-delta', id: 'gate-call-id', delta: ':"send"}' },
+          { type: 'tool-input-end', id: 'gate-call-id' },
+          {
+            type: 'tool-call',
+            toolCallId: 'gate-call-id',
+            toolName: 'gateTool',
+            input: '{"action":"send"}',
+          },
+          {
+            type: 'finish',
+            finishReason: 'tool-calls',
+            usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          },
+        ]),
+      }),
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'You are a helpful assistant.',
+      model: mockModel,
+      tools: {
+        gateTool: createTool({
+          id: 'gateTool',
+          description: 'A gated tool',
+          inputSchema: z.object({ action: z.string() }),
+          execute: vi.fn(),
+          onInputStart,
+          onInputDelta,
+          onInputAvailable,
+        }),
+      },
+    });
+
+    const stream = await agent.stream('Hello', {
+      maxSteps: 1,
+      toolGatePolicy: {
+        id: 'approval-policy',
+        evaluate: ({ subject }) =>
+          subject.boundary === 'tool-call'
+            ? { effect: 'requireApproval', reason: 'external write' }
+            : { effect: 'allow', reason: 'model disclosure allowed' },
+      },
+    });
+
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type === 'tool-call-approval') break;
+    }
+
+    expect(onInputStart).not.toHaveBeenCalled();
+    expect(onInputDelta).not.toHaveBeenCalled();
+    expect(onInputAvailable).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -70,6 +70,7 @@ import { ChunkFrom } from '../stream';
 import type { MastraAgentNetworkStream } from '../stream';
 import type { FullOutput, MastraModelOutput } from '../stream/base/output';
 import { createTool } from '../tools';
+import { setToolGateRuntimeStateForRun } from '../tools/tool-gate';
 import type { ToolToConvert } from '../tools/tool-builder/builder';
 import { isMastraTool, isProviderTool } from '../tools/toolchecks';
 import type { CoreTool } from '../tools/types';
@@ -5156,6 +5157,11 @@ export class Agent<
         resourceId,
       }) ||
       randomUUID();
+    if (options.toolGatePolicy) {
+      setToolGateRuntimeStateForRun(requestContext, runId, {
+        policy: options.toolGatePolicy,
+      });
+    }
     const instructions = options.instructions || (await this.getInstructions({ requestContext }));
 
     // Set Tracing context

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -9,6 +9,7 @@ import type { VersionOverrides } from '../mastra/types';
 import type { ObservabilityContext, TracingOptions } from '../observability';
 import type { ErrorProcessorOrWorkflow, InputProcessorOrWorkflow, OutputProcessorOrWorkflow } from '../processors';
 import type { RequestContext } from '../request-context';
+import type { ToolGatePolicy } from '../tools/tool-gate';
 import type { OutputWriter } from '../workflows/types';
 import type { MessageListInput } from './message-list';
 import type {
@@ -464,6 +465,9 @@ export type AgentExecutionOptionsBase<OUTPUT> = {
 
   /** Request Context containing dynamic configuration and state */
   requestContext?: RequestContext<any>; // @TODO: Figure out how to type this without breaking all the inner types
+
+  /** Experimental runtime policy for model-visible tools and server-side tool calls. */
+  toolGatePolicy?: ToolGatePolicy;
 
   /**
    * Per-invocation version overrides for sub-agents (and future primitives).

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -33,6 +33,11 @@ import type {
 } from '../../../stream/types';
 import { ChunkFrom, readModelStreamTransport } from '../../../stream/types';
 import { findProviderToolByName, inferProviderExecuted } from '../../../tools/provider-tool-utils';
+import {
+  createToolGateSubjectForTool,
+  evaluateToolGateForRequest,
+  getToolGateRuntimeState,
+} from '../../../tools/tool-gate';
 import type { ToolToConvert } from '../../../tools/tool-builder/builder';
 import { isMastraTool } from '../../../tools/toolchecks';
 import { makeCoreTool } from '../../../utils';
@@ -63,6 +68,7 @@ type ProcessOutputStreamOptions<OUTPUT = undefined> = {
   logger?: IMastraLogger;
   transportRef?: StreamTransportRef;
   transportResolver?: () => StreamTransport | undefined;
+  toolGatePolicyActive?: boolean;
 };
 
 function buildResponseModelMetadata(
@@ -83,6 +89,74 @@ function buildResponseModelMetadata(
   return Object.keys(metadata).length > 0 ? { metadata } : undefined;
 }
 
+function getSpecificToolChoiceName(toolChoice: ToolChoice<any> | undefined): string | undefined {
+  return typeof toolChoice === 'object' && toolChoice !== null && 'toolName' in toolChoice
+    ? String(toolChoice.toolName)
+    : undefined;
+}
+
+async function applyToolGateToModelInput<TOOLS extends ToolSet>({
+  currentStep,
+  requestContext,
+  runId,
+  threadId,
+  resourceId,
+}: {
+  currentStep: {
+    tools?: TOOLS | undefined;
+    toolChoice?: ToolChoice<TOOLS> | undefined;
+    activeTools?: (keyof TOOLS)[] | undefined;
+  };
+  requestContext: RequestContext;
+  runId: string;
+  threadId?: string;
+  resourceId?: string;
+}): Promise<void> {
+  if (!getToolGateRuntimeState(requestContext, { runId })?.policy) return;
+  if (!currentStep.tools) return;
+
+  const toolEntries = Object.entries(currentStep.tools);
+  if (toolEntries.length === 0) return;
+
+  const activeToolNames = currentStep.activeTools?.map(String);
+  const deniedToolNames = new Set<string>();
+
+  for (const [toolName, tool] of toolEntries) {
+    if (activeToolNames && !activeToolNames.includes(toolName)) continue;
+
+    const decision = await evaluateToolGateForRequest({
+      requestContext,
+      subject: createToolGateSubjectForTool({
+        boundary: 'model-input',
+        toolName,
+        tool,
+      }),
+      runId,
+      threadId,
+      resourceId,
+    });
+
+    if (decision?.effect === 'deny') {
+      deniedToolNames.add(toolName);
+    }
+  }
+
+  if (deniedToolNames.size === 0) return;
+
+  currentStep.tools = Object.fromEntries(toolEntries.filter(([toolName]) => !deniedToolNames.has(toolName))) as TOOLS;
+
+  if (currentStep.activeTools) {
+    currentStep.activeTools = currentStep.activeTools.filter(
+      toolName => !deniedToolNames.has(String(toolName)),
+    ) as (keyof TOOLS)[];
+  }
+
+  const chosenToolName = getSpecificToolChoiceName(currentStep.toolChoice);
+  if (chosenToolName && deniedToolNames.has(chosenToolName)) {
+    currentStep.toolChoice = Object.keys(currentStep.tools).length > 0 ? ('auto' as ToolChoice<TOOLS>) : undefined;
+  }
+}
+
 async function processOutputStream<OUTPUT = undefined>({
   tools,
   messageId,
@@ -96,6 +170,7 @@ async function processOutputStream<OUTPUT = undefined>({
   logger,
   transportRef,
   transportResolver,
+  toolGatePolicyActive,
 }: ProcessOutputStreamOptions<OUTPUT>): Promise<CollectedChunk[]> {
   let transportSet = false;
   const collectedChunks: CollectedChunk[] = [];
@@ -146,7 +221,7 @@ async function processOutputStream<OUTPUT = undefined>({
           tools?.[chunk.payload.toolName] ||
           Object.values(tools || {})?.find(tool => `id` in tool && tool.id === chunk.payload.toolName);
 
-        if (tool && 'onInputStart' in tool) {
+        if (!toolGatePolicyActive && tool && 'onInputStart' in tool) {
           try {
             await tool?.onInputStart?.({
               toolCallId: chunk.payload.toolCallId,
@@ -167,7 +242,7 @@ async function processOutputStream<OUTPUT = undefined>({
           tools?.[chunk.payload.toolName || ''] ||
           Object.values(tools || {})?.find(tool => `id` in tool && tool.id === chunk.payload.toolName);
 
-        if (tool && 'onInputDelta' in tool) {
+        if (!toolGatePolicyActive && tool && 'onInputDelta' in tool) {
           try {
             await tool?.onInputDelta?.({
               inputTextDelta: chunk.payload.argsTextDelta,
@@ -641,6 +716,16 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             }
           }
 
+          if (requestContext && getToolGateRuntimeState(requestContext, { runId })?.policy) {
+            await applyToolGateToModelInput({
+              currentStep,
+              requestContext,
+              runId,
+              threadId: _internal?.threadId,
+              resourceId: _internal?.resourceId,
+            });
+          }
+
           // Store activeTools on _internal so toolCallStep can enforce them
           if (_internal) {
             _internal.stepActiveTools = currentStep.activeTools as string[] | undefined;
@@ -874,6 +959,7 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
               logger,
               transportRef: _internal?.transportRef,
               transportResolver,
+              toolGatePolicyActive: requestContext ? !!getToolGateRuntimeState(requestContext, { runId })?.policy : false,
             });
 
             // Build messages from the full chunk sequence and add to messageList.

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -8,6 +8,7 @@ import { ChunkFrom } from '../../../stream/types';
 import { createTool } from '../../../tools';
 import { ToolStream } from '../../../tools/stream';
 import { CoreToolBuilder } from '../../../tools/tool-builder/builder';
+import { getToolGateRuntimeState, setToolGateRuntimeState } from '../../../tools/tool-gate';
 import type { MastraToolInvocationOptions } from '../../../tools/types';
 import type { OuterLLMRun } from '../../types';
 import { createToolCallStep } from './tool-call-step';
@@ -398,6 +399,159 @@ describe('createToolCallStep needsApprovalFn enriched context', () => {
       result: toolResult,
       ...makeInputData(),
     });
+  });
+});
+
+describe('createToolCallStep tool gate enforcement', () => {
+  let controller: { enqueue: Mock };
+  let suspend: Mock;
+  let streamState: { serialize: Mock };
+  let messageList: MessageList;
+
+  const makeInputData = (args: Record<string, unknown> = { action: 'send' }) => ({
+    toolCallId: 'gate-call-id',
+    toolName: 'gate-tool',
+    args,
+  });
+
+  const makeExecuteParams = (requestContext: RequestContext, overrides: any = {}) => ({
+    ...makeBaseExecuteParams(suspend, { requestContext }),
+    writer: new ToolStream({
+      prefix: 'tool',
+      callId: 'gate-call-id',
+      name: 'gate-tool',
+      runId: 'gate-run-id',
+    }),
+    inputData: makeInputData(),
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    controller = { enqueue: vi.fn() };
+    suspend = vi.fn().mockReturnValue(new Promise(() => {}));
+    streamState = { serialize: vi.fn().mockReturnValue('serialized-state') };
+    messageList = createMessageList();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it('rejects denied tool calls before execution', async () => {
+    const execute = vi.fn().mockResolvedValue({ ok: true });
+    const onInputAvailable = vi.fn();
+    const requestContext = new RequestContext();
+    setToolGateRuntimeState(requestContext, {
+      policy: {
+        id: 'deny-policy',
+        evaluate: ({ subject, args }) => {
+          expect(subject.boundary).toBe('tool-call');
+          expect(args).toEqual({ action: 'delete' });
+          return { effect: 'deny', reason: 'delete is disabled' };
+        },
+      },
+    });
+
+    const toolCallStep = createToolCallStep({
+      tools: {
+        'gate-tool': { execute, onInputAvailable },
+      },
+      messageList,
+      controller,
+      runId: 'gate-run-id',
+      streamState,
+    } as any);
+
+    const result = await toolCallStep.execute(
+      makeExecuteParams(requestContext, {
+        inputData: makeInputData({ action: 'delete' }),
+      }),
+    );
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(onInputAvailable).not.toHaveBeenCalled();
+    expect(result.error?.name).toBe('ToolNotFoundError');
+    expect(String(result.error?.message)).toContain('delete is disabled');
+    expect(getToolGateRuntimeState(requestContext)?.decisions?.[0]).toMatchObject({
+      effect: 'deny',
+      toolCallId: 'gate-call-id',
+    });
+  });
+
+  it('does not let needsApprovalFn downgrade tool gate approval', async () => {
+    const execute = vi.fn();
+    const requestContext = new RequestContext();
+    setToolGateRuntimeState(requestContext, {
+      policy: {
+        id: 'approval-policy',
+        evaluate: () => ({ effect: 'requireApproval', reason: 'external write' }),
+      },
+    });
+
+    const toolCallStep = createToolCallStep({
+      tools: {
+        'gate-tool': {
+          execute,
+          needsApprovalFn: vi.fn().mockReturnValue(false),
+        },
+      },
+      messageList,
+      controller,
+      runId: 'gate-run-id',
+      streamState,
+    } as any);
+
+    const executePromise = toolCallStep.execute(makeExecuteParams(requestContext));
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(suspend).toHaveBeenCalled();
+    expect(controller.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-call-approval',
+      }),
+    );
+
+    await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
+  });
+
+  it('does not accept model-provided resumeData for tool gate approval', async () => {
+    const execute = vi.fn();
+    const requestContext = new RequestContext();
+    setToolGateRuntimeState(requestContext, {
+      policy: {
+        id: 'approval-policy',
+        evaluate: () => ({ effect: 'requireApproval', reason: 'external write' }),
+      },
+    });
+
+    const toolCallStep = createToolCallStep({
+      tools: {
+        'gate-tool': { execute },
+      },
+      messageList,
+      controller,
+      runId: 'gate-run-id',
+      streamState,
+    } as any);
+
+    const executePromise = toolCallStep.execute(
+      makeExecuteParams(requestContext, {
+        inputData: makeInputData({ action: 'send', resumeData: { approved: true } }),
+      }),
+    );
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(suspend).toHaveBeenCalled();
+    expect(controller.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'tool-call-approval',
+      }),
+    );
+
+    await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
   });
 });
 

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -10,6 +10,11 @@ import { toStandardSchema, standardSchemaToJSONSchema } from '../../../schema';
 import { ChunkFrom } from '../../../stream/types';
 import type { ProviderMetadata } from '../../../stream/types';
 import { findProviderToolByName } from '../../../tools/provider-tool-utils';
+import {
+  createToolGateSubjectForTool,
+  evaluateToolGateForRequest,
+  getToolGateRuntimeState,
+} from '../../../tools/tool-gate';
 import type { MastraToolInvocationOptions } from '../../../tools/types';
 import { ensureSerializable } from '../../../utils';
 import type { SuspendOptions } from '../../../workflows';
@@ -250,23 +255,6 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         };
       }
 
-      if (tool && 'onInputAvailable' in tool) {
-        try {
-          await tool?.onInputAvailable?.({
-            toolCallId: inputData.toolCallId,
-            input: inputData.args,
-            messages: messageList.get.input.aiV5.model(),
-            abortSignal: options?.abortSignal,
-          });
-        } catch (error) {
-          logger?.error('Error calling onInputAvailable', error);
-        }
-      }
-
-      if (!tool.execute) {
-        return inputData;
-      }
-
       try {
         const requireToolApproval = requestContext.get('__mastra_requireToolApproval');
 
@@ -279,16 +267,56 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
           resumeDataFromArgs = resumeDataFromInput;
         }
 
-        const resumeData = resumeDataFromArgs ?? workflowResumeData;
+        const toolGateDecision = getToolGateRuntimeState(requestContext, { runId })?.policy
+          ? await evaluateToolGateForRequest({
+              requestContext,
+              subject: createToolGateSubjectForTool({
+                boundary: 'tool-call',
+                toolName: inputData.toolName,
+                tool,
+              }),
+              args,
+              runId,
+              threadId: _internal?.threadId,
+              resourceId: _internal?.resourceId,
+              toolCallId: inputData.toolCallId,
+            })
+          : undefined;
 
-        const isResumeToolCall = !!resumeDataFromArgs;
+        if (toolGateDecision?.effect === 'deny') {
+          const reason = toolGateDecision.message || toolGateDecision.reason;
+          return {
+            error: new ToolNotFoundError(
+              `Tool "${inputData.toolName}" is blocked by runtime tool policy.${reason ? ` ${reason}` : ''}`,
+            ),
+            ...inputData,
+          };
+        }
+        const toolGateRequiresApproval = toolGateDecision?.effect === 'requireApproval';
+
+        if (tool && 'onInputAvailable' in tool && !toolGateRequiresApproval) {
+          try {
+            await tool?.onInputAvailable?.({
+              toolCallId: inputData.toolCallId,
+              input: inputData.args,
+              messages: messageList.get.input.aiV5.model(),
+              abortSignal: options?.abortSignal,
+            });
+          } catch (error) {
+            logger?.error('Error calling onInputAvailable', error);
+          }
+        }
+
+        if (!tool.execute) {
+          return inputData;
+        }
 
         // Check if approval is required
         // requireApproval can be:
         // - boolean (from Mastra createTool or mapped from AI SDK needsApproval: true)
         // - undefined (no approval needed)
         // If needsApprovalFn exists, evaluate it with the tool args and context
-        let toolRequiresApproval = requireToolApproval || (tool as any).requireApproval;
+        let toolRequiresApproval = requireToolApproval || (tool as any).requireApproval || toolGateRequiresApproval;
         if ((tool as any).needsApprovalFn) {
           // Evaluate the function with parsed args and available context
           try {
@@ -296,7 +324,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
               requestContext: requestContext ? Object.fromEntries(requestContext.entries()) : {},
               workspace: _internal?.stepWorkspace,
             });
-            toolRequiresApproval = needsApprovalResult;
+            toolRequiresApproval = toolGateRequiresApproval || needsApprovalResult;
           } catch (error) {
             // Log error to help developers debug faulty needsApprovalFn implementations
             logger?.error(`Error evaluating needsApprovalFn for tool ${inputData.toolName}:`, error);
@@ -304,6 +332,9 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
             toolRequiresApproval = true;
           }
         }
+
+        const resumeData = toolGateRequiresApproval ? workflowResumeData : (resumeDataFromArgs ?? workflowResumeData);
+        const isResumeToolCall = toolGateRequiresApproval ? !!workflowResumeData : !!resumeDataFromArgs;
 
         // Schema for tool call approval - used for both streaming and metadata
         const approvalSchema = toStandardSchema(
@@ -368,6 +399,19 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
                 ...inputData,
               };
             }
+          }
+        }
+
+        if (tool && 'onInputAvailable' in tool && toolGateRequiresApproval) {
+          try {
+            await tool?.onInputAvailable?.({
+              toolCallId: inputData.toolCallId,
+              input: inputData.args,
+              messages: messageList.get.input.aiV5.model(),
+              abortSignal: options?.abortSignal,
+            });
+          } catch (error) {
+            logger?.error('Error calling onInputAvailable', error);
           }
         }
 

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -1,6 +1,18 @@
 export * from './tool';
 export * from './types';
 export * from './ui-types';
+export type {
+  ToolGateBoundary,
+  ToolGateDecision,
+  ToolGateDecisionRecord,
+  ToolGateEffect,
+  ToolGateEvaluation,
+  ToolGateEvaluator,
+  ToolGatePolicy,
+  ToolGateRequestEvaluation,
+  ToolGateSource,
+  ToolGateSubject,
+} from './tool-gate';
 export { isProviderDefinedTool, isProviderTool, isVercelTool } from './toolchecks';
 export { ToolStream } from './stream';
 export { type ValidationError, isValidationError } from './validation';

--- a/packages/core/src/tools/tool-gate.test.ts
+++ b/packages/core/src/tools/tool-gate.test.ts
@@ -6,11 +6,14 @@ import {
   createProviderToolGateSubject,
   createToolGateDecisionRecord,
   createToolGateSubject,
+  createToolGateSubjectForTool,
+  evaluateToolGateForRequest,
   evaluateToolGatePolicy,
   getToolGateRuntimeState,
   hydrateToolGateRuntimeState,
   serializeToolGateRuntimeState,
   setToolGateRuntimeState,
+  setToolGateRuntimeStateForRun,
 } from './tool-gate';
 import type { CoreTool } from './types';
 
@@ -112,6 +115,54 @@ describe('tool gate subjects', () => {
           readOnlyHint: true,
           destructiveHint: false,
         },
+      },
+    });
+  });
+
+  it('builds provider and MCP subjects from concrete tool objects', () => {
+    expect(
+      createToolGateSubjectForTool({
+        boundary: 'model-input',
+        toolName: 'webSearch',
+        tool: {
+          type: 'provider-defined',
+          id: 'openai.web_search',
+          name: 'web_search',
+          args: { search_context_size: 'low' },
+        },
+      }),
+    ).toMatchObject({
+      source: {
+        source: 'provider',
+        providerToolId: 'openai.web_search',
+        providerName: 'openai',
+        modelFacingName: 'web_search',
+      },
+      provider: {
+        id: 'openai.web_search',
+        args: { search_context_size: 'low' },
+      },
+    });
+
+    expect(
+      createToolGateSubjectForTool({
+        boundary: 'tool-call',
+        toolName: 'list_files',
+        tool: {
+          id: 'list_files',
+          mcpMetadata: {
+            serverName: 'filesystem',
+          },
+          mcp: {
+            toolType: 'workflow',
+          },
+        },
+      }),
+    ).toMatchObject({
+      source: {
+        source: 'mcp',
+        serverName: 'filesystem',
+        toolType: 'workflow',
       },
     });
   });
@@ -252,6 +303,90 @@ describe('tool gate runtime state', () => {
 
     clearToolGateRuntimeState(requestContext);
     expect(getToolGateRuntimeState(requestContext)).toBeUndefined();
+  });
+
+  it('evaluates and records the policy attached to a request', async () => {
+    const requestContext = new RequestContext();
+    const subject = createToolGateSubject({
+      boundary: 'tool-call',
+      toolName: 'sendEmail',
+      source: { source: 'client' },
+    });
+
+    setToolGateRuntimeState(requestContext, {
+      policy: {
+        id: 'workspace-policy',
+        evaluate: evaluation => ({
+          effect: evaluation.args ? 'deny' : 'allow',
+          reason: 'args-aware rule',
+        }),
+      },
+    });
+
+    const record = await evaluateToolGateForRequest({
+      requestContext,
+      subject,
+      args: { to: 'external@example.com' },
+      runId: 'run-1',
+      toolCallId: 'tool-call-1',
+      evaluatedAt: '2026-05-06T00:00:00.000Z',
+    });
+
+    expect(record).toMatchObject({
+      effect: 'deny',
+      reason: 'args-aware rule',
+      policyId: 'workspace-policy',
+      runId: 'run-1',
+      toolCallId: 'tool-call-1',
+    });
+    expect(getToolGateRuntimeState(requestContext)?.decisions).toHaveLength(1);
+  });
+
+  it('keeps invocation policies isolated by run id on a reused RequestContext', async () => {
+    const requestContext = new RequestContext();
+    const subject = createToolGateSubject({
+      boundary: 'tool-call',
+      toolName: 'sendEmail',
+      source: { source: 'client' },
+    });
+
+    setToolGateRuntimeStateForRun(requestContext, 'run-1', {
+      policy: {
+        id: 'run-1-policy',
+        evaluate: () => ({ effect: 'deny', reason: 'first run rule' }),
+      },
+    });
+    setToolGateRuntimeStateForRun(requestContext, 'run-2', {
+      policy: {
+        id: 'run-2-policy',
+        evaluate: () => ({ effect: 'allow', reason: 'second run rule' }),
+      },
+    });
+
+    const firstRecord = await evaluateToolGateForRequest({
+      requestContext,
+      subject,
+      runId: 'run-1',
+    });
+    const secondRecord = await evaluateToolGateForRequest({
+      requestContext,
+      subject,
+      runId: 'run-2',
+    });
+
+    expect(firstRecord).toMatchObject({
+      effect: 'deny',
+      policyId: 'run-1-policy',
+      runId: 'run-1',
+    });
+    expect(secondRecord).toMatchObject({
+      effect: 'allow',
+      policyId: 'run-2-policy',
+      runId: 'run-2',
+    });
+    expect(getToolGateRuntimeState(requestContext, { runId: 'run-1' })?.decisions).toHaveLength(1);
+    expect(getToolGateRuntimeState(requestContext, { runId: 'run-2' })?.decisions).toHaveLength(1);
+    expect(getToolGateRuntimeState(requestContext)?.policy).toBeUndefined();
   });
 });
 

--- a/packages/core/src/tools/tool-gate.ts
+++ b/packages/core/src/tools/tool-gate.ts
@@ -1,5 +1,6 @@
 import type { RequestContext } from '../request-context';
 import type { CoreTool, MCPToolProperties, McpMetadata } from './types';
+import { isProviderTool } from './toolchecks';
 
 export type ToolGateBoundary = 'model-input' | 'tool-call' | 'dynamic-search' | 'dynamic-load';
 
@@ -90,7 +91,17 @@ export type ToolGateRuntimeState = {
   decisions?: ToolGateDecisionRecord[];
 };
 
-const toolGateRuntimeState = new WeakMap<RequestContext, ToolGateRuntimeState>();
+export type ToolGateRequestEvaluation = Omit<ToolGateEvaluation, 'requestContext'> & {
+  requestContext: RequestContext;
+  evaluatedAt?: string;
+};
+
+type ToolGateRuntimeStateStore = {
+  defaultState?: ToolGateRuntimeState;
+  runStates?: Map<string, ToolGateRuntimeState>;
+};
+
+const toolGateRuntimeState = new WeakMap<RequestContext, ToolGateRuntimeStateStore>();
 
 function copyToolGateRecord(record: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
   if (!record) return undefined;
@@ -146,6 +157,34 @@ function copyDecisionRecord(record: ToolGateDecisionRecord): ToolGateDecisionRec
     },
     metadata: copyToolGateRecord(record.metadata),
   };
+}
+
+function copyRuntimeState(state: ToolGateRuntimeState): ToolGateRuntimeState {
+  return {
+    ...state,
+    policyId: state.policy?.id ?? state.policyId,
+    decisions: state.decisions?.map(copyDecisionRecord),
+  };
+}
+
+function assertPolicyIdMatchesState(state: ToolGateRuntimeState): void {
+  if (state.policyId && state.policy?.id && state.policyId !== state.policy.id) {
+    throw new Error(
+      `Tool Gate policyId mismatch: state policyId "${state.policyId}" does not match policy id "${state.policy.id}".`,
+    );
+  }
+}
+
+function getStoredRuntimeState(
+  requestContext: RequestContext,
+  options?: { runId?: string },
+): ToolGateRuntimeState | undefined {
+  const store = toolGateRuntimeState.get(requestContext);
+  if (!store) return undefined;
+  if (options?.runId) {
+    return store.runStates?.get(options.runId) ?? store.defaultState;
+  }
+  return store.defaultState;
 }
 
 function copySerializableRecord(record: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
@@ -286,6 +325,42 @@ export function createProviderToolGateSubject({
   });
 }
 
+export function createToolGateSubjectForTool({
+  boundary,
+  toolName,
+  tool,
+}: {
+  boundary: ToolGateBoundary;
+  toolName: string;
+  tool?: unknown;
+}): ToolGateSubject {
+  if (isProviderTool(tool)) {
+    return createProviderToolGateSubject({
+      boundary,
+      toolName,
+      tool: tool as Partial<CoreTool> & { id: string },
+    });
+  }
+
+  const coreTool = tool as (Partial<CoreTool> & { mcpMetadata?: McpMetadata }) | undefined;
+  const mcpMetadata = coreTool?.mcpMetadata;
+  const mcp = coreTool?.mcp;
+
+  return createToolGateSubject({
+    boundary,
+    toolName,
+    tool: coreTool,
+    source: mcpMetadata
+      ? {
+          source: 'mcp',
+          serverName: mcpMetadata.serverName,
+          serverVersion: mcpMetadata.serverVersion,
+          toolType: mcp?.toolType,
+        }
+      : { source: 'unknown' },
+  });
+}
+
 export function createToolGateDecisionRecord({
   decision,
   subject,
@@ -340,41 +415,130 @@ export async function evaluateToolGatePolicy({
   });
 }
 
-export function setToolGateRuntimeState(requestContext: RequestContext, state: ToolGateRuntimeState): void {
-  if (state.policyId && state.policy?.id && state.policyId !== state.policy.id) {
-    throw new Error(
-      `Tool Gate policyId mismatch: state policyId "${state.policyId}" does not match policy id "${state.policy.id}".`,
-    );
-  }
+export async function evaluateToolGateForRequest({
+  requestContext,
+  subject,
+  args,
+  runId,
+  threadId,
+  resourceId,
+  toolCallId,
+  evaluatedAt,
+}: ToolGateRequestEvaluation): Promise<ToolGateDecisionRecord | undefined> {
+  const state = getStoredRuntimeState(requestContext, { runId });
+  if (!state?.policy) return undefined;
 
+  const record = await evaluateToolGatePolicy({
+    policy: state.policy,
+    evaluation: {
+      subject,
+      requestContext,
+      args,
+      runId,
+      threadId,
+      resourceId,
+      toolCallId,
+    },
+    evaluatedAt,
+  });
+  appendToolGateDecision(requestContext, record);
+
+  return record;
+}
+
+export function setToolGateRuntimeState(requestContext: RequestContext, state: ToolGateRuntimeState): void {
+  assertPolicyIdMatchesState(state);
+
+  const store = toolGateRuntimeState.get(requestContext) ?? {};
   toolGateRuntimeState.set(requestContext, {
-    ...state,
-    policyId: state.policy?.id ?? state.policyId,
-    decisions: state.decisions?.map(copyDecisionRecord),
+    ...store,
+    defaultState: copyRuntimeState(state),
   });
 }
 
-export function getToolGateRuntimeState(requestContext: RequestContext): ToolGateRuntimeState | undefined {
-  const state = toolGateRuntimeState.get(requestContext);
-  if (!state) return undefined;
+export function setToolGateRuntimeStateForRun(
+  requestContext: RequestContext,
+  runId: string,
+  state: ToolGateRuntimeState,
+): void {
+  assertPolicyIdMatchesState(state);
 
-  return {
-    ...state,
-    decisions: state.decisions?.map(copyDecisionRecord),
-  };
+  const store = toolGateRuntimeState.get(requestContext) ?? {};
+  const runStates = new Map(store.runStates);
+  runStates.set(runId, copyRuntimeState(state));
+
+  toolGateRuntimeState.set(requestContext, {
+    ...store,
+    runStates,
+  });
 }
 
-export function clearToolGateRuntimeState(requestContext: RequestContext): void {
-  toolGateRuntimeState.delete(requestContext);
+export function getToolGateRuntimeState(
+  requestContext: RequestContext,
+  options?: { runId?: string },
+): ToolGateRuntimeState | undefined {
+  const state = getStoredRuntimeState(requestContext, options);
+  if (!state) return undefined;
+
+  return copyRuntimeState(state);
+}
+
+export function clearToolGateRuntimeState(requestContext: RequestContext, options?: { runId?: string }): void {
+  if (!options?.runId) {
+    const store = toolGateRuntimeState.get(requestContext);
+    if (!store?.runStates?.size) {
+      toolGateRuntimeState.delete(requestContext);
+      return;
+    }
+    toolGateRuntimeState.set(requestContext, {
+      runStates: store.runStates,
+    });
+    return;
+  }
+
+  const store = toolGateRuntimeState.get(requestContext);
+  if (!store?.runStates) return;
+
+  const runStates = new Map(store.runStates);
+  runStates.delete(options.runId);
+  if (!store.defaultState && runStates.size === 0) {
+    toolGateRuntimeState.delete(requestContext);
+    return;
+  }
+
+  toolGateRuntimeState.set(requestContext, {
+    ...store,
+    runStates,
+  });
 }
 
 export function appendToolGateDecision(requestContext: RequestContext, record: ToolGateDecisionRecord): void {
-  const state = toolGateRuntimeState.get(requestContext) ?? {};
-  const decisions = state.decisions ? [...state.decisions, copyDecisionRecord(record)] : [copyDecisionRecord(record)];
+  const store = toolGateRuntimeState.get(requestContext) ?? {};
+  const copiedRecord = copyDecisionRecord(record);
+
+  const defaultDecisions = store.defaultState?.decisions
+    ? [...store.defaultState.decisions, copiedRecord]
+    : [copiedRecord];
+  const nextDefaultState = {
+    ...(store.defaultState ?? {}),
+    decisions: defaultDecisions,
+  };
+
+  let nextRunStates = store.runStates;
+  if (record.runId && store.runStates?.has(record.runId)) {
+    nextRunStates = new Map(store.runStates);
+    const runState = nextRunStates.get(record.runId) ?? {};
+    const runDecisions = runState.decisions ? [...runState.decisions, copiedRecord] : [copiedRecord];
+    nextRunStates.set(record.runId, {
+      ...runState,
+      decisions: runDecisions,
+    });
+  }
 
   toolGateRuntimeState.set(requestContext, {
-    ...state,
-    decisions,
+    ...store,
+    defaultState: nextDefaultState,
+    runStates: nextRunStates,
   });
 }
 

--- a/packages/core/src/tools/tool-gate.ts
+++ b/packages/core/src/tools/tool-gate.ts
@@ -485,14 +485,7 @@ export function getToolGateRuntimeState(
 
 export function clearToolGateRuntimeState(requestContext: RequestContext, options?: { runId?: string }): void {
   if (!options?.runId) {
-    const store = toolGateRuntimeState.get(requestContext);
-    if (!store?.runStates?.size) {
-      toolGateRuntimeState.delete(requestContext);
-      return;
-    }
-    toolGateRuntimeState.set(requestContext, {
-      runStates: store.runStates,
-    });
+    toolGateRuntimeState.delete(requestContext);
     return;
   }
 


### PR DESCRIPTION
## Summary
- add experimental `toolGatePolicy` execution option for non-durable agent runs
- filter model-visible tools after processors and `prepareStep`
- reject denied server-side tool calls and escalate Tool Gate approval without allowing model-provided `resumeData` to satisfy approval
- keep call-site policies scoped by run id when a `RequestContext` is reused

## Scope
This builds on PF-175. It intentionally does not include dynamic tool search/load filtering or durable resume serialization; those belong in later PRs.

## Verification
- `pnpm --filter ./packages/core test -- src/tools/tool-gate.test.ts src/loop/workflows/agentic-execution/tool-call-step.test.ts src/agent/__tests__/active-tools-enforcement.test.ts`
- `pnpm --filter ./packages/core check`
- Codex review: no blocking findings after fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a way for AI agents to have their tool access controlled at runtime. It's like giving a robot a list of tools it can use, but also requiring someone to approve which tools it actually tries to use during execution.

## Summary

Implements experimental `toolGatePolicy` execution option for non-durable agent runs, enabling runtime enforcement of tool access policies. The feature filters model-visible tools after processors and after `prepareStep`, rejects server-side tool calls that violate the policy, and escalates approval requests when necessary. Importantly, when escalation occurs, model-provided `resumeData` is not used to satisfy the approval decision. Call-site policies are scoped by run ID to prevent policy reuse when a `RequestContext` is shared across multiple runs.

## Key Changes

**Core Tool Gate Implementation** (`packages/core/src/tools/tool-gate.ts`)
- Refactored runtime state management to use per-request-context store with run-scoped state
- Added new public API functions:
  - `createToolGateSubjectForTool()`: Creates tool gate subjects from concrete tool objects (provider-defined and MCP-like tools)
  - `evaluateToolGateForRequest()`: Evaluates policies against a request and records decisions
  - `setToolGateRuntimeStateForRun()`: Stores policy state scoped to a specific run ID
- Updated `ToolGateRuntimeState` type to include decision records

**Agent Execution Integration** (`packages/core/src/agent/`)
- Added `toolGatePolicy` optional property to `AgentExecutionOptionsBase` type
- Integrated policy state storage in agent execution flow via `setToolGateRuntimeStateForRun`

**Tool Filtering & Gating** (`packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts`)
- Integrated tool-gate policy enforcement into LLM execution
- Gates tool calls and inputs conditionally based on policy
- Guards tool lifecycle callbacks (`onInputStart`, `onInputDelta`) behind the policy flag
- Propagates policy state through streaming pipeline

**Tool Call Step Enforcement** (`packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts`)
- Evaluates tool gate policy when available
- Enforces denial or approval flow for tool calls
- Handles approval paths with updated `resumeData` logic to prevent model-provided data from satisfying approvals
- Updated `onInputAvailable` invocation to respect gating
- Enhanced `needsApprovalFn` handling with error-safe fallback

**Type Exports** (`packages/core/src/tools/index.ts`)
- Exported Tool Gate-related types: `ToolGateBoundary`, `ToolGateDecision`, `ToolGateDecisionRecord`, `ToolGateEffect`, `ToolGateEvaluation`, `ToolGateEvaluator`, `ToolGatePolicy`, `ToolGateRequestEvaluation`, `ToolGateSource`, `ToolGateSubject`

## Test Coverage

- Added comprehensive test suite in `packages/core/src/agent/__tests__/active-tools-enforcement.test.ts` covering:
  - Filtering of denied gate tools before model invocation after `prepareStep`
  - Non-reuse of call-site tool gate policy across successive calls within the same `RequestContext`
  - Ensuring streaming input hooks are not invoked before tool-call policy decisions

- Extended `packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts` with tool-gate enforcement validation:
  - Pre-execution denial handling
  - Interaction with `needsApprovalFn`
  - Proper handling of model-provided `resumeData`

- Updated `packages/core/src/tools/tool-gate.test.ts` with:
  - Tests for creating tool gate subjects from concrete tool objects
  - Validation of policy evaluation and decision recording with run-id isolation
  - Request context linkage verification

## Scope Boundaries

- Builds on PF-175
- Does not include dynamic tool search/load filtering or durable resume serialization (deferred to later PRs)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->