### PR TITLE
[PF-349] Register harness plan approvals

### DIFF
--- a/packages/core/src/harness/v1/session.suspend.test.ts
+++ b/packages/core/src/harness/v1/session.suspend.test.ts
@@ -240,6 +240,7 @@ describe('Session — suspend capture on message()', () => {
 
     const pending = session.getRecord().pendingResume!;
     expect(pending.kind).toBe('plan-approval');
+    expect(pending.itemId).toBe('plan-approval:tc-4');
     expect(pending.payload).toEqual({ title: 'Refactor X', plan: 'do A then B' });
     expect(pending.transitionModeId).toBe('builder');
     expect(session.getDisplayState().pending?.kind).toBe('plan-approval');
@@ -285,6 +286,39 @@ describe('Session — suspend capture on message()', () => {
       options: [{ label: 'yes' }],
       selectionMode: 'single_select',
     });
+  });
+
+  it('keeps a plan approval registered by the tool before suspend capture', async () => {
+    const { harness } = setup([
+      { id: 'planner', agentId: 'default', transitionsTo: 'builder' },
+      { id: 'builder', agentId: 'default' },
+    ]);
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.switchMode({ mode: 'planner' });
+
+    await (session as any)._registerPlanApproval({
+      planId: 'tc-plan',
+      title: 'registered title',
+      plan: 'registered plan',
+      runId: 'run-plan',
+      toolCallId: 'tc-plan',
+      modeId: 'planner',
+    });
+    await (session as any)._maybeCaptureSuspend({
+      runId: 'run-plan',
+      finishReason: 'suspended',
+      suspendPayload: {
+        toolCallId: 'tc-plan',
+        toolName: 'submit_plan',
+        args: { title: 'stale title', plan: 'stale plan' },
+      },
+    });
+
+    const pending = session.getRecord().pendingResume!;
+    expect(pending.kind).toBe('plan-approval');
+    expect(pending.itemId).toBe('tc-plan');
+    expect(pending.payload).toEqual({ title: 'registered title', plan: 'registered plan' });
+    expect(pending.transitionModeId).toBe('builder');
   });
 });
 

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -97,6 +97,7 @@ import type {
   ModelAuthStatus,
   PermissionPolicy,
   QueueOptions,
+  RegisterPlanApprovalParams,
   RegisterQuestionParams,
   SessionInjectSystemReminderOptions,
   SessionInjectSystemReminderResult,
@@ -3401,6 +3402,62 @@ export class Session {
     });
   }
 
