### PR TITLE
[PF-347] Guard queued attachment references

### DIFF
--- a/packages/core/src/harness/v1/attachments.test.ts
+++ b/packages/core/src/harness/v1/attachments.test.ts
@@ -3,6 +3,12 @@ import { createHash } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 
 import { setupHarness } from './__test-utils__';
+import {
+  HarnessAttachmentInUseError,
+  HarnessAttachmentUnavailableError,
+  HarnessQueueFullError,
+  HarnessValidationError,
+} from './errors';
 
 describe('Harness.attachments', () => {
   it('uploads attachments with digest metadata and deletes them by attachment id', async () => {
@@ -103,5 +109,110 @@ describe('Harness.attachments', () => {
         attachmentId: result.attachmentId,
       }),
     ).resolves.toBeNull();
+  });
+
+  it('guards uploaded attachments once a queued item references them', async () => {
+    const { harness, storage, agent } = setupHarness();
+    agent.enqueueRun({ finishReason: 'stop', text: 'queued reply' });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const result = await harness.attachments.upload({
+      sessionId: session.id,
+      data: new Uint8Array([1, 2, 3]),
+      filename: 'note.bin',
+      contentType: 'application/octet-stream',
+    });
+
+    await session.queue({ content: 'use this', attachments: [result] });
+
+    await expect(
+      storage.listAttachmentReferences({ sessionId: session.id, attachmentId: result.attachmentId }),
+    ).resolves.toEqual([{ source: 'queued_item', sourceId: expect.any(String) }]);
+    await expect(
+      harness.attachments.delete({ sessionId: session.id, attachmentId: result.attachmentId }),
+    ).rejects.toBeInstanceOf(HarnessAttachmentInUseError);
+  });
+
+  it('rejects queue admission for cross-session or mismatched attachment refs', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const other = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const result = await harness.attachments.upload({
+      sessionId: session.id,
+      data: new Uint8Array([1, 2, 3]),
+      filename: 'note.bin',
+      contentType: 'application/octet-stream',
+    });
+
+    await expect(other.queue({ content: 'bad', attachments: [result] })).rejects.toBeInstanceOf(HarnessValidationError);
+    await expect(
+      session.queue({ content: 'bad', attachments: [{ ...result, sha256: '0'.repeat(64) }] }),
+    ).rejects.toBeInstanceOf(HarnessValidationError);
+    await expect(
+      session.queue({ content: 'bad', attachments: [{ attachmentId: 'missing', resourceId: 'u' }] }),
+    ).rejects.toBeInstanceOf(HarnessAttachmentUnavailableError);
+  });
+
+  it('rejects a queued turn when an admitted attachment digest changes before drain', async () => {
+    const { harness, storage, agent } = setupHarness();
+    let releaseManual!: () => void;
+    const manualGate = new Promise<void>(resolve => {
+      releaseManual = resolve;
+    });
+    agent.enqueueRun({ finishReason: 'stop', text: 'manual', holdUntil: manualGate });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const result = await harness.attachments.upload({
+      sessionId: session.id,
+      data: new Uint8Array([1, 2, 3]),
+      filename: 'note.bin',
+      contentType: 'application/octet-stream',
+    });
+
+    const manual = session.message({ content: 'hold drain' });
+    await new Promise(resolve => setImmediate(resolve));
+    const queued = session.queue({ content: 'use this', attachments: [result] });
+    await new Promise(resolve => setImmediate(resolve));
+
+    const record = await storage.getAttachmentRecord({ sessionId: session.id, attachmentId: result.attachmentId });
+    expect(record).not.toBeNull();
+    record!.sha256 = '0'.repeat(64);
+
+    releaseManual();
+
+    await expect(queued).rejects.toMatchObject({ reason: 'digest_mismatch', attachmentId: result.attachmentId });
+    await expect(manual).resolves.toMatchObject({ text: 'manual' });
+    expect(agent.streamCalls).toHaveLength(1);
+  });
+
+  it('does not record attachment references for queue items rejected by capacity', async () => {
+    const { harness, storage, agent } = setupHarness({ sessions: { maxQueueDepth: 1 } });
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'r1',
+      suspendPayload: { toolCallId: 'tc-1', toolName: 'shell', args: { cmd: 'x' } },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const first = await harness.attachments.upload({
+      sessionId: session.id,
+      data: new Uint8Array([1]),
+      filename: 'first.bin',
+      contentType: 'application/octet-stream',
+    });
+    const second = await harness.attachments.upload({
+      sessionId: session.id,
+      data: new Uint8Array([2]),
+      filename: 'second.bin',
+      contentType: 'application/octet-stream',
+    });
+
+    const queued = session.queue({ content: 'first', attachments: [first] });
+    queued.catch(() => {});
+    await new Promise(resolve => setImmediate(resolve));
+
+    await expect(session.queue({ content: 'second', attachments: [second] })).rejects.toBeInstanceOf(
+      HarnessQueueFullError,
+    );
+    await expect(
+      storage.listAttachmentReferences({ sessionId: session.id, attachmentId: second.attachmentId }),
+    ).resolves.toEqual([]);
   });
 });

--- a/packages/core/src/harness/v1/errors.ts
+++ b/packages/core/src/harness/v1/errors.ts
@@ -96,6 +96,30 @@ export class HarnessQueueFullError extends Error {
   }
 }
 
