### PR TITLE
[PF-342] Refresh Harness v1 source gap ledger

### DIFF
--- a/harness-spec-brainstorming/IMPLEMENTATION_READINESS.md
+++ b/harness-spec-brainstorming/IMPLEMENTATION_READINESS.md
@@ -170,14 +170,36 @@ classDiagram
   `sendMessage(...)`, process-local heartbeat timers, `currentThreadId`, and
   in-memory pending resolvers. It is not the v1 stateless `Harness` plus
   durable `Session` model.
-- Current `Mastra` has `agents`, `workflows`, `channels`, storage, pubsub,
-  background tasks, and scheduler config, but no `harness` config slot, no
-  `getHarness(...)`, no awaited Harness boot barrier, and no
-  `mastra.harnessChannels` operator surface. Channel and background task
-  initialization are currently fire-and-forget from construction time.
+- Current `packages/core/src/harness/v1` now provides a local Harness/Session
+  baseline: `Harness.session(...)`, `closeSession`, `deleteSession`,
+  `listSessions`, `shutdown`, thread CRUD/settings through MemoryStorage,
+  model catalog/auth-status reads, event subscription, `Session.message(...)`,
+  `signal(...)`, `queue(...)`, `respondToToolApproval`,
+  `respondToToolSuspension`, `respondToQuestion`, `respondToPlanApproval`,
+  mode/model/state mutation, display snapshots, `listMessages`, skills,
+  permissions, subagents, goals, abort, idle waiting, and workspace lifecycle.
+- Current `Mastra` has `harnesses?: Record<string, HarnessV1>`,
+  `getHarness(name)`, and `getHarnesses()`. Harnesses bind after agents are
+  registered. It still has no awaited Harness boot/readiness barrier, no
+  Harness-owned worker startup/shutdown semantics, no singular/default
+  `harness` config sugar, and no `mastra.harnessChannels` operator surface.
+  Channel and background task initialization are currently fire-and-forget from
+  construction time.
 - Current channel support is split between platform `ChannelProvider` routes and
   legacy `AgentChannels`. It does not have the Harness v1 `ChannelBinding`,
   `ChannelInboxItem`, `ChannelActionReceipt`, or `ChannelOutboxItem` ledgers.
+- Current Harness storage owns `SessionRecord` rows, session leases, and
+  attachment metadata/bytes through core in-memory storage and the LibSQL
+  adapter. It does not yet own durable operation admission/result/tombstone
+  rows, channel ledgers, wakeup rows, or worker claim/receipt rows.
+- Current `Harness.attachments.upload(...)` and `Harness.attachments.delete(...)`
+  still throw even though the storage domain has attachment primitives.
+- Current per-turn `HarnessRequestContext` exposes identity, state,
+  workspace, subagent, and `useSkill(...)` helpers, but `ctx.registerQuestion`
+  and `ctx.registerPlanApproval` still throw.
+- Current server packages expose `/channels/...` and other existing route
+  families, but no `/harness/...` route family. Current `client-js` and React
+  packages have no `RemoteHarness` / `RemoteSession` resource or hooks.
 - Current `WorkflowScheduler` claims schedule fires by advancing `nextFireAt`
   before publishing `workflow.start`; Harness v1 needs `HarnessWakeupItem` as
   the durable recovery boundary before session queue admission.
@@ -197,19 +219,19 @@ classDiagram
 
 ## Missing Implementation Capabilities
 
