### PR TITLE
[PF-345] Implement local harness attachment upload/delete

### DIFF
--- a/packages/core/src/harness/v1/attachments.test.ts
+++ b/packages/core/src/harness/v1/attachments.test.ts
@@ -1,0 +1,107 @@
+import { createHash } from 'node:crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import { setupHarness } from './__test-utils__';
+
+describe('Harness.attachments', () => {
+  it('uploads attachments with digest metadata and deletes them by attachment id', async () => {
+    const { harness, storage } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const source = Buffer.from('hello attachment');
+    const expectedSha256 = createHash('sha256').update(source).digest('hex');
+    const result = await harness.attachments.upload({
+      sessionId: session.id,
+      data: source,
+      filename: 'note.txt',
+      contentType: 'text/plain',
+    });
+
+    expect(result.resourceId).toBe('u');
+    expect(result.ownerSessionId).toBe(session.id);
+    expect(result.bytes).toBe(source.length);
+    expect(result.sha256).toBe(expectedSha256);
+    expect(result.source).toBe('preupload');
+
+    const record = await storage.getAttachmentRecord({
+      sessionId: session.id,
+      attachmentId: result.attachmentId,
+    });
+    expect(record).not.toBeNull();
+    expect(record).toMatchObject({
+      ownerSessionId: session.id,
+      name: 'note.txt',
+      mimeType: 'text/plain',
+      bytes: source.length,
+      sha256: expectedSha256,
+      source: 'preupload',
+    });
+
+    source[0] = 'j'.charCodeAt(0);
+
+    const loaded = await storage.loadAttachment({
+      sessionId: session.id,
+      attachmentId: result.attachmentId,
+    });
+    expect(loaded).not.toBeNull();
+    expect(loaded).toMatchObject({
+      name: 'note.txt',
+      mimeType: 'text/plain',
+      bytes: source.length,
+      sha256: expectedSha256,
+    });
+    expect(Buffer.from(loaded!.data).toString()).toBe('hello attachment');
+
+    await harness.attachments.delete({ attachmentId: result.attachmentId, sessionId: session.id });
+
+    await expect(
+      storage.getAttachmentRecord({
+        sessionId: session.id,
+        attachmentId: result.attachmentId,
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      storage.loadAttachment({
+        sessionId: session.id,
+        attachmentId: result.attachmentId,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('uses the explicit owning session instead of the most-recent resource session', async () => {
+    const { harness, storage } = setupHarness();
+    const older = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const newer = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const result = await harness.attachments.upload({
+      sessionId: older.id,
+      resourceId: 'u',
+      data: new Uint8Array([1, 2, 3]),
+      filename: 'older.bin',
+      contentType: 'application/octet-stream',
+    });
+
+    await expect(
+      storage.getAttachmentRecord({
+        sessionId: older.id,
+        attachmentId: result.attachmentId,
+      }),
+    ).resolves.toMatchObject({ ownerSessionId: older.id });
+    await expect(
+      storage.getAttachmentRecord({
+        sessionId: newer.id,
+        attachmentId: result.attachmentId,
+      }),
+    ).resolves.toBeNull();
+
+    await harness.attachments.delete({ sessionId: older.id, attachmentId: result.attachmentId });
+
+    await expect(
+      storage.getAttachmentRecord({
+        sessionId: older.id,
+        attachmentId: result.attachmentId,
+      }),
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -13,10 +13,9 @@
  *   - `harness.models.*` exposes the static model catalog and auth-status
  *     resolver.
  *
- * Known remaining gaps are deliberately visible here: `attachments.upload` and
- * `attachments.delete` still throw, and production server routes, remote SDKs,
- * durable admission/result rows, channels, wakeups, and worker recovery live in
- * follow-up Harness v1 lanes.
+ * Known remaining gaps are deliberately visible here: production server routes,
+ * remote SDKs, durable admission/result rows, channels, wakeups, and worker
+ * recovery live in follow-up Harness v1 lanes.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -1354,11 +1353,42 @@ export class Harness {
   };
 
   attachments = {
-    upload: async (_opts: AttachmentUploadOptions): Promise<AttachmentRef> => {
-      throw new Error('Harness.attachments.upload: not implemented');
+    upload: async (opts: AttachmentUploadOptions): Promise<AttachmentRef> => {
+      const storage = this._requireStorage('attachments.upload()');
+      const session = await this.session(
+        opts.resourceId ? { sessionId: opts.sessionId, resourceId: opts.resourceId } : { sessionId: opts.sessionId },
+      );
+      const data =
+        opts.data instanceof Uint8Array
+          ? new Uint8Array(opts.data)
+          : new Uint8Array(await new Response(opts.data).arrayBuffer());
+      const attachmentId = `attachment-${randomUUID()}`;
+      const saved = await storage.saveAttachment({
+        sessionId: session.id,
+        attachmentId,
+        name: opts.filename,
+        mimeType: opts.contentType,
+        source: 'preupload',
+        data,
+      });
+      return {
+        attachmentId: saved.attachmentId,
+        resourceId: session.resourceId,
+        ownerSessionId: session.id,
+        bytes: saved.bytes,
+        sha256: saved.sha256,
+        source: 'preupload',
+      };
     },
-    delete: async (_opts: AttachmentDeleteOptions): Promise<void> => {
-      throw new Error('Harness.attachments.delete: not implemented');
+    delete: async (opts: AttachmentDeleteOptions): Promise<void> => {
+      const storage = this._requireStorage('attachments.delete()');
+      const session = await this.session(
+        opts.resourceId ? { sessionId: opts.sessionId, resourceId: opts.resourceId } : { sessionId: opts.sessionId },
+      );
+      await storage.deleteAttachment({
+        sessionId: session.id,
+        attachmentId: opts.attachmentId,
+      });
     },
   };
 

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -16,7 +16,11 @@ import type { ToolsInput } from '../../agent/types';
 import type { Mastra } from '../../mastra';
 import type { RequestContext } from '../../request-context';
 import type { MastraCompositeStore } from '../../storage/base';
-import type { HarnessStorage, SessionRecord as StoredSessionRecord } from '../../storage/domains/harness';
+import type {
+  AttachmentSource,
+  HarnessStorage,
+  SessionRecord as StoredSessionRecord,
+} from '../../storage/domains/harness';
 import type { MastraModelOutput, FullOutput } from '../../stream/base/output';
 import type { Workspace } from '../../workspace';
 import type { WorkspaceProvider, WorkspaceProviderContext } from './workspace-provider';
@@ -536,6 +540,10 @@ export type SessionRecord = StoredSessionRecord;
 export interface AttachmentRef {
   attachmentId: string;
   resourceId: string;
+  ownerSessionId?: string;
+  bytes?: number;
+  sha256?: string;
+  source?: AttachmentSource;
 }
 
 // ---------------------------------------------------------------------------
@@ -719,15 +727,17 @@ export interface SessionLoadByIdOptions {
 }
 
 export interface AttachmentUploadOptions {
-  resourceId: string;
-  data: Buffer | ReadableStream<Uint8Array>;
+  sessionId: string;
+  resourceId?: string;
+  data: Buffer | Uint8Array | ReadableStream<Uint8Array>;
   filename: string;
   contentType: string;
 }
 
 export interface AttachmentDeleteOptions {
   attachmentId: string;
-  resourceId: string;
+  sessionId: string;
+  resourceId?: string;
 }
 
 export interface ShutdownOptions {

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -668,6 +668,8 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
     name: { type: 'text', nullable: false },
     mime_type: { type: 'text', nullable: false },
     size_bytes: { type: 'bigint', nullable: false },
+    sha256: { type: 'text', nullable: false },
+    source: { type: 'text', nullable: false },
     created_at: { type: 'bigint', nullable: false },
     data_b64: { type: 'text', nullable: false },
   },

--- a/packages/core/src/storage/domains/harness/base.ts
+++ b/packages/core/src/storage/domains/harness/base.ts
@@ -7,6 +7,7 @@ import type {
   ReleaseSessionLeaseInput,
   RenewSessionLeaseInput,
   SaveAttachmentInput,
+  SaveAttachmentResult,
   SaveSessionOptions,
   SaveSessionResult,
   SessionLeaseResult,
@@ -75,9 +76,9 @@ export class HarnessStorageSessionNotFoundError extends Error {
  *      (HARNESS_V1_SPEC.md §5.8). Acquire-renew-release pattern with TTL.
  *
  *   3. **Attachment metadata** — index rows mapping `attachmentId` to
- *      `(sessionId, name, mimeType, sizeBytes)` and the underlying bytes.
- *      Adapters are free to delegate the bytes to a separate blob store
- *      (S3, R2, local disk) under the same interface.
+ *      `(ownerSessionId, name, mimeType, bytes, sha256, source)` and the
+ *      underlying bytes. Adapters are free to delegate the bytes to a
+ *      separate blob store (S3, R2, local disk) under the same interface.
  *
  * Threads and messages are NOT in this domain — they live under
  * `MemoryStorage`. The harness layer composes the two.
@@ -194,10 +195,11 @@ export abstract class HarnessStorage extends StorageDomain {
    * Persist an attachment's bytes and index row.
    *
    * Adapters MAY delegate the bytes to a blob store but the index row
-   * (filename, mime type, size, owning session) must be queryable through
-   * `loadAttachment`.
+   * (filename, mime type, size, digest, source, owning session) must be
+   * queryable through `getAttachmentRecord`; `loadAttachment` returns the
+   * byte payload plus replay-validation metadata.
    */
-  abstract saveAttachment(opts: SaveAttachmentInput): Promise<void>;
+  abstract saveAttachment(opts: SaveAttachmentInput): Promise<SaveAttachmentResult>;
 
   /**
    * Load an attachment by (sessionId, attachmentId). Returns null when the

--- a/packages/core/src/storage/domains/harness/inmemory.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import type { InMemoryDB } from '../inmemory-db';
 import {
   HarnessStorage,
@@ -13,6 +15,7 @@ import type {
   ReleaseSessionLeaseInput,
   RenewSessionLeaseInput,
   SaveAttachmentInput,
+  SaveAttachmentResult,
   SaveSessionOptions,
   SaveSessionResult,
   SessionLeaseResult,
@@ -179,19 +182,31 @@ export class InMemoryHarness extends HarnessStorage {
   // Attachments
   // -------------------------------------------------------------------------
 
-  async saveAttachment({ sessionId, attachmentId, name, mimeType, data }: SaveAttachmentInput): Promise<void> {
+  async saveAttachment({
+    sessionId,
+    attachmentId,
+    name,
+    mimeType,
+    source,
+    data,
+  }: SaveAttachmentInput): Promise<SaveAttachmentResult> {
     const key = attachmentKey(sessionId, attachmentId);
+    const bytes = data.byteLength;
+    const sha256 = sha256Hex(data);
     const record: AttachmentRecord = {
+      ownerSessionId: sessionId,
       attachmentId,
-      sessionId,
       name,
       mimeType,
-      sizeBytes: data.byteLength,
+      bytes,
+      sha256,
+      source,
       createdAt: Date.now(),
     };
     this.db.harnessAttachmentRecords.set(key, record);
     // Copy the bytes so callers can reuse their buffer.
     this.db.harnessAttachmentBytes.set(key, new Uint8Array(data));
+    return { attachmentId, bytes, sha256 };
   }
 
   async loadAttachment({
@@ -205,7 +220,13 @@ export class InMemoryHarness extends HarnessStorage {
     const record = this.db.harnessAttachmentRecords.get(key);
     const bytes = this.db.harnessAttachmentBytes.get(key);
     if (!record || !bytes) return null;
-    return { name: record.name, mimeType: record.mimeType, data: new Uint8Array(bytes) };
+    return {
+      name: record.name,
+      mimeType: record.mimeType,
+      bytes: record.bytes,
+      sha256: record.sha256,
+      data: new Uint8Array(bytes),
+    };
   }
 
   async deleteAttachment({ sessionId, attachmentId }: { sessionId: string; attachmentId: string }): Promise<void> {
@@ -254,8 +275,12 @@ export class InMemoryHarness extends HarnessStorage {
  * separator means session-prefix scans for `deleteAttachmentsForSession` are
  * unambiguous regardless of the contents of the ids.
  */
-function attachmentKey(sessionId: string, attachmentId: string): string {
-  return `${sessionId}\u0000${attachmentId}`;
+function attachmentKey(ownerSessionId: string, attachmentId: string): string {
+  return `${ownerSessionId}\u0000${attachmentId}`;
+}
+
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
 }
 
 /**

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -45,11 +45,22 @@ export interface TokenUsage {
  * A persisted attachment reference on a queued or pending message.
  *
  * `kind: 'ref'` points at a row in the harness attachment index (the bytes
- * live in BlobStore or whatever the adapter delegates to).
+ * live in BlobStore or whatever the adapter delegates to). Durable refs carry
+ * owner, size, digest, and source metadata so recovery can validate the bytes
+ * that were admitted.
  * `kind: 'url'` is a remote URL fetched at message-build time.
  */
 export type PersistedAttachment =
-  | { kind: 'ref'; name: string; mimeType: string; attachmentId: string }
+  | {
+      kind: 'ref';
+      name: string;
+      mimeType: string;
+      ownerSessionId: string;
+      attachmentId: string;
+      bytes: number;
+      sha256: string;
+      source: AttachmentSource;
+    }
   | { kind: 'url'; name: string; mimeType: string; url: string };
 
 /**
@@ -176,6 +187,8 @@ export interface SessionWorkspaceState {
   state: unknown;
 }
 
+export type AttachmentSource = 'inline' | 'preupload' | 'url' | 'provider';
+
 /**
  * Durable session state. Loaded on hydration, flushed under the session's
  * write lease (see HARNESS_V1_SPEC.md §5.8).
@@ -281,16 +294,20 @@ export interface SessionSummary {
  * harness-domain pointer.
  */
 export interface AttachmentRecord {
+  /** Session that owns the attachment bytes. */
+  ownerSessionId: string;
   /** Stable identifier referenced by `PersistedAttachment.attachmentId`. */
   attachmentId: string;
-  /** Owning session — bytes are deleted with the session. */
-  sessionId: string;
   /** Original filename (display only). */
   name: string;
   /** MIME type, validated at upload. */
   mimeType: string;
   /** Size of the underlying bytes. */
-  sizeBytes: number;
+  bytes: number;
+  /** Hex SHA-256 digest of the underlying bytes. */
+  sha256: string;
+  /** Where the attachment came from. */
+  source: AttachmentSource;
   /** Epoch ms. */
   createdAt: number;
 }
@@ -351,11 +368,20 @@ export interface SaveAttachmentInput {
   attachmentId: string;
   name: string;
   mimeType: string;
+  source: AttachmentSource;
   data: Uint8Array;
+}
+
+export interface SaveAttachmentResult {
+  attachmentId: string;
+  bytes: number;
+  sha256: string;
 }
 
 export interface LoadedAttachment {
   name: string;
   mimeType: string;
+  bytes: number;
+  sha256: string;
   data: Uint8Array;
 }

--- a/stores/_test-utils/src/domains/harness/index.ts
+++ b/stores/_test-utils/src/domains/harness/index.ts
@@ -289,6 +289,7 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           attachmentId: 'a1',
           name: 'note.txt',
           mimeType: 'text/plain',
+          source: 'preupload',
           data: new Uint8Array([1, 2, 3]),
         });
 
@@ -446,6 +447,7 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           attachmentId: 'a1',
           name: 'note.txt',
           mimeType: 'text/plain',
+          source: 'preupload',
           data: new Uint8Array([1, 2, 3, 4]),
         });
 
@@ -467,6 +469,7 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           attachmentId: 'shared',
           name: 'a.txt',
           mimeType: 'text/plain',
+          source: 'preupload',
           data: new Uint8Array([1]),
         });
         await harness.saveAttachment({
@@ -474,6 +477,7 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           attachmentId: 'shared',
           name: 'b.txt',
           mimeType: 'text/plain',
+          source: 'preupload',
           data: new Uint8Array([2]),
         });
 
@@ -490,6 +494,7 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           attachmentId: 'a1',
           name: 'first.txt',
           mimeType: 'text/plain',
+          source: 'preupload',
           data: new Uint8Array([1]),
         });
         await harness.saveAttachment({
@@ -497,6 +502,7 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           attachmentId: 'a1',
           name: 'second.txt',
           mimeType: 'text/plain',
+          source: 'preupload',
           data: new Uint8Array([2, 3]),
         });
 
@@ -515,6 +521,7 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           attachmentId: 'a1',
           name: 'bin',
           mimeType: 'application/octet-stream',
+          source: 'preupload',
           data: random,
         });
 
@@ -530,6 +537,7 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           attachmentId: 'a1',
           name: 'n.txt',
           mimeType: 'text/plain',
+          source: 'preupload',
           data: new Uint8Array([1, 2, 3]),
         });
 
@@ -539,11 +547,13 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
         });
         expect(record).toMatchObject({
           attachmentId: 'a1',
-          sessionId: 'session-1',
+          ownerSessionId: 'session-1',
           name: 'n.txt',
           mimeType: 'text/plain',
-          sizeBytes: 3,
+          bytes: 3,
+          source: 'preupload',
         });
+        expect(record?.sha256).toHaveLength(64);
         expect(record?.createdAt).toBeGreaterThan(0);
       });
 
@@ -554,6 +564,7 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           attachmentId: 'a1',
           name: 'n',
           mimeType: 'text/plain',
+          source: 'preupload',
           data: new Uint8Array([1]),
         });
 
