### PR TITLE
Enforce Harness tool permissions through Tool Gate

### DIFF
--- a/.changeset/strong-lions-bake.md
+++ b/.changeset/strong-lions-bake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Harness tool permissions so denied tools stay hidden or blocked at runtime, including provider tools and resumed approvals. Explicit deny rules now override yolo mode and session grants.

--- a/.changeset/strong-lions-bake.md
+++ b/.changeset/strong-lions-bake.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed Harness tool permissions so denied tools stay hidden or blocked at runtime, including provider tools and resumed approvals. Explicit deny rules now override yolo mode and session grants.
+Fixed Harness tool permissions so denied tools stay hidden from models and blocked at runtime, including provider tools and resumed approvals. Explicit deny rules now take precedence over approval shortcuts and temporary access grants.

--- a/packages/core/src/agent/__tests__/active-tools-enforcement.test.ts
+++ b/packages/core/src/agent/__tests__/active-tools-enforcement.test.ts
@@ -293,6 +293,60 @@ describe('activeTools enforcement at execution time', () => {
     ]);
   });
 
+  it('hides provider-executed tools that require local approval before calling the model', async () => {
+    const seenModelTools: string[][] = [];
+
+    const mockModel = new MockLanguageModelV2({
+      doGenerate: async ({ tools }: any) => {
+        seenModelTools.push(Array.isArray(tools) ? tools.map(tool => tool.name) : Object.keys(tools ?? {}));
+
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          text: 'Done.',
+          content: [{ type: 'text' as const, text: 'Done.' }],
+          warnings: [],
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'test-agent',
+      instructions: 'You are a helpful assistant.',
+      model: mockModel,
+      tools: {
+        localTool: createTool({
+          id: 'localTool',
+          description: 'A local tool',
+          inputSchema: z.object({ value: z.string() }),
+          execute: vi.fn(),
+        }),
+        webSearch: {
+          type: 'provider-defined',
+          id: 'openai.web_search',
+          name: 'web_search',
+          args: { search_context_size: 'low' },
+        } as any,
+      },
+    });
+
+    await agent.generate('Hello', {
+      maxSteps: 1,
+      toolGatePolicy: {
+        id: 'provider-approval-policy',
+        evaluate: ({ subject }) =>
+          subject.toolName === 'webSearch'
+            ? { effect: 'requireApproval', reason: 'provider approval is local only' }
+            : { effect: 'allow', reason: 'tool is allowed' },
+      },
+    });
+
+    expect(seenModelTools[0]).toContain('localTool');
+    expect(seenModelTools[0]).not.toContain('webSearch');
+  });
+
   it('does not reuse a call-site tool gate policy on later calls with the same requestContext', async () => {
     const requestContext = new RequestContext();
     const seenModelTools: string[][] = [];

--- a/packages/core/src/agent/durable/utils/resolve-runtime.test.ts
+++ b/packages/core/src/agent/durable/utils/resolve-runtime.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { toolRequiresApproval } from './resolve-runtime';
+
+describe('durable tool approval resolution', () => {
+  it('does not let needsApprovalFn downgrade global approval', async () => {
+    const tool = {
+      needsApprovalFn: vi.fn().mockReturnValue(false),
+    } as any;
+
+    await expect(toolRequiresApproval(tool, true, { action: 'send' })).resolves.toBe(true);
+    expect(tool.needsApprovalFn).toHaveBeenCalledWith({ action: 'send' });
+  });
+
+  it('does not let needsApprovalFn downgrade tool-owned approval', async () => {
+    const tool = {
+      requireApproval: true,
+      needsApprovalFn: vi.fn().mockReturnValue(false),
+    } as any;
+
+    await expect(toolRequiresApproval(tool, false, { action: 'send' })).resolves.toBe(true);
+  });
+
+  it('allows needsApprovalFn to raise approval when no other source requires it', async () => {
+    const tool = {
+      needsApprovalFn: vi.fn().mockReturnValue(true),
+    } as any;
+
+    await expect(toolRequiresApproval(tool, false, { action: 'delete' })).resolves.toBe(true);
+  });
+
+  it('does not require approval when all approval sources are false', async () => {
+    const tool = {
+      requireApproval: false,
+      needsApprovalFn: vi.fn().mockReturnValue(false),
+    } as any;
+
+    await expect(toolRequiresApproval(tool, false, { action: 'read' })).resolves.toBe(false);
+  });
+});

--- a/packages/core/src/agent/durable/utils/resolve-runtime.test.ts
+++ b/packages/core/src/agent/durable/utils/resolve-runtime.test.ts
@@ -8,7 +8,20 @@ describe('durable tool approval resolution', () => {
     } as any;
 
     await expect(toolRequiresApproval(tool, true, { action: 'send' })).resolves.toBe(true);
-    expect(tool.needsApprovalFn).toHaveBeenCalledWith({ action: 'send' });
+    expect(tool.needsApprovalFn).toHaveBeenCalledWith({ action: 'send' }, {});
+  });
+
+  it('passes request context and workspace to needsApprovalFn', async () => {
+    const tool = {
+      needsApprovalFn: vi.fn().mockReturnValue(false),
+    } as any;
+    const context = {
+      requestContext: { userId: 'user-123' },
+      workspace: { id: 'workspace-123' },
+    } as any;
+
+    await expect(toolRequiresApproval(tool, false, { action: 'send' }, context)).resolves.toBe(false);
+    expect(tool.needsApprovalFn).toHaveBeenCalledWith({ action: 'send' }, context);
   });
 
   it('does not let needsApprovalFn downgrade tool-owned approval', async () => {

--- a/packages/core/src/agent/durable/utils/resolve-runtime.ts
+++ b/packages/core/src/agent/durable/utils/resolve-runtime.ts
@@ -245,9 +245,9 @@ export function resolveTool(toolName: string, mastra?: Mastra): CoreTool | undef
 /**
  * Check if a tool requires human approval.
  *
- * If the tool has a `needsApprovalFn`, it takes precedence over both the
- * global `requireToolApproval` flag and the tool-level `requireApproval` flag.
- * This matches the behavior of the non-durable agent's tool-call-step.
+ * Tool-owned approval, global approval, and `needsApprovalFn` are additive.
+ * A dynamic approval function can require approval for specific args, but it
+ * cannot lower approval already required by the tool or run options.
  */
 export async function toolRequiresApproval(
   tool: CoreTool,
@@ -256,10 +256,9 @@ export async function toolRequiresApproval(
 ): Promise<boolean> {
   let requires = !!(globalRequireApproval || (tool as any).requireApproval);
 
-  // needsApprovalFn overrides all other flags (e.g., skill tools return false)
   if ((tool as any).needsApprovalFn) {
     try {
-      requires = await (tool as any).needsApprovalFn(args ?? {});
+      requires = Boolean(await (tool as any).needsApprovalFn(args ?? {})) || requires;
     } catch {
       // On error, default to requiring approval (safe default)
       requires = true;

--- a/packages/core/src/agent/durable/utils/resolve-runtime.ts
+++ b/packages/core/src/agent/durable/utils/resolve-runtime.ts
@@ -253,12 +253,13 @@ export async function toolRequiresApproval(
   tool: CoreTool,
   globalRequireApproval?: boolean,
   args?: Record<string, unknown>,
+  context?: { requestContext?: Record<string, unknown>; workspace?: Workspace },
 ): Promise<boolean> {
   let requires = !!(globalRequireApproval || (tool as any).requireApproval);
 
   if ((tool as any).needsApprovalFn) {
     try {
-      requires = Boolean(await (tool as any).needsApprovalFn(args ?? {})) || requires;
+      requires = Boolean(await (tool as any).needsApprovalFn(args ?? {}, context ?? {})) || requires;
     } catch {
       // On error, default to requiring approval (safe default)
       requires = true;

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.test.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.test.ts
@@ -202,6 +202,76 @@ describe('durable LLM Tool Gate enforcement', () => {
     expect(modelToolChoice).toEqual({ type: 'auto' });
   });
 
+  it('hides provider-executed tools that require local approval', async () => {
+    let modelToolNames: string[] = [];
+    const model = new MockLanguageModelV2({
+      doStream: async (options: any) => {
+        modelToolNames = Array.isArray(options.tools)
+          ? options.tools.map((tool: any) => tool.name)
+          : Object.keys(options.tools ?? {});
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+        };
+      },
+    });
+
+    const requestContext = new RequestContext();
+    setToolGateRuntimeStateForRun(requestContext, RUN_ID, {
+      policy: {
+        id: 'runtime-policy',
+        evaluate: async ({ subject }) =>
+          subject.toolName === 'webSearch'
+            ? { effect: 'requireApproval', reason: 'provider approval is local only' }
+            : { effect: 'allow', reason: 'allowed' },
+      },
+    });
+
+    const messageList = new MessageList();
+    messageList.add('Use a tool', 'input');
+    globalRunRegistry.set(RUN_ID, {
+      tools: {
+        localTool: { description: 'Allowed local tool' },
+        webSearch: {
+          type: 'provider-defined',
+          id: 'openai.web_search',
+          name: 'web_search',
+        },
+      },
+      model: model as any,
+      requestContext,
+    } as any);
+
+    const step = createDurableLLMExecutionStep();
+
+    await (step as any).execute({
+      inputData: {
+        runId: RUN_ID,
+        agentId: 'agent-1',
+        agentName: 'Agent 1',
+        messageListState: messageList.serialize(),
+        toolsMetadata: [],
+        modelConfig: {
+          provider: 'mock',
+          modelId: 'mock-model-id',
+        },
+        options: {},
+        state: {
+          toolGate: { policyId: 'runtime-policy' },
+        },
+        messageId: 'message-1',
+      },
+      mastra: { getLogger: () => undefined },
+      requestContext,
+    });
+
+    expect(modelToolNames).toEqual(['localTool']);
+  });
+
   it('does not adopt an ambient Tool Gate policy when durable state has no policy id', async () => {
     let modelToolNames: string[] = [];
     const model = new MockLanguageModelV2({

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -50,19 +50,20 @@ async function applyDurableToolGateToModelInput({
 
   const deniedToolNames = new Set<string>();
   for (const [toolName, tool] of entries) {
+    const subject = createToolGateSubjectForTool({
+      boundary: 'model-input',
+      toolName,
+      tool,
+    });
     const decision = await evaluateToolGateForRequest({
       requestContext,
-      subject: createToolGateSubjectForTool({
-        boundary: 'model-input',
-        toolName,
-        tool,
-      }),
+      subject,
       runId,
       threadId,
       resourceId,
     });
 
-    if (decision?.effect === 'deny') {
+    if (decision?.effect === 'deny' || (decision?.effect === 'requireApproval' && subject.source.source === 'provider')) {
       deniedToolNames.add(toolName);
     }
   }

--- a/packages/core/src/agent/durable/workflows/steps/tool-call.ts
+++ b/packages/core/src/agent/durable/workflows/steps/tool-call.ts
@@ -328,7 +328,10 @@ export function createDurableToolCallStep() {
 
       // 2. Check if tool requires approval
       const requiresApproval =
-        (await toolRequiresApproval(tool, agentOptions.requireToolApproval, args)) ||
+        (await toolRequiresApproval(tool, agentOptions.requireToolApproval, args, {
+          requestContext: requestContextForRun ? Object.fromEntries(requestContextForRun.entries()) : {},
+          workspace,
+        })) ||
         toolGateDecision?.effect === 'requireApproval';
       const hadApprovalBeforeResume = durableToolCallWasApproved(requestContextForRun, runId, toolCallId);
 

--- a/packages/core/src/harness/harness-tool-gate-policy.test.ts
+++ b/packages/core/src/harness/harness-tool-gate-policy.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Agent } from '../agent';
+import { InMemoryStore } from '../storage/mock';
+import type { ToolGatePolicy } from '../tools/tool-gate';
+import { Harness } from './harness';
+import type { PermissionRules } from './types';
+
+function createAgent() {
+  return new Agent({
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+}
+
+function createMockStreamResponse() {
+  const chunks: any[] = [
+    { type: 'text-start', payload: { id: 'msg-1' } },
+    { type: 'text-delta', payload: { id: 'msg-1', text: 'Hello' } },
+    { type: 'text-end', payload: { id: 'msg-1' } },
+    { type: 'step-end', payload: {} },
+    { type: 'finish', payload: {} },
+  ];
+
+  return {
+    fullStream: (async function* () {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    })(),
+  };
+}
+
+describe('Harness tool gate policy', () => {
+  let agent: Agent;
+  let harness: Harness<{
+    permissionRules?: PermissionRules;
+    yolo?: boolean;
+  }>;
+
+  beforeEach(() => {
+    agent = createAgent();
+    harness = new Harness({
+      id: 'test-harness',
+      storage: new InMemoryStore(),
+      initialState: {
+        permissionRules: {
+          categories: { edit: 'ask', execute: 'deny' },
+          tools: {
+            dangerousTool: 'deny',
+            reviewedTool: 'ask',
+            allowedTool: 'allow',
+            allowedButCategoryDeniedTool: 'allow',
+            stableDeleteTool: 'deny',
+          },
+        },
+        yolo: false,
+      },
+      toolCategoryResolver: toolName => {
+        if (toolName === 'categoryTool') return 'edit';
+        if (toolName === 'categoryDeniedTool' || toolName === 'allowedButCategoryDeniedTool') return 'execute';
+        return null;
+      },
+      modes: [{ id: 'default', name: 'Default', default: true, agent }],
+    });
+
+    vi.spyOn(agent, 'stream').mockResolvedValue(createMockStreamResponse() as any);
+    (harness as any).currentThreadId = 'test-thread-123';
+  });
+
+  it('passes Harness permission rules to the agent as a tool gate policy', async () => {
+    await harness.sendMessage({ content: 'hello' });
+
+    const streamSpy = vi.mocked(agent.stream);
+    const [, streamOptions] = streamSpy.mock.calls[0]!;
+    const policy = streamOptions.toolGatePolicy as ToolGatePolicy;
+
+    expect(streamOptions.requireToolApproval).toBe(false);
+    expect(policy.id).toBe('harness:test-harness:tool-permissions');
+    await expect(
+      Promise.resolve(
+        policy.evaluate({
+          subject: {
+            boundary: 'model-input',
+            toolName: 'dangerousTool',
+            source: { source: 'assigned' },
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      effect: 'deny',
+      metadata: {
+        harnessId: 'test-harness',
+        modeId: 'default',
+      },
+    });
+    await expect(
+      Promise.resolve(
+        policy.evaluate({
+          subject: {
+            boundary: 'tool-call',
+            toolName: 'reviewedTool',
+            source: { source: 'assigned' },
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({ effect: 'requireApproval' });
+    await expect(
+      Promise.resolve(
+        policy.evaluate({
+          subject: {
+            boundary: 'model-input',
+            toolName: 'allowedTool',
+            source: { source: 'assigned' },
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({ effect: 'allow' });
+  });
+
+  it('uses model-facing names and stable tool ids when resolving permission rules', async () => {
+    await harness.sendMessage({ content: 'hello' });
+
+    const streamSpy = vi.mocked(agent.stream);
+    const [, streamOptions] = streamSpy.mock.calls[0]!;
+    const policy = streamOptions.toolGatePolicy as ToolGatePolicy;
+
+    await expect(
+      Promise.resolve(
+        policy.evaluate({
+          subject: {
+            boundary: 'model-input',
+            toolName: 'delete',
+            toolId: 'stableDeleteTool',
+            source: { source: 'assigned' },
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({ effect: 'deny' });
+    await expect(
+      Promise.resolve(
+        policy.evaluate({
+          subject: {
+            boundary: 'model-input',
+            toolName: 'categoryDeniedTool',
+            source: { source: 'assigned' },
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({ effect: 'deny' });
+    await expect(
+      Promise.resolve(
+        policy.evaluate({
+          subject: {
+            boundary: 'model-input',
+            toolName: 'allowedButCategoryDeniedTool',
+            source: { source: 'assigned' },
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({ effect: 'deny' });
+  });
+
+  it('does not let yolo or session grants override explicit deny', async () => {
+    (harness as any).state.yolo = true;
+    harness.grantSessionTool({ toolName: 'dangerousTool' });
+
+    await harness.sendMessage({ content: 'hello' });
+
+    const streamSpy = vi.mocked(agent.stream);
+    const [, streamOptions] = streamSpy.mock.calls[0]!;
+    const policy = streamOptions.toolGatePolicy as ToolGatePolicy;
+
+    await expect(
+      Promise.resolve(
+        policy.evaluate({
+          subject: {
+            boundary: 'tool-call',
+            toolName: 'dangerousTool',
+            source: { source: 'assigned' },
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({ effect: 'deny' });
+    await expect(
+      Promise.resolve(
+        policy.evaluate({
+          subject: {
+            boundary: 'tool-call',
+            toolName: 'categoryDeniedTool',
+            source: { source: 'assigned' },
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({ effect: 'deny' });
+  });
+
+  it('passes the same policy into approval and resume paths', async () => {
+    const approveSpy = vi.spyOn(agent, 'approveToolCall').mockResolvedValue(createMockStreamResponse() as any);
+    const declineSpy = vi.spyOn(agent, 'declineToolCall').mockResolvedValue(createMockStreamResponse() as any);
+    const resumeSpy = vi.spyOn(agent, 'resumeStream').mockResolvedValue(createMockStreamResponse() as any);
+
+    (harness as any).currentRunId = 'run-1';
+    await (harness as any).handleToolApprove({ toolCallId: 'call-1' });
+    await (harness as any).handleToolDecline({ toolCallId: 'call-1' });
+
+    (harness as any).pendingSuspensionRunId = 'run-1';
+    (harness as any).pendingSuspensionToolCallId = 'call-1';
+    await (harness as any).handleToolResume({ resumeData: { approved: true } });
+
+    expect(approveSpy.mock.calls[0]![0]).toMatchObject({
+      requireToolApproval: false,
+      toolGatePolicy: expect.objectContaining({ id: 'harness:test-harness:tool-permissions' }),
+    });
+    expect(declineSpy.mock.calls[0]![0]).toMatchObject({
+      requireToolApproval: false,
+      toolGatePolicy: expect.objectContaining({ id: 'harness:test-harness:tool-permissions' }),
+    });
+    expect(resumeSpy.mock.calls[0]![1]).toMatchObject({
+      requireToolApproval: false,
+      toolGatePolicy: expect.objectContaining({ id: 'harness:test-harness:tool-permissions' }),
+    });
+  });
+});

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -10,6 +10,7 @@ import { toStandardSchema } from '../schema';
 import type { StandardSchemaWithJSON } from '../schema';
 import type { MemoryStorage } from '../storage/domains/memory/base';
 import type { ObservationalMemoryRecord } from '../storage/types';
+import type { ToolGatePolicy } from '../tools/tool-gate';
 import { safeStringify } from '../utils';
 import { Workspace } from '../workspace/workspace';
 import type { WorkspaceConfig } from '../workspace/workspace';
@@ -1367,29 +1368,94 @@ export class Harness<TState = {}> {
   }
 
   /**
-   * Resolve whether a tool call should be auto-approved, denied, or asked.
-   * Resolution chain: yolo → per-tool policy → session tool grant →
-   * session category grant → category policy → "ask"
+   * Resolve whether a tool should be allowed, denied, or require approval.
+   * Explicit denies beat yolo and session grants. Otherwise, tool-specific
+   * rules beat category rules. Yolo skips approval, but it does not make denied
+   * tools available.
    */
-  private resolveToolApproval(toolName: string): PermissionPolicy {
+  private resolveToolApproval(toolName: string, aliases: string[] = []): PermissionPolicy {
     const state = this.state as Record<string, unknown>;
-    if (state.yolo === true) return 'allow';
-
     const rules = this.getPermissionRules();
+    const toolNames = [toolName, ...aliases.filter(alias => alias && alias !== toolName)];
 
-    const toolPolicy = rules.tools[toolName];
-    if (toolPolicy) return toolPolicy;
+    const toolPolicies = toolNames
+      .map(name => rules.tools[name])
+      .filter((policy): policy is PermissionPolicy => policy !== undefined);
+    if (toolPolicies.includes('deny')) return 'deny';
 
-    if (this.sessionGrantedTools.has(toolName)) return 'allow';
+    const categories = [
+      ...new Set(toolNames.map(name => this.getToolCategory({ toolName: name })).filter(category => category !== null)),
+    ] as ToolCategory[];
 
-    const category = this.getToolCategory({ toolName });
-    if (category) {
+    const categoryPolicies = categories
+      .map(category => rules.categories[category])
+      .filter((policy): policy is PermissionPolicy => policy !== undefined);
+    if (categoryPolicies.includes('deny')) return 'deny';
+
+    if (state.yolo === true) return 'allow';
+    if (toolPolicies.includes('ask')) return 'ask';
+    if (toolPolicies.includes('allow')) return 'allow';
+
+    if (toolNames.some(name => this.sessionGrantedTools.has(name))) return 'allow';
+
+    for (const category of categories) {
       if (this.sessionGrantedCategories.has(category)) return 'allow';
-      const categoryPolicy = rules.categories[category];
-      if (categoryPolicy) return categoryPolicy;
     }
 
+    if (categoryPolicies.includes('ask')) return 'ask';
+    if (categoryPolicies.includes('allow')) return 'allow';
+
     return 'ask';
+  }
+
+  private buildToolGatePolicy(): ToolGatePolicy {
+    return {
+      id: `harness:${this.id}:tool-permissions`,
+      description: 'Harness permission rules enforced by the core tool gate.',
+      evaluate: ({ subject }) => {
+        const policy = this.resolveToolApproval(subject.toolName, subject.toolId ? [subject.toolId] : []);
+        const category =
+          this.getToolCategory({ toolName: subject.toolName }) ??
+          (subject.toolId ? this.getToolCategory({ toolName: subject.toolId }) : null);
+
+        if (policy === 'deny') {
+          return {
+            effect: 'deny',
+            reason: 'Harness permission policy denied this tool.',
+            ruleId: category ? `harness-category:${category}` : `harness-tool:${subject.toolName}`,
+            metadata: {
+              harnessId: this.id,
+              modeId: this.currentModeId,
+              category,
+            },
+          };
+        }
+
+        if (policy === 'ask') {
+          return {
+            effect: 'requireApproval',
+            reason: 'Harness permission policy requires approval for this tool.',
+            ruleId: category ? `harness-category:${category}` : `harness-tool:${subject.toolName}`,
+            metadata: {
+              harnessId: this.id,
+              modeId: this.currentModeId,
+              category,
+            },
+          };
+        }
+
+        return {
+          effect: 'allow',
+          reason: 'Harness permission policy allowed this tool.',
+          ruleId: category ? `harness-category:${category}` : `harness-tool:${subject.toolName}`,
+          metadata: {
+            harnessId: this.id,
+            modeId: this.currentModeId,
+            category,
+          },
+        };
+      },
+    };
   }
 
   // ===========================================================================
@@ -1427,8 +1493,6 @@ export class Harness<TState = {}> {
     try {
       const requestContext = await this.buildRequestContext(requestContextInput);
 
-      const isYolo = (this.state as Record<string, unknown>).yolo === true;
-
       const streamOptions: Record<string, unknown> = {
         memory: { thread: this.currentThreadId, resource: this.resourceId },
         abortSignal: this.abortController.signal,
@@ -1439,7 +1503,8 @@ export class Harness<TState = {}> {
         // Doesn't do anything when OM is enabled though, OM does its own saving per step
         // actually disable for now, it still breaks OM somehow! TODO fix it
         savePerStep: false,
-        requireToolApproval: !isYolo,
+        requireToolApproval: false,
+        toolGatePolicy: this.buildToolGatePolicy(),
         modelSettings: { temperature: 1 },
         ...(tracingContext && { tracingContext }),
         ...(tracingOptions && { tracingOptions }),
@@ -2580,11 +2645,11 @@ export class Harness<TState = {}> {
     }
 
     const requestContext = await this.buildRequestContext(requestContextInput);
-    const isYolo = (this.state as Record<string, unknown>).yolo === true;
     const response = await agent.approveToolCall({
       runId: this.currentRunId,
       toolCallId,
-      requireToolApproval: !isYolo,
+      requireToolApproval: false,
+      toolGatePolicy: this.buildToolGatePolicy(),
       memory: this.currentThreadId ? { thread: this.currentThreadId, resource: this.resourceId } : undefined,
       abortSignal: this.abortController.signal,
       requestContext,
@@ -2611,11 +2676,11 @@ export class Harness<TState = {}> {
     }
 
     const requestContext = await this.buildRequestContext(requestContextInput);
-    const isYolo = (this.state as Record<string, unknown>).yolo === true;
     const response = await agent.declineToolCall({
       runId: this.currentRunId,
       toolCallId,
-      requireToolApproval: !isYolo,
+      requireToolApproval: false,
+      toolGatePolicy: this.buildToolGatePolicy(),
       memory: this.currentThreadId ? { thread: this.currentThreadId, resource: this.resourceId } : undefined,
       abortSignal: this.abortController.signal,
       requestContext,
@@ -2643,11 +2708,11 @@ export class Harness<TState = {}> {
     }
 
     const requestContext = await this.buildRequestContext(requestContextInput);
-    const isYolo = (this.state as Record<string, unknown>).yolo === true;
     const response = await agent.resumeStream(resumeData, {
       runId: this.pendingSuspensionRunId,
       toolCallId: this.pendingSuspensionToolCallId ?? undefined,
-      requireToolApproval: !isYolo,
+      requireToolApproval: false,
+      toolGatePolicy: this.buildToolGatePolicy(),
       memory: this.currentThreadId ? { thread: this.currentThreadId, resource: this.resourceId } : undefined,
       abortSignal: this.abortController.signal,
       requestContext,
@@ -3258,6 +3323,7 @@ export class Harness<TState = {}> {
         // Recursive forking is blocked at runtime instead: see the patched
         // `subagent` execute that the forked tool path installs in `tools.ts`.
         getParentToolsets: forkRequestContext => this.buildToolsets(forkRequestContext ?? requestContext),
+        getToolGatePolicy: () => this.buildToolGatePolicy(),
       });
     }
 

--- a/packages/core/src/harness/subagent-tool.test.ts
+++ b/packages/core/src/harness/subagent-tool.test.ts
@@ -191,14 +191,16 @@ describe('createSubagentTool requestContext forwarding', () => {
     expect(result.isError).toBe(false);
   });
 
-  it('passes maxSteps, abortSignal, and requireToolApproval alongside requestContext', async () => {
+  it('passes maxSteps, abortSignal, approval options, and requestContext', async () => {
     const abortController = new AbortController();
+    const toolGatePolicy = { id: 'harness:test:tool-permissions', evaluate: vi.fn() };
     mockStream.mockResolvedValue(createMockStreamResponse('done'));
 
     const tool = createSubagentTool({
       subagents,
       resolveModel,
       fallbackModelId: 'test-model',
+      getToolGatePolicy: () => toolGatePolicy,
     });
 
     const requestContext = new RequestContext();
@@ -220,6 +222,7 @@ describe('createSubagentTool requestContext forwarding', () => {
       stopWhen: undefined,
       abortSignal: abortController.signal,
       requireToolApproval: false,
+      toolGatePolicy,
     });
     // Subagent gets a copy of the request context (not the original)
     expect(streamOpts.requestContext).toBeInstanceOf(RequestContext);

--- a/packages/core/src/harness/tools.ts
+++ b/packages/core/src/harness/tools.ts
@@ -5,6 +5,7 @@ import type { ToolsInput, ToolsetsInput } from '../agent/types';
 import type { MastraLanguageModel } from '../llm/model/shared.types';
 import { RequestContext } from '../request-context';
 import { createTool } from '../tools/tool';
+import type { ToolGatePolicy } from '../tools/tool-gate';
 import { createWorkspaceTools } from '../workspace/tools/tools';
 
 import type { HarnessQuestionAnswer, HarnessRequestContext, HarnessSubagent } from './types';
@@ -812,6 +813,8 @@ export interface CreateSubagentToolOptions {
    * stability, but its runtime execute function is patched to block recursion.
    */
   getParentToolsets?: (requestContext?: RequestContext) => Promise<ToolsetsInput | undefined>;
+  /** Returns the current Harness-authored Tool Gate policy for nested subagent runs. */
+  getToolGatePolicy?: () => ToolGatePolicy | undefined;
 }
 
 /**
@@ -1079,11 +1082,13 @@ Use this tool when:
       let partialText = '';
 
       try {
+        const toolGatePolicy = opts.getToolGatePolicy?.();
         const response = await subagentToRun.stream(task, {
           maxSteps: streamMaxSteps,
           stopWhen: streamStopWhen,
           abortSignal,
           requireToolApproval: false,
+          ...(toolGatePolicy ? { toolGatePolicy } : {}),
           requestContext: subagentRequestContext,
           ...(streamMemory && { memory: streamMemory }),
           ...(forkedToolsets && { toolsets: forkedToolsets }),

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -350,7 +350,8 @@ export type PermissionPolicy = 'allow' | 'ask' | 'deny';
 
 /**
  * Permission rules for controlling tool approval behavior.
- * Per-tool overrides take precedence over category policies.
+ * Explicit deny rules take precedence over yolo and session grants. Otherwise,
+ * per-tool rules take precedence over category rules.
  */
 export interface PermissionRules {
   categories: Partial<Record<ToolCategory, PermissionPolicy>>;

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -124,19 +124,20 @@ async function applyToolGateToModelInput<TOOLS extends ToolSet>({
   for (const [toolName, tool] of toolEntries) {
     if (activeToolNames && !activeToolNames.includes(toolName)) continue;
 
+    const subject = createToolGateSubjectForTool({
+      boundary: 'model-input',
+      toolName,
+      tool,
+    });
     const decision = await evaluateToolGateForRequest({
       requestContext,
-      subject: createToolGateSubjectForTool({
-        boundary: 'model-input',
-        toolName,
-        tool,
-      }),
+      subject,
       runId,
       threadId,
       resourceId,
     });
 
-    if (decision?.effect === 'deny') {
+    if (decision?.effect === 'deny' || (decision?.effect === 'requireApproval' && subject.source.source === 'provider')) {
       deniedToolNames.add(toolName);
     }
   }

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -372,13 +372,13 @@ describe('createToolCallStep needsApprovalFn enriched context', () => {
     await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
   });
 
-  it('should skip approval when needsApprovalFn returns false', async () => {
+  it('should skip approval when needsApprovalFn returns false and no other approval source requires it', async () => {
     const needsApprovalFn = vi.fn().mockReturnValue(false);
     const toolResult = { deleted: true };
     const tools = {
       'ctx-tool': {
         execute: vi.fn().mockResolvedValue(toolResult),
-        requireApproval: true,
+        requireApproval: false,
         needsApprovalFn,
       },
     };
@@ -399,6 +399,66 @@ describe('createToolCallStep needsApprovalFn enriched context', () => {
       result: toolResult,
       ...makeInputData(),
     });
+  });
+
+  it('does not let needsApprovalFn downgrade tool-owned approval', async () => {
+    const needsApprovalFn = vi.fn().mockReturnValue(false);
+    const tools = {
+      'ctx-tool': {
+        execute: vi.fn(),
+        requireApproval: true,
+        needsApprovalFn,
+      },
+    };
+
+    const toolCallStep = createToolCallStep({
+      tools,
+      messageList,
+      controller,
+      runId: 'tool-owned-approval-run-id',
+      streamState,
+    });
+
+    const executePromise = toolCallStep.execute(makeExecuteParams());
+
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(needsApprovalFn).toHaveBeenCalled();
+    expect(tools['ctx-tool'].execute).not.toHaveBeenCalled();
+    expect(suspend).toHaveBeenCalled();
+
+    await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
+  });
+
+  it('does not let needsApprovalFn downgrade global approval', async () => {
+    const requestContext = new RequestContext();
+    requestContext.set('__mastra_requireToolApproval', true);
+    const needsApprovalFn = vi.fn().mockReturnValue(false);
+    const tools = {
+      'ctx-tool': {
+        execute: vi.fn(),
+        requireApproval: false,
+        needsApprovalFn,
+      },
+    };
+
+    const toolCallStep = createToolCallStep({
+      tools,
+      messageList,
+      controller,
+      runId: 'global-approval-run-id',
+      streamState,
+    });
+
+    const executePromise = toolCallStep.execute(makeExecuteParams({ requestContext }));
+
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(needsApprovalFn).toHaveBeenCalled();
+    expect(tools['ctx-tool'].execute).not.toHaveBeenCalled();
+    expect(suspend).toHaveBeenCalled();
+
+    await expect(Promise.race([executePromise, Promise.resolve('completed')])).resolves.toBe('completed');
   });
 });
 
@@ -605,6 +665,47 @@ describe('createToolCallStep provider-executed tools', () => {
     });
 
     expect(result).toEqual(inputData);
+    expect(suspend).not.toHaveBeenCalled();
+  });
+
+  it('rejects provider-executed tools that require local Tool Gate approval', async () => {
+    const requestContext = new RequestContext();
+    setToolGateRuntimeState(requestContext, {
+      policy: {
+        id: 'approval-policy',
+        evaluate: () => ({ effect: 'requireApproval', reason: 'provider approval is local only' }),
+      },
+    });
+    const tools = {
+      webSearch: {
+        type: 'provider-defined' as const,
+        id: 'openai.web_search',
+        name: 'web_search',
+      },
+    } as unknown as ToolSet;
+
+    const step = createToolCallStep({
+      tools,
+      messageList,
+      controller,
+      runId: 'test-run',
+    } as unknown as OuterLLMRun);
+
+    const inputData = {
+      toolCallId: 'call-123',
+      toolName: 'web_search',
+      args: { query: 'test' },
+      providerExecuted: true,
+    };
+
+    const result = await step.execute({
+      ...makeBaseExecuteParams(suspend, { requestContext }),
+      writer: new ToolStream({ prefix: 'tool', callId: 'call-123', name: 'web_search', runId: 'test-run' }),
+      inputData,
+    });
+
+    expect(result.error?.name).toBe('ToolNotFoundError');
+    expect(String(result.error?.message)).toContain('requires local approval');
     expect(suspend).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -264,9 +264,7 @@ describe('createToolCallStep tool approval workflow', () => {
     expectNoToolExecution();
   });
 
-  it('should return inputData as-is for provider-executed tools (no client execution)', async () => {
-    // Provider-executed tools are handled by the stream path (tool-call + tool-result chunks
-    // in llm-execution-step), so tool-call-step just passes through inputData unchanged.
+  it('should reject provider-executed tool calls when the tool is not active', async () => {
     const inputData = {
       ...makeInputData(),
       toolName: 'web_search_20250305',
@@ -275,8 +273,7 @@ describe('createToolCallStep tool approval workflow', () => {
 
     const result = await toolCallStep.execute(makeExecuteParams({ inputData }));
 
-    expect(result).toEqual(inputData);
-    expect(result.result).toBeUndefined();
+    expect(result.error?.name).toBe('ToolNotFoundError');
     expectNoToolExecution();
   });
 

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -230,9 +230,8 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         }
       };
 
-      // Provider-executed tools are handled entirely by the stream path
-      // (tool-call and tool-result chunks in llm-execution-step), so skip client execution.
-      if (inputData.providerExecuted) {
+      const toolGatePolicyActive = !!getToolGateRuntimeState(requestContext, { runId })?.policy;
+      if (inputData.providerExecuted && !toolGatePolicyActive) {
         return inputData;
       }
 
@@ -267,7 +266,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
           resumeDataFromArgs = resumeDataFromInput;
         }
 
-        const toolGateDecision = getToolGateRuntimeState(requestContext, { runId })?.policy
+        const toolGateDecision = toolGatePolicyActive
           ? await evaluateToolGateForRequest({
               requestContext,
               subject: createToolGateSubjectForTool({
@@ -294,6 +293,21 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         }
         const toolGateRequiresApproval = toolGateDecision?.effect === 'requireApproval';
 
+        // Provider-executed tools are handled by the stream path, but still pass
+        // through the final Tool Gate checkpoint before they are accepted.
+        if (inputData.providerExecuted) {
+          if (toolGateRequiresApproval) {
+            return {
+              error: new ToolNotFoundError(
+                `Tool "${inputData.toolName}" requires local approval and cannot be executed by the provider.`,
+              ),
+              ...inputData,
+            };
+          }
+
+          return inputData;
+        }
+
         if (tool && 'onInputAvailable' in tool && !toolGateRequiresApproval) {
           try {
             await tool?.onInputAvailable?.({
@@ -316,7 +330,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         // - boolean (from Mastra createTool or mapped from AI SDK needsApproval: true)
         // - undefined (no approval needed)
         // If needsApprovalFn exists, evaluate it with the tool args and context
-        let toolRequiresApproval = requireToolApproval || (tool as any).requireApproval || toolGateRequiresApproval;
+        let toolRequiresApproval = Boolean(requireToolApproval || (tool as any).requireApproval || toolGateRequiresApproval);
         if ((tool as any).needsApprovalFn) {
           // Evaluate the function with parsed args and available context
           try {
@@ -324,7 +338,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
               requestContext: requestContext ? Object.fromEntries(requestContext.entries()) : {},
               workspace: _internal?.stepWorkspace,
             });
-            toolRequiresApproval = toolGateRequiresApproval || needsApprovalResult;
+            toolRequiresApproval = toolRequiresApproval || Boolean(needsApprovalResult);
           } catch (error) {
             // Log error to help developers debug faulty needsApprovalFn implementations
             logger?.error(`Error evaluating needsApprovalFn for tool ${inputData.toolName}:`, error);

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -230,11 +230,6 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
         }
       };
 
-      const toolGatePolicyActive = !!getToolGateRuntimeState(requestContext, { runId })?.policy;
-      if (inputData.providerExecuted && !toolGatePolicyActive) {
-        return inputData;
-      }
-
       // Resolve the tool key for activeTools enforcement (may differ from toolName when matched by id)
       const toolKey = stepTools?.[inputData.toolName]
         ? inputData.toolName
@@ -266,6 +261,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
           resumeDataFromArgs = resumeDataFromInput;
         }
 
+        const toolGatePolicyActive = !!getToolGateRuntimeState(requestContext, { runId })?.policy;
         const toolGateDecision = toolGatePolicyActive
           ? await evaluateToolGateForRequest({
               requestContext,


### PR DESCRIPTION
## Summary
- route Harness permission rules through the internal Tool Gate policy instead of the old global approval-only path
- keep explicit denies stronger than yolo/session grants and propagate the policy into approve/decline/resume/subagent runs
- hide provider-executed tools that require local approval before model exposure and reject stale provider-executed calls that still require local approval
- make needsApprovalFn additive in both non-durable and durable tool approval paths

## Validation
- pnpm --filter ./packages/core test -- src/harness/harness-tool-gate-policy.test.ts src/harness/subagent-tool.test.ts src/loop/workflows/agentic-execution/tool-call-step.test.ts src/agent/__tests__/active-tools-enforcement.test.ts src/agent/durable/utils/resolve-runtime.test.ts src/agent/durable/workflows/steps/llm-execution.test.ts
- pnpm --filter ./packages/core check
- git diff --check

## Review
- Reviewed locally with Claude, Gemini, and Codex. Codex found the duplicate Harness approval path and durable additive-approval gap; both are fixed in this PR.

## Note
This branch intentionally targets the fork main because it builds on the fork's Tool Gate/Flow Signals baseline that is not yet present on official mastra-ai/main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes Harness use a smarter "Tool Gate" checker to decide if a tool can run: it can say "allow", "deny", or "ask for approval". Denies always win, approval requirements from multiple sources are combined, and provider-run tools that need local approval are hidden or rejected to keep model runs safe.

---

## Summary

Routes Harness tool permission decisions through a dedicated Tool Gate policy and consistently applies that policy across all tool execution paths (send/approve/decline/resume, subagents, agentic and durable execution). Key behavioral guarantees: explicit denies override yolo/session grants, approval requirements from global/tool/gate/needing-fn are treated additively (OR), provider-executed tools that require local approval are removed from model-facing tool lists and rejected at runtime.

### Key changes

- Harness
  - Replaced prior simple approval resolution with resolveToolApproval(toolName, aliases) and buildToolGatePolicy(), producing ToolGatePolicy objects with allow/deny/requireApproval effects and rule metadata.
  - All agent calls that previously relied on requireToolApproval/yolo now pass toolGatePolicy (or getToolGatePolicy callback for subagents); approval/decline/resume flows forward the same policy object.

- Tool gate enforcement for model inputs
  - applyToolGateToModelInput / applyDurableToolGateToModelInput now remove tools when decision.effect === 'deny' OR when effect === 'requireApproval' and the subject source is provider—ensuring provider tools requiring local approval are hidden from the model.

- Runtime tool-call behavior
  - Agentic tool-call step no longer early-exits for provider-executed tools; it evaluates the tool gate and rejects provider-executed calls that require local approval with ToolNotFoundError-like behavior.
  - Durable tool-call step passes a plain requestContext + workspace into toolRequiresApproval.

- Approval resolution semantics
  - toolRequiresApproval (resolve-runtime) signature extended to accept a context object and now ORs needsApprovalFn result into existing require flags instead of replacing them; exceptions default to requiring approval (safe fallback).
  - needsApprovalFn can raise approval requirement but cannot downgrade an existing required approval (global or tool-level).

- Subagent integration
  - createSubagentTool accepts optional getToolGatePolicy and includes toolGatePolicy in subagent.stream options when provided.

### Files / symbols touched (high level)
- packages/core/src/harness/harness.ts — buildToolGatePolicy, resolveToolApproval, wiring to agent/subagent and approval/resume paths
- packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts — applyToolGateToModelInput and agentic tool-call gating and rejection
- packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts — reuse subject creation and denial logic
- packages/core/src/agent/durable/utils/resolve-runtime.ts — toolRequiresApproval (signature + additive logic)
- packages/core/src/agent/durable/workflows/steps/tool-call.ts — durable step passes requestContext into toolRequiresApproval
- packages/core/src/harness/tools.ts, packages/core/src/harness/types.ts — API comment and CreateSubagentToolOptions update
- Tests added/updated covering harness tool-gate policy, active-tools enforcement, durable resolution, LLM execution, agentic tool-call step, subagent wiring.

### Testing / validation
- Unit tests run (pnpm --filter ./packages/core test) updated or added for:
  - harness tool gate policy send/approve/decline/resume flows
  - active-tools enforcement (provider tools hidden)
  - durable runtime approval resolution (additive semantics)
  - durable LLM execution step tool filtering
  - agentic tool-call step approval enforcement and provider-executed rejection
  - subagent tool wiring includes getToolGatePolicy
- pnpm --filter ./packages/core check and git diff --check performed.
- Local reviews with Claude, Gemini, and Codex; identified duplicate approval path and durable additive-approval gap which were fixed in this PR.

### Behavior notes
- Explicit deny rules take precedence over yolo and session grants.
- Approval requirements from global flag, tool.requireApproval, tool gate policy, and needsApprovalFn are combined; any true means approval is required.
- Provider-executed tools that require local approval are hidden from models and rejected at runtime to avoid inadvertent provider calls without local approval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->