-1. **V1 Harness and Session surface.** Add a new v1 surface with stateless
-   `Harness`, durable `Session`, `harness.session(...)`, `listSessions`,
-   `closeSession`, `deleteSession`, `Session.message(...)`, `Session.queue(...)`,
-   inbox response methods, display state, attachments, goals, and local/remote
-   type separation. Keep legacy Harness behavior isolated until migration is
-   intentional.
-2. **Harness storage domain.** Add storage interfaces and adapters for
-   `SessionRecord`, session leases/version CAS, `QueuedItem`,
-   `QueueAdmissionReceipt`, pending inbox fields, `InboxResponseReceipt`,
-   `HarnessRunOperationalState`, child-session lookup, `HarnessWakeupItem`, and
-   channel ledgers by extending Mastra's storage-domain pattern. Thread/message
-   reads and writes must stay on the configured MemoryStorage-backed message log
-   or an equivalent shared adapter, not a Harness-only duplicate log.
+1. **Local v1 parity gaps.** Complete the local surface that still throws or is
+   intentionally narrow: `Harness.attachments.upload/delete`,
+   request-context `registerQuestion` / `registerPlanApproval`, code-registered
+   skills plus stronger skill-schema validation, and close/delete fences that
+   rely on the durable row families below. Keep legacy Harness behavior isolated
+   until migration is intentional.
+2. **Harness storage domain.** Extend the current session/lease/attachment
+   domain with storage interfaces and adapters for `QueueAdmissionReceipt`,
+   operation tombstones/results, pending inbox response receipts,
+   `HarnessRunOperationalState`, `HarnessWakeupItem`, channel ledgers, and
+   worker claim/receipt rows. Thread/message reads and writes must stay on the
+   configured MemoryStorage-backed message log or an equivalent shared adapter,
+   not a Harness-only duplicate log.
 3. **Admission idempotency and result correlation.** Implement `admissionId`
    plus stable admission hash handling for `message(...)` accepted signals and
    `queue(...)` durable appends. Accepted signals must expose terminal status by
@@ -231,9 +253,9 @@ classDiagram
    `addTools` where storage must replay, persist subagent sessions with
    `parentSessionId`, and fail closed when agents, models, tools, MCP bindings,
    or workspace providers drift.
-6. **Mastra harness registration.** Add `new Mastra({ harness })` and
-   `new Mastra({ harness: { name: harness } })`, normalize default sugar, expose
-   `getHarness(name?)`, and wire Harness readiness into the Mastra/server
+6. **Mastra harness lifecycle.** Extend the existing
+   `new Mastra({ harnesses })` / `getHarness(name)` registry with any accepted
+   default/singular sugar, then wire Harness readiness into the Mastra/server
    bootstrap and shutdown lifecycle before server routes accept Harness traffic.
 7. **Harness channel registry.** Build an init-time registry for
    `(harnessName, channelId, providerId)`, provider-owned callback bindings,

--- a/harness-spec-brainstorming/sections/11-migration-from-current-harness/06-current-vs-v1-status-ledger.md
+++ b/harness-spec-brainstorming/sections/11-migration-from-current-harness/06-current-vs-v1-status-ledger.md
@@ -33,6 +33,40 @@ records (§5.1, §5.2) stay with their owning sections and are not re-exported
 through the v1 runtime entry; clients reach them via the §13.3 wire surface
 or §5.2 `HarnessStorageDomain` instead.
 
+#### PF-342 source-alignment snapshot
+
+This ledger still classifies spec names against legacy/current Mastra collision
+risk. It is not a claim that `@mastra/core/harness/v1` is empty: as of
+`9770d5c86efcd3533008a650ae266393828b0e0b`, the v1 subpath has a local
+implementation in `packages/core/src/harness/v1/**`.
+
+Source-confirmed local surfaces now present:
+
+- `Harness` and `Session` classes under `packages/core/src/harness/v1`.
+- Mastra registry support through `harnesses?: Record<string, HarnessV1>`,
+  `getHarness(name)`, and `getHarnesses()` in
+  `packages/core/src/mastra/index.ts`.
+- Local session resolver/lifecycle, thread CRUD/settings, model catalog reads,
+  event subscription, message/signal/queue execution, inbox response methods,
+  display state, message listing, mode/model/state mutation, permissions,
+  workspace-backed skills, subagents, goals, abort, and idle waiting.
+- Harness storage for session records, leases, and attachments in core
+  in-memory storage and the LibSQL adapter.
+
+Source-confirmed gaps that remain missing or intentionally throwing:
+
+- `Harness.attachments.upload(...)` and `Harness.attachments.delete(...)` throw
+  in `packages/core/src/harness/v1/harness.ts`.
+- `ctx.registerQuestion(...)` and `ctx.registerPlanApproval(...)` throw in
+  `packages/core/src/harness/v1/session.ts`.
+- The Harness storage domain has no durable operation admission/result/
+  tombstone rows, channel ledger rows, wakeup rows, or worker claim/receipt
+  rows.
+- No `/harness/...` server route family exists under `packages/server/src`.
+- No `RemoteHarness` / `RemoteSession` client-js or React SDK surface exists.
+- No Harness channel registry/bridge ledgers/workers or `HarnessWakeupItem`
+  worker implementation exists.
+
 #### 11.6a Names that overlap with current Mastra code
 
 These 20 names appear under the exact same identifier in both the v1 spec
