### PR TITLE
[PF-165] Prototype Flow Signals processor mapping

### DIFF
--- a/.changeset/wacky-parrots-share.md
+++ b/.changeset/wacky-parrots-share.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Added an internal Flow Signals processor-step mapping prototype for tool policy decisions.
+Improved Flow Signals tool policy handling in `@mastra/core` by applying allow and deny decisions during processor steps.

--- a/.changeset/wacky-parrots-share.md
+++ b/.changeset/wacky-parrots-share.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added an internal Flow Signals processor-step mapping prototype for tool policy decisions.

--- a/packages/core/src/flow-signals/internal/processor-step-tool-policy.test.ts
+++ b/packages/core/src/flow-signals/internal/processor-step-tool-policy.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+import type { MastraDBMessage } from '../../agent/message-list';
+import type { ProcessInputStepArgs, Processor } from '../../processors';
+import type { FlowPolicy } from '../schemas';
+import { selectFlowDecision } from '../selector';
+import { applyProcessorStepToolPolicyDecision, buildProcessorStepToolPolicyDecisionFrame } from './processor-step-tool-policy';
+
+const basePolicy: FlowPolicy = {
+  version: 1,
+  id: 'flow-policy.tools',
+  requiredCapabilities: [],
+  allowedTools: ['search'],
+  deniedTools: ['send_email'],
+  requiredEvidence: [],
+  maxRetries: 1,
+  clarificationRequired: false,
+};
+
+class TestTripWire extends Error {
+  constructor(
+    reason: string,
+    public readonly options: unknown,
+  ) {
+    super(reason);
+  }
+}
+
+function createMessage(): MastraDBMessage {
+  return {
+    id: 'message-1',
+    role: 'user',
+    content: {
+      format: 2,
+      parts: [{ type: 'text', text: 'Search but do not email anyone.' }],
+    },
+    createdAt: new Date('2026-05-06T00:00:00.000Z'),
+    threadId: 'thread-1',
+    resourceId: 'resource-1',
+  };
+}
+
+function createProcessorArgs(
+  overrides: Partial<ProcessInputStepArgs> = {},
+): Pick<
+  ProcessInputStepArgs,
+  | 'abort'
+  | 'activeTools'
+  | 'messages'
+  | 'resourceId'
+  | 'retryCount'
+  | 'runId'
+  | 'stepNumber'
+  | 'toolChoice'
+  | 'tools'
+> {
+  const message = createMessage();
+
+  return {
+    abort: (reason?: string, options?: any): never => {
+      throw new TestTripWire(reason ?? 'Flow decision aborted', options);
+    },
+    activeTools: ['search', 'send_email'],
+    messages: [message],
+    resourceId: 'resource-1',
+    retryCount: 0,
+    runId: 'run-1',
+    stepNumber: 0,
+    toolChoice: { type: 'tool', toolName: 'send_email' } as any,
+    tools: {
+      search: { description: 'Search documents' },
+      send_email: { description: 'Send email' },
+    },
+    ...overrides,
+  };
+}
+
+describe('processor step Flow Signals tool policy mapping', () => {
+  it('maps processor step state into a DecisionFrame and consumes the decision as processor output', async () => {
+    const processor: Processor = {
+      id: 'flow-tool-policy-prototype',
+      processInputStep: async args => {
+        const frame = buildProcessorStepToolPolicyDecisionFrame({ args, policy: basePolicy });
+        const decision = selectFlowDecision(frame, basePolicy);
+        return applyProcessorStepToolPolicyDecision({ args, decision });
+      },
+    };
+
+    const result = await processor.processInputStep!(createProcessorArgs() as ProcessInputStepArgs);
+
+    expect(result).toEqual({
+      tools: {
+        search: { description: 'Search documents' },
+      },
+      activeTools: ['search'],
+      toolChoice: 'auto',
+    });
+  });
+
+  it('keeps the DecisionFrame tied to processor lifecycle data', () => {
+    const args = createProcessorArgs({ stepNumber: 2 });
+    const frame = buildProcessorStepToolPolicyDecisionFrame({ args, policy: basePolicy });
+
+    expect(frame).toMatchObject({
+      id: 'processor-step:run-1:2:tool-policy',
+      decisionPoint: 'post_tool_batch',
+      request: {
+        runId: 'run-1',
+        threadId: 'thread-1',
+        resourceId: 'resource-1',
+      },
+      signals: {
+        entities: {
+          toolRefs: ['search', 'send_email'],
+        },
+      },
+      state: {
+        revision: 2,
+        retryCount: 0,
+      },
+      refs: [{ id: 'message-1', kind: 'message' }],
+    });
+  });
+
+  it('maps blocking Flow decisions to the existing processor abort path', () => {
+    const policy: FlowPolicy = {
+      ...basePolicy,
+      id: 'flow-policy.evidence',
+      allowedTools: [],
+      deniedTools: [],
+      requiredEvidence: [{ id: 'retrieval.evidence', kind: 'retrieval', requiredCount: 1, match: {} }],
+    };
+    const args = createProcessorArgs();
+    const frame = buildProcessorStepToolPolicyDecisionFrame({ args, policy });
+    const decision = selectFlowDecision(frame, policy);
+
+    expect(() => applyProcessorStepToolPolicyDecision({ args, decision })).toThrow(TestTripWire);
+
+    try {
+      applyProcessorStepToolPolicyDecision({ args, decision });
+      expect.fail('Expected a TripWire');
+    } catch (error) {
+      expect(error).toBeInstanceOf(TestTripWire);
+      expect((error as TestTripWire).message).toBe('Flow decision requires evidence before continuing');
+      expect((error as TestTripWire).options).toMatchObject({
+        retry: false,
+        metadata: {
+          flowDecisionId: decision.id,
+          flowAction: 'require_evidence',
+        },
+      });
+    }
+  });
+
+  it('does not claim policy-required capabilities unless runtime capabilities are supplied', () => {
+    const policy: FlowPolicy = {
+      ...basePolicy,
+      id: 'flow-policy.capability',
+      allowedTools: [],
+      deniedTools: [],
+      requiredCapabilities: ['retrieval'],
+    };
+    const args = createProcessorArgs();
+    const frame = buildProcessorStepToolPolicyDecisionFrame({ args, policy });
+    const decision = selectFlowDecision(frame, policy);
+
+    expect(() => applyProcessorStepToolPolicyDecision({ args, decision })).toThrow(TestTripWire);
+
+    const frameWithCapability = buildProcessorStepToolPolicyDecisionFrame({
+      args,
+      policy,
+      capabilities: ['retrieval'],
+    });
+    const decisionWithCapability = selectFlowDecision(frameWithCapability, policy);
+
+    expect(decisionWithCapability.actions.some(action => action.type === 'require_capability')).toBe(false);
+  });
+
+  it('clears denied object tool choices that omit an explicit type discriminator', () => {
+    const args = createProcessorArgs({
+      toolChoice: { toolName: 'send_email' } as any,
+    });
+    const frame = buildProcessorStepToolPolicyDecisionFrame({ args, policy: basePolicy });
+    const decision = selectFlowDecision(frame, basePolicy);
+    const result = applyProcessorStepToolPolicyDecision({ args, decision });
+
+    expect(result.toolChoice).toBe('auto');
+  });
+});