@@ -569,6 +580,7 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           attachmentId: 'a1',
           name: 'n',
           mimeType: 'text/plain',
+          source: 'preupload',
           data: new Uint8Array([1]),
         });
         await harness.saveAttachment({
@@ -576,6 +588,7 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           attachmentId: 'a2',
           name: 'n',
           mimeType: 'text/plain',
+          source: 'preupload',
           data: new Uint8Array([2]),
         });
 
@@ -595,6 +608,7 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           attachmentId: 'a1',
           name: 'n',
           mimeType: 'text/plain',
+          source: 'preupload',
           data: new Uint8Array([1]),
         });
 

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -1,0 +1,102 @@
+import { createHash } from 'node:crypto';
+
+import { createClient } from '@libsql/client';
+import { TABLE_HARNESS_ATTACHMENTS } from '@mastra/core/storage';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { HarnessLibSQL } from './index';
+
+describe('HarnessLibSQL attachments', () => {
+  let storage: HarnessLibSQL;
+
+  beforeEach(async () => {
+    const client = createClient({ url: ':memory:' });
+    storage = new HarnessLibSQL({ client });
+    await storage.init();
+  });
+
+  it('stores bytes with digest/source metadata and deletes by owning session', async () => {
+    const data = new Uint8Array([1, 2, 3, 4]);
+    const expectedSha256 = createHash('sha256').update(data).digest('hex');
+
+    const saved = await storage.saveAttachment({
+      sessionId: 'session-1',
+      attachmentId: 'a1',
+      name: 'note.txt',
+      mimeType: 'text/plain',
+      source: 'preupload',
+      data,
+    });
+    expect(saved).toEqual({ attachmentId: 'a1', bytes: 4, sha256: expectedSha256 });
+
+    const record = await storage.getAttachmentRecord({ sessionId: 'session-1', attachmentId: 'a1' });
+    expect(record).toMatchObject({
+      ownerSessionId: 'session-1',
+      attachmentId: 'a1',
+      name: 'note.txt',
+      mimeType: 'text/plain',
+      bytes: 4,
+      sha256: expectedSha256,
+      source: 'preupload',
+    });
+
+    const loaded = await storage.loadAttachment({ sessionId: 'session-1', attachmentId: 'a1' });
+    expect(loaded).toMatchObject({
+      name: 'note.txt',
+      mimeType: 'text/plain',
+      bytes: 4,
+      sha256: expectedSha256,
+    });
+    expect(Array.from(loaded?.data ?? [])).toEqual([1, 2, 3, 4]);
+
+    await storage.deleteAttachment({ sessionId: 'session-1', attachmentId: 'a1' });
+    await expect(storage.loadAttachment({ sessionId: 'session-1', attachmentId: 'a1' })).resolves.toBeNull();
+  });
+
+  it('backfills digest/source metadata when init sees the old attachment table shape', async () => {
+    const client = createClient({ url: ':memory:' });
+    const data = new Uint8Array([9, 8, 7]);
+    const dataB64 = Buffer.from(data).toString('base64');
+    const expectedSha256 = createHash('sha256').update(data).digest('hex');
+
+    await client.execute(`
+      CREATE TABLE ${TABLE_HARNESS_ATTACHMENTS} (
+        session_id TEXT NOT NULL,
+        attachment_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        mime_type TEXT NOT NULL,
+        size_bytes INTEGER NOT NULL,
+        created_at INTEGER NOT NULL,
+        data_b64 TEXT NOT NULL,
+        PRIMARY KEY (session_id, attachment_id)
+      )
+    `);
+    await client.execute({
+      sql: `INSERT INTO ${TABLE_HARNESS_ATTACHMENTS}
+            (session_id, attachment_id, name, mime_type, size_bytes, created_at, data_b64)
+            VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      args: ['session-1', 'a1', 'legacy.bin', 'application/octet-stream', data.byteLength, Date.now(), dataB64],
+    });
+
+    const legacyStorage = new HarnessLibSQL({ client });
+    await legacyStorage.init();
+
+    const loaded = await legacyStorage.loadAttachment({ sessionId: 'session-1', attachmentId: 'a1' });
+    expect(loaded).toMatchObject({
+      name: 'legacy.bin',
+      mimeType: 'application/octet-stream',
+      bytes: 3,
+      sha256: expectedSha256,
+    });
+    expect(Array.from(loaded?.data ?? [])).toEqual([9, 8, 7]);
+
+    const record = await legacyStorage.getAttachmentRecord({ sessionId: 'session-1', attachmentId: 'a1' });
+    expect(record).toMatchObject({ source: 'preupload', sha256: expectedSha256, bytes: 3 });
+
+    await legacyStorage.init();
+    await expect(legacyStorage.loadAttachment({ sessionId: 'session-1', attachmentId: 'a1' })).resolves.toMatchObject({
+      bytes: 3,
+      sha256: expectedSha256,
+    });
+  });
+});

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import type { Client } from '@libsql/client';
 import {
   HarnessStorage,
@@ -17,6 +19,7 @@ import type {
   ReleaseSessionLeaseInput,
   RenewSessionLeaseInput,
   SaveAttachmentInput,
+  SaveAttachmentResult,
   SaveSessionOptions,
   SaveSessionResult,
   SessionLeaseResult,
@@ -36,7 +39,8 @@ import type { LibSQLDomainConfig } from '../../db';
  *
  * Attachments live in `mastra_harness_attachments` with a composite primary
  * key on `(session_id, attachment_id)`. Bytes are stored base64-encoded in
- * `data_b64` for now; see the schema comment in core for the rationale.
+ * `data_b64` for now and the digest/source metadata is stored alongside the
+ * byte payload.
  */
 export class HarnessLibSQL extends HarnessStorage {
   #db: LibSQLDB;
@@ -64,6 +68,12 @@ export class HarnessLibSQL extends HarnessStorage {
       schema: TABLE_SCHEMAS[TABLE_HARNESS_ATTACHMENTS],
       compositePrimaryKey: attachmentsConfig?.compositePrimaryKey,
     });
+    await this.#db.alterTable({
+      tableName: TABLE_HARNESS_ATTACHMENTS,
+      schema: TABLE_SCHEMAS[TABLE_HARNESS_ATTACHMENTS],
+      ifNotExists: ['sha256', 'source'],
+    });
+    await this.#backfillAttachmentMetadata();
   }
 
   async dangerouslyClearAll(): Promise<void> {
@@ -291,20 +301,32 @@ export class HarnessLibSQL extends HarnessStorage {
   // Attachments
   // -------------------------------------------------------------------------
 
-  async saveAttachment({ sessionId, attachmentId, name, mimeType, data }: SaveAttachmentInput): Promise<void> {
+  async saveAttachment({
+    sessionId,
+    attachmentId,
+    name,
+    mimeType,
+    source,
+    data,
+  }: SaveAttachmentInput): Promise<SaveAttachmentResult> {
+    const sha256 = sha256Hex(data);
+    const bytes = data.byteLength;
     const dataB64 = bytesToBase64(data);
     await this.#client.execute({
       sql: `INSERT INTO ${TABLE_HARNESS_ATTACHMENTS}
-            (session_id, attachment_id, name, mime_type, size_bytes, created_at, data_b64)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            (session_id, attachment_id, name, mime_type, size_bytes, sha256, source, created_at, data_b64)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(session_id, attachment_id) DO UPDATE SET
               name = excluded.name,
               mime_type = excluded.mime_type,
               size_bytes = excluded.size_bytes,
+              sha256 = excluded.sha256,
+              source = excluded.source,
               created_at = excluded.created_at,
               data_b64 = excluded.data_b64`,
-      args: [sessionId, attachmentId, name, mimeType, data.byteLength, Date.now(), dataB64],
+      args: [sessionId, attachmentId, name, mimeType, bytes, sha256, source, Date.now(), dataB64],
     });
+    return { attachmentId, bytes, sha256 };
   }
 
   async loadAttachment({
@@ -315,7 +337,7 @@ export class HarnessLibSQL extends HarnessStorage {
     attachmentId: string;
   }): Promise<LoadedAttachment | null> {
     const result = await this.#client.execute({
-      sql: `SELECT name, mime_type, data_b64 FROM ${TABLE_HARNESS_ATTACHMENTS}
+      sql: `SELECT name, mime_type, size_bytes, sha256, data_b64 FROM ${TABLE_HARNESS_ATTACHMENTS}
             WHERE session_id = ? AND attachment_id = ?`,
       args: [sessionId, attachmentId],
     });
@@ -324,6 +346,8 @@ export class HarnessLibSQL extends HarnessStorage {
     return {
       name: String(row.name),
       mimeType: String(row.mime_type),
+      bytes: Number(row.size_bytes),
+      sha256: String(row.sha256),
       data: base64ToBytes(String(row.data_b64)),
     };
   }
@@ -351,7 +375,7 @@ export class HarnessLibSQL extends HarnessStorage {
     attachmentId: string;
   }): Promise<AttachmentRecord | null> {
     const result = await this.#client.execute({
-      sql: `SELECT session_id, attachment_id, name, mime_type, size_bytes, created_at
+      sql: `SELECT session_id, attachment_id, name, mime_type, size_bytes, sha256, source, created_at
             FROM ${TABLE_HARNESS_ATTACHMENTS}
             WHERE session_id = ? AND attachment_id = ?`,
       args: [sessionId, attachmentId],
@@ -359,13 +383,44 @@ export class HarnessLibSQL extends HarnessStorage {
     const row = result.rows[0];
     if (!row) return null;
     return {
-      sessionId: String(row.session_id),
+      ownerSessionId: String(row.session_id),
       attachmentId: String(row.attachment_id),
       name: String(row.name),
       mimeType: String(row.mime_type),
-      sizeBytes: Number(row.size_bytes),
+      bytes: Number(row.size_bytes),
+      sha256: String(row.sha256),
+      source: toAttachmentSource(row.source),
       createdAt: Number(row.created_at),
     };
+  }
+
+  async #backfillAttachmentMetadata(): Promise<void> {
+    for (;;) {
+      const result = await this.#client.execute({
+        sql: `SELECT session_id, attachment_id, data_b64, sha256, source
+              FROM ${TABLE_HARNESS_ATTACHMENTS}
+              WHERE sha256 IS NULL OR sha256 = '' OR source IS NULL OR source = ''
+              LIMIT 100`,
+      });
+      if (result.rows.length === 0) return;
+
+      for (const row of result.rows) {
+        const sha256 =
+          row.sha256 != null && String(row.sha256).length > 0
+            ? String(row.sha256)
+            : sha256Hex(base64ToBytes(String(row.data_b64)));
+        // Legacy rows predate source tracking; they were written through the
+        // staged local upload path, so `preupload` is the least lossy default.
+        const source =
+          row.source != null && String(row.source).length > 0 ? toAttachmentSource(row.source) : 'preupload';
+        await this.#client.execute({
+          sql: `UPDATE ${TABLE_HARNESS_ATTACHMENTS}
+                SET sha256 = ?, source = ?
+                WHERE session_id = ? AND attachment_id = ?`,
+          args: [sha256, source, String(row.session_id), String(row.attachment_id)],
+        });
+      }
+    }
   }
 }
 
@@ -504,4 +559,15 @@ function base64ToBytes(b64: string): Uint8Array {
   const out = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
   return out;
+}
+
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function toAttachmentSource(value: unknown): AttachmentRecord['source'] {
+  if (value === 'inline' || value === 'preupload' || value === 'url' || value === 'provider') {
+    return value;
+  }
+  return 'preupload';
 }


### PR DESCRIPTION
Linear: PF-345

Summary:
- Implements local Harness.attachments.upload/delete against an explicit owning sessionId.
- Persists attachment bytes with bytes/sha256/source metadata in in-memory and LibSQL harness storage.
- Adds LibSQL schema migration/backfill for legacy attachment rows.
- Adds focused core and LibSQL coverage, including multi-session owner targeting.

Open PR overlap checked before implementation and rechecked before PR:
- #69 core agent/durable/flow/tool/workflow paths, no Harness v1 attachment/storage overlap.
- #68 legacy harness/tool-gate paths, no Harness v1 attachment/storage overlap.
- #58 ClickHouse memory storage only.

Checks run:
- pnpm --filter @mastra/core test src/harness/v1/attachments.test.ts
- pnpm --filter @mastra/libsql test src/storage/domains/harness/index.test.ts
- pnpm --filter @mastra/libsql test src/storage/index.test.ts
- pnpm --filter @mastra/core typecheck
- pnpm --filter @mastra/core build:lib
- pnpm --filter @mastra/libsql build:lib
- npx -y prettier@3.8.3 --check packages/core/src/harness/v1/harness.ts packages/core/src/harness/v1/attachments.test.ts packages/core/src/harness/v1/types.ts packages/core/src/storage/constants.ts packages/core/src/storage/domains/harness/base.ts packages/core/src/storage/domains/harness/inmemory.ts packages/core/src/storage/domains/harness/types.ts stores/_test-utils/src/domains/harness/index.ts stores/libsql/src/storage/domains/harness/index.ts stores/libsql/src/storage/domains/harness/index.test.ts
- git diff --check

Notes:
- Guarded delete / in-use reference checks remain intentionally out of scope for this PF-345 slice and should land with the attachment admission/reference lane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds the ability to upload and delete file attachments (like documents or data) to a harness system, with each attachment tied to a specific session. When you upload a file, the system automatically computes a checksum (sha256) to verify the file's integrity and keeps track of where the file came from. When you delete an attachment, it removes it completely.

## Overview

Implements local `Harness.attachments.upload` and `Harness.attachments.delete` operations scoped to explicit owning `sessionId`s. Attachment bytes are persisted alongside metadata (`bytes`, `sha256`, `source`) in both in-memory and LibSQL storage, with schema evolution and backfill support for legacy rows.

## Changes

### Core Harness Operations

- **`harness.attachments.upload`**: Converts incoming `opts.data` into `Uint8Array`, persists via `storage.saveAttachment` with `source: 'preupload'`, and returns an `AttachmentRef` populated with saved metadata (bytes, sha256, ownerSessionId).
- **`harness.attachments.delete`**: Resolves the session and calls `storage.deleteAttachment` for the given `attachmentId`.
- Requires harness storage; attachment ownership is tied to an explicitly provided `sessionId` even if a newer resource session exists.

### Type System

**`AttachmentRef`** extended with optional fields:
- `ownerSessionId?: string` — session that owns the attachment
- `bytes?: number` — size of attachment data
- `sha256?: string` — SHA-256 digest of content
- `source?: AttachmentSource` — origin label (`'inline' | 'preupload' | 'url' | 'provider'`)

**`AttachmentUploadOptions` and `AttachmentDeleteOptions`** refactored:
- Now require `sessionId: string` (previously optional)
- `resourceId` made optional (previously required)

**New `AttachmentSource` type**: Union of `'inline' | 'preupload' | 'url' | 'provider'`

### Storage Schema and Implementation

**Base contract (`HarnessStorage`):**
- `saveAttachment` now returns `SaveAttachmentResult` (previously `void`) containing `bytes` and `sha256`
- Index row now includes `(ownerSessionId, name, mimeType, bytes, sha256, source)`

**In-Memory storage (`InMemoryHarness`):**
- Computes SHA-256 digest for all saved attachments
- Persists `sha256` and `source` metadata alongside byte payload
- `loadAttachment` includes `sha256` in returned payload
- Attachment keys now keyed by `(ownerSessionId, attachmentId)`

**LibSQL storage (`HarnessLibSQL`):**
- Schema evolution: `mastra_harness_attachments` table altered to add `sha256` and `source` columns
- Backfill routine populates missing digests and sources for legacy rows (computing sha256 from stored bytes and defaulting source to `'preupload'`)
- `saveAttachment` uses upsert with `ON CONFLICT(session_id, attachment_id) DO UPDATE` to persist new metadata
- `loadAttachment` and `getAttachmentRecord` updated to return `sha256` and source
- Helper functions added: `sha256Hex()` for digest computation and `toAttachmentSource()` for normalization

### Test Coverage

- **Core harness tests** (`attachments.test.ts`): Verify SHA-256 computation and source preservation on upload; multi-session owner targeting on delete
- **LibSQL tests** (`index.test.ts`): Verify metadata persistence, attachment deletion, and schema backfill for legacy rows
- **Test utilities** updated to validate new attachment record shape with `ownerSessionId`, `bytes`, and 64-character `sha256` digest

## Out of Scope

Guarded delete / in-use reference checks deferred to attachment admission/reference work.

## Verification

PR verified for no overlap with Harness v1 storage in other concurrent PRs. All core and LibSQL unit tests pass; typecheck and formatting checks pass.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/79)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->