@@ -82,10 +116,10 @@ entries are not Notes blocks and are exempt.
   `BackgroundTaskRowStatus` (§5.1b.2); no independent literals live at the
   projection site. Current code declares an independent union missing the
   `'dead'` terminal status. The alias commits the public name to the 7-literal
-  storage taxonomy (`pending | running | completed | failed | cancelled |
-  timed_out | dead`); current code must reach literal parity with §5.1b.2
-  before the alias ships. Any future literal-set change is a public-API
-  change governed by §11.6.
+  storage taxonomy of seven literals (`pending`, `running`, `completed`,
+  `failed`, `cancelled`, `timed_out`, `dead`); current code must reach literal
+  parity with §5.1b.2 before the alias ships. Any future literal-set change is
+  a public-API change governed by §11.6.
 
 **`Harness`**
 

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -2,16 +2,21 @@
  * Harness v1 — top-level entry point.
  *
  * See HARNESS_V1_SPEC.md §4 for the full surface. This module currently
- * implements the "resolver + lifecycle" slice (M1):
+ * implements the local Harness shell:
  *
  *   - `new Harness(config)` validates modes/agents and binds storage.
  *   - `harness.session(opts)` finds-or-creates sessions per §5.3, acquiring
  *     the durable lease and hydrating from `HarnessStorage`.
- *   - `harness.closeSession`, `harness.listSessions`, `harness.shutdown`
- *     handle the lifecycle paths needed for that slice.
+ *   - `harness.closeSession`, `harness.deleteSession`, `harness.listSessions`,
+ *     and `harness.shutdown` handle local lifecycle paths.
+ *   - `harness.threads.*` composes with MemoryStorage for thread CRUD/settings.
+ *   - `harness.models.*` exposes the static model catalog and auth-status
+ *     resolver.
  *
- * Everything else (message, queue, attachments, threads, intervals, …) is
- * still a stub and throws "not implemented".
+ * Known remaining gaps are deliberately visible here: `attachments.upload` and
+ * `attachments.delete` still throw, and production server routes, remote SDKs,
+ * durable admission/result rows, channels, wakeups, and worker recovery live in
+ * follow-up Harness v1 lanes.
  */
 
 import { randomUUID } from 'node:crypto';

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -3,9 +3,15 @@
  *
  * This is the in-memory authority for a single SessionRecord (§5.4). The
  * Harness creates one instance per live session and routes all writes to
- * the underlying record through it. The full surface is described in §4.2;
- * the M1 slice ships only identity + lifecycle. Everything else still throws
- * `Not implemented`.
+ * the underlying record through it. The full surface is described in §4.2.
+ *
+ * The current local surface includes message/signal/queue turns, mode/model
+ * and state mutation, display snapshots, message listing, pending inbox
+ * responses, permissions, workspace-backed skills, subagents, goals, event
+ * forwarding, abort, and idle waiting. It is not yet the production remote or
+ * recovery surface: durable admission/result rows, server routes, remote SDKs,
+ * channels, wakeups, and request-context `registerQuestion` /
+ * `registerPlanApproval` support remain follow-up lanes.
  *
  * Lifecycle states tracked here:
  *   - 'live'    — session is in the harness's live map and holds the lease.


### PR DESCRIPTION
## Summary
- update stale Harness v1 source headers so they describe the current local surface instead of the old M1-only slice
- refresh `IMPLEMENTATION_READINESS.md` with source-confirmed implemented surfaces and remaining gaps
- add a PF-342 source-alignment snapshot to the current-vs-v1 status ledger