--- a/packages/core/src/flow-signals/internal/processor-step-tool-policy.ts
+++ b/packages/core/src/flow-signals/internal/processor-step-tool-policy.ts
@@ -1,0 +1,175 @@
+import type { ToolChoice } from '@internal/ai-sdk-v5';
+import type { ProcessInputStepArgs, ProcessInputStepResult } from '../../processors';
+import type { DecisionFrame, FlowDecision, FlowPolicy } from '../schemas';
+import { FLOW_SIGNALS_VERSION } from '../schemas';
+
+// Internal prototype only. Do not export this from the flow-signals entrypoint
+// until another processor mapping proves the same adapter shape.
+export type BuildProcessorStepToolPolicyFrameOptions = {
+  args: Pick<
+    ProcessInputStepArgs,
+    'activeTools' | 'messages' | 'resourceId' | 'retryCount' | 'runId' | 'stepNumber' | 'tools'
+  >;
+  policy: FlowPolicy;
+  frameId?: string;
+  capabilities?: string[];
+};
+
+export type ApplyProcessorStepToolPolicyDecisionOptions = {
+  args: Pick<ProcessInputStepArgs, 'abort' | 'activeTools' | 'toolChoice' | 'tools'>;
+  decision: FlowDecision;
+};
+
+export function buildProcessorStepToolPolicyDecisionFrame({
+  args,
+  policy,
+  frameId,
+  capabilities,
+}: BuildProcessorStepToolPolicyFrameOptions): DecisionFrame {
+  const toolNames = Object.keys(args.tools ?? {});
+  const messageRefs = args.messages.map(message => ({
+    id: message.id,
+    kind: 'message' as const,
+  }));
+  const firstThreadId = args.messages.find(message => message.threadId)?.threadId;
+
+  return {
+    version: FLOW_SIGNALS_VERSION,
+    id: frameId ?? `processor-step:${args.runId ?? 'run'}:${args.stepNumber}:tool-policy`,
+    decisionPoint: args.stepNumber === 0 ? 'turn_start' : 'post_tool_batch',
+    request: {
+      runId: args.runId,
+      threadId: firstThreadId,
+      resourceId: args.resourceId,
+      featureFlags: [],
+    },
+    signals: {
+      version: FLOW_SIGNALS_VERSION,
+      sources: ['system_state'],
+      tasks: [],
+      requestedOutput: {},
+      requestedCapabilities: [],
+      entities: {
+        documents: [],
+        toolRefs: toolNames,
+        urls: [],
+        identifiers: [],
+      },
+      ambiguity: {
+        status: 'clear',
+        blocking: false,
+      },
+    },
+    state: {
+      version: FLOW_SIGNALS_VERSION,
+      runId: args.runId,
+      revision: args.stepNumber,
+      retryCount: args.retryCount,
+      capabilities: capabilities ?? [],
+      decisions: [],
+      evidence: {
+        version: FLOW_SIGNALS_VERSION,
+        entries: [],
+      },
+      refs: messageRefs,
+    },
+    refs: messageRefs,
+  };
+}
+
+export function applyProcessorStepToolPolicyDecision({
+  args,
+  decision,
+}: ApplyProcessorStepToolPolicyDecisionOptions): ProcessInputStepResult {
+  for (const action of decision.actions) {
+    if (action.type === 'ask_clarification') {
+      args.abort(action.question ?? 'Flow decision requires clarification', {
+        retry: false,
+        metadata: { flowDecisionId: decision.id, flowAction: action.type },
+      });
+    }
+
+    if (action.type === 'require_capability') {
+      args.abort(`Flow decision requires capabilities: ${action.capabilities.join(', ')}`, {
+        retry: false,
+        metadata: { flowDecisionId: decision.id, flowAction: action.type, capabilities: action.capabilities },
+      });
+    }
+
+    if (action.type === 'require_evidence') {
+      args.abort('Flow decision requires evidence before continuing', {
+        retry: false,
+        metadata: { flowDecisionId: decision.id, flowAction: action.type, requirements: action.requirements },
+      });
+    }
+
+    if (action.type === 'retry') {
+      args.abort(action.reason, {
+        retry: true,
+        metadata: { flowDecisionId: decision.id, flowAction: action.type },
+      });
+    }
+
+    if (action.type === 'fail') {
+      args.abort(action.reason, {
+        retry: false,
+        metadata: { flowDecisionId: decision.id, flowAction: action.type },
+      });
+    }
+  }
+
+  const result: ProcessInputStepResult = {};
+
+  for (const action of decision.actions) {
+    if (action.type !== 'apply_tool_policy') {
+      continue;
+    }
+
+    if (args.tools) {
+      const nextTools: Record<string, unknown> = {};
+      for (const [toolName, tool] of Object.entries(args.tools)) {
+        const allowedByList = action.allowedTools.length === 0 || action.allowedTools.includes(toolName);
+        const deniedByList = action.deniedTools.includes(toolName);
+        if (allowedByList && !deniedByList) {
+          nextTools[toolName] = tool;
+        }
+      }
+      result.tools = nextTools;
+    }
+
+    if (args.activeTools) {
+      result.activeTools = args.activeTools.filter(toolName => {
+        const allowedByList = action.allowedTools.length === 0 || action.allowedTools.includes(toolName);
+        const deniedByList = action.deniedTools.includes(toolName);
+        return allowedByList && !deniedByList;
+      });
+    }
+
+    if (isToolChoiceBlockedByFlowPolicy(args.toolChoice, action.allowedTools, action.deniedTools)) {
+      result.toolChoice = 'auto';
+    }
+  }
+
+  return result;
+}
+
+function isToolChoiceBlockedByFlowPolicy(
+  toolChoice: ToolChoice<any> | undefined,
+  allowedTools: string[],
+  deniedTools: string[],
+): boolean {
+  if (!toolChoice || typeof toolChoice !== 'object' || !('toolName' in toolChoice)) {
+    return false;
+  }
+
+  const toolName = toolChoice.toolName;
+  if (typeof toolName !== 'string') {
+    return false;
+  }
+
+  if (deniedTools.includes(toolName)) {
+    return true;
+  }
+
+  return allowedTools.length > 0 && !allowedTools.includes(toolName);
+}