+  private async _registerPlanApproval(
+    params: RegisterPlanApprovalParams & { runId?: string; toolCallId?: string; modeId?: string },
+  ): Promise<void> {
+    this._assertLive('ctx.registerPlanApproval');
+    if (typeof params.planId !== 'string' || params.planId.length === 0) {
+      throw new HarnessValidationError('ctx.registerPlanApproval.planId', 'must be a non-empty string');
+    }
+    if (params.title !== undefined && typeof params.title !== 'string') {
+      throw new HarnessValidationError('ctx.registerPlanApproval.title', 'must be a string when provided');
+    }
+    if (typeof params.plan !== 'string' || params.plan.length === 0) {
+      throw new HarnessValidationError('ctx.registerPlanApproval.plan', 'must be a non-empty string');
+    }
+    const runId = params.runId ?? this._currentRunId;
+    const toolCallId = params.toolCallId ?? params.planId;
+    if (!runId) {
+      throw new HarnessValidationError('ctx.registerPlanApproval.runId', 'active run id is required');
+    }
+    const submittingModeId = params.modeId ?? this._record.modeId;
+    const submittingMode = this._harness._getMode(submittingModeId);
+    const pending: PendingResume = {
+      kind: 'plan-approval',
+      itemId: params.planId,
+      runId,
+      toolCallId,
+      toolName: SUBMIT_PLAN_TOOL_NAME,
+      source: (this._record.subagentDepth ?? 0) > 0 ? 'subagent' : 'parent',
+      requestedAt: Date.now(),
+      payload: {
+        ...(params.title !== undefined ? { title: params.title } : {}),
+        plan: params.plan,
+      },
+      ...(submittingMode.transitionsTo ? { transitionModeId: submittingMode.transitionsTo } : {}),
+    };
+    let registered = false;
+    await this._flushUpdate(prev => {
+      const current = prev.pendingResume;
+      if (current) {
+        if (current.kind === 'plan-approval' && current.runId === runId && current.toolCallId === toolCallId) {
+          return prev;
+        }
+        throw new HarnessValidationError('ctx.registerPlanApproval', `pending resume is already "${current.kind}"`);
+      }
+      registered = true;
+      return { ...prev, pendingResume: pending };
+    });
+    if (!registered) return;
+    this._emitTurnEvent({
+      type: 'suspension_required',
+      kind: 'plan-approval',
+      toolCallId,
+      toolName: SUBMIT_PLAN_TOOL_NAME,
+      runId,
+    });
+  }
+
   /**
    * Settle a queued item's resolver with success and remove it from the
    * head of `pendingQueue`. The CAS write here is the durable record that
@@ -3554,9 +3611,7 @@ export class Session {
       }) as HarnessRequestContext<unknown>['setState'],
       abortSignal: turn.abortSignal,
       registerQuestion: params => session._registerQuestion(params),
-      registerPlanApproval: () => {
-        throw new HarnessConfigError('ctx.registerPlanApproval', 'not implemented in this milestone');
-      },
+      registerPlanApproval: params => session._registerPlanApproval({ ...params, modeId: turn.modeId }),
       // Subagent linkage — set from the record so spawned sessions report
       // their depth + parent linkage on the harness slot.
       subagentDepth: this._record.subagentDepth ?? 0,

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -1021,7 +1021,7 @@ export interface RegisterQuestionParams {
 /** Parameters accepted by `ctx.registerPlanApproval(...)` from a suspending tool. */
 export interface RegisterPlanApprovalParams {
   planId: string;
-  title: string;
+  title?: string;
   plan: string;
 }
 