## Source evidence inspected
- `packages/core/src/harness/v1/harness.ts`
- `packages/core/src/harness/v1/session.ts`
- `packages/core/src/storage/domains/harness/**`
- `stores/libsql/src/storage/domains/harness/**`
- `packages/core/src/mastra/index.ts`
- `packages/server/src/**`
- `client-sdks/client-js/src/**`
- `client-sdks/react/src/**`
- `harness-spec-brainstorming/IMPLEMENTATION_READINESS.md`
- `harness-spec-brainstorming/sections/11-migration-from-current-harness/06-current-vs-v1-status-ledger.md`

## Non-goals
- no storage, server, channel, SDK, wakeup, or runtime behavior changes
- no implementation of attachment upload/delete or request-context question/plan registration

## Checks
- `npx -y prettier@3.8.3 --check harness-spec-brainstorming/IMPLEMENTATION_READINESS.md harness-spec-brainstorming/sections/11-migration-from-current-harness/06-current-vs-v1-status-ledger.md packages/core/src/harness/v1/harness.ts packages/core/src/harness/v1/session.ts`
- `git diff --check`
- source-evidence `rg` checks for Harness v1 gaps and existing registry/storage/server/SDK surfaces

Linear: PF-342, PF-344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation

This PR is like updating a project checklist: it refreshes the documentation and code comments to accurately describe what features of Harness v1 have actually been built and what work still needs to be done, without changing any actual functionality.

## Changes Overview

### Documentation Updates

**harness-spec-brainstorming/IMPLEMENTATION_READINESS.md**
- Expanded the "Current Code Baseline" section to explicitly describe the existing local v1 harness/session surface in `packages/core/src/harness/v1`, including the current Mastra harness registry behavior
- Detailed current gaps: attachment upload/delete operations, specific request-context registrations, code-registered skills, remote harness support, and missing `/harness/...` routes
- Refined "Missing Implementation Capabilities" to distinguish between:
  - Item 1: Local v1 throws and fences (attachments, request-context registrations, close/delete behavior)
  - Item 2: Extended storage domain interfaces for durable ledger, admission, results, tombstones, and wakeup mechanics
- Reframed item 6 as "Mastra harness lifecycle," clarifying how Harness readiness integrates with Mastra/server bootstrap/shutdown sequencing

**harness-spec-brainstorming/sections/11-migration-from-current-harness/06-current-vs-v1-status-ledger.md**
- Added "PF-342 source-alignment snapshot" section confirming v1 surfaces are not empty
- Documented confirmed v1 implementations: Harness/Session classes, harness registry APIs, session lifecycle/execution, and harness storage
- Listed remaining v1 gaps: attachment operations, session registration helpers, durable storage row families, server routes, and remote client surfaces
- Updated `BackgroundTaskStatus` entry to clarify v1 defines it as a transparent alias of the underlying row status taxonomy, requiring literal parity before shipping

### Code Comment Updates

**packages/core/src/harness/v1/harness.ts**
- Updated module header to document the local "Harness shell" responsibilities
- Called out known gaps: `attachments.upload`/`attachments.delete` still throwing; production/remote/worker recovery lanes in follow-up work
- No code changes

**packages/core/src/harness/v1/session.ts**
- Updated module-level comment to reflect current "local surface" capabilities in-memory
- Enumerated supported feature areas: message/signal/queue turns, mode/model mutation, display snapshots, pending inbox responses, permissions, skills/subagents/goals, event forwarding, abort/idle waiting
- Clarified what remains unimplemented: remote durability/recovery and related request-context support
- Removed outdated M1-slice assumptions
- No code changes

## Summary

This is a documentation refresh PR that updates headers, implementation readiness docs, and migration ledgers to accurately reflect the current state of Harness v1 implementation. It clarifies what surfaces are present (local harness/session with in-memory operations, harness registry, basic lifecycle) and what gaps remain (attachment operations, durable storage extensions, remote support, server routes). No functional changes to code behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/78)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->