### PR DESCRIPTION
## Summary

- add an internal Flow Signals processor-step prototype that maps processor runtime state into a DecisionFrame
- consume FlowDecision actions through existing processor outputs for tool narrowing and existing abort semantics for blocking/retry/fail actions
- keep the adapter under flow-signals/internal with no public export until another processor consumer proves the shape

## Verification

- pnpm --filter ./packages/core test -- src/flow-signals
- git diff --check

## Review notes

- Local Codex review found two issues: required capabilities defaulting too permissive, and toolChoice objects without type discriminators not being cleared. Both are fixed and covered by tests.
- Claude timed out without usable feedback.
- Gemini failed inside its restricted CLI tool layer.

Linear: PF-165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This adds a small internal "traffic cop" that checks which tools a processor may use and enforces allow/deny rules — if a chosen tool is blocked, it clears that choice and falls back to "auto."

## Overview

Adds an internal prototype Flow Signals processor-step adapter that:
- Builds a DecisionFrame representing processor runtime state for tool-policy decisions.
- Consumes FlowDecision actions and translates them into processor outputs or aborts.
- Applies allow/deny semantics to filter tools and activeTools, and resets blocked toolChoice to "auto".
- Uses existing processor abort semantics for blocking actions (clarification, capability-required, evidence-required, retry, fail).
- Is placed under flow-signals/internal and is not publicly exported.