@@ -1059,7 +1059,7 @@ export interface HarnessRequestContext<TState = unknown> {
   /** Register a pending question (used by `ask_user` and custom suspending tools). */
   registerQuestion: (params: RegisterQuestionParams) => Promise<void>;
   /** Register a pending plan approval (used by `submit_plan` and custom suspending tools). */
-  registerPlanApproval: (params: RegisterPlanApprovalParams) => void;
+  registerPlanApproval: (params: RegisterPlanApprovalParams) => Promise<void>;
 
   /** Depth of the session in the subagent tree. `0` for the parent. */
   subagentDepth: number;

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -48,6 +48,7 @@ type AddToolMetadataOptions = {
 
 type HarnessToolContextSlot = {
   registerQuestion?: (params: Record<string, unknown>) => Promise<void>;
+  registerPlanApproval?: (params: Record<string, unknown>) => Promise<void>;
 };
 
 function buildToolRequestContext(
@@ -55,19 +56,33 @@ function buildToolRequestContext(
   opts: { runId: string; toolCallId: string },
 ): RequestContext {
   const harness = requestContext.get('harness') as HarnessToolContextSlot | undefined;
-  if (!harness?.registerQuestion) return requestContext;
+  if (!harness?.registerQuestion && !harness?.registerPlanApproval) return requestContext;
 
   const overlay = new RequestContext<unknown>(
     Array.from(requestContext.entries() as IterableIterator<[string, unknown]>),
   );
   overlay.set('harness', {
     ...harness,
-    registerQuestion: async (params: Record<string, unknown>) =>
-      harness.registerQuestion!({
-        ...params,
-        runId: typeof params.runId === 'string' ? params.runId : opts.runId,
-        toolCallId: typeof params.toolCallId === 'string' ? params.toolCallId : opts.toolCallId,
-      }),
+    ...(harness.registerQuestion
+      ? {
+          registerQuestion: async (params: Record<string, unknown>) =>
+            harness.registerQuestion!({
+              ...params,
+              runId: typeof params.runId === 'string' ? params.runId : opts.runId,
+              toolCallId: typeof params.toolCallId === 'string' ? params.toolCallId : opts.toolCallId,
+            }),
+        }
+      : {}),
+    ...(harness.registerPlanApproval
+      ? {
+          registerPlanApproval: async (params: Record<string, unknown>) =>
+            harness.registerPlanApproval!({
+              ...params,
+              runId: typeof params.runId === 'string' ? params.runId : opts.runId,
+              toolCallId: typeof params.toolCallId === 'string' ? params.toolCallId : opts.toolCallId,
+            }),
+        }
+      : {}),
   });
   return overlay;
 }

--- a/packages/core/src/tools/builtin/__tests__/submit-plan.test.ts
+++ b/packages/core/src/tools/builtin/__tests__/submit-plan.test.ts
@@ -58,6 +58,49 @@ describe('submitPlan tool (standalone)', () => {
     expect(suspended).toBe(true);
   });
 
+  it('registers a Harness plan approval before suspending when the harness slot is present', async () => {
+    const requestContext = new RequestContext();
+    const registrations: unknown[] = [];
+    requestContext.set('harness', {
+      registerPlanApproval: async (params: unknown) => {
+        registrations.push(params);
+      },
+    });
+
+    await expect(
+      submitPlan.execute!(
+        { title: 'Add darkmode', plan: '# Overview\nSteps...' },
+        {
+          ...makeAgentCtx({
+            suspend: async () => {
+              throw new Error('SUSPEND_MARKER');
+            },
+          }),
+          requestContext,
+          agent: {
+            agentId: 'test-agent',
+            runId: 'run-1',
+            toolCallId: 'call-1',
+            messages: [],
+            suspend: async () => {
+              throw new Error('SUSPEND_MARKER');
+            },
+          },
+        },
+      ),
+    ).rejects.toThrow('SUSPEND_MARKER');
+
+    expect(registrations).toEqual([
+      {
+        planId: 'call-1',
+        title: 'Add darkmode',
+        plan: '# Overview\nSteps...',
+        runId: 'run-1',
+        toolCallId: 'call-1',
+      },
+    ]);
+  });
+
   it('returns the resume payload on second pass (approval path)', async () => {
     const result = await submitPlan.execute!({ plan: '...' }, makeAgentCtx({ resumeData: { approved: true } }));
     expect(result).toEqual({ approved: true });

--- a/packages/core/src/tools/builtin/submit-plan.ts
+++ b/packages/core/src/tools/builtin/submit-plan.ts
@@ -41,11 +41,33 @@ export const submitPlan = createTool({
   suspendSchema: z.object({}),
   resumeSchema,
   execute: async (_input, ctx) => {
+    const input = _input as z.infer<typeof inputSchema>;
     const resumeData = ctx.agent?.resumeData as z.infer<typeof resumeSchema> | undefined;
     if (resumeData !== undefined) return resumeData;
 
     if (!ctx.agent?.suspend) {
       throw new Error(`${SUBMIT_PLAN_TOOL_ID} requires an agent execution context with suspend support.`);
+    }
+
+    const harness = ctx.requestContext?.get('harness') as
+      | {
+          registerPlanApproval?: (params: {
+            planId: string;
+            title?: string;
+            plan: string;
+            runId?: string;
+            toolCallId?: string;
+          }) => Promise<void>;
+        }
+      | undefined;
+    if (harness?.registerPlanApproval && ctx.agent.runId) {
+      await harness.registerPlanApproval({
+        planId: ctx.agent.toolCallId,
+        ...(input.title !== undefined ? { title: input.title } : {}),
+        plan: input.plan,
+        runId: ctx.agent.runId,
+        toolCallId: ctx.agent.toolCallId,
+      });
     }
 
     await ctx.agent.suspend({});


### PR DESCRIPTION
## Summary
- make Harness v1 plan approval registration async and durable instead of throwing from the harness request-context slot
- have the built-in submit_plan tool register its plan approval before legacy suspend
- extend the per-tool request-context overlay so both question and plan registration receive active runId/toolCallId without exposing those fields on public params
- preserve pre-registered plan payloads during suspend capture and freeze the submitting mode transitionsTo target at registration time

## Scope note
This stays scoped to request-context plan approval registration. It does not implement admission/result receipts, server routes, channel actions, or InboxResponseReceipt idempotency.

## Verification
- pnpm install
- pnpm --filter @internal/test-utils... build
- pnpm --filter @internal/ai-sdk-v4 --filter @internal/ai-sdk-v5 --filter @internal/ai-v6 build
- pnpm --filter @mastra/schema-compat build
- pnpm --filter @internal/core build:lib
- pnpm --filter @internal/external-types build:lib
- pnpm --filter @mastra/core test src/tools/builtin/__tests__/submit-plan.test.ts src/harness/v1/session.suspend.test.ts src/harness/v1/session.builtin-tools.test.ts
- pnpm --filter @mastra/core typecheck
- pnpm --filter @mastra/core build:lib
- pnpm prettier --check packages/core/src/harness/v1/session.suspend.test.ts packages/core/src/harness/v1/session.ts packages/core/src/harness/v1/types.ts packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts packages/core/src/tools/builtin/__tests__/submit-plan.test.ts packages/core/src/tools/builtin/submit-plan.ts
- git diff --check

Linear: PF-349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR adds a way for tools to safely ask for approval before doing something important. Instead of just crashing when they need approval, tools can now register a "plan approval request" that the system remembers and keeps track of—even if the tool has to pause and come back later.

---

## Changes Overview

This PR implements asynchronous, durable plan approval registration for Harness v1 sessions, enabling the built-in `submitPlan` tool to register pending approvals before suspending rather than throwing errors.

### Core Implementation

**session.ts** – Implemented `ctx.registerPlanApproval` that:
- Validates `planId`, `title`, and `plan` parameters
- Derives active `runId` and `toolCallId` from the current execution context
- Creates a `PendingResume` record of kind `plan-approval` with optional `transitionModeId`
- Persists to storage with idempotency (no-op if already registered)
- Emits `suspension_required` signal

**types.ts** – API changes:
- Made `RegisterPlanApprovalParams.title` optional (`title?: string`)
- Changed `HarnessRequestContext.registerPlanApproval` return type from `void` to `Promise<void>` (now async)

### Integration Points

**tool-call-step.ts** – Extended `buildToolRequestContext` to:
- Accept optional `registerPlanApproval` harness hook
- Inject normalized `runId` and `toolCallId` into both `registerQuestion` and `registerPlanApproval` wrappers
- Prevent early returns when either hook is present

**submit-plan.ts** – Updated tool to:
- Check for existing `resumeData` and return early if present
- Call `registerPlanApproval` when Harness context is available before suspending
- Pass `planId`, `title`, `plan`, `runId`, and `toolCallId` to registration

### Testing

**session.suspend.test.ts** – Added verification that suspended plan approvals preserve registered data (`kind`, `itemId`, `payload`, `transitionModeId`) rather than stale suspend payloads

**submit-plan.test.ts** – Added test validating `submitPlan` calls `registerPlanApproval` before suspension when Harness context is present

### Technical Details

- Plan approval payloads are frozen at registration time, capturing the submitting mode's `transitionsTo` target
- Registration is idempotent—duplicate attempts are no-ops
- Per-turn `modeId` context is passed to ensure mode-derived transition behavior is correct
- Pre-registered plan payloads survive suspend capture and freeze cycles

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/82)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->