### PR TITLE
[PF-348] Register harness questions durably

### DIFF
--- a/packages/core/src/harness/v1/session.suspend.test.ts
+++ b/packages/core/src/harness/v1/session.suspend.test.ts
@@ -210,6 +210,7 @@ describe('Session — suspend capture on message()', () => {
 
     const pending = session.getRecord().pendingResume!;
     expect(pending.kind).toBe('question');
+    expect(pending.itemId).toBe('question:tc-3');
     expect(pending.payload).toEqual({
       question: 'pick a color',
       options: [{ label: 'red' }, { label: 'blue' }],
@@ -252,6 +253,38 @@ describe('Session — suspend capture on message()', () => {
     await session.message({ content: 'hi' });
 
     expect(session.getRecord().pendingResume).toBeUndefined();
+  });
+
+  it('keeps a question registered by the tool before suspend capture', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await (session as any)._registerQuestion({
+      questionId: 'tc-registered',
+      question: 'registered prompt',
+      options: [{ label: 'yes' }],
+      selectionMode: 'single_select',
+      runId: 'run-registered',
+      toolCallId: 'tc-registered',
+    });
+    await (session as any)._maybeCaptureSuspend({
+      runId: 'run-registered',
+      finishReason: 'suspended',
+      suspendPayload: {
+        toolCallId: 'tc-registered',
+        toolName: 'ask_user',
+        args: { question: 'stale prompt' },
+      },
+    });
+
+    const pending = session.getRecord().pendingResume!;
+    expect(pending.kind).toBe('question');
+    expect(pending.itemId).toBe('tc-registered');
+    expect(pending.payload).toEqual({
+      question: 'registered prompt',
+      options: [{ label: 'yes' }],
+      selectionMode: 'single_select',
+    });
   });
 });
 

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -97,6 +97,7 @@ import type {
   ModelAuthStatus,
   PermissionPolicy,
   QueueOptions,
+  RegisterQuestionParams,
   SessionInjectSystemReminderOptions,
   SessionInjectSystemReminderResult,
   SessionSignalOptions,
@@ -1920,8 +1921,18 @@ export class Session {
     if (!payload || !full.runId) return;
 
     const kind = this._classifyResumeKind(payload);
+    const existing = this._record.pendingResume;
+    if (
+      existing &&
+      existing.kind === kind &&
+      existing.runId === full.runId &&
+      existing.toolCallId === payload.toolCallId
+    ) {
+      return;
+    }
     const pending: PendingResume = {
       kind,
+      itemId: `${kind}:${payload.toolCallId}`,
       runId: full.runId,
       toolCallId: payload.toolCallId,
       toolName: payload.toolName,
@@ -3332,6 +3343,64 @@ export class Session {
     }
   }
 
+  private async _registerQuestion(
+    params: RegisterQuestionParams & { runId?: string; toolCallId?: string },
+  ): Promise<void> {
+    this._assertLive('ctx.registerQuestion');
+    if (typeof params.questionId !== 'string' || params.questionId.length === 0) {
+      throw new HarnessValidationError('ctx.registerQuestion.questionId', 'must be a non-empty string');
+    }
+    if (typeof params.question !== 'string' || params.question.length === 0) {
+      throw new HarnessValidationError('ctx.registerQuestion.question', 'must be a non-empty string');
+    }
+    if (
+      params.selectionMode !== undefined &&
+      params.selectionMode !== 'single_select' &&
+      params.selectionMode !== 'multi_select'
+    ) {
+      throw new HarnessValidationError('ctx.registerQuestion.selectionMode', 'must be single_select or multi_select');
+    }
+    const runId = params.runId ?? this._currentRunId;
+    const toolCallId = params.toolCallId ?? params.questionId;
+    if (!runId) {
+      throw new HarnessValidationError('ctx.registerQuestion.runId', 'active run id is required');
+    }
+    const pending: PendingResume = {
+      kind: 'question',
+      itemId: params.questionId,
+      runId,
+      toolCallId,
+      toolName: ASK_USER_TOOL_NAME,
+      source: (this._record.subagentDepth ?? 0) > 0 ? 'subagent' : 'parent',
+      requestedAt: Date.now(),
+      payload: {
+        question: params.question,
+        ...(params.options ? { options: params.options } : {}),
+        ...(params.selectionMode ? { selectionMode: params.selectionMode } : {}),
+      },
+    };
+    let registered = false;
+    await this._flushUpdate(prev => {
+      const current = prev.pendingResume;
+      if (current) {
+        if (current.kind === 'question' && current.runId === runId && current.toolCallId === toolCallId) {
+          return prev;
+        }
+        throw new HarnessValidationError('ctx.registerQuestion', `pending resume is already "${current.kind}"`);
+      }
+      registered = true;
+      return { ...prev, pendingResume: pending };
+    });
+    if (!registered) return;
+    this._emitTurnEvent({
+      type: 'suspension_required',
+      kind: 'question',
+      toolCallId,
+      toolName: ASK_USER_TOOL_NAME,
+      runId,
+    });
+  }
+
   /**
    * Settle a queued item's resolver with success and remove it from the
    * head of `pendingQueue`. The CAS write here is the durable record that
@@ -3484,9 +3553,7 @@ export class Session {
         return session.setState(updatesOrUpdater as Partial<unknown>);
       }) as HarnessRequestContext<unknown>['setState'],
       abortSignal: turn.abortSignal,
-      registerQuestion: () => {
-        throw new HarnessConfigError('ctx.registerQuestion', 'not implemented in this milestone');
-      },
+      registerQuestion: params => session._registerQuestion(params),
       registerPlanApproval: () => {
         throw new HarnessConfigError('ctx.registerPlanApproval', 'not implemented in this milestone');
       },

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -1057,7 +1057,7 @@ export interface HarnessRequestContext<TState = unknown> {
   abortSignal: AbortSignal;
 
   /** Register a pending question (used by `ask_user` and custom suspending tools). */
-  registerQuestion: (params: RegisterQuestionParams) => void;
+  registerQuestion: (params: RegisterQuestionParams) => Promise<void>;
   /** Register a pending plan approval (used by `submit_plan` and custom suspending tools). */
   registerPlanApproval: (params: RegisterPlanApprovalParams) => void;
 

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -6,6 +6,7 @@ import { createBackgroundTask } from '../../../background-tasks/create';
 import { resolveBackgroundConfig } from '../../../background-tasks/resolve-config';
 import type { BackgroundTaskProgressChunk, ToolBackgroundConfig } from '../../../background-tasks/types';
 import type { MastraDBMessage } from '../../../memory';
+import { RequestContext } from '../../../request-context';
 import { toStandardSchema, standardSchemaToJSONSchema } from '../../../schema';
 import { safeEnqueue } from '../../../stream/base';
 import { ChunkFrom } from '../../../stream/types';
@@ -44,6 +45,32 @@ type AddToolMetadataOptions = {
       suspendPayload: unknown;
     }
 );
+
+type HarnessToolContextSlot = {
+  registerQuestion?: (params: Record<string, unknown>) => Promise<void>;
+};
+
+function buildToolRequestContext(
+  requestContext: RequestContext,
+  opts: { runId: string; toolCallId: string },
+): RequestContext {
+  const harness = requestContext.get('harness') as HarnessToolContextSlot | undefined;
+  if (!harness?.registerQuestion) return requestContext;
+
+  const overlay = new RequestContext<unknown>(
+    Array.from(requestContext.entries() as IterableIterator<[string, unknown]>),
+  );
+  overlay.set('harness', {
+    ...harness,
+    registerQuestion: async (params: Record<string, unknown>) =>
+      harness.registerQuestion!({
+        ...params,
+        runId: typeof params.runId === 'string' ? params.runId : opts.runId,
+        toolCallId: typeof params.toolCallId === 'string' ? params.toolCallId : opts.toolCallId,
+      }),
+  });
+  return overlay;
+}
 
 export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = undefined>({
   tools,
@@ -527,9 +554,14 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
           Object.keys(resumeData).length === 1 &&
           'approved' in resumeData;
         const resumeDataToPassToToolOptions = shouldStripApprovalResumeData ? undefined : resumeData;
+        const toolRequestContext = buildToolRequestContext(requestContext, {
+          runId,
+          toolCallId: inputData.toolCallId,
+        });
 
         const toolOptions: MastraToolInvocationOptions = {
           abortSignal: options?.abortSignal,
+          runId,
           toolCallId: inputData.toolCallId,
           // Pass all messages (input + response + memory) so sub-agents (agent-* tools) receive
           // the full conversation context and can make better decisions. Each sub-agent invocation
@@ -541,7 +573,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
           // Pass workspace from _internal (set by llmExecutionStep via prepareStep/processInputStep)
           workspace: _internal?.stepWorkspace,
           // Forward requestContext so tools receive values set by the workflow step
-          requestContext,
+          requestContext: toolRequestContext,
           // Let tools that read thread history mid-stream (e.g. forked subagents
           // cloning the parent thread) drain the save queue so the store reflects
           // the latest user/assistant messages before they read.

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -107,6 +107,8 @@ export interface QueuedItem {
  */
 export interface PendingResume {
   kind: 'tool-approval' | 'tool-suspension' | 'question' | 'plan-approval';
+  /** Stable pending interaction id used by inbox/route callers. */
+  itemId?: string;
   runId: string;
   toolCallId: string;
   /** Populated for tool-approval / tool-suspension; omitted otherwise. */

--- a/packages/core/src/tools/builtin/__tests__/ask-user.test.ts
+++ b/packages/core/src/tools/builtin/__tests__/ask-user.test.ts
@@ -63,6 +63,50 @@ describe('askUser tool (standalone)', () => {
     expect(suspendPayload).toEqual({});
   });
 
+  it('registers a Harness question before suspending when the harness slot is present', async () => {
+    const requestContext = new RequestContext();
+    const registrations: unknown[] = [];
+    requestContext.set('harness', {
+      registerQuestion: async (params: unknown) => {
+        registrations.push(params);
+      },
+    });
+
+    await expect(
+      askUser.execute!(
+        { question: 'Pick one', options: [{ label: 'a' }], selectionMode: 'single_select' },
+        {
+          ...makeAgentCtx({
+            suspend: async () => {
+              throw new Error('SUSPEND_MARKER');
+            },
+          }),
+          requestContext,
+          agent: {
+            agentId: 'test-agent',
+            runId: 'run-1',
+            toolCallId: 'call-1',
+            messages: [],
+            suspend: async () => {
+              throw new Error('SUSPEND_MARKER');
+            },
+          },
+        },
+      ),
+    ).rejects.toThrow('SUSPEND_MARKER');
+
+    expect(registrations).toEqual([
+      {
+        questionId: 'call-1',
+        question: 'Pick one',
+        options: [{ label: 'a' }],
+        selectionMode: 'single_select',
+        runId: 'run-1',
+        toolCallId: 'call-1',
+      },
+    ]);
+  });
+
   it('returns resumeData when present (acts as identity on second pass)', async () => {
     const result = await askUser.execute!(
       { question: 'Pick one', options: [{ label: 'a' }, { label: 'b' }], selectionMode: 'single_select' },

--- a/packages/core/src/tools/builtin/ask-user.ts
+++ b/packages/core/src/tools/builtin/ask-user.ts
@@ -39,11 +39,35 @@ export const askUser = createTool({
   suspendSchema: z.object({}),
   resumeSchema,
   execute: async (_input, ctx) => {
+    const input = _input as z.infer<typeof inputSchema>;
     const resumeData = ctx.agent?.resumeData as z.infer<typeof resumeSchema> | undefined;
     if (resumeData !== undefined) return resumeData;
 
     if (!ctx.agent?.suspend) {
       throw new Error(`${ASK_USER_TOOL_ID} requires an agent execution context with suspend support.`);
+    }
+
+    const harness = ctx.requestContext?.get('harness') as
+      | {
+          registerQuestion?: (params: {
+            questionId: string;
+            question: string;
+            options?: Array<{ label: string; description?: string }>;
+            selectionMode?: 'single_select' | 'multi_select';
+            runId?: string;
+            toolCallId?: string;
+          }) => Promise<void>;
+        }
+      | undefined;
+    if (harness?.registerQuestion && ctx.agent.runId) {
+      await harness.registerQuestion({
+        questionId: ctx.agent.toolCallId,
+        question: input.question,
+        ...(input.options ? { options: input.options } : {}),
+        ...(input.selectionMode ? { selectionMode: input.selectionMode } : {}),
+        runId: ctx.agent.runId,
+        toolCallId: ctx.agent.toolCallId,
+      });
     }
 
     await ctx.agent.suspend({});

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -448,11 +448,12 @@ export class CoreToolBuilder extends MastraBase {
             // Nest agent-specific properties under 'agent' key
             // Do NOT include workflow context even if workflow properties exist
             // (agents use workflows internally but tools should see agent context)
-            const { suspend, resumeData, threadId, resourceId, ...restBaseContext } = baseContext;
+            const { suspend, resumeData, runId, threadId, resourceId, ...restBaseContext } = baseContext;
             toolContext = {
               ...restBaseContext,
               agent: {
                 agentId: options.agentId || '',
+                runId,
                 toolCallId: execOptions.toolCallId || '',
                 messages: execOptions.messages || [],
                 suspend,

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -330,6 +330,7 @@ export class Tool<
             // Reorganize agent context - nest agent-specific properties under 'agent' key
             const {
               agentId,
+              runId,
               toolCallId,
               messages,
               suspend,
@@ -343,6 +344,7 @@ export class Tool<
               ...rest,
               agent: {
                 agentId: agentId || '',
+                runId,
                 toolCallId,
                 messages,
                 suspend,

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -86,6 +86,7 @@ export type ToolPayloadTransformPolicy = {
 export interface AgentToolExecutionContext<TSuspend, TResume> {
   // Always present when called from agent context
   agentId: string;
+  runId?: string;
   toolCallId: string;
   messages: any[];
   suspend: (suspendPayload: TSuspend, suspendOptions?: SuspendOptions) => Promise<void>;
@@ -144,6 +145,7 @@ export interface MCPToolExecutionContext {
 export type MastraToolInvocationOptions = ToolInvocationOptions &
   Partial<ObservabilityContext> & {
     suspend?: (suspendPayload: any, suspendOptions?: SuspendOptions) => Promise<any>;
+    runId?: string;
     resumeData?: any;
     outputWriter?: OutputWriter;
     /**


### PR DESCRIPTION
## Summary
- make Harness v1 question registration async and durable instead of throwing from the harness request-context slot
- wrap per-tool request contexts so harness question registration gets the active runId/toolCallId without exposing those fields on public RegisterQuestionParams
- have the built-in ask_user tool register its question before legacy suspend, and prevent suspend-capture from clobbering an already registered question
- add pendingResume.itemId for inbox/route callers and focused tests for registration/capture behavior

## Scope note
This PR intentionally does not implement the full durable InboxResponseReceipt / responseId / resumeAttemptId boundary. Council/source review showed the current agent/server support contract is not present yet, so adding those fields here would overclaim idempotency. That remains follow-up work for the receipt/server boundary lane.

## Verification
- pnpm --filter @internal/test-utils... build
- pnpm --filter @internal/ai-sdk-v4 --filter @internal/ai-sdk-v5 --filter @internal/ai-v6 build
- pnpm --filter @mastra/schema-compat build
- pnpm --filter @mastra/core test src/tools/builtin/__tests__/ask-user.test.ts src/harness/v1/session.suspend.test.ts
- pnpm --filter @mastra/core typecheck
- pnpm --filter @mastra/core build:lib
- pnpm prettier --check packages/core/src/harness/v1/session.suspend.test.ts packages/core/src/harness/v1/session.ts packages/core/src/harness/v1/types.ts packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts packages/core/src/storage/domains/harness/types.ts packages/core/src/tools/builtin/__tests__/ask-user.test.ts packages/core/src/tools/builtin/ask-user.ts packages/core/src/tools/tool-builder/builder.ts packages/core/src/tools/tool.ts packages/core/src/tools/types.ts
- git diff --check

Linear: PF-348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When an AI agent asks a user a question and then pauses to wait for the answer, this PR makes sure that question gets saved properly and durably—instead of throwing an error. It prevents the same question from being saved twice, and makes sure the pause handler knows which question is pending.

---

## Detailed Changes

### Core Functionality: Durable Question Registration

**packages/core/src/harness/v1/session.ts**
- Introduced `_registerQuestion(...)` private helper that validates question registration, derives `runId`/`toolCallId` from context, and persistently stores a `PendingResume` of `kind: 'question'`
- Wired `ctx.registerQuestion` in per-turn `RequestContext` to delegate to `session._registerQuestion` instead of throwing a "not implemented" error
- Updated `_maybeCaptureSuspend` to be idempotent: if an existing `pendingResume` matches the newly classified suspension details, it returns without re-writing storage or duplicate events
- Lines changed: +70/-3

**packages/core/src/harness/v1/types.ts**
- Made `registerQuestion` callback asynchronous: changed from `void` to `Promise<void>` in `HarnessRequestContext`
- Lines changed: +1/-1

### Built-in ask_user Tool Integration

**packages/core/src/tools/builtin/ask-user.ts**
- Enhanced `execute` implementation to detect a Harness in `ctx.requestContext` and call `harness.registerQuestion` with question text, options, `selectionMode`, `runId`, and `toolCallId` before suspending
- Tool continues to suspend normally and resume via existing mechanisms
- Lines changed: +24/-0

### Request Context Wrapping

**packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts**
- Introduced `buildToolRequestContext` helper that overlays harness-specific behavior on the workflow's `requestContext`
- When `harness.registerQuestion` is present, the helper wraps it to auto-fill `runId`/`toolCallId` from the current tool invocation options
- Tool invocation now uses this constructed context instead of the original one
- Lines changed: +33/-1

### Context and Type Updates

**packages/core/src/tools/types.ts**
- `AgentToolExecutionContext` now includes optional `runId?: string`
- `MastraToolInvocationOptions` now exposes optional `runId?: string`
- Lines changed: +2/-0

**packages/core/src/tools/tool.ts**
- Updated tool execute wrapper to include `runId` in `organizedContext.agent` for agent execution contexts
- Lines changed: +2/-0

**packages/core/src/tools/tool-builder/builder.ts**
- Extracts `runId` from `baseContext` and nests it under `agent` key in `toolContext` for agent execution branch
- Lines changed: +2/-1

**packages/core/src/storage/domains/harness/types.ts**
- Added optional `itemId?: string` field to `PendingResume` for inbox/route callers to track stable pending interaction identifiers
- Lines changed: +2/-0

### Testing

**packages/core/src/tools/builtin/__tests__/ask-user.test.ts**
- Added test verifying that `askUser` registers a Harness question with proper question metadata before suspending
- Lines changed: +44/-0

**packages/core/src/harness/v1/session.suspend.test.ts**
- Enhanced existing v1 session suspend/resume coverage: verifies `pendingResume.itemId` is set to `question:<toolCallId>` when a suspended chunk is produced by `ask_user`
- Added regression test ensuring `_maybeCaptureSuspend` does not overwrite an already-registered question; retains the original question's prompt/options and sets `pendingResume` to the expected `question` kind
- Lines changed: +33/-0

---

## Scope & Notes

This PR does not implement the full durable InboxResponseReceipt / responseId / resumeAttemptId boundary. The agent/server support contract for that boundary is not yet present; implementing those fields here would overclaim idempotency and is deferred to follow-up work.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/81)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->