### PR TITLE
feat(core): enforce Tool Gate in durable runs

### DIFF
--- a/.changeset/tender-socks-smoke.md
+++ b/.changeset/tender-socks-smoke.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added durable Tool Gate parity for agent runs. Durable preparation now records Tool Gate runtime state, durable LLM steps hide denied tools before model calls, and durable tool execution rejects denied calls or escalates approval according to the original run policy.

--- a/packages/core/src/agent/durable/__tests__/durable-agent-tools.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-tools.test.ts
@@ -114,6 +114,14 @@ function _createToolCallThenTextModel(toolName: string, args: Record<string, unk
   });
 }
 
+async function drain(stream: ReadableStream<any>): Promise<any[]> {
+  const chunks: any[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
 // ============================================================================
 // Tool Registration Tests
 // ============================================================================
@@ -316,6 +324,94 @@ describe('DurableAgent tool execution through workflow', () => {
     // Tools with execute should be in registry
     const tools = durableAgent.runRegistry.getTools(result.runId);
     expect(tools.greet).toBeDefined();
+  });
+
+  it('serializes Tool Gate state during durable preparation', async () => {
+    const mockModel = new MockLanguageModelV2({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+        ]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+      }),
+    });
+
+    const baseAgent = new Agent({
+      id: 'tool-gate-prepare-agent',
+      name: 'Tool Gate Prepare Agent',
+      instructions: 'Test',
+      model: mockModel as LanguageModelV2,
+    });
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+
+    const result = await durableAgent.prepare('Test', {
+      toolGatePolicy: {
+        id: 'durable-prepare-policy',
+        evaluate: async () => ({ effect: 'allow', reason: 'allowed' }),
+      },
+    });
+
+    expect(result.workflowInput.state.toolGate).toMatchObject({
+      policyId: 'durable-prepare-policy',
+    });
+  });
+
+  it('hides Tool Gate denied tools from durable model calls', async () => {
+    let modelToolNames: string[] = [];
+    const mockModel = new MockLanguageModelV2({
+      doStream: async (options: any) => {
+        modelToolNames = Array.isArray(options.tools)
+          ? options.tools.map((tool: any) => tool.name)
+          : Object.keys(options.tools ?? {});
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+        };
+      },
+    });
+
+    const publicTool = createTool({
+      id: 'public',
+      description: 'Allowed tool',
+      inputSchema: z.object({ input: z.string() }),
+      execute: async ({ input }) => input,
+    });
+    const secretTool = createTool({
+      id: 'secret',
+      description: 'Denied tool',
+      inputSchema: z.object({ input: z.string() }),
+      execute: async ({ input }) => input,
+    });
+
+    const baseAgent = new Agent({
+      id: 'tool-gate-model-agent',
+      name: 'Tool Gate Model Agent',
+      instructions: 'Use tools',
+      model: mockModel as LanguageModelV2,
+      tools: { public: publicTool, secret: secretTool },
+    });
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+
+    const result = await durableAgent.stream('Test', {
+      toolGatePolicy: {
+        id: 'durable-model-policy',
+        evaluate: async ({ subject }) => ({
+          effect: subject.boundary === 'model-input' && subject.toolName === 'secret' ? 'deny' : 'allow',
+          reason: 'durable model input policy',
+        }),
+      },
+    });
+
+    await drain(result.fullStream as ReadableStream<any>);
+    result.cleanup();
+
+    expect(modelToolNames).toContain('public');
+    expect(modelToolNames).not.toContain('secret');
   });
 
   it('should handle tool with async execution', async () => {

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -38,6 +38,8 @@ export interface DurableAgentStreamOptions<OUTPUT = undefined> {
   runId?: string;
   /** Request Context containing dynamic configuration and state */
   requestContext?: AgentExecutionOptions<OUTPUT>['requestContext'];
+  /** Experimental runtime policy for model-visible tools and server-side tool calls. */
+  toolGatePolicy?: AgentExecutionOptions<OUTPUT>['toolGatePolicy'];
   /** Maximum number of steps to run */
   maxSteps?: number;
   /** Additional tool sets that can be used for this execution */

--- a/packages/core/src/agent/durable/preparation.ts
+++ b/packages/core/src/agent/durable/preparation.ts
@@ -8,6 +8,11 @@ import type { InputProcessorOrWorkflow, OutputProcessorOrWorkflow, ErrorProcesso
 import type { ProcessorState } from '../../processors/runner';
 import { RequestContext, MASTRA_VERSIONS_KEY, mergeVersionOverrides } from '../../request-context';
 import type { VersionOverrides } from '../../request-context';
+import {
+  getToolGateRuntimeState,
+  serializeToolGateRuntimeState,
+  setToolGateRuntimeStateForRun,
+} from '../../tools/tool-gate';
 import type { CoreTool } from '../../tools/types';
 import type { Workspace } from '../../workspace';
 import type { Agent } from '../agent';
@@ -135,6 +140,12 @@ export async function prepareForDurableExecution<OUTPUT = undefined>(
   }
   if (mergedVersions) {
     requestContext.set(MASTRA_VERSIONS_KEY, mergedVersions);
+  }
+
+  if (execOptions?.toolGatePolicy) {
+    setToolGateRuntimeStateForRun(requestContext, runId, {
+      policy: execOptions.toolGatePolicy,
+    });
   }
 
   // 4. Resolve thread/memory context
@@ -341,6 +352,7 @@ export async function prepareForDurableExecution<OUTPUT = undefined>(
       threadExists,
       savePerStep,
       observationalMemory,
+      toolGate: serializeToolGateRuntimeState(getToolGateRuntimeState(requestContext, { runId })),
     },
     messageId,
   });

--- a/packages/core/src/agent/durable/types.ts
+++ b/packages/core/src/agent/durable/types.ts
@@ -18,6 +18,7 @@ import type { ProcessorState } from '../../processors/runner';
 import type { RequestContext } from '../../request-context';
 import type { ChunkType } from '../../stream/types';
 import type { CoreTool } from '../../tools/types';
+import type { ToolGateSerializableState } from '../../tools/tool-gate';
 import type { Workspace } from '../../workspace';
 import type { MessageList } from '../message-list';
 import type { SerializedMessageListState } from '../message-list/state';
@@ -114,6 +115,8 @@ export interface SerializableDurableState {
   savePerStep?: boolean;
   /** Whether observational memory is enabled (suppresses savePerStep) */
   observationalMemory?: boolean;
+  /** Serializable Tool Gate snapshot for durable resume/debug parity */
+  toolGate?: ToolGateSerializableState;
 }
 
 /**

--- a/packages/core/src/agent/durable/utils/serialize-state.ts
+++ b/packages/core/src/agent/durable/utils/serialize-state.ts
@@ -1,6 +1,7 @@
 import type { JSONSchema7 } from 'json-schema';
 import type { MastraLanguageModel } from '../../../llm/model/shared.types';
 import type { MemoryConfig } from '../../../memory/types';
+import type { ToolGateSerializableState } from '../../../tools/tool-gate';
 import type { CoreTool } from '../../../tools/types';
 import type { MessageList } from '../../message-list';
 import type { AgentModelManagerConfig } from '../../types';
@@ -143,6 +144,7 @@ export function serializeDurableState(params: {
   threadExists?: boolean;
   savePerStep?: boolean;
   observationalMemory?: boolean;
+  toolGate?: ToolGateSerializableState;
 }): SerializableDurableState {
   return {
     memoryConfig: params.memoryConfig,
@@ -151,6 +153,7 @@ export function serializeDurableState(params: {
     threadExists: params.threadExists,
     savePerStep: params.savePerStep,
     observationalMemory: params.observationalMemory,
+    toolGate: params.toolGate,
   };
 }
 

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.test.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.test.ts
@@ -1,0 +1,449 @@
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RequestContext } from '../../../../request-context';
+import { setToolGateRuntimeStateForRun } from '../../../../tools/tool-gate';
+import { MessageList } from '../../../message-list';
+import { globalRunRegistry } from '../../run-registry';
+import { createDurableLLMExecutionStep } from './llm-execution';
+
+const RUN_ID = 'run-llm-tool-gate';
+
+afterEach(() => {
+  globalRunRegistry.delete(RUN_ID);
+});
+
+describe('durable LLM Tool Gate enforcement', () => {
+  it('hides all tools when serialized Tool Gate state exists but runtime policy is unavailable', async () => {
+    let modelToolNames: string[] = [];
+    const model = new MockLanguageModelV2({
+      doStream: async (options: any) => {
+        modelToolNames = Array.isArray(options.tools)
+          ? options.tools.map((tool: any) => tool.name)
+          : Object.keys(options.tools ?? {});
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+        };
+      },
+    });
+
+    const messageList = new MessageList();
+    messageList.add('Use a tool', 'input');
+    globalRunRegistry.set(RUN_ID, {
+      tools: {
+        public: { description: 'Allowed tool' },
+        secret: { description: 'Denied tool' },
+      },
+      model: model as any,
+      requestContext: new RequestContext(),
+    } as any);
+
+    const step = createDurableLLMExecutionStep();
+
+    await (step as any).execute({
+      inputData: {
+        runId: RUN_ID,
+        agentId: 'agent-1',
+        agentName: 'Agent 1',
+        messageListState: messageList.serialize(),
+        toolsMetadata: [],
+        modelConfig: {
+          provider: 'mock',
+          modelId: 'mock-model-id',
+        },
+        options: {},
+        state: {
+          toolGate: { policyId: 'missing-runtime-policy' },
+        },
+        messageId: 'message-1',
+      },
+      mastra: { getLogger: () => undefined },
+      requestContext: new RequestContext(),
+    });
+
+    expect(modelToolNames).toEqual([]);
+  });
+
+  it('hides all tools when serialized Tool Gate policy does not match runtime policy', async () => {
+    let modelToolNames: string[] = [];
+    const model = new MockLanguageModelV2({
+      doStream: async (options: any) => {
+        modelToolNames = Array.isArray(options.tools)
+          ? options.tools.map((tool: any) => tool.name)
+          : Object.keys(options.tools ?? {});
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+        };
+      },
+    });
+
+    const requestContext = new RequestContext();
+    setToolGateRuntimeStateForRun(requestContext, RUN_ID, {
+      policy: {
+        id: 'wrong-runtime-policy',
+        evaluate: async () => ({ effect: 'allow', reason: 'wrong policy allows everything' }),
+      },
+    });
+
+    const messageList = new MessageList();
+    messageList.add('Use a tool', 'input');
+    globalRunRegistry.set(RUN_ID, {
+      tools: {
+        public: { description: 'Allowed tool' },
+        secret: { description: 'Denied tool' },
+      },
+      model: model as any,
+      requestContext,
+    } as any);
+
+    const step = createDurableLLMExecutionStep();
+
+    await (step as any).execute({
+      inputData: {
+        runId: RUN_ID,
+        agentId: 'agent-1',
+        agentName: 'Agent 1',
+        messageListState: messageList.serialize(),
+        toolsMetadata: [],
+        modelConfig: {
+          provider: 'mock',
+          modelId: 'mock-model-id',
+        },
+        options: {},
+        state: {
+          toolGate: { policyId: 'original-runtime-policy' },
+        },
+        messageId: 'message-1',
+      },
+      mastra: { getLogger: () => undefined },
+      requestContext,
+    });
+
+    expect(modelToolNames).toEqual([]);
+  });
+
+  it('does not preserve a stale specific tool choice when Tool Gate denies that tool', async () => {
+    let modelToolNames: string[] = [];
+    let modelToolChoice: any;
+    const model = new MockLanguageModelV2({
+      doStream: async (options: any) => {
+        modelToolNames = Array.isArray(options.tools)
+          ? options.tools.map((tool: any) => tool.name)
+          : Object.keys(options.tools ?? {});
+        modelToolChoice = options.toolChoice;
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+        };
+      },
+    });
+
+    const requestContext = new RequestContext();
+    setToolGateRuntimeStateForRun(requestContext, RUN_ID, {
+      policy: {
+        id: 'runtime-policy',
+        evaluate: async ({ subject }) => ({
+          effect: subject.toolName === 'secret' ? 'deny' : 'allow',
+          reason: 'secret denied',
+        }),
+      },
+    });
+
+    const messageList = new MessageList();
+    messageList.add('Use a tool', 'input');
+    globalRunRegistry.set(RUN_ID, {
+      tools: {
+        public: { description: 'Allowed tool' },
+        secret: { description: 'Denied tool' },
+      },
+      model: model as any,
+      requestContext,
+    } as any);
+
+    const step = createDurableLLMExecutionStep();
+
+    await (step as any).execute({
+      inputData: {
+        runId: RUN_ID,
+        agentId: 'agent-1',
+        agentName: 'Agent 1',
+        messageListState: messageList.serialize(),
+        toolsMetadata: [],
+        modelConfig: {
+          provider: 'mock',
+          modelId: 'mock-model-id',
+        },
+        options: {
+          toolChoice: { toolName: 'secret' },
+        },
+        state: {
+          toolGate: { policyId: 'runtime-policy' },
+        },
+        messageId: 'message-1',
+      },
+      mastra: { getLogger: () => undefined },
+      requestContext,
+    });
+
+    expect(modelToolNames).toEqual(['public']);
+    expect(modelToolChoice).toEqual({ type: 'auto' });
+  });
+
+  it('does not adopt an ambient Tool Gate policy when durable state has no policy id', async () => {
+    let modelToolNames: string[] = [];
+    const model = new MockLanguageModelV2({
+      doStream: async (options: any) => {
+        modelToolNames = Array.isArray(options.tools)
+          ? options.tools.map((tool: any) => tool.name)
+          : Object.keys(options.tools ?? {});
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+        };
+      },
+    });
+
+    const requestContext = new RequestContext();
+    setToolGateRuntimeStateForRun(requestContext, RUN_ID, {
+      policy: {
+        id: 'ambient-policy',
+        evaluate: async ({ subject }) => ({
+          effect: subject.toolName === 'secret' ? 'deny' : 'allow',
+          reason: 'ambient policy should not apply',
+        }),
+      },
+    });
+
+    const messageList = new MessageList();
+    messageList.add('Use a tool', 'input');
+    globalRunRegistry.set(RUN_ID, {
+      tools: {
+        public: { description: 'Allowed tool' },
+        secret: { description: 'Denied tool' },
+      },
+      model: model as any,
+      requestContext,
+    } as any);
+
+    const step = createDurableLLMExecutionStep();
+
+    await (step as any).execute({
+      inputData: {
+        runId: RUN_ID,
+        agentId: 'agent-1',
+        agentName: 'Agent 1',
+        messageListState: messageList.serialize(),
+        toolsMetadata: [],
+        modelConfig: {
+          provider: 'mock',
+          modelId: 'mock-model-id',
+        },
+        options: {},
+        state: {},
+        messageId: 'message-1',
+      },
+      mastra: { getLogger: () => undefined },
+      requestContext,
+    });
+
+    expect(modelToolNames).toEqual(['public', 'secret']);
+  });
+
+  it('uses the registry request context instead of a transient step context for Tool Gate policy', async () => {
+    let modelToolNames: string[] = [];
+    const model = new MockLanguageModelV2({
+      doStream: async (options: any) => {
+        modelToolNames = Array.isArray(options.tools)
+          ? options.tools.map((tool: any) => tool.name)
+          : Object.keys(options.tools ?? {});
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+        };
+      },
+    });
+
+    const registryRequestContext = new RequestContext();
+    setToolGateRuntimeStateForRun(registryRequestContext, RUN_ID, {
+      policy: {
+        id: 'runtime-policy',
+        evaluate: async ({ subject }) => ({
+          effect: subject.toolName === 'secret' ? 'deny' : 'allow',
+          reason: 'secret denied',
+        }),
+      },
+    });
+
+    const messageList = new MessageList();
+    messageList.add('Use a tool', 'input');
+    globalRunRegistry.set(RUN_ID, {
+      tools: {
+        public: { description: 'Allowed tool' },
+        secret: { description: 'Denied tool' },
+      },
+      model: model as any,
+      requestContext: registryRequestContext,
+    } as any);
+
+    const step = createDurableLLMExecutionStep();
+
+    await (step as any).execute({
+      inputData: {
+        runId: RUN_ID,
+        agentId: 'agent-1',
+        agentName: 'Agent 1',
+        messageListState: messageList.serialize(),
+        toolsMetadata: [],
+        modelConfig: {
+          provider: 'mock',
+          modelId: 'mock-model-id',
+        },
+        options: {},
+        state: {
+          toolGate: { policyId: 'runtime-policy' },
+        },
+        messageId: 'message-1',
+      },
+      mastra: { getLogger: () => undefined },
+      requestContext: new RequestContext(),
+    });
+
+    expect(modelToolNames).toEqual(['public']);
+  });
+
+  it('passes the registry request context to durable LLM API error processors', async () => {
+    const registryRequestContext = new RequestContext();
+    let processedRequestContext: RequestContext | undefined;
+    const processAPIError = vi.fn(async ({ requestContext }) => {
+      processedRequestContext = requestContext;
+      return undefined;
+    });
+
+    const messageList = new MessageList();
+    messageList.add('Use a tool', 'input');
+    globalRunRegistry.set(RUN_ID, {
+      tools: {},
+      model: { specificationVersion: 'v1' } as any,
+      requestContext: registryRequestContext,
+      errorProcessors: [{ id: 'capture-context', processAPIError }],
+    } as any);
+
+    const step = createDurableLLMExecutionStep();
+
+    await expect(
+      (step as any).execute({
+        inputData: {
+          runId: RUN_ID,
+          agentId: 'agent-1',
+          agentName: 'Agent 1',
+          messageListState: messageList.serialize(),
+          toolsMetadata: [],
+          modelConfig: {
+            provider: 'mock',
+            modelId: 'mock-model-id',
+          },
+          options: {},
+          state: {},
+          messageId: 'message-1',
+        },
+        mastra: { getLogger: () => undefined },
+        requestContext: new RequestContext(),
+      }),
+    ).rejects.toThrow('Unsupported model version');
+
+    expect(processAPIError).toHaveBeenCalledOnce();
+    expect(processedRequestContext).toBe(registryRequestContext);
+  });
+
+  it('clears generic tool choice when Tool Gate denies all tools', async () => {
+    let modelToolNames: string[] = [];
+    let modelToolChoice: any = 'unset';
+    const model = new MockLanguageModelV2({
+      doStream: async (options: any) => {
+        modelToolNames = Array.isArray(options.tools)
+          ? options.tools.map((tool: any) => tool.name)
+          : Object.keys(options.tools ?? {});
+        modelToolChoice = options.toolChoice;
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+        };
+      },
+    });
+
+    const requestContext = new RequestContext();
+    setToolGateRuntimeStateForRun(requestContext, RUN_ID, {
+      policy: {
+        id: 'runtime-policy',
+        evaluate: async () => ({
+          effect: 'deny',
+          reason: 'all denied',
+        }),
+      },
+    });
+
+    const messageList = new MessageList();
+    messageList.add('Use a tool', 'input');
+    globalRunRegistry.set(RUN_ID, {
+      tools: {
+        public: { description: 'Allowed tool' },
+        secret: { description: 'Denied tool' },
+      },
+      model: model as any,
+      requestContext,
+    } as any);
+
+    const step = createDurableLLMExecutionStep();
+
+    await (step as any).execute({
+      inputData: {
+        runId: RUN_ID,
+        agentId: 'agent-1',
+        agentName: 'Agent 1',
+        messageListState: messageList.serialize(),
+        toolsMetadata: [],
+        modelConfig: {
+          provider: 'mock',
+          modelId: 'mock-model-id',
+        },
+        options: {
+          toolChoice: 'required',
+        },
+        state: {
+          toolGate: { policyId: 'runtime-policy' },
+        },
+        messageId: 'message-1',
+      },
+      mastra: { getLogger: () => undefined },
+      requestContext,
+    });
+
+    expect(modelToolNames).toEqual([]);
+    expect(modelToolChoice).toBeUndefined();
+  });
+});

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -5,9 +5,15 @@ import type { PubSub } from '../../../../events/pubsub';
 import type { Mastra } from '../../../../mastra';
 import type { SpanType, AIModelGenerationSpan, ExportedSpan, IModelSpanTracker } from '../../../../observability';
 import { ProcessorRunner } from '../../../../processors/runner';
+import type { RequestContext } from '../../../../request-context';
 import { execute } from '../../../../stream/aisdk/v5/execute';
 import { MastraModelOutput } from '../../../../stream/base/output';
 import type { TextDeltaPayload, ToolCallPayload } from '../../../../stream/types';
+import {
+  createToolGateSubjectForTool,
+  evaluateToolGateForRequest,
+  getToolGateRuntimeState,
+} from '../../../../tools/tool-gate';
 import { createStep } from '../../../../workflows';
 import { PUBSUB_SYMBOL } from '../../../../workflows/constants';
 import { MessageList } from '../../../message-list';
@@ -18,6 +24,62 @@ import { globalRunRegistry } from '../../run-registry';
 import { emitChunkEvent, emitStepStartEvent } from '../../stream-adapter';
 import type { DurableAgenticWorkflowInput, DurableLLMStepOutput, DurableToolCallInput } from '../../types';
 import { resolveRuntimeDependencies, resolveModelFromListEntry } from '../../utils/resolve-runtime';
+
+function getDurableSpecificToolChoiceName(toolChoice: ToolChoice<ToolSet> | undefined): string | undefined {
+  if (!toolChoice || typeof toolChoice === 'string') return undefined;
+  return 'toolName' in toolChoice ? String(toolChoice.toolName) : undefined;
+}
+
+async function applyDurableToolGateToModelInput({
+  requestContext,
+  runId,
+  threadId,
+  resourceId,
+  tools,
+  toolChoice,
+}: {
+  requestContext: RequestContext;
+  runId: string;
+  threadId?: string;
+  resourceId?: string;
+  tools: ToolSet;
+  toolChoice?: ToolChoice<ToolSet>;
+}): Promise<{ tools: ToolSet; toolChoice?: ToolChoice<ToolSet> }> {
+  const entries = Object.entries(tools);
+  if (entries.length === 0) return { tools, toolChoice };
+
+  const deniedToolNames = new Set<string>();
+  for (const [toolName, tool] of entries) {
+    const decision = await evaluateToolGateForRequest({
+      requestContext,
+      subject: createToolGateSubjectForTool({
+        boundary: 'model-input',
+        toolName,
+        tool,
+      }),
+      runId,
+      threadId,
+      resourceId,
+    });
+
+    if (decision?.effect === 'deny') {
+      deniedToolNames.add(toolName);
+    }
+  }
+
+  if (deniedToolNames.size === 0) return { tools, toolChoice };
+
+  const nextTools = Object.fromEntries(entries.filter(([toolName]) => !deniedToolNames.has(toolName))) as ToolSet;
+  const chosenToolName = getDurableSpecificToolChoiceName(toolChoice);
+  const hasVisibleTools = Object.keys(nextTools).length > 0;
+  const nextToolChoice = !hasVisibleTools
+    ? undefined
+    : chosenToolName && deniedToolNames.has(chosenToolName)
+      ? ('auto' as ToolChoice<ToolSet>)
+      : toolChoice;
+
+  return { tools: nextTools, toolChoice: nextToolChoice };
+}
 
 /**
  * Input schema for the durable LLM execution step
@@ -186,6 +248,10 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
 
             let currentMessageId = messageId;
 
+            const registryEntry = globalRunRegistry.get(runId);
+            const executionAbortSignal = (registryEntry as any)?.abortSignal ?? abortSignal;
+            const requestContextForRun = registryEntry?.requestContext ?? requestContext;
+
             // 5. Prepare tools - cast through unknown as CoreTool and ToolSet are structurally compatible at runtime
             let currentModel = model;
             let currentTools = tools as unknown as ToolSet;
@@ -195,7 +261,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
             // 6. Rebuild MODEL_GENERATION span from passed data
             // For durable execution, ONE model_generation span is created BEFORE the workflow starts
             // and passed through each iteration. This ensures all steps are children of the same span.
-            const observability = mastra?.observability?.getSelectedInstance({ requestContext });
+            const observability = mastra?.observability?.getSelectedInstance({ requestContext: requestContextForRun });
 
             // modelSpanData is passed through from the workflow input (created in create-inngest-agent.ts)
             const inputModelSpanData = (inputData as any).modelSpanData as
@@ -223,8 +289,6 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                   }
                 : undefined;
 
-            const registryEntry = globalRunRegistry.get(runId);
-            const executionAbortSignal = (registryEntry as any)?.abortSignal ?? abortSignal;
             if (registryEntry?.inputProcessors?.length) {
               const inputStepWriter = pubsub
                 ? {
@@ -246,7 +310,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                 stepNumber: stepIndex,
                 steps: (inputData as any).accumulatedSteps ?? [],
                 tracingContext: modelSpanTracker?.getTracingContext() ?? tracingContext,
-                requestContext,
+                requestContext: requestContextForRun,
                 runId,
                 resourceId: (registryEntry as any)?.resourceId,
                 model: currentModel,
@@ -271,6 +335,36 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                 ...currentModelSettings,
                 ...(processInputStepResult.modelSettings ?? {}),
               };
+            }
+
+            const durableToolGatePolicyId = typedInput.state.toolGate?.policyId;
+            const toolGatePolicy = requestContextForRun
+              ? getToolGateRuntimeState(requestContextForRun, { runId })?.policy
+              : undefined;
+            const isToolGatePolicyValidForRun =
+              toolGatePolicy && durableToolGatePolicyId && toolGatePolicy.id === durableToolGatePolicyId;
+
+            if (requestContextForRun && isToolGatePolicyValidForRun) {
+              const gated = await applyDurableToolGateToModelInput({
+                requestContext: requestContextForRun,
+                runId,
+                threadId: typedInput.state.threadId,
+                resourceId: typedInput.state.resourceId,
+                tools: currentTools,
+                toolChoice: currentToolChoice,
+              });
+              currentTools = gated.tools;
+              currentToolChoice = gated.toolChoice;
+            } else if (durableToolGatePolicyId) {
+              logger?.warn?.('[DurableAgent] Tool Gate policy unavailable during durable LLM step; clearing tools', {
+                runId,
+                threadId: typedInput.state.threadId,
+                resourceId: typedInput.state.resourceId,
+                expectedPolicyId: durableToolGatePolicyId,
+                actualPolicyId: toolGatePolicy?.id,
+              });
+              currentTools = {};
+              currentToolChoice = undefined;
             }
 
             // Get messages for LLM (using async llmPrompt for proper format conversion)
@@ -338,7 +432,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
               options: {
                 runId,
                 tracingContext: modelSpanTracker?.getTracingContext() ?? tracingContext,
-                requestContext,
+                requestContext: requestContextForRun,
               },
             });
 
@@ -567,13 +661,14 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                 });
                 const currentMessageList = new MessageList();
                 currentMessageList.deserialize(typedInput.messageListState);
+                const requestContextForRun = registryEntry.requestContext ?? requestContext;
                 const { retry } = await runner.runProcessAPIError({
                   error: lastError,
                   messages: currentMessageList.get.all.db(),
                   messageList: currentMessageList,
                   stepNumber: (inputData as any).stepIndex ?? 0,
                   steps: [],
-                  requestContext,
+                  requestContext: requestContextForRun,
                 });
                 if (retry) {
                   logger?.debug?.(`processAPIError requested retry for model ${modelId}`, { runId });

--- a/packages/core/src/agent/durable/workflows/steps/tool-call-bg.test.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call-bg.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RequestContext } from '../../../../request-context';
+import { setToolGateRuntimeStateForRun } from '../../../../tools/tool-gate';
 import { PUBSUB_SYMBOL } from '../../../../workflows/constants';
 import { globalRunRegistry } from '../../run-registry';
 import { createDurableToolCallStep } from './tool-call';
@@ -24,7 +26,7 @@ vi.mock('../../stream-adapter', () => ({
 const { createBackgroundTask } = await import('../../../../background-tasks/create');
 const { resolveBackgroundConfig } = await import('../../../../background-tasks/resolve-config');
 const { emitChunkEvent } = await import('../../stream-adapter');
-const { resolveTool: _resolveTool } = await import('../../utils/resolve-runtime');
+const { resolveTool: _resolveTool, toolRequiresApproval } = await import('../../utils/resolve-runtime');
 
 const RUN_ID = 'run-bg-1';
 const AGENT_ID = 'agent-1';
@@ -93,14 +95,24 @@ function setupRegistry(overrides: Record<string, any> = {}) {
   return { messageList, saveQueueManager, bgManager, entry };
 }
 
-function executeStep(pubsub: any, initData: any, input?: any, resumeData?: any) {
+function copySerializableRequestContext(requestContext: RequestContext) {
+  return new RequestContext(Array.from(requestContext.entries()));
+}
+
+function executeStep(
+  pubsub: any,
+  initData: any,
+  input?: any,
+  resumeData?: any,
+  overrides: { requestContext?: RequestContext; suspend?: ReturnType<typeof vi.fn> } = {},
+) {
   const step = createDurableToolCallStep();
   return (step as any).execute({
     inputData: input ?? baseInput(),
     mastra: { getLogger: () => undefined },
-    suspend: vi.fn(),
+    suspend: overrides.suspend ?? vi.fn(),
     resumeData,
-    requestContext: new Map(),
+    requestContext: overrides.requestContext ?? new RequestContext(),
     getInitData: () => initData,
     [PUBSUB_SYMBOL]: pubsub,
   });
@@ -112,10 +124,326 @@ afterEach(() => {
 });
 
 describe('durable tool-call background task dispatch', () => {
+  it('rejects a durable tool call denied by Tool Gate before execution', async () => {
+    const pubsub = mockPubsub();
+    const requestContext = new RequestContext();
+    const { entry } = setupRegistry({ requestContext });
+    setToolGateRuntimeStateForRun(requestContext, RUN_ID, {
+      policy: {
+        id: 'deny-durable-tool',
+        evaluate: async ({ subject }) => ({
+          effect: subject.boundary === 'tool-call' ? 'deny' : 'allow',
+          reason: 'blocked in durable run',
+        }),
+      },
+    });
+
+    const result = await executeStep(
+      pubsub,
+      makeInitData({
+        state: {
+          threadId: 'thread-1',
+          resourceId: 'user-1',
+          toolGate: { policyId: 'deny-durable-tool' },
+        },
+      }),
+      undefined,
+      undefined,
+      { requestContext },
+    );
+
+    expect(result.error).toMatchObject({
+      name: 'ToolNotFoundError',
+      message: expect.stringContaining('blocked by runtime tool policy'),
+    });
+    expect(entry.tools[TOOL_NAME].execute).not.toHaveBeenCalled();
+    expect(vi.mocked(emitChunkEvent)).toHaveBeenCalledWith(
+      pubsub,
+      RUN_ID,
+      expect.objectContaining({
+        type: 'tool-error',
+        payload: expect.objectContaining({
+          toolCallId: TOOL_CALL_ID,
+          toolName: TOOL_NAME,
+        }),
+      }),
+    );
+  });
+
+  it('rejects durable tool calls when serialized Tool Gate state has no runtime policy', async () => {
+    const pubsub = mockPubsub();
+    const { entry } = setupRegistry();
+
+    const result = await executeStep(
+      pubsub,
+      makeInitData({
+        state: {
+          threadId: 'thread-1',
+          resourceId: 'user-1',
+          toolGate: { policyId: 'missing-runtime-policy' },
+        },
+      }),
+    );
+
+    expect(result.error).toMatchObject({
+      name: 'ToolNotFoundError',
+      message: expect.stringContaining('missing-runtime-policy'),
+    });
+    expect(entry.tools[TOOL_NAME].execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects durable tool calls when serialized Tool Gate policy does not match runtime policy', async () => {
+    const pubsub = mockPubsub();
+    const requestContext = new RequestContext();
+    const { entry } = setupRegistry({ requestContext });
+    setToolGateRuntimeStateForRun(requestContext, RUN_ID, {
+      policy: {
+        id: 'wrong-runtime-policy',
+        evaluate: async () => ({ effect: 'allow', reason: 'wrong policy allows everything' }),
+      },
+    });
+
+    const result = await executeStep(
+      pubsub,
+      makeInitData({
+        state: {
+          threadId: 'thread-1',
+          resourceId: 'user-1',
+          toolGate: { policyId: 'original-runtime-policy' },
+        },
+      }),
+      undefined,
+      undefined,
+      { requestContext },
+    );
+
+    expect(result.error).toMatchObject({
+      name: 'ToolNotFoundError',
+      message: expect.stringContaining('original-runtime-policy'),
+    });
+    expect(result.error.message).toContain('wrong-runtime-policy');
+    expect(entry.tools[TOOL_NAME].execute).not.toHaveBeenCalled();
+  });
+
+  it('does not apply an ambient Tool Gate policy when durable state has no policy id', async () => {
+    const pubsub = mockPubsub();
+    const requestContext = new RequestContext();
+    const { entry } = setupRegistry({ requestContext, backgroundTaskManager: undefined });
+    setToolGateRuntimeStateForRun(requestContext, RUN_ID, {
+      policy: {
+        id: 'ambient-policy',
+        evaluate: async () => ({ effect: 'deny', reason: 'ambient policy should not apply' }),
+      },
+    });
+
+    const result = await executeStep(pubsub, makeInitData(), undefined, undefined, { requestContext });
+
+    expect(result.result).toEqual({ summary: 'done' });
+    expect(entry.tools[TOOL_NAME].execute).toHaveBeenCalledOnce();
+  });
+
+  it('uses the registry request context instead of a transient step context for Tool Gate policy', async () => {
+    const pubsub = mockPubsub();
+    const registryRequestContext = new RequestContext();
+    const { entry } = setupRegistry({ requestContext: registryRequestContext, backgroundTaskManager: undefined });
+    setToolGateRuntimeStateForRun(registryRequestContext, RUN_ID, {
+      policy: {
+        id: 'allow-durable-tool',
+        evaluate: async () => ({ effect: 'allow', reason: 'registry policy allows the tool' }),
+      },
+    });
+
+    const result = await executeStep(
+      pubsub,
+      makeInitData({
+        state: {
+          threadId: 'thread-1',
+          resourceId: 'user-1',
+          toolGate: { policyId: 'allow-durable-tool' },
+        },
+      }),
+      undefined,
+      undefined,
+      { requestContext: new RequestContext() },
+    );
+
+    expect(result.result).toEqual({ summary: 'done' });
+    expect(entry.tools[TOOL_NAME].execute).toHaveBeenCalledOnce();
+  });
+
+  it('escalates durable approval when Tool Gate requires approval', async () => {
+    const pubsub = mockPubsub();
+    const requestContext = new RequestContext();
+    const suspend = vi.fn();
+    const { entry } = setupRegistry({ requestContext });
+    setToolGateRuntimeStateForRun(requestContext, RUN_ID, {
+      policy: {
+        id: 'approve-durable-tool',
+        evaluate: async ({ subject }) => ({
+          effect: subject.boundary === 'tool-call' ? 'requireApproval' : 'allow',
+          reason: 'approval required in durable run',
+        }),
+      },
+    });
+
+    await executeStep(
+      pubsub,
+      makeInitData({
+        state: {
+          threadId: 'thread-1',
+          resourceId: 'user-1',
+          toolGate: { policyId: 'approve-durable-tool' },
+        },
+      }),
+      undefined,
+      undefined,
+      { requestContext, suspend },
+    );
+
+    expect(suspend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'approval',
+        toolCallId: TOOL_CALL_ID,
+        toolName: TOOL_NAME,
+      }),
+      { resumeLabel: TOOL_CALL_ID },
+    );
+    expect(entry.tools[TOOL_NAME].execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects approval-required durable tool calls when resume data does not approve them', async () => {
+    const pubsub = mockPubsub();
+    const requestContext = new RequestContext();
+    const { entry } = setupRegistry({ requestContext });
+    setToolGateRuntimeStateForRun(requestContext, RUN_ID, {
+      policy: {
+        id: 'approve-durable-tool',
+        evaluate: async ({ subject }) => ({
+          effect: subject.boundary === 'tool-call' ? 'requireApproval' : 'allow',
+          reason: 'approval required in durable run',
+        }),
+      },
+    });
+
+    const result = await executeStep(
+      pubsub,
+      makeInitData({
+        state: {
+          threadId: 'thread-1',
+          resourceId: 'user-1',
+          toolGate: { policyId: 'approve-durable-tool' },
+        },
+      }),
+      undefined,
+      {},
+      { requestContext },
+    );
+
+    expect(result).toMatchObject({
+      result: 'Tool call approval was not provided by the user',
+      denied: true,
+      deniedReason: 'Tool call approval was not provided by the user',
+    });
+    expect(entry.tools[TOOL_NAME].execute).not.toHaveBeenCalled();
+  });
+
+  it('allows an approved durable tool call to resume later with tool-specific resume data', async () => {
+    const pubsub = mockPubsub();
+    const requestContext = new RequestContext();
+    const { entry } = setupRegistry({ requestContext, backgroundTaskManager: undefined });
+    entry.tools[TOOL_NAME].execute.mockImplementation(async (_args: any, context: any) => ({
+      resumeData: context.resumeData,
+    }));
+    const policy = {
+      id: 'approve-durable-tool',
+      evaluate: async ({ subject }: any) => ({
+        effect: subject.boundary === 'tool-call' ? 'requireApproval' : 'allow',
+        reason: 'approval required in durable run',
+      }),
+    } as const;
+    setToolGateRuntimeStateForRun(requestContext, RUN_ID, {
+      policy,
+    });
+
+    const initData = makeInitData({
+      state: {
+        threadId: 'thread-1',
+        resourceId: 'user-1',
+        toolGate: { policyId: 'approve-durable-tool' },
+      },
+    });
+
+    await executeStep(pubsub, initData, undefined, { approved: true }, { requestContext });
+
+    const replayRequestContext = copySerializableRequestContext(requestContext);
+    setToolGateRuntimeStateForRun(replayRequestContext, RUN_ID, { policy });
+
+    const result = await executeStep(
+      pubsub,
+      initData,
+      undefined,
+      { continue: true },
+      { requestContext: replayRequestContext },
+    );
+
+    expect(result.result).toEqual({ resumeData: { continue: true } });
+    expect(entry.tools[TOOL_NAME].execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not re-suspend a replayed durable tool call that was already approved', async () => {
+    const pubsub = mockPubsub();
+    const requestContext = new RequestContext();
+    const suspend = vi.fn();
+    const { entry } = setupRegistry({ requestContext, backgroundTaskManager: undefined });
+    const policy = {
+      id: 'approve-durable-tool',
+      evaluate: async ({ subject }: any) => ({
+        effect: subject.boundary === 'tool-call' ? 'requireApproval' : 'allow',
+        reason: 'approval required in durable run',
+      }),
+    } as const;
+    setToolGateRuntimeStateForRun(requestContext, RUN_ID, { policy });
+
+    const initData = makeInitData({
+      state: {
+        threadId: 'thread-1',
+        resourceId: 'user-1',
+        toolGate: { policyId: 'approve-durable-tool' },
+      },
+    });
+
+    await executeStep(pubsub, initData, undefined, { approved: true }, { requestContext });
+
+    const replayRequestContext = copySerializableRequestContext(requestContext);
+    setToolGateRuntimeStateForRun(replayRequestContext, RUN_ID, { policy });
+
+    const result = await executeStep(pubsub, initData, undefined, undefined, {
+      requestContext: replayRequestContext,
+      suspend,
+    });
+
+    expect(result.result).toEqual({ summary: 'done' });
+    expect(suspend).not.toHaveBeenCalled();
+    expect(entry.tools[TOOL_NAME].execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes approval resume data through for in-execution tool approval resumes', async () => {
+    const pubsub = mockPubsub();
+    const { entry } = setupRegistry({ backgroundTaskManager: undefined });
+    entry.tools[TOOL_NAME].execute.mockImplementation(async (_args: any, context: any) => ({
+      resumeData: context.resumeData,
+    }));
+
+    const result = await executeStep(pubsub, makeInitData(), undefined, { approved: true });
+
+    expect(result.result).toEqual({ resumeData: { approved: true } });
+  });
+
   it('emits denied tool-result chunk via PubSub when approval resume is declined', async () => {
     const pubsub = mockPubsub();
     setupRegistry();
     const initData = makeInitData();
+    vi.mocked(toolRequiresApproval).mockResolvedValueOnce(true);
 
     const result = await executeStep(pubsub, initData, undefined, { approved: false });
 

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -6,7 +6,13 @@ import type { PubSub } from '../../../../events/pubsub';
 import type { Mastra } from '../../../../mastra';
 import type { MastraMemory } from '../../../../memory/memory';
 import type { MemoryConfig } from '../../../../memory/types';
+import type { RequestContext } from '../../../../request-context';
 import { ChunkFrom } from '../../../../stream/types';
+import {
+  createToolGateSubjectForTool,
+  evaluateToolGateForRequest,
+  getToolGateRuntimeState,
+} from '../../../../tools/tool-gate';
 import { createStep } from '../../../../workflows';
 import { PUBSUB_SYMBOL } from '../../../../workflows/constants';
 import type { SuspendOptions } from '../../../../workflows/step';
@@ -15,9 +21,18 @@ import type { SaveQueueManager } from '../../../save-queue';
 import { DurableStepIds } from '../../constants';
 import { globalRunRegistry } from '../../run-registry';
 import { emitSuspendedEvent, emitChunkEvent } from '../../stream-adapter';
-import type { DurableToolCallInput, SerializableDurableOptions, AgentSuspendedEventData } from '../../types';
+import type {
+  DurableToolCallInput,
+  SerializableDurableOptions,
+  SerializableDurableState,
+  AgentSuspendedEventData,
+} from '../../types';
 import { resolveTool, toolRequiresApproval } from '../../utils/resolve-runtime';
 import { serializeError } from '../../utils/serialize-state';
+
+const DURABLE_TOOL_CALL_APPROVALS_CONTEXT_KEY = 'mastra__durableToolCallApprovals';
+
+type DurableToolCallApprovalState = Record<string, string[]>;
 
 /**
  * Input schema for the durable tool call step.
@@ -97,6 +112,49 @@ async function flushMessagesBeforeSuspension({
   }
 }
 
+function isApprovalResumeData(resumeData: unknown): resumeData is { approved: boolean } {
+  return typeof resumeData === 'object' && resumeData !== null && 'approved' in resumeData;
+}
+
+function getDurableToolCallApprovalState(
+  requestContext: RequestContext | undefined,
+): DurableToolCallApprovalState | undefined {
+  const value = requestContext?.get(DURABLE_TOOL_CALL_APPROVALS_CONTEXT_KEY);
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value as DurableToolCallApprovalState;
+}
+
+function durableToolCallWasApproved(
+  requestContext: RequestContext | undefined,
+  runId: string,
+  toolCallId: string,
+): boolean {
+  const state = getDurableToolCallApprovalState(requestContext);
+  const approvedToolCalls = state?.[runId];
+
+  return Array.isArray(approvedToolCalls) && approvedToolCalls.includes(toolCallId);
+}
+
+function markDurableToolCallApproved(
+  requestContext: RequestContext | undefined,
+  runId: string,
+  toolCallId: string,
+): void {
+  if (!requestContext) return;
+
+  const approvalState = getDurableToolCallApprovalState(requestContext) ?? {};
+  const approvedToolCalls = Array.isArray(approvalState[runId]) ? approvalState[runId] : [];
+  if (approvedToolCalls.includes(toolCallId)) return;
+
+  requestContext.set(DURABLE_TOOL_CALL_APPROVALS_CONTEXT_KEY, {
+    ...approvalState,
+    [runId]: [...approvedToolCalls, toolCallId],
+  });
+}
+
 /**
  * Create a durable tool call step.
  *
@@ -132,12 +190,7 @@ export function createDurableToolCallStep() {
         runId: string;
         agentId: string;
         options: SerializableDurableOptions;
-        state: {
-          threadId?: string;
-          resourceId?: string;
-          memoryConfig?: MemoryConfig;
-          threadExists?: boolean;
-        };
+        state: SerializableDurableState;
       }>();
 
       const { runId, options: agentOptions, state } = initData;
@@ -182,6 +235,7 @@ export function createDurableToolCallStep() {
       const saveQueueManager = registryEntry?.saveQueueManager;
       const memory = registryEntry?.memory;
       const workspace = registryEntry?.workspace;
+      const requestContextForRun = registryEntry?.requestContext ?? requestContext;
       let threadExists = state?.threadExists ?? false;
 
       // Reconstruct MessageList from workflow state if available
@@ -209,60 +263,130 @@ export function createDurableToolCallStep() {
           },
         });
 
-      // 2. Check if tool requires approval
-      const requiresApproval = await toolRequiresApproval(tool, agentOptions.requireToolApproval, args);
+      const durableToolGatePolicyId = state?.toolGate?.policyId;
+      const toolGateRuntimePolicy = requestContextForRun
+        ? getToolGateRuntimeState(requestContextForRun, { runId })?.policy
+        : undefined;
+      const isToolGatePolicyValidForRun =
+        toolGateRuntimePolicy && durableToolGatePolicyId && toolGateRuntimePolicy.id === durableToolGatePolicyId;
+      const toolGateDecision =
+        requestContextForRun && isToolGatePolicyValidForRun
+          ? await evaluateToolGateForRequest({
+              requestContext: requestContextForRun,
+              subject: createToolGateSubjectForTool({
+                boundary: 'tool-call',
+                toolName,
+                tool,
+              }),
+              args,
+              runId,
+              threadId: state?.threadId,
+              resourceId: state?.resourceId,
+              toolCallId,
+            })
+          : undefined;
 
-      if (requiresApproval && !resumeData) {
-        const resumeSchema = JSON.stringify({
-          type: 'object',
-          properties: {
-            approved: { type: 'boolean' },
-          },
-          required: ['approved'],
-        });
-
-        // Emit approval chunk via PubSub (mirrors base agent's controller.enqueue)
+      if (!isToolGatePolicyValidForRun && durableToolGatePolicyId) {
+        const actualPolicy = toolGateRuntimePolicy ? ` Found "${toolGateRuntimePolicy.id}" instead.` : '';
+        const error = {
+          name: 'ToolNotFoundError',
+          message: `Tool "${toolName}" is blocked because runtime tool policy "${durableToolGatePolicyId}" is unavailable for this durable run.${actualPolicy}`,
+        };
         if (pubsub) {
           await emitChunkEvent(pubsub, runId, {
-            type: 'tool-call-approval',
+            type: 'tool-error',
             runId,
             from: ChunkFrom.AGENT,
-            payload: { toolCallId, toolName, args, resumeSchema },
+            payload: { toolCallId, toolName, args, error },
           });
         }
-
-        // Emit suspended event for the stream adapter
-        if (pubsub) {
-          await emitSuspendedEvent(pubsub, runId, {
-            toolCallId,
-            toolName,
-            args,
-            type: 'approval',
-            resumeSchema,
-          });
-        }
-
-        // Flush messages before suspension
-        await doFlush();
-
-        // Suspend and wait for approval
-        return suspend(
-          {
-            type: 'approval',
-            toolCallId,
-            toolName,
-            args,
-          },
-          {
-            resumeLabel: toolCallId,
-          },
-        );
+        return {
+          ...typedInput,
+          error,
+        };
       }
 
-      // Check if resuming from approval
-      if (resumeData && typeof resumeData === 'object' && resumeData !== null && 'approved' in resumeData) {
-        if (!(resumeData as { approved: boolean }).approved) {
-          const deniedReason = 'Tool call was not approved by the user';
+      if (toolGateDecision?.effect === 'deny') {
+        const reason = toolGateDecision.message || toolGateDecision.reason;
+        const error = {
+          name: 'ToolNotFoundError',
+          message: `Tool "${toolName}" is blocked by runtime tool policy.${reason ? ` ${reason}` : ''}`,
+        };
+        if (pubsub) {
+          await emitChunkEvent(pubsub, runId, {
+            type: 'tool-error',
+            runId,
+            from: ChunkFrom.AGENT,
+            payload: { toolCallId, toolName, args, error },
+          });
+        }
+        return {
+          ...typedInput,
+          error,
+        };
+      }
+
+      // 2. Check if tool requires approval
+      const requiresApproval =
+        (await toolRequiresApproval(tool, agentOptions.requireToolApproval, args)) ||
+        toolGateDecision?.effect === 'requireApproval';
+      const hadApprovalBeforeResume = durableToolCallWasApproved(requestContextForRun, runId, toolCallId);
+
+      if (requiresApproval) {
+        if (!hadApprovalBeforeResume && !resumeData) {
+          const resumeSchema = JSON.stringify({
+            type: 'object',
+            properties: {
+              approved: { type: 'boolean' },
+            },
+            required: ['approved'],
+          });
+
+          // Emit approval chunk via PubSub (mirrors base agent's controller.enqueue)
+          if (pubsub) {
+            await emitChunkEvent(pubsub, runId, {
+              type: 'tool-call-approval',
+              runId,
+              from: ChunkFrom.AGENT,
+              payload: { toolCallId, toolName, args, resumeSchema },
+            });
+          }
+
+          // Emit suspended event for the stream adapter
+          if (pubsub) {
+            await emitSuspendedEvent(pubsub, runId, {
+              toolCallId,
+              toolName,
+              args,
+              type: 'approval',
+              resumeSchema,
+            });
+          }
+
+          // Flush messages before suspension
+          await doFlush();
+
+          // Suspend and wait for approval
+          return suspend(
+            {
+              type: 'approval',
+              toolCallId,
+              toolName,
+              args,
+            },
+            {
+              resumeLabel: toolCallId,
+            },
+          );
+        }
+
+        if (isApprovalResumeData(resumeData) && resumeData.approved === true) {
+          markDurableToolCallApproved(requestContextForRun, runId, toolCallId);
+        } else if (!hadApprovalBeforeResume) {
+          const deniedReason =
+            isApprovalResumeData(resumeData) && resumeData.approved === false
+              ? 'Tool call was not approved by the user'
+              : 'Tool call approval was not provided by the user';
           if (pubsub) {
             try {
               await emitChunkEvent(pubsub, runId, {
@@ -286,8 +410,13 @@ export function createDurableToolCallStep() {
 
       // Check if resuming from in-execution suspension
       // Pass resumeData through to the tool so it can continue from where it left off
+      const shouldPassApprovalResumeToTool =
+        isApprovalResumeData(resumeData) && (!requiresApproval || hadApprovalBeforeResume);
       const isResumingFromSuspension =
-        resumeData && typeof resumeData === 'object' && resumeData !== null && !('approved' in resumeData);
+        resumeData &&
+        typeof resumeData === 'object' &&
+        resumeData !== null &&
+        (!isApprovalResumeData(resumeData) || shouldPassApprovalResumeToTool);
 
       // 3. Check for background task execution
       const bgManager = registryEntry?.backgroundTaskManager;
@@ -339,7 +468,7 @@ export function createDurableToolCallStep() {
                       toolCallId,
                       messages: [],
                       workspace,
-                      requestContext,
+                      requestContext: requestContextForRun,
                       abortSignal: taskContext?.abortSignal,
                     });
                   },
@@ -535,7 +664,7 @@ export function createDurableToolCallStep() {
           toolCallId,
           messages: [],
           workspace,
-          requestContext,
+          requestContext: requestContextForRun,
           resumeData: isResumingFromSuspension ? resumeData : undefined,
 
           // In-execution suspend callback — allows tools to suspend mid-execution


### PR DESCRIPTION
## Summary
- carry Tool Gate runtime policy state into durable workflow input
- hide denied tools from durable model calls and clear stale denied toolChoice values
- reject denied durable tool calls and escalate approval from Tool Gate policy, including replay-safe approval resume state

## Validation
- pnpm --filter ./packages/core test -- src/agent/durable/workflows/steps/llm-execution.test.ts src/agent/durable/workflows/steps/tool-call-bg.test.ts src/agent/durable/__tests__/durable-agent-tools.test.ts
- pnpm --filter ./packages/core check
- git diff --check
- codex review: no blocking findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

This PR makes paused AI workflows remember which tools they're allowed to use, hides tools the AI shouldn't see, blocks forbidden tool calls (or requests approval), and preserves those decisions when the workflow resumes.

## Summary

Enforces Tool Gate runtime policy in durable agent workflows so tool visibility and execution decisions remain consistent across durable run boundaries (prepare → run → resume). Main behaviors:

- Tool Gate Policy Propagation: captures Tool Gate runtime state during durable preparation and serializes it into the workflow input so policy decisions persist across pauses/resumes.
- LLM-Level Tool Visibility Control: LLM execution step filters out denied tools from model-visible tool lists and clears stale toolChoice selections before making model calls.
- Tool Execution Validation & Approval Flow: tool-call step validates tool invocations against Tool Gate; denies denied calls with explicit reasons or escalates for approval according to the runtime policy. Approval marks are stored per-run in request context and are replay-safe for resume.
- Background Task & Context Propagation: requestContext (including tool-gate/approval state) is propagated to background tool executions; PubSub emits tool-call/tool-result/tool-error and suspended/denied events as appropriate.

## Changed Modules

- packages/core/src/agent/durable/durable-agent.ts
  - Adds optional toolGatePolicy on DurableAgentStreamOptions.

- packages/core/src/agent/durable/types.ts
  - SerializableDurableState includes optional toolGate: ToolGateSerializableState.

- packages/core/src/agent/durable/preparation.ts
  - Captures and embeds serialized Tool Gate runtime state into durable workflow input.

- packages/core/src/agent/durable/utils/serialize-state.ts
  - serializeDurableState accepts/includes toolGate in serialized snapshots.

- packages/core/src/agent/durable/workflows/steps/llm-execution.ts
  - Applies durable tool-gate checks before model input: filters tools and clears denied toolChoice.

- packages/core/src/agent/durable/workflows/steps/tool-call.ts
  - Adds DURABLE_TOOL_CALL_APPROVALS_CONTEXT_KEY and DurableToolCallApprovalState to persist per-run approvals.
  - Integrates Tool Gate checks into tool-call flow, handles denial reasons, approval escalation, resume-safe approval state, and emits appropriate PubSub chunks.
  - Ensures requestContext propagation for synchronous and background tool execution and resumes.

- packages/core/src/agent/durable/__tests__ and step tests
  - Expanded tests covering tool hiding, denial rejection, approval escalation and resume, requestContext propagation, background task flows, and PubSub emissions.
  - Test utilities updated/added (e.g., drain stream helper).

## API/Type Surface

- Additive-only changes: new optional fields/types (toolGate/toolGatePolicy, approval context key/type) and durable snapshot shape extended to include toolGate. No removals or breaking signature changes.

## Validation

- Unit tests targeted at durable workflows and tool-call behavior were added/updated and are listed in the PR objectives.
- Type checking passed for the core package.
- Style/lint checks and codex review reported no blocking findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->