+export class HarnessAttachmentInUseError extends Error {
+  readonly name = 'HarnessAttachmentInUseError';
+  constructor(
+    public readonly sessionId: string,
+    public readonly attachmentId: string,
+    public readonly references: ReadonlyArray<{ source: string; sourceId: string; retainedUntil?: number }>,
+  ) {
+    super(`Attachment "${attachmentId}" for session "${sessionId}" is still in use`);
+  }
+}
+
+export type HarnessAttachmentUnavailableReason = 'not_found' | 'digest_mismatch' | 'bytes_mismatch';
+
+export class HarnessAttachmentUnavailableError extends Error {
+  readonly name = 'HarnessAttachmentUnavailableError';
+  constructor(
+    public readonly sessionId: string,
+    public readonly reason: HarnessAttachmentUnavailableReason,
+    public readonly attachmentId?: string,
+  ) {
+    super(`Attachment${attachmentId ? ` "${attachmentId}"` : ''} for session "${sessionId}" is unavailable: ${reason}`);
+  }
+}
+
 /**
  * `spawn_subagent` called from a session whose `subagentDepth` is at or
  * above `HarnessConfig.subagents.maxDepth`. Surfaces as a tool error

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -31,6 +31,7 @@ import type {
   TokenUsage,
 } from '../../storage/domains/harness';
 import {
+  HarnessStorageAttachmentInUseError,
   HarnessStorageLeaseConflictError,
   HarnessStorageSessionNotFoundError,
   HarnessStorageVersionConflictError,
@@ -40,6 +41,7 @@ import { InMemoryStore } from '../../storage/mock';
 import type { Workspace } from '../../workspace';
 
 import {
+  HarnessAttachmentInUseError,
   HarnessConfigError,
   HarnessModelNotFoundError,
   HarnessSessionClosedError,
@@ -1385,10 +1387,17 @@ export class Harness {
       const session = await this.session(
         opts.resourceId ? { sessionId: opts.sessionId, resourceId: opts.resourceId } : { sessionId: opts.sessionId },
       );
-      await storage.deleteAttachment({
-        sessionId: session.id,
-        attachmentId: opts.attachmentId,
-      });
+      try {
+        await storage.deleteAttachment({
+          sessionId: session.id,
+          attachmentId: opts.attachmentId,
+        });
+      } catch (err) {
+        if (err instanceof HarnessStorageAttachmentInUseError) {
+          throw new HarnessAttachmentInUseError(err.sessionId, err.attachmentId, err.references);
+        }
+        throw err;
+      }
     },
   };
 

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -37,9 +37,12 @@ import type {
   GoalJudgeDecision,
   GoalState,
   HarnessStorage,
+  HarnessStorageAttachmentUnavailableError,
   PendingResume,
   PermissionRules,
+  PersistedAttachment,
   QueuedItem,
+  SaveAttachmentReferenceInput,
   SessionGrants,
   SessionRecord,
 } from '../../storage/domains/harness';
@@ -52,6 +55,7 @@ import type { StoredMessageRow } from '../_shared/message-conversion';
 import type { HarnessMessage } from '../types';
 
 import {
+  HarnessAttachmentUnavailableError,
   HarnessConfigError,
   HarnessOverrideConflictError,
   HarnessQueueFullError,
@@ -79,6 +83,7 @@ import { createSpawnSubagentTool, SPAWN_SUBAGENT_TOOL_ID } from './spawn-subagen
 import type {
   AgentResult,
   AgentStream,
+  AttachmentRef,
   GoalOptions,
   HarnessMode,
   HarnessRequestContext,
@@ -178,6 +183,16 @@ function assertPolicy(method: string, value: unknown): asserts value is Permissi
   if (typeof value !== 'string' || !PERMISSION_POLICIES.includes(value as PermissionPolicy)) {
     throw new HarnessValidationError(method, `policy must be one of ${PERMISSION_POLICIES.join(' | ')}`);
   }
+}
+
+function isStorageAttachmentUnavailableError(err: unknown): err is HarnessStorageAttachmentUnavailableError {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as { code?: unknown }).code === 'harness.storage.attachment_unavailable' &&
+    typeof (err as { sessionId?: unknown }).sessionId === 'string' &&
+    typeof (err as { attachmentId?: unknown }).attachmentId === 'string'
+  );
 }
 
 function truncateForJudge(value: string): string {
@@ -3096,28 +3111,42 @@ export class Session {
       throw new HarnessQueueFullError(this.id, cap);
     }
 
+    const attachments = await this._resolveAttachmentRefs('queue().attachments', opts.attachments ?? []);
     const item: QueuedItem = {
       id: `q-${randomUUID()}`,
       enqueuedAt: Date.now(),
       content: opts.content,
-      attachments: [],
+      attachments,
       ...(opts.model !== undefined ? { model: opts.model } : {}),
       ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
       ...(opts.yolo !== undefined ? { yolo: opts.yolo } : {}),
     };
+    const attachmentReferences = attachments
+      .filter((attachment): attachment is Extract<PersistedAttachment, { kind: 'ref' }> => attachment.kind === 'ref')
+      .map(attachment => ({
+        sessionId: attachment.ownerSessionId,
+        attachmentId: attachment.attachmentId,
+        source: 'queued_item' as const,
+        sourceId: item.id,
+      }));
 
-    // Atomic check + append: re-check capacity inside the updater so a
-    // concurrent in-process `queue()` cannot push us past the cap.
-    let admitted = true;
-    await this._flushUpdate(prev => {
-      if ((prev.pendingQueue?.length ?? 0) >= cap) {
-        admitted = false;
-        return prev;
+    try {
+      // Atomic check + append: re-check capacity inside the updater so a
+      // concurrent in-process `queue()` cannot push us past the cap.
+      await this._flushUpdate(
+        prev => {
+          if ((prev.pendingQueue?.length ?? 0) >= cap) {
+            throw new HarnessQueueFullError(this.id, cap);
+          }
+          return { ...prev, pendingQueue: [...(prev.pendingQueue ?? []), item] };
+        },
+        { attachmentReferences },
+      );
+    } catch (err) {
+      if (isStorageAttachmentUnavailableError(err)) {
+        throw new HarnessAttachmentUnavailableError(err.sessionId, 'not_found', err.attachmentId);
       }
-      return { ...prev, pendingQueue: [...(prev.pendingQueue ?? []), item] };
-    });
-    if (!admitted) {
-      throw new HarnessQueueFullError(this.id, cap);
+      throw err;
     }
 
     return new Promise<AgentResult>((resolve, reject) => {
@@ -3126,6 +3155,41 @@ export class Session {
       // settles the resolver via `_completeQueuedTurn` / `_failQueuedTurn`.
       void this._maybeDrainQueue();
     });
+  }
+
+  private async _resolveAttachmentRefs(field: string, refs: AttachmentRef[]): Promise<PersistedAttachment[]> {
+    const attachments: PersistedAttachment[] = [];
+    for (let i = 0; i < refs.length; i += 1) {
+      const ref = refs[i]!;
+      const ownerSessionId = ref.ownerSessionId ?? this.id;
+      if (ownerSessionId !== this.id) {
+        throw new HarnessValidationError(`${field}[${i}].ownerSessionId`, 'attachment must belong to this session');
+      }
+      const record = await this._storage.getAttachmentRecord({
+        sessionId: this.id,
+        attachmentId: ref.attachmentId,
+      });
+      if (!record) {
+        throw new HarnessAttachmentUnavailableError(this.id, 'not_found', ref.attachmentId);
+      }
+      if (ref.bytes !== undefined && ref.bytes !== record.bytes) {
+        throw new HarnessValidationError(`${field}[${i}].bytes`, 'attachment byte count does not match storage');
+      }
+      if (ref.sha256 !== undefined && ref.sha256 !== record.sha256) {
+        throw new HarnessValidationError(`${field}[${i}].sha256`, 'attachment digest does not match storage');
+      }
+      attachments.push({
+        kind: 'ref',
+        name: record.name,
+        mimeType: record.mimeType,
+        ownerSessionId: record.ownerSessionId,
+        attachmentId: record.attachmentId,
+        bytes: record.bytes,
+        sha256: record.sha256,
+        source: record.source,
+      });
+    }
+    return attachments;
   }
 
   /**
@@ -3193,6 +3257,7 @@ export class Session {
    * stays in place (suspended) or is removed (complete / error).
    */
   private async _runQueuedTurn(item: QueuedItem): Promise<FullOutput<unknown>> {
+    await this._validateQueuedAttachmentRefs(item);
     const effectiveModeId = item.mode ?? this._record.modeId;
     const mode = this._harness._getMode(effectiveModeId);
     const agent = this._harness.getAgentForMode(effectiveModeId);
@@ -3237,6 +3302,33 @@ export class Session {
       return full;
     } finally {
       this._endTurn(turnAbortController);
+    }
+  }
+
+  private async _validateQueuedAttachmentRefs(item: QueuedItem): Promise<void> {
+    for (const attachment of item.attachments) {
+      if (attachment.kind !== 'ref') continue;
+      const loaded = await this._storage.loadAttachment({
+        sessionId: attachment.ownerSessionId,
+        attachmentId: attachment.attachmentId,
+      });
+      if (!loaded) {
+        throw new HarnessAttachmentUnavailableError(attachment.ownerSessionId, 'not_found', attachment.attachmentId);
+      }
+      if (loaded.sha256 !== attachment.sha256) {
+        throw new HarnessAttachmentUnavailableError(
+          attachment.ownerSessionId,
+          'digest_mismatch',
+          attachment.attachmentId,
+        );
+      }
+      if (loaded.bytes !== attachment.bytes) {
+        throw new HarnessAttachmentUnavailableError(
+          attachment.ownerSessionId,
+          'bytes_mismatch',
+          attachment.attachmentId,
+        );
+      }
     }
   }
 