## Changes

- packages/core/src/flow-signals/internal/processor-step-tool-policy.ts
  - Exported types:
    - BuildProcessorStepToolPolicyFrameOptions
    - ApplyProcessorStepToolPolicyDecisionOptions
  - Exported functions:
    - buildProcessorStepToolPolicyDecisionFrame(options): constructs a DecisionFrame with versioning, run/thread/resource context, message refs, tool refs, revision/retry state, and optional runtime capabilities.
    - applyProcessorStepToolPolicyDecision(options): iterates FlowDecision actions and:
      - Calls args.abort(...) for ask_clarification, require_capability, require_evidence, retry, and fail actions (with appropriate retry/metadata).
      - For apply_tool_policy actions, filters args.tools and args.activeTools using allowedTools/deniedTools and sets result.toolChoice = 'auto' when the current choice is blocked.
  - Helper: isToolChoiceBlockedByFlowPolicy validates toolChoice shape and enforces allow/deny list logic (denies win; explicit allow list restricts others).

- packages/core/src/flow-signals/internal/processor-step-tool-policy.test.ts
  - New Vitest suite covering:
    - Mapping processor state into a DecisionFrame and producing processor outputs that whitelist allowed tools and normalize toolChoice to 'auto'.
    - DecisionFrame ties to lifecycle identifiers (run/thread/resource, revision, retryCount, decisionPoint).
    - Mapping evidence-required and other blocking Flow actions into processor aborts with expected messages and metadata (tested via TestTripWire).
    - Ensuring require_capability actions are not emitted unless runtime capabilities are supplied.
    - Clearing denied toolChoice objects that omit an explicit type discriminator (resulting in 'auto').
  - Local test helpers simulate processor args and assert outputs/abort metadata.

- .changeset/wacky-parrots-share.md
  - Patch changeset for @mastra/core noting improved Flow Signals tool policy handling by applying allow/deny decisions during processor steps.

## Review notes / fixes

- Two issues identified in local review were fixed and covered by tests:
  1. Required capabilities were previously defaulting too permissive — now require runtime capabilities to be present before emitting require_capability.
  2. toolChoice objects lacking an explicit type discriminator are cleared when denied by policy (normalized to 'auto').

## Verification

- Tests: pnpm --filter ./packages/core test -- src/flow-signals
- Style/check: git diff --check
<!-- end of auto-generated comment: release notes by coderabbit.ai -->