@@ -3300,16 +3392,23 @@ export class Session {
    * adopt the returned version. Single point of truth so every setter
    * stays consistent with the lease + version contract (§5.8).
    */
-  private _flushUpdate(update: (prev: SessionRecord) => SessionRecord): Promise<void> {
+  private _flushUpdate(
+    update: (prev: SessionRecord) => SessionRecord,
+    opts?: { attachmentReferences?: SaveAttachmentReferenceInput[] },
+  ): Promise<void> {
     const run = async (): Promise<void> => {
       const next: SessionRecord = {
         ...update(this._record),
         lastActivityAt: Date.now(),
       };
-      const saved = await this._storage.saveSession(next, {
+      const saveOpts = {
         ownerId: this._ownerId,
         ifVersion: this._record.version,
-      });
+      };
+      const saved =
+        opts?.attachmentReferences && opts.attachmentReferences.length > 0
+          ? await this._storage.saveSessionWithAttachmentReferences(next, saveOpts, opts.attachmentReferences)
+          : await this._storage.saveSession(next, saveOpts);
       this._record = { ...next, version: saved.version };
     };
     // Chain so concurrent callers serialize against the latest in-memory

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -47,6 +47,7 @@ export const TABLE_CHANNEL_CONFIG = 'mastra_channel_config';
 // Harness tables (HARNESS_V1_SPEC.md §5)
 export const TABLE_HARNESS_SESSIONS = 'mastra_harness_sessions';
 export const TABLE_HARNESS_ATTACHMENTS = 'mastra_harness_attachments';
+export const TABLE_HARNESS_ATTACHMENT_REFERENCES = 'mastra_harness_attachment_references';
 
 /** Union of all core table name constants. */
 export type TABLE_NAMES =
@@ -83,7 +84,8 @@ export type TABLE_NAMES =
   | typeof TABLE_CHANNEL_INSTALLATIONS
   | typeof TABLE_CHANNEL_CONFIG
   | typeof TABLE_HARNESS_SESSIONS
-  | typeof TABLE_HARNESS_ATTACHMENTS;
+  | typeof TABLE_HARNESS_ATTACHMENTS
+  | typeof TABLE_HARNESS_ATTACHMENT_REFERENCES;
 
 export const SCORERS_SCHEMA: Record<string, StorageColumn> = {
   id: { type: 'text', nullable: false, primaryKey: true },
@@ -673,6 +675,14 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
     created_at: { type: 'bigint', nullable: false },
     data_b64: { type: 'text', nullable: false },
   },
+  [TABLE_HARNESS_ATTACHMENT_REFERENCES]: {
+    session_id: { type: 'text', nullable: false },
+    attachment_id: { type: 'text', nullable: false },
+    source: { type: 'text', nullable: false },
+    source_id: { type: 'text', nullable: false },
+    retained_until: { type: 'bigint', nullable: true },
+    created_at: { type: 'bigint', nullable: false },
+  },
 };
 
 /**
@@ -684,6 +694,10 @@ export const TABLE_CONFIGS: Partial<Record<TABLE_NAMES, StorageTableConfig>> = {
   [TABLE_HARNESS_ATTACHMENTS]: {
     columns: TABLE_SCHEMAS[TABLE_HARNESS_ATTACHMENTS],
     compositePrimaryKey: ['session_id', 'attachment_id'],
+  },
+  [TABLE_HARNESS_ATTACHMENT_REFERENCES]: {
+    columns: TABLE_SCHEMAS[TABLE_HARNESS_ATTACHMENT_REFERENCES],
+    compositePrimaryKey: ['session_id', 'attachment_id', 'source', 'source_id'],
   },
 };
 

--- a/packages/core/src/storage/domains/harness/base.ts
+++ b/packages/core/src/storage/domains/harness/base.ts
@@ -1,12 +1,14 @@
 import { StorageDomain } from '../base';
 import type {
   AcquireSessionLeaseInput,
+  AttachmentReference,
   AttachmentRecord,
   ListSessionsInput,
   LoadedAttachment,
   ReleaseSessionLeaseInput,
   RenewSessionLeaseInput,
   SaveAttachmentInput,
+  SaveAttachmentReferenceInput,
   SaveAttachmentResult,
   SaveSessionOptions,
   SaveSessionResult,
@@ -45,6 +47,34 @@ export class HarnessStorageLeaseConflictError extends Error {
     public readonly expiresAt: number,
   ) {
     super(`Session "${sessionId}" lease held by "${heldBy}" until ${new Date(expiresAt).toISOString()}`);
+  }
+}
+
+/**
+ * Thrown by guarded attachment delete when durable references still point at
+ * the bytes. The harness layer maps this to the public
+ * `HarnessAttachmentInUseError`.
+ */
+export class HarnessStorageAttachmentInUseError extends Error {
+  readonly name = 'HarnessStorageAttachmentInUseError';
+  readonly code = 'harness.storage.attachment_in_use' as const;
+  constructor(
+    public readonly sessionId: string,
+    public readonly attachmentId: string,
+    public readonly references: AttachmentReference[],
+  ) {
+    super(`Attachment "${attachmentId}" for session "${sessionId}" is still referenced`);
+  }
+}
+
+export class HarnessStorageAttachmentUnavailableError extends Error {
+  readonly name = 'HarnessStorageAttachmentUnavailableError';
+  readonly code = 'harness.storage.attachment_unavailable' as const;
+  constructor(
+    public readonly sessionId: string,
+    public readonly attachmentId: string,
+  ) {
+    super(`Attachment "${attachmentId}" for session "${sessionId}" is not available`);
   }
 }
 
@@ -138,6 +168,19 @@ export abstract class HarnessStorage extends StorageDomain {
   abstract saveSession(record: SessionRecord, opts: SaveSessionOptions): Promise<SaveSessionResult>;
 
   /**
+   * CAS write of a session record plus durable attachment reference rows in
+   * one adapter operation. Used by queue admission so a racing attachment
+   * delete either happens before the queued item exists, or observes the new
+   * reference and fails. Implementations must also reject if any referenced
+   * attachment row is missing. The session record must already exist.
+   */
+  abstract saveSessionWithAttachmentReferences(
+    record: SessionRecord,
+    opts: SaveSessionOptions,
+    references: SaveAttachmentReferenceInput[],
+  ): Promise<SaveSessionResult>;
+
+  /**
    * Hard-delete of a single session record. The harness layer's
    * `harness.deleteSession(...)` walks the `parentSessionId` chain and
    * calls this method once per descendant — adapters do NOT implement
@@ -209,13 +252,15 @@ export abstract class HarnessStorage extends StorageDomain {
 
   /**
    * Delete a single attachment. No-op when the row is missing.
+   * Throws `HarnessStorageAttachmentInUseError` while references remain.
    */
   abstract deleteAttachment(opts: { sessionId: string; attachmentId: string }): Promise<void>;
 
   /**
    * Delete all attachments owned by a session. Called from `deleteSession`
    * implementations so the index does not leak rows when a session is torn
-   * down.
+   * down. Referenced rows are skipped; force cleanup belongs to the lifecycle
+   * delete lane.
    */
   abstract deleteAttachmentsForSession(opts: { sessionId: string }): Promise<void>;
 
@@ -224,6 +269,18 @@ export abstract class HarnessStorage extends StorageDomain {
    * metadata listings (e.g. message rendering).
    */
   abstract getAttachmentRecord(opts: { sessionId: string; attachmentId: string }): Promise<AttachmentRecord | null>;
+
+  /**
+   * Register durable references to attachment bytes. Source ids are scoped by
+   * source: queued item id for `queued_item`, message id for
+   * `message_history`, run id for `current_run`, and source-specific row ids
+   * for channel/wakeup/outbox references.
+   */
+  abstract recordAttachmentReferences(references: SaveAttachmentReferenceInput[]): Promise<void>;
+
+  abstract deleteAttachmentReferences(references: SaveAttachmentReferenceInput[]): Promise<void>;
+
+  abstract listAttachmentReferences(opts: { sessionId: string; attachmentId: string }): Promise<AttachmentReference[]>;
 
   // -------------------------------------------------------------------------
   // Test-only

--- a/packages/core/src/storage/domains/harness/inmemory.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.ts
@@ -3,17 +3,21 @@ import { createHash } from 'node:crypto';
 import type { InMemoryDB } from '../inmemory-db';
 import {
   HarnessStorage,
+  HarnessStorageAttachmentInUseError,
+  HarnessStorageAttachmentUnavailableError,
   HarnessStorageLeaseConflictError,
   HarnessStorageSessionNotFoundError,
   HarnessStorageVersionConflictError,
 } from './base';
 import type {
   AcquireSessionLeaseInput,
+  AttachmentReference,
   AttachmentRecord,
   ListSessionsInput,
   LoadedAttachment,
   ReleaseSessionLeaseInput,
   RenewSessionLeaseInput,
+  SaveAttachmentReferenceInput,
   SaveAttachmentInput,
   SaveAttachmentResult,
   SaveSessionOptions,
@@ -109,6 +113,47 @@ export class InMemoryHarness extends HarnessStorage {
     };
 
     this.db.harnessSessions.set(record.id, stored);
+    return { version: nextVersion };
+  }
+
+  async saveSessionWithAttachmentReferences(
+    record: SessionRecord,
+    opts: SaveSessionOptions,
+    references: SaveAttachmentReferenceInput[],
+  ): Promise<SaveSessionResult> {
+    const existing = this.db.harnessSessions.get(record.id);
+
+    if (existing) {
+      assertLeaseHolder(existing, opts.ownerId);
+
+      if (existing.version !== opts.ifVersion) {
+        throw new HarnessStorageVersionConflictError(record.id, opts.ifVersion, existing.version);
+      }
+    } else {
+      throw new HarnessStorageVersionConflictError(record.id, opts.ifVersion, 0);
+    }
+
+    for (const ref of references) {
+      if (!this.db.harnessAttachmentRecords.has(attachmentKey(ref.sessionId, ref.attachmentId))) {
+        throw new HarnessStorageAttachmentUnavailableError(ref.sessionId, ref.attachmentId);
+      }
+    }
+
+    const nextVersion = opts.ifVersion + 1;
+    const stored: SessionRecord = {
+      ...record,
+      version: nextVersion,
+      ownerId: existing.ownerId,
+      leaseExpiresAt: existing.leaseExpiresAt,
+    };
+    this.db.harnessSessions.set(record.id, stored);
+    for (const ref of references) {
+      this.db.harnessAttachmentReferences.set(attachmentReferenceKey(ref), {
+        source: ref.source,
+        sourceId: ref.sourceId,
+        ...(ref.retainedUntil !== undefined ? { retainedUntil: ref.retainedUntil } : {}),
+      });
+    }
     return { version: nextVersion };
   }
 
@@ -230,6 +275,10 @@ export class InMemoryHarness extends HarnessStorage {
   }
 
   async deleteAttachment({ sessionId, attachmentId }: { sessionId: string; attachmentId: string }): Promise<void> {
+    const references = await this.listAttachmentReferences({ sessionId, attachmentId });
+    if (references.length > 0) {
+      throw new HarnessStorageAttachmentInUseError(sessionId, attachmentId, references);
+    }
     const key = attachmentKey(sessionId, attachmentId);
     this.db.harnessAttachmentRecords.delete(key);
     this.db.harnessAttachmentBytes.delete(key);
@@ -239,6 +288,9 @@ export class InMemoryHarness extends HarnessStorage {
     const prefix = `${sessionId}\u0000`;
     for (const key of this.db.harnessAttachmentRecords.keys()) {
       if (key.startsWith(prefix)) {
+        const [, attachmentId] = splitAttachmentKey(key);
+        const references = await this.listAttachmentReferences({ sessionId, attachmentId });
+        if (references.length > 0) continue;
         this.db.harnessAttachmentRecords.delete(key);
         this.db.harnessAttachmentBytes.delete(key);
       }
@@ -255,6 +307,37 @@ export class InMemoryHarness extends HarnessStorage {
     return this.db.harnessAttachmentRecords.get(attachmentKey(sessionId, attachmentId)) ?? null;
   }
 
+  async recordAttachmentReferences(references: SaveAttachmentReferenceInput[]): Promise<void> {
+    for (const ref of references) {
+      this.db.harnessAttachmentReferences.set(attachmentReferenceKey(ref), {
+        source: ref.source,
+        sourceId: ref.sourceId,
+        ...(ref.retainedUntil !== undefined ? { retainedUntil: ref.retainedUntil } : {}),
+      });
+    }
+  }
+
+  async deleteAttachmentReferences(references: SaveAttachmentReferenceInput[]): Promise<void> {
+    for (const ref of references) {
+      this.db.harnessAttachmentReferences.delete(attachmentReferenceKey(ref));
+    }
+  }
+
+  async listAttachmentReferences({
+    sessionId,
+    attachmentId,
+  }: {
+    sessionId: string;
+    attachmentId: string;
+  }): Promise<AttachmentReference[]> {
+    const prefix = `${sessionId}\u0000${attachmentId}\u0000`;
+    const refs: AttachmentReference[] = [];
+    for (const [key, ref] of this.db.harnessAttachmentReferences) {
+      if (key.startsWith(prefix)) refs.push({ ...ref });
+    }
+    return refs.sort((a, b) => a.source.localeCompare(b.source) || a.sourceId.localeCompare(b.sourceId));
+  }
+
   // -------------------------------------------------------------------------
   // Test-only
   // -------------------------------------------------------------------------
@@ -263,6 +346,7 @@ export class InMemoryHarness extends HarnessStorage {
     this.db.harnessSessions.clear();
     this.db.harnessAttachmentRecords.clear();
     this.db.harnessAttachmentBytes.clear();
+    this.db.harnessAttachmentReferences.clear();
   }
 }
 
@@ -277,6 +361,15 @@ export class InMemoryHarness extends HarnessStorage {
  */
 function attachmentKey(ownerSessionId: string, attachmentId: string): string {
   return `${ownerSessionId}\u0000${attachmentId}`;
+}
+
+function splitAttachmentKey(key: string): [string, string] {
+  const [ownerSessionId = '', attachmentId = ''] = key.split('\u0000');
+  return [ownerSessionId, attachmentId];
+}
+
+function attachmentReferenceKey(ref: SaveAttachmentReferenceInput): string {
+  return `${ref.sessionId}\u0000${ref.attachmentId}\u0000${ref.source}\u0000${ref.sourceId}`;
 }
 
 function sha256Hex(bytes: Uint8Array): string {

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -189,6 +189,15 @@ export interface SessionWorkspaceState {
 
 export type AttachmentSource = 'inline' | 'preupload' | 'url' | 'provider';
 
+export type AttachmentReferenceSource =
+  | 'queued_item'
+  | 'queue_receipt'
+  | 'current_run'
+  | 'message_history'
+  | 'channel_inbox'
+  | 'wakeup'
+  | 'outbox';
+
 /**
  * Durable session state. Loaded on hydration, flushed under the session's
  * write lease (see HARNESS_V1_SPEC.md §5.8).
@@ -384,4 +393,16 @@ export interface LoadedAttachment {
   bytes: number;
   sha256: string;
   data: Uint8Array;
+}
+
+export interface AttachmentReference {
+  source: AttachmentReferenceSource;
+  sourceId: string;
+  retainedUntil?: number;
+}
+
+export interface SaveAttachmentReferenceInput extends AttachmentReference {
+  /** Session that owns the referenced attachment bytes. */
+  sessionId: string;
+  attachmentId: string;
 }

--- a/packages/core/src/storage/domains/inmemory-db.ts
+++ b/packages/core/src/storage/domains/inmemory-db.ts
@@ -20,7 +20,7 @@ import type {
   ExperimentResult,
 } from '../types';
 import type { AgentVersion } from './agents';
-import type { AttachmentRecord, SessionRecord } from './harness/types';
+import type { AttachmentRecord, AttachmentReference, SessionRecord } from './harness/types';
 import type { MCPClientVersion } from './mcp-clients';
 import type { MCPServerVersion } from './mcp-servers';
 import type { TraceEntry } from './observability';
@@ -89,6 +89,7 @@ export class InMemoryDB {
   readonly harnessSessions = new Map<string, SessionRecord>();
   readonly harnessAttachmentRecords = new Map<string, AttachmentRecord>();
   readonly harnessAttachmentBytes = new Map<string, Uint8Array>();
+  readonly harnessAttachmentReferences = new Map<string, AttachmentReference>();
 
   /**
    * Clears all data from all collections.
@@ -131,5 +132,6 @@ export class InMemoryDB {
     this.harnessSessions.clear();
     this.harnessAttachmentRecords.clear();
     this.harnessAttachmentBytes.clear();
+    this.harnessAttachmentReferences.clear();
   }
 }

--- a/packages/core/src/storage/domains/operations/inmemory.ts
+++ b/packages/core/src/storage/domains/operations/inmemory.ts
@@ -47,6 +47,7 @@ export class StoreOperationsInMemory extends StoreOperations {
       mastra_channel_config: new Map(),
       mastra_harness_sessions: new Map(),
       mastra_harness_attachments: new Map(),
+      mastra_harness_attachment_references: new Map(),
     };
   }
 

--- a/stores/_test-utils/src/domains/harness/index.ts
+++ b/stores/_test-utils/src/domains/harness/index.ts
@@ -573,6 +573,44 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
         expect(await harness.loadAttachment({ sessionId: 'session-1', attachmentId: 'a1' })).toBeNull();
       });
 
+      it('lists attachment references and blocks guarded delete while references remain', async () => {
+        if (!harness) return;
+        await harness.saveAttachment({
+          sessionId: 'session-1',
+          attachmentId: 'a1',
+          name: 'n',
+          mimeType: 'text/plain',
+          source: 'preupload',
+          data: new Uint8Array([1]),
+        });
+        await harness.recordAttachmentReferences([
+          {
+            sessionId: 'session-1',
+            attachmentId: 'a1',
+            source: 'queued_item',
+            sourceId: 'q1',
+          },
+        ]);
+
+        await expect(harness.listAttachmentReferences({ sessionId: 'session-1', attachmentId: 'a1' })).resolves.toEqual(
+          [{ source: 'queued_item', sourceId: 'q1' }],
+        );
+        await expect(harness.deleteAttachment({ sessionId: 'session-1', attachmentId: 'a1' })).rejects.toMatchObject({
+          references: [{ source: 'queued_item', sourceId: 'q1' }],
+        });
+
+        await harness.deleteAttachmentReferences([
+          {
+            sessionId: 'session-1',
+            attachmentId: 'a1',
+            source: 'queued_item',
+            sourceId: 'q1',
+          },
+        ]);
+        await harness.deleteAttachment({ sessionId: 'session-1', attachmentId: 'a1' });
+        await expect(harness.loadAttachment({ sessionId: 'session-1', attachmentId: 'a1' })).resolves.toBeNull();
+      });
+
       it('deletes only attachments for the requested session in deleteAttachmentsForSession', async () => {
         if (!harness) return;
         await harness.saveAttachment({
@@ -591,10 +629,18 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           source: 'preupload',
           data: new Uint8Array([2]),
         });
+        await harness.recordAttachmentReferences([
+          {
+            sessionId: 'session-a',
+            attachmentId: 'a1',
+            source: 'queued_item',
+            sourceId: 'q1',
+          },
+        ]);
 
         await harness.deleteAttachmentsForSession({ sessionId: 'session-a' });
 
-        expect(await harness.loadAttachment({ sessionId: 'session-a', attachmentId: 'a1' })).toBeNull();
+        expect(await harness.loadAttachment({ sessionId: 'session-a', attachmentId: 'a1' })).not.toBeNull();
         expect(await harness.loadAttachment({ sessionId: 'session-b', attachmentId: 'a2' })).not.toBeNull();
       });
     });

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -3,21 +3,26 @@ import { createHash } from 'node:crypto';
 import type { Client } from '@libsql/client';
 import {
   HarnessStorage,
+  HarnessStorageAttachmentInUseError,
+  HarnessStorageAttachmentUnavailableError,
   HarnessStorageLeaseConflictError,
   HarnessStorageSessionNotFoundError,
   HarnessStorageVersionConflictError,
   TABLE_CONFIGS,
+  TABLE_HARNESS_ATTACHMENT_REFERENCES,
   TABLE_HARNESS_ATTACHMENTS,
   TABLE_HARNESS_SESSIONS,
   TABLE_SCHEMAS,
 } from '@mastra/core/storage';
 import type {
   AcquireSessionLeaseInput,
+  AttachmentReference,
   AttachmentRecord,
   ListSessionsInput,
   LoadedAttachment,
   ReleaseSessionLeaseInput,
   RenewSessionLeaseInput,
+  SaveAttachmentReferenceInput,
   SaveAttachmentInput,
   SaveAttachmentResult,
   SaveSessionOptions,
@@ -68,6 +73,12 @@ export class HarnessLibSQL extends HarnessStorage {
       schema: TABLE_SCHEMAS[TABLE_HARNESS_ATTACHMENTS],
       compositePrimaryKey: attachmentsConfig?.compositePrimaryKey,
     });
+    const attachmentRefsConfig = TABLE_CONFIGS[TABLE_HARNESS_ATTACHMENT_REFERENCES];
+    await this.#db.createTable({
+      tableName: TABLE_HARNESS_ATTACHMENT_REFERENCES,
+      schema: TABLE_SCHEMAS[TABLE_HARNESS_ATTACHMENT_REFERENCES],
+      compositePrimaryKey: attachmentRefsConfig?.compositePrimaryKey,
+    });
     await this.#db.alterTable({
       tableName: TABLE_HARNESS_ATTACHMENTS,
       schema: TABLE_SCHEMAS[TABLE_HARNESS_ATTACHMENTS],
@@ -77,6 +88,7 @@ export class HarnessLibSQL extends HarnessStorage {
   }
 
   async dangerouslyClearAll(): Promise<void> {
+    await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_ATTACHMENT_REFERENCES}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_ATTACHMENTS}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_SESSIONS}`);
   }
@@ -203,6 +215,89 @@ export class HarnessLibSQL extends HarnessStorage {
     }
 
     return { version: nextVersion };
+  }
+
+  async saveSessionWithAttachmentReferences(
+    record: SessionRecord,
+    opts: SaveSessionOptions,
+    references: SaveAttachmentReferenceInput[],
+  ): Promise<SaveSessionResult> {
+    if (opts.ifVersion === 0) {
+      throw new HarnessStorageVersionConflictError(record.id, opts.ifVersion, 0);
+    }
+
+    const nextVersion = opts.ifVersion + 1;
+    const cols = sessionColumnValues(record, nextVersion);
+    const updateNames = cols.names.filter(n => n !== 'owner_id' && n !== 'lease_expires_at' && n !== 'id');
+    const updateValues = updateNames.map(n => cols.values[cols.names.indexOf(n)]);
+    const setClause = updateNames.map(n => `${n} = ?`).join(', ');
+
+    const tx = await this.#client.transaction('write');
+    try {
+      const updateResult = await tx.execute({
+        sql: `UPDATE ${TABLE_HARNESS_SESSIONS}
+              SET ${setClause}
+              WHERE id = ?
+                AND version = ?
+                AND (
+                  owner_id IS NULL
+                  OR lease_expires_at IS NULL
+                  OR lease_expires_at <= ?
+                  OR owner_id = ?
+                )`,
+        args: [...updateValues, record.id, opts.ifVersion, Date.now(), opts.ownerId],
+      });
+
+      if (updateResult.rowsAffected === 0) {
+        await tx.rollback();
+        await this.#throwSaveSessionConflict(record, opts);
+      }
+
+      const createdAt = Date.now();
+      for (const ref of references) {
+        const attachment = await tx.execute({
+          sql: `SELECT attachment_id
+                FROM ${TABLE_HARNESS_ATTACHMENTS}
+                WHERE session_id = ? AND attachment_id = ?
+                LIMIT 1`,
+          args: [ref.sessionId, ref.attachmentId],
+        });
+        if (attachment.rows.length === 0) {
+          throw new HarnessStorageAttachmentUnavailableError(ref.sessionId, ref.attachmentId);
+        }
+        await tx.execute({
+          sql: `INSERT INTO ${TABLE_HARNESS_ATTACHMENT_REFERENCES}
+                (session_id, attachment_id, source, source_id, retained_until, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(session_id, attachment_id, source, source_id) DO UPDATE SET
+                  retained_until = excluded.retained_until`,
+          args: [ref.sessionId, ref.attachmentId, ref.source, ref.sourceId, ref.retainedUntil ?? null, createdAt],
+        });
+      }
+
+      await tx.commit();
+      return { version: nextVersion };
+    } catch (err) {
+      if (!tx.closed) await tx.rollback();
+      throw err;
+    }
+  }
+
+  async #throwSaveSessionConflict(record: SessionRecord, opts: SaveSessionOptions): Promise<never> {
+    const existing = await this.loadSession({ sessionId: record.id });
+    if (!existing) {
+      throw new HarnessStorageVersionConflictError(record.id, opts.ifVersion, 0);
+    }
+    const now = Date.now();
+    const leaseHeld =
+      existing.ownerId !== undefined &&
+      existing.leaseExpiresAt !== undefined &&
+      existing.leaseExpiresAt > now &&
+      existing.ownerId !== opts.ownerId;
+    if (leaseHeld) {
+      throw new HarnessStorageLeaseConflictError(record.id, existing.ownerId!, existing.leaseExpiresAt!);
+    }
+    throw new HarnessStorageVersionConflictError(record.id, opts.ifVersion, existing.version);
   }
 
   async deleteSession({ sessionId }: { sessionId: string }): Promise<void> {
@@ -353,16 +448,33 @@ export class HarnessLibSQL extends HarnessStorage {
   }
 
   async deleteAttachment({ sessionId, attachmentId }: { sessionId: string; attachmentId: string }): Promise<void> {
-    await this.#client.execute({
+    const result = await this.#client.execute({
       sql: `DELETE FROM ${TABLE_HARNESS_ATTACHMENTS}
-            WHERE session_id = ? AND attachment_id = ?`,
+            WHERE session_id = ? AND attachment_id = ?
+              AND NOT EXISTS (
+                SELECT 1 FROM ${TABLE_HARNESS_ATTACHMENT_REFERENCES} refs
+                WHERE refs.session_id = ${TABLE_HARNESS_ATTACHMENTS}.session_id
+                  AND refs.attachment_id = ${TABLE_HARNESS_ATTACHMENTS}.attachment_id
+              )`,
       args: [sessionId, attachmentId],
     });
+    if (result.rowsAffected === 0) {
+      const references = await this.listAttachmentReferences({ sessionId, attachmentId });
+      if (references.length > 0) {
+        throw new HarnessStorageAttachmentInUseError(sessionId, attachmentId, references);
+      }
+    }
   }
 
   async deleteAttachmentsForSession({ sessionId }: { sessionId: string }): Promise<void> {
     await this.#client.execute({
-      sql: `DELETE FROM ${TABLE_HARNESS_ATTACHMENTS} WHERE session_id = ?`,
+      sql: `DELETE FROM ${TABLE_HARNESS_ATTACHMENTS}
+            WHERE session_id = ?
+              AND NOT EXISTS (
+                SELECT 1 FROM ${TABLE_HARNESS_ATTACHMENT_REFERENCES} refs
+                WHERE refs.session_id = ${TABLE_HARNESS_ATTACHMENTS}.session_id
+                  AND refs.attachment_id = ${TABLE_HARNESS_ATTACHMENTS}.attachment_id
+              )`,
       args: [sessionId],
     });
   }
@@ -392,6 +504,47 @@ export class HarnessLibSQL extends HarnessStorage {
       source: toAttachmentSource(row.source),
       createdAt: Number(row.created_at),
     };
+  }
+
+  async recordAttachmentReferences(references: SaveAttachmentReferenceInput[]): Promise<void> {
+    const createdAt = Date.now();
+    for (const ref of references) {
+      await this.#client.execute({
+        sql: `INSERT INTO ${TABLE_HARNESS_ATTACHMENT_REFERENCES}
+              (session_id, attachment_id, source, source_id, retained_until, created_at)
+              VALUES (?, ?, ?, ?, ?, ?)
+              ON CONFLICT(session_id, attachment_id, source, source_id) DO UPDATE SET
+                retained_until = excluded.retained_until`,
+        args: [ref.sessionId, ref.attachmentId, ref.source, ref.sourceId, ref.retainedUntil ?? null, createdAt],
+      });
+    }
+  }
+
+  async deleteAttachmentReferences(references: SaveAttachmentReferenceInput[]): Promise<void> {
+    for (const ref of references) {
+      await this.#client.execute({
+        sql: `DELETE FROM ${TABLE_HARNESS_ATTACHMENT_REFERENCES}
+              WHERE session_id = ? AND attachment_id = ? AND source = ? AND source_id = ?`,
+        args: [ref.sessionId, ref.attachmentId, ref.source, ref.sourceId],
+      });
+    }
+  }
+
+  async listAttachmentReferences({
+    sessionId,
+    attachmentId,
+  }: {
+    sessionId: string;
+    attachmentId: string;
+  }): Promise<AttachmentReference[]> {
+    const result = await this.#client.execute({
+      sql: `SELECT source, source_id, retained_until
+            FROM ${TABLE_HARNESS_ATTACHMENT_REFERENCES}
+            WHERE session_id = ? AND attachment_id = ?
+            ORDER BY source ASC, source_id ASC`,
+      args: [sessionId, attachmentId],
+    });
+    return result.rows.map(rowToAttachmentReference);
   }
 
   async #backfillAttachmentMetadata(): Promise<void> {
@@ -570,4 +723,27 @@ function toAttachmentSource(value: unknown): AttachmentRecord['source'] {
     return value;
   }
   return 'preupload';
+}
+
+function rowToAttachmentReference(row: Record<string, unknown>): AttachmentReference {
+  return {
+    source: toAttachmentReferenceSource(row.source),
+    sourceId: String(row.source_id),
+    ...(row.retained_until == null ? {} : { retainedUntil: Number(row.retained_until) }),
+  };
+}
+
+function toAttachmentReferenceSource(value: unknown): AttachmentReference['source'] {
+  if (
+    value === 'queued_item' ||
+    value === 'queue_receipt' ||
+    value === 'current_run' ||
+    value === 'message_history' ||
+    value === 'channel_inbox' ||
+    value === 'wakeup' ||
+    value === 'outbox'
+  ) {
+    return value;
+  }
+  return 'queued_item';
 }


### PR DESCRIPTION
## Summary
- add durable harness attachment reference storage and table metadata
- register queued attachment references atomically with queue admission
- guard attachment deletes while references remain and validate queued attachment bytes/digests before drain
- keep referenced session attachments during session attachment cleanup until lifecycle force cleanup lands

## Scope
This implements the local queued-item slice for PF-347. It intentionally does not implement message-history clone promotion, server/channel/wakeup references, URL ingestion, or model file-part dispatch; those remain in later Harness roadmap lanes.

## Verification
- pnpm --filter @mastra/core test src/harness/v1/attachments.test.ts
- pnpm --filter @mastra/libsql test src/storage/domains/harness/index.test.ts
- pnpm --filter @mastra/libsql test src/storage/index.test.ts
- pnpm --filter @mastra/core typecheck
- pnpm --filter @mastra/core build:lib
- pnpm --filter @mastra/libsql build:lib
- pnpm prettier --check packages/core/src/harness/v1/attachments.test.ts packages/core/src/harness/v1/errors.ts packages/core/src/harness/v1/harness.ts packages/core/src/harness/v1/session.ts packages/core/src/storage/constants.ts packages/core/src/storage/domains/harness/base.ts packages/core/src/storage/domains/harness/inmemory.ts packages/core/src/storage/domains/harness/types.ts packages/core/src/storage/domains/inmemory-db.ts packages/core/src/storage/domains/operations/inmemory.ts stores/_test-utils/src/domains/harness/index.ts stores/libsql/src/storage/domains/harness/index.ts
- git diff --check

Linear: PF-347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you have files (attachments) stored in a system, and multiple tasks queue up to use those files. This PR adds a protection system to make sure: (1) you can't delete a file while some task is still waiting to use it, and (2) before running a queued task, the system double-checks that the file still exists and hasn't been secretly modified since the task was added to the queue.

---

## Changes Overview

This PR implements durable attachment reference tracking for the Harness v1 queue system. It adds the ability to record which queued items, runs, or messages reference which attachments, validates attachment availability before queue execution, and prevents deletion of attachments while they have active references.

### Core Storage Layer

**New table and schema** (`packages/core/src/storage/constants.ts`):
- Added `mastra_harness_attachment_references` table to track attachment-to-session references
- Composite primary key spanning `session_id`, `attachment_id`, `source`, and `source_id`

**Storage domain API** (`packages/core/src/storage/domains/harness/base.ts`):
- Added `HarnessStorageAttachmentInUseError` and `HarnessStorageAttachmentUnavailableError` for attachment lifecycle failures
- New abstract methods: `saveSessionWithAttachmentReferences()` for atomic session + reference writes, `recordAttachmentReferences()`, `deleteAttachmentReferences()`, and `listAttachmentReferences()`
- Updated attachment deletion to document that it may reject if references exist

**Reference types** (`packages/core/src/storage/domains/harness/types.ts`):
- Added `AttachmentReferenceSource` union type for reference origins (e.g., `queued_item`, `queue_receipt`, `current_run`)
- Added `AttachmentReference` and `SaveAttachmentReferenceInput` interfaces to structure reference metadata

### In-Memory Implementation

**In-memory storage** (`packages/core/src/storage/domains/harness/inmemory.ts`):
- Implemented `saveSessionWithAttachmentReferences()` with lease/version ownership validation
- Updated `deleteAttachment()` to reject when references exist, throwing `HarnessAttachmentInUseError`
- Updated `deleteAttachmentsForSession()` to skip deleting referenced attachments
- Added reference management methods (`recordAttachmentReferences`, `deleteAttachmentReferences`, `listAttachmentReferences`)
- Updated cleanup to clear attachment references

**In-memory database** (`packages/core/src/storage/domains/inmemory-db.ts`):
- Added `harnessAttachmentReferences` map for tracking references

**In-memory operations** (`packages/core/src/storage/domains/operations/inmemory.ts`):
- Initialized `mastra_harness_attachment_references` table

### LibSQL Implementation

**LibSQL storage** (`stores/libsql/src/storage/domains/harness/index.ts`):
- Implemented `saveSessionWithAttachmentReferences()` with optimistic CAS update, followed by upsert of reference rows
- Updated `deleteAttachment()` to check references table and throw `HarnessAttachmentInUseError` if references exist
- Implemented `recordAttachmentReferences()`, `deleteAttachmentReferences()`, and `listAttachmentReferences()` with proper SQL ordering
- Added helper functions for reference row mapping and source type conversion

### Harness Runtime

**Public API layer** (`packages/core/src/harness/v1/errors.ts`):
- Added `HarnessAttachmentInUseError` for user-facing attachment-in-use failures
- Added `HarnessAttachmentUnavailableReason` and `HarnessAttachmentUnavailableError` with structured reason codes (`not_found`, `digest_mismatch`, `bytes_mismatch`)

**Harness wrapper** (`packages/core/src/harness/v1/harness.ts`):
- Updated `attachments.delete()` to catch storage "in use" errors and rethrow as `HarnessAttachmentInUseError` with session/attachment context

**Session runtime** (`packages/core/src/harness/v1/session.ts`):
- Queue admission now resolves attachment references into persisted data and atomically saves session with references via `saveSessionWithAttachmentReferences()`
- Remaps storage "attachment unavailable" errors to `HarnessAttachmentUnavailableError`
- Queue execution validates that queued attachment references still exist and match stored sha256/byte counts before running the turn via new `_validateQueuedAttachmentRefs()` step
- Gracefully handles validation failures with typed error detection

### Conformance Tests

**Core tests** (`packages/core/src/harness/v1/attachments.test.ts`):
- Added test for preventing attachment deletion when referenced by queued items
- Added tests for queue admission validation (cross-session references, metadata mismatches)
- Added test for digest mismatch detection during queue drain
- Added test ensuring attachment references aren't recorded for rejected queue items

**Storage conformance** (`stores/_test-utils/src/domains/harness/index.ts`):
- Added conformance test for `listAttachmentReferences()` behavior
- Updated `deleteAttachmentsForSession` test to verify referenced attachments are preserved

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/80)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->