### PR TITLE
[PF-350] Add code-registered Harness skills

### DIFF
--- a/.changeset/pf-350-harness-code-skills.md
+++ b/.changeset/pf-350-harness-code-skills.md
@@ -1,0 +1,36 @@
+---
+'@mastra/core': major
+---
+
+Adds support for defining Harness v1 skills directly in `new Harness({ skills: [...] })`.
+
+Configuration-defined skills are available to every session without requiring workspace setup. They resolve by `name` and take precedence over workspace skills with the same name.
+
+Skill argument validation is stricter. `metadata.args` schemas reject unsupported or malformed fields before dispatch, and supplied args must be JSON-serializable. Supported schema fields are `required`, `properties`, `type`, `enum`, `items`, and boolean `additionalProperties`.
+
+Existing workspace skills that declare unsupported JSON-schema-like fields such as `pattern`, `minimum`, or `minLength` should remove those fields or move that validation into the skill prompt before calling `session.skills.use()`.
+
+```ts
+const harness = new Harness({
+  agents,
+  modes,
+  skills: [
+    {
+      name: 'triage',
+      description: 'Classify a bug report before dispatch',
+      instructions: 'Read the bug report and return a severity and owner.',
+      metadata: {
+        args: {
+          required: ['ticketId'],
+          properties: {
+            ticketId: { type: 'string' },
+          },
+        },
+      },
+    },
+  ],
+});
+
+const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+await session.skills.use('triage', { args: { ticketId: 'PF-350' } });
+```

--- a/.changeset/pf-350-harness-code-skills.md
+++ b/.changeset/pf-350-harness-code-skills.md
@@ -6,9 +6,20 @@ Adds support for defining Harness v1 skills directly in `new Harness({ skills: [
 
 Configuration-defined skills are available to every session without requiring workspace setup. They resolve by `name` and take precedence over workspace skills with the same name.
 
+Configuration-defined skill metadata must contain only primitives, arrays, and plain objects. This prevents returned skill descriptors from sharing mutable class instances with the original Harness config.
+
 Skill argument validation is stricter. `metadata.args` schemas reject unsupported or malformed fields before dispatch, and supplied args must be JSON-serializable. Supported schema fields are `required`, `properties`, `type`, `enum`, `items`, and boolean `additionalProperties`.
 
 Existing workspace skills that declare unsupported JSON-schema-like fields such as `pattern`, `minimum`, or `minLength` should remove those fields or move that validation into the skill prompt before calling `session.skills.use()`.
+
+**Before**
+
+- Workspace skill `metadata.args` could include unsupported schema-like fields and still reach execution.
+
+**After**
+
+- Unsupported or malformed `metadata.args` fields fail before execution with `HarnessSkillArgsValidationError`.
+- Move constraints like `pattern`, `minimum`, and `minLength` into skill instructions or custom runtime validation.
 
 ```ts
 const harness = new Harness({

--- a/harness-spec-brainstorming/sections/04-public-api/06-skills.md
+++ b/harness-spec-brainstorming/sections/04-public-api/06-skills.md
@@ -3,17 +3,19 @@
 A **skill** is a named, parameterised prompt invoked via
 `session.skills.use(ref, opts)`.
 
-**Skills are session-scoped and workspace-sourced in v1.** A skill is
-"available" only when a specific session can resolve its `ref` against the
-session workspace's configured core `WorkspaceSkills` source/resolver (§2.7).
-These are about what your *project* offers (e.g. a repo shipping
-`lint-and-format` or `e2e-tests-studio` checked into source control). A common
-filesystem deployment convention is `.claude/skills/<name>/SKILL.md`, but the
-configured workspace owns the actual paths, source, and discovery mechanics.
-Whether two sessions share the same set depends on the workspace ownership
-model (§2.7): a `shared` workspace gives every session the same workspace
-skills; a `per-resource` workspace partitions them by tenant; a `per-session`
-workspace gives each session its own.
+**Skills are session-scoped in v1.** A skill is "available" only when a
+specific session can resolve its `ref` against the static
+`HarnessConfig.skills` registry or the session workspace's configured core
+`WorkspaceSkills` source/resolver (§2.7). Code-registered skills are about what
+the deployment always offers. Workspace skills are about what the current
+project offers (e.g. a repo shipping `lint-and-format` or `e2e-tests-studio`
+checked into source control). A common filesystem deployment convention is
+`.claude/skills/<name>/SKILL.md`, but the configured workspace owns the actual
+paths, source, and discovery mechanics. Whether two sessions share the same
+workspace skill set depends on the workspace ownership model (§2.7): a
+`shared` workspace gives every session the same workspace skills; a
+`per-resource` workspace partitions them by tenant; a `per-session` workspace
+gives each session its own.
 
 A session is the thing that has both a harness identity and a workspace
 identity, so a session is where the workspace skill source is reachable. The
@@ -21,100 +23,105 @@ harness has no "execute a skill" method — there's no session for it to execute
 against. `session.skills.use(ref)` is the only public caller-facing invocation
 surface. Model-facing skill activation through agent tools is
 implementation/compatibility material (§11), and when a v1 session exposes that
-path for activation it must resolve from the same workspace catalog rather than
-an alternate view.
-
-Code-registered skills (a static `HarnessConfig.skills` registry) are not part
-of v1. The harness has no `harness.skills` surface and no per-deployment skill
-list. Future revisions may layer a code-registered source on top of the
-workspace source; spec callers must not assume one exists today.
+path for activation it must resolve from the same code + workspace catalog
+rather than an alternate view. The harness has no `harness.skills` surface and
+no separate per-deployment skill list; the session surface is the public
+inspection and invocation boundary.
 
 ```ts
 interface HarnessSkill {
-  name: string;                                // Lookup key for `use`
-  description: string;                         // Shown in tool catalogues / UIs
-  instructions: string;                        // The prompt body. May reference args.
-  category?: string;                           // Optional grouping label
-                                               //   surfaced by `list({ category })`.
-  filePath?: string;                           // Optional path-like locator when
-                                               //   the workspace source exposes one.
-  metadata?: Record<string, unknown>;          // Workspace frontmatter passthrough
-                                               //   (e.g. `goal` flag, custom keys).
+  name: string; // Lookup key for `use`
+  description: string; // Shown in tool catalogues / UIs
+  instructions: string; // The prompt body. May reference args.
+  category?: string; // Optional grouping label
+  filePath?: string; // Optional path-like locator when
+  //   the workspace source exposes one.
+  metadata?: Record<string, unknown>; // Static or workspace metadata
+  //   (e.g. `goal` flag, custom keys).
 }
 
 interface UseSkillOptions {
-  args?: Record<string, unknown>;              // Validated against the workspace
-                                               //   skill's declared required args.
-  model?: string;                              // Per-turn model override.
+  args?: Record<string, unknown>; // Validated against the resolved
+  //   skill's declared args schema.
+  modelOverride?: string; // Per-turn model override.
   // Admission idempotency lands in a follow-up slice (§5.2).
 }
 ```
 
+Code-registered skills are supplied directly in this descriptor shape.
 Workspace-discovered skills are projected into this descriptor shape. Current
 core `Skill.source` values such as local, external, or managed content all
 project into the same `HarnessSkill` — v1 does not expose a source discriminator
-because there is only one source. Workspace-only `references`, `scripts`,
+on the session inspection surface. Workspace-only `references`, `scripts`,
 `assets`, license, and compatibility remain owned by the `WorkspaceSkills`
 source/resolver; frontmatter metadata is passed through on the projection so
 callers can filter by author-defined flags (e.g. `metadata.goal === true`).
 
-**Resolution.** When `session.skills.use('triage')` is called, the harness
+**Resolution.** When `session.skills.use('triage')` is called, the harness first
+checks the code-registered `HarnessConfig.skills` registry by `name`. If a code
+skill matches, it wins and the workspace is not consulted. Otherwise the harness
 delegates to the resolved session workspace's configured core `WorkspaceSkills`
-surface. `ref` may be a frontmatter `name:` value or a workspace-relative path
-under the configured skills source — core Workspace owns source, path, glob,
-duplicate-name, and provider-specific discovery semantics. If the ref does not
-resolve, `use` throws `HarnessSkillNotFoundError` with `searchedSources:
-['workspace']`. Sessions with no configured workspace always throw
-`HarnessSkillNotFoundError` from `use`.
+surface. Workspace `ref` values may be a frontmatter `name:` value or a
+workspace-relative path under the configured skills source — core Workspace
+owns source, path, glob, duplicate-name, and provider-specific discovery
+semantics. If a workspace lookup resolves to a skill whose `name` is already
+owned by a code-registered skill, the workspace skill is treated as shadowed and
+does not execute. If the ref does not resolve, `use` throws
+`HarnessSkillNotFoundError` with `searchedSources` containing the catalogues
+that were available for lookup.
 
 **Workspace discovery.**
 
 - Discovery runs asynchronously on the first `session.skills.use`,
-`session.skills.get`, or `session.skills.list` call per in-memory session
-instance, and the discovered catalog is cached for that instance's lifetime by
-default. Files added, removed, or edited in the workspace after that point are
-not visible until the cache is dropped. Concurrent calls during a generation
-build must coalesce on a single-flight shared promise covering workspace
-readiness and workspace skill discovery.
+  `session.skills.get`, or `session.skills.list` call per in-memory session
+  instance that needs the workspace catalog. Code-registered `get` / `use`
+  matches can resolve without materializing the workspace. Once workspace
+  discovery runs, the discovered catalog is cached for that instance's lifetime
+  by default. Files added, removed, or edited in the workspace after that point
+  are not visible until the cache is dropped. Concurrent calls during a
+  generation build must coalesce on a single-flight shared promise covering
+  workspace readiness and workspace skill discovery.
 - Workspace resolution, provider mismatch, resume, loss, or discovery failures
-surface through the relevant workspace error boundary from §2.7 rather than
-degrading to an empty catalog.
+  surface through the relevant workspace error boundary from §2.7 rather than
+  degrading to an empty catalog.
 - The in-session refresh path is `await session.skills.refresh()`. It clears
-the cached workspace-discovery generation; the next `list` / `get` / `use` call
-re-runs workspace discovery through the configured workspace skill source. A
-TUI exposing a "reload skills" command should call this; long-running server
-sessions can call it on a workspace-mutation hook (e.g. after a `git pull` in a
-`shared` workspace, or when the configured skill source reports a change).
+  the cached workspace-discovery generation; the next `list` / `get` / `use` call
+  re-runs workspace discovery through the configured workspace skill source. A
+  TUI exposing a "reload skills" command should call this; long-running server
+  sessions can call it on a workspace-mutation hook (e.g. after a `git pull` in a
+  `shared` workspace, or when the configured skill source reports a change).
 - `refresh` is local-only. Workspace discovery requires server-side access to
-the configured workspace skill source/resolver, so the method is absent from
-`RemoteSession` (§13.5). It invalidates the cache generation; an older
-in-flight discovery result must not repopulate the cache after refresh. A
-remote client that wants the same effect should ask the server for it through a
-product-specific route, or close and re-open the session.
+  the configured workspace skill source/resolver, so the method is absent from
+  `RemoteSession` (§13.5). It invalidates the cache generation; an older
+  in-flight discovery result must not repopulate the cache after refresh. A
+  remote client that wants the same effect should ask the server for it through a
+  product-specific route, or close and re-open the session.
 - When the configured workspace skill source uses filesystem-style `SKILL.md`
-files, the file format mirrors Anthropic's skill spec: a YAML frontmatter block
-with `name` + `description`, followed by a Markdown body containing the
-instructions.
+  files, the file format mirrors Anthropic's skill spec: a YAML frontmatter block
+  with `name` + `description`, followed by a Markdown body containing the
+  instructions.
 - Discovery mechanics such as paths, globs, recursion, duplicate-name
-tie-breaking, staleness checks, and custom sources are owned by the configured
-core `WorkspaceSkills` source/resolver (§2.7), not by a Harness scanner.
-- If the session has no workspace, no skills are available and every `use`
-call throws `HarnessSkillNotFoundError`.
+  tie-breaking, staleness checks, and custom sources are owned by the configured
+  core `WorkspaceSkills` source/resolver (§2.7), not by a Harness scanner.
+- If the session has no workspace, only code-registered skills are available.
+  A non-matching `use` call throws `HarnessSkillNotFoundError`.
 
-**Args validation.** When the resolved workspace skill declares required args
-(via frontmatter or the workspace skill source's declared schema), the harness
-validates `opts.args` covers every required key before dispatch. Missing keys
-throw `HarnessSkillArgsValidationError` with `skillName` and a structured
-`validationError` describing the missing keys.
+**Args validation.** When the resolved skill declares `metadata.args`, the
+harness validates the schema shape and supplied `opts.args` before dispatch.
+The current supported schema fields are `required`, `properties`, `type`,
+`enum`, `items`, and boolean `additionalProperties`. Unsupported or malformed
+schema shapes, missing required keys, type/enum/property failures, non-object
+`opts.args`, non-JSON-serializable args, and non-JSON-serializable enum schema
+values throw `HarnessSkillArgsValidationError` before any turn starts.
 
 **Args injection.** When a skill is invoked with `args`, the harness builds the
 prompt by appending a JSON code block to the skill's `instructions` body (no
 special delimiters). Skill authors should reference the args naturally in their
-Markdown — e.g. *"Use the values in the JSON block below to..."*. When `args`
+Markdown — e.g. _"Use the values in the JSON block below to..."_. When `args`
 is absent or empty, no JSON block is appended.
 
 **Model-facing compatibility.** The v1 `use(...)` operation resolves the skill,
-validates declared required args, injects args, then delegates to the
+validates declared args schema and supplied args, injects args, then delegates to the
 signal-driven `message(...)` path. It does not depend on the model calling a
 skill tool. Existing model-facing skill tools and processors may be kept as
 compatibility surfaces, but activation/catalog behavior that claims to
@@ -125,10 +132,10 @@ file-oriented helpers such as skill search across workspace content or reading
 
 **Inspection — session surface only.**
 
-- **Session surface** — discovery view of workspace-resolved skills. This is
-the "what can this session actually invoke?" answer, and matches what `use`
-will resolve. The first two methods are async because workspace discovery
-requires I/O against the configured skill source.
+- **Session surface** — discovery view of code + workspace-resolved skills. This is
+  the "what can this session actually invoke?" answer, and matches what `use`
+  will resolve. The first two methods are async because workspace discovery
+  requires I/O against the configured skill source.
   - `session.skills.list(): Promise<HarnessSkill[]>`
   - `session.skills.get(name: string): Promise<HarnessSkill | undefined>`
   - `session.skills.refresh(): Promise<void>` — drops the cached discovery

--- a/harness-spec-brainstorming/sections/04-public-api/06-skills.md
+++ b/harness-spec-brainstorming/sections/04-public-api/06-skills.md
@@ -48,7 +48,10 @@ interface UseSkillOptions {
 }
 ```
 
-Code-registered skills are supplied directly in this descriptor shape.
+Code-registered skills are supplied directly in this descriptor shape. Their
+`metadata` values must contain only primitives, arrays, and plain objects so
+returned descriptors cannot share mutable class instances with the original
+deployment config.
 Workspace-discovered skills are projected into this descriptor shape. Current
 core `Skill.source` values such as local, external, or managed content all
 project into the same `HarnessSkill` — v1 does not expose a source discriminator

--- a/packages/core/src/harness/v1/__test-utils__/setup.ts
+++ b/packages/core/src/harness/v1/__test-utils__/setup.ts
@@ -34,6 +34,8 @@ export interface HarnessTestSetupOptions {
   toolCategoryResolver?: HarnessConfig['toolCategoryResolver'];
   /** Optional model catalog (§9). */
   models?: HarnessConfig['models'];
+  /** Optional code-registered skill catalog (§4.6/§9). */
+  skills?: HarnessConfig['skills'];
   /** Optional model auth-status resolver (§9). */
   modelAuthStatusResolver?: HarnessConfig['modelAuthStatusResolver'];
 }
@@ -65,6 +67,7 @@ export function setupHarness(opts: HarnessTestSetupOptions = {}): HarnessTestSet
     ...(opts.defaultPermissionPolicy ? { defaultPermissionPolicy: opts.defaultPermissionPolicy } : {}),
     ...(opts.toolCategoryResolver ? { toolCategoryResolver: opts.toolCategoryResolver } : {}),
     ...(opts.models ? { models: opts.models } : {}),
+    ...(opts.skills ? { skills: opts.skills } : {}),
     ...(opts.modelAuthStatusResolver ? { modelAuthStatusResolver: opts.modelAuthStatusResolver } : {}),
   });
   const firstAgent = Object.values(agents)[0]!;

--- a/packages/core/src/harness/v1/errors.ts
+++ b/packages/core/src/harness/v1/errors.ts
@@ -181,16 +181,15 @@ export class HarnessModelNotFoundError extends Error {
 }
 
 /**
- * `session.skills.use(ref)` could not resolve `ref` in the session's workspace
- * skills catalogue. `searchedSources` reports which sources were consulted
- * before giving up so callers can distinguish "no workspace configured" from
- * "workspace consulted but nothing matched". See spec §4.6.
+ * `session.skills.use(ref)` could not resolve `ref` in the session's skill
+ * catalogues. `searchedSources` reports which catalogues were available for
+ * lookup before giving up. See spec §4.6.
  */
 export class HarnessSkillNotFoundError extends Error {
   readonly name = 'HarnessSkillNotFoundError';
   constructor(
     public readonly skillName: string,
-    public readonly searchedSources: ReadonlyArray<'workspace'>,
+    public readonly searchedSources: ReadonlyArray<'code-registered' | 'workspace'>,
   ) {
     super(`Skill "${skillName}" not found (searched: ${searchedSources.join(', ') || 'none'})`);
   }
@@ -198,9 +197,7 @@ export class HarnessSkillNotFoundError extends Error {
 
 /**
  * `session.skills.use(ref, { args })` failed args validation against the
- * resolved skill's declared schema. Phase 2 only enforces the
- * `args.required[]` frontmatter list; richer schema validation lands with
- * idempotency in a follow-up slice. See spec §4.6.
+ * resolved skill's declared schema. See spec §4.6.
  */
 export class HarnessSkillArgsValidationError extends Error {
   readonly name = 'HarnessSkillArgsValidationError';

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -60,6 +60,7 @@ import type {
   AttachmentUploadOptions,
   HarnessConfig,
   HarnessMode,
+  HarnessSkill,
   ModelAuthStatus,
   ModelInfo,
   PermissionPolicy,
@@ -90,6 +91,55 @@ const DEFAULT_SUBAGENT_MAX_DEPTH = 1;
 const DEFAULT_GOAL_MAX_TURNS = 50;
 const DEFAULT_PERMISSION_POLICY: PermissionPolicy = 'ask';
 
+function cloneHarnessSkill(skill: HarnessSkill): HarnessSkill {
+  return {
+    ...skill,
+    ...(skill.metadata ? { metadata: cloneSkillMetadata(skill.metadata, new WeakMap()) } : {}),
+  };
+}
+
+function cloneSkillMetadata(
+  metadata: Record<string, unknown>,
+  seen: WeakMap<object, unknown>,
+): Record<string, unknown> {
+  const existing = seen.get(metadata);
+  if (existing && typeof existing === 'object' && !Array.isArray(existing)) {
+    return existing as Record<string, unknown>;
+  }
+  const clone: Record<string, unknown> = {};
+  seen.set(metadata, clone);
+  for (const [key, value] of Object.entries(metadata)) {
+    clone[key] = cloneSkillMetadataValue(value, seen);
+  }
+  return clone;
+}
+
+function cloneSkillMetadataValue(value: unknown, seen: WeakMap<object, unknown>): unknown {
+  if (Array.isArray(value)) {
+    const existing = seen.get(value);
+    if (Array.isArray(existing)) return existing;
+    const clone: unknown[] = [];
+    seen.set(value, clone);
+    for (const child of value) {
+      clone.push(cloneSkillMetadataValue(child, seen));
+    }
+    return clone;
+  }
+  if (value && typeof value === 'object') {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype === Object.prototype || prototype === null) {
+      return cloneSkillMetadata(value as Record<string, unknown>, seen);
+    }
+  }
+  return value;
+}
+
+function isPlainSkillMetadata(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
 export class Harness {
   /** Process-scoped owner id used as the lease holder for all sessions. */
   readonly ownerId: string;
@@ -118,6 +168,7 @@ export class Harness {
   private readonly _toolCategoryResolver?: (toolName: string) => ToolCategory | null;
   private readonly _modelCatalog: ReadonlyMap<string, ModelInfo>;
   private readonly _modelAuthStatusResolver?: (modelId: string) => ModelAuthStatus | Promise<ModelAuthStatus>;
+  private readonly _codeSkills: ReadonlyMap<string, HarnessSkill>;
   private readonly _emitter = new EventEmitter();
   /** Per-session unsubscribers so harness-level subscribers see session events too. */
   private readonly _sessionEventBridges = new Map<string, HarnessEventUnsubscribe>();
@@ -230,6 +281,40 @@ export class Harness {
     }
     this._modelCatalog = catalog;
     this._modelAuthStatusResolver = config.modelAuthStatusResolver;
+
+    // Code-registered skills (§4.6 / §9). Static deployment catalog; session
+    // workspace skills are layered after these and lose on name conflicts.
+    const codeSkills = new Map<string, HarnessSkill>();
+    if (config.skills !== undefined) {
+      if (!Array.isArray(config.skills)) {
+        throw new HarnessConfigError('skills', 'must be an array of HarnessSkill');
+      }
+      for (const entry of config.skills) {
+        if (!entry || typeof entry.name !== 'string' || entry.name.length === 0) {
+          throw new HarnessConfigError('skills', 'every entry must have a non-empty string `name`');
+        }
+        if (typeof entry.description !== 'string') {
+          throw new HarnessConfigError('skills', `entry "${entry.name}" must have a string \`description\``);
+        }
+        if (typeof entry.instructions !== 'string') {
+          throw new HarnessConfigError('skills', `entry "${entry.name}" must have a string \`instructions\``);
+        }
+        if (entry.category !== undefined && typeof entry.category !== 'string') {
+          throw new HarnessConfigError('skills', `entry "${entry.name}" must have a string \`category\``);
+        }
+        if (entry.filePath !== undefined && (typeof entry.filePath !== 'string' || entry.filePath.length === 0)) {
+          throw new HarnessConfigError('skills', `entry "${entry.name}" must have a non-empty string \`filePath\``);
+        }
+        if (entry.metadata !== undefined && !isPlainSkillMetadata(entry.metadata)) {
+          throw new HarnessConfigError('skills', `entry "${entry.name}" must have object \`metadata\``);
+        }
+        if (codeSkills.has(entry.name)) {
+          throw new HarnessConfigError('skills', `duplicate skill name "${entry.name}"`);
+        }
+        codeSkills.set(entry.name, cloneHarnessSkill(entry));
+      }
+    }
+    this._codeSkills = codeSkills;
 
     // Workspace (§2.7). Three ownership models; registry handles lifecycle.
     // Cross-checks against the subagent registry happen below.
@@ -480,6 +565,18 @@ export class Harness {
   /** @internal — Session reads this to render the `agentType` enum in the spawn tool's input schema. */
   _listSubagentTypeIds(): string[] {
     return Array.from(this._subagentTypes.keys());
+  }
+
+  /** @internal — Session merges static skills before workspace-discovered skills. */
+  _listCodeSkills(): HarnessSkill[] {
+    return Array.from(this._codeSkills.values()).map(cloneHarnessSkill);
+  }
+
+  /** @internal — Session resolves code-registered skills by name. */
+  _getCodeSkill(ref: string): HarnessSkill | undefined {
+    const byName = this._codeSkills.get(ref);
+    if (byName) return cloneHarnessSkill(byName);
+    return undefined;
   }
 
   /** @internal — Session enforces the subagent depth cap inside the spawn tool. */

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -140,6 +140,26 @@ function isPlainSkillMetadata(value: unknown): value is Record<string, unknown> 
   return prototype === Object.prototype || prototype === null;
 }
 
+function hasOnlyCloneableSkillMetadataValues(value: unknown, seen: WeakSet<object>): boolean {
+  if (typeof value === 'function') return false;
+  if (Array.isArray(value)) {
+    if (seen.has(value)) return true;
+    seen.add(value);
+    const supported = value.every(child => hasOnlyCloneableSkillMetadataValues(child, seen));
+    seen.delete(value);
+    return supported;
+  }
+  if (value && typeof value === 'object') {
+    if (!isPlainSkillMetadata(value)) return false;
+    if (seen.has(value)) return true;
+    seen.add(value);
+    const supported = Object.values(value).every(child => hasOnlyCloneableSkillMetadataValues(child, seen));
+    seen.delete(value);
+    return supported;
+  }
+  return true;
+}
+
 export class Harness {
   /** Process-scoped owner id used as the lease holder for all sessions. */
   readonly ownerId: string;
@@ -307,6 +327,15 @@ export class Harness {
         }
         if (entry.metadata !== undefined && !isPlainSkillMetadata(entry.metadata)) {
           throw new HarnessConfigError('skills', `entry "${entry.name}" must have object \`metadata\``);
+        }
+        if (
+          entry.metadata !== undefined &&
+          !hasOnlyCloneableSkillMetadataValues(entry.metadata, new WeakSet<object>())
+        ) {
+          throw new HarnessConfigError(
+            'skills',
+            `entry "${entry.name}" metadata must contain only primitives, arrays, and plain objects`,
+          );
         }
         if (codeSkills.has(entry.name)) {
           throw new HarnessConfigError('skills', `duplicate skill name "${entry.name}"`);

--- a/packages/core/src/harness/v1/session.skills.test.ts
+++ b/packages/core/src/harness/v1/session.skills.test.ts
@@ -1,8 +1,9 @@
 /**
- * Harness v1 — `session.listSkills` / `getSkill` / `refreshSkills` (§4.6).
+ * Harness v1 — `session.skills.list` / `get` / `refresh` (§4.6).
  *
- * Phase 1: workspace-discovered skills only. Code-registered skills and
- * `useSkill` programmatic execution land in a follow-up slice.
+ * Code-registered skills merge ahead of workspace-discovered skills.
+ * Workspace skills remain discoverable unless a static descriptor owns the
+ * same name.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -12,7 +13,7 @@ import { InMemoryDB } from '../../storage/domains/inmemory-db';
 import type { Workspace } from '../../workspace';
 
 import { MockAgent, setupHarness } from './__test-utils__';
-import { HarnessSessionClosedError, HarnessValidationError } from './errors';
+import { HarnessConfigError, HarnessSessionClosedError, HarnessValidationError } from './errors';
 import { Harness } from './harness';
 import type { HarnessSkill } from './types';
 import type { WorkspaceProvider } from './workspace-provider';
@@ -21,6 +22,7 @@ type FakeSkillMeta = {
   name: string;
   description: string;
   path?: string;
+  instructions?: string;
   metadata?: Record<string, unknown>;
 };
 
@@ -38,13 +40,13 @@ class FakeWorkspaceSkills {
     }));
   }
   async get(name: string) {
-    const e = this.entries.find(x => x.name === name);
+    const e = this.entries.find(x => x.name === name || x.path === name || `skills/${x.name}` === name);
     if (!e) return null;
     return {
       name: e.name,
       description: e.description,
       path: e.path ?? `skills/${e.name}`,
-      instructions: `# ${e.name}\n\nFake body.`,
+      instructions: e.instructions ?? `# ${e.name}\n\nFake body.`,
       source: { type: 'local' as const, projectPath: '/fake' },
       references: [],
       scripts: [],
@@ -114,6 +116,43 @@ describe('Session skill discovery (§4.6)', () => {
     expect(await session.skills.get('anything')).toBeUndefined();
   });
 
+  it('returns code-registered skills when no workspace is configured', async () => {
+    const { harness } = setupHarness({
+      skills: [{ name: 'code-only', description: 'Code only', instructions: 'Code body.' }],
+    });
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    expect(await session.skills.list()).toMatchObject([
+      { name: 'code-only', description: 'Code only', instructions: 'Code body.' },
+    ]);
+    expect(await session.skills.get('code-only')).toMatchObject({ name: 'code-only' });
+  });
+
+  it('gets a code-registered skill without materializing the workspace', async () => {
+    const provider: WorkspaceProvider = {
+      providerId: 'p-unavailable',
+      resumable: true,
+      create: async () => {
+        throw new Error('workspace unavailable');
+      },
+      resume: async () => {
+        throw new Error('workspace unavailable');
+      },
+    };
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    const harness = new Harness({
+      agents: { default: new MockAgent({ id: 'default' }) } as any,
+      modes: [{ id: 'm', agentId: 'default' }],
+      defaultModeId: 'm',
+      sessions: { storage },
+      workspace: { kind: 'per-session', provider },
+      skills: [{ name: 'code-only', description: 'Code only', instructions: 'Code body.' }],
+    });
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    expect(await session.skills.get('code-only')).toMatchObject({ name: 'code-only' });
+  });
+
   it('returns an empty list when the workspace has no skills surface', async () => {
     const provider = resumableProviderFor(null);
     const storage = new InMemoryHarness({ db: new InMemoryDB() });
@@ -142,16 +181,134 @@ describe('Session skill discovery (§4.6)', () => {
       name: 'lint',
       description: 'Lint the repo',
       filePath: 'skills/lint',
-      instructions: '',
+      instructions: '# lint\n\nFake body.',
     });
     expect(skills[1]).toMatchObject<Partial<HarnessSkill>>({
       name: 'format',
       description: 'Format files',
       filePath: 'tools/format/SKILL.md',
+      instructions: '# format\n\nFake body.',
     });
   });
 
-  it('getSkill returns the matching descriptor or undefined', async () => {
+  it('materializes listed workspace skills by path when names are duplicated', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      {
+        name: 'shared',
+        description: 'A',
+        path: 'skills/a/SKILL.md',
+        instructions: 'A body.',
+      },
+      {
+        name: 'shared',
+        description: 'B',
+        path: 'skills/b/SKILL.md',
+        instructions: 'B body.',
+      },
+    ]);
+    const harness = makeHarnessWithSkills(fakeSkills);
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    expect(await session.skills.list()).toMatchObject([
+      { name: 'shared', filePath: 'skills/a/SKILL.md', instructions: 'A body.' },
+      { name: 'shared', filePath: 'skills/b/SKILL.md', instructions: 'B body.' },
+    ]);
+  });
+
+  it('lists code-registered skills before workspace skills and keeps code precedence on conflicts', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      { name: 'shared', description: 'Workspace shared' },
+      { name: 'workspace-only', description: 'Workspace only' },
+    ]);
+    const provider = resumableProviderFor(fakeSkills);
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    const harness = new Harness({
+      agents: { default: new MockAgent({ id: 'default' }) } as any,
+      modes: [{ id: 'm', agentId: 'default' }],
+      defaultModeId: 'm',
+      sessions: { storage },
+      workspace: { kind: 'per-session', provider },
+      skills: [{ name: 'shared', description: 'Code shared', instructions: 'Code body.' }],
+    });
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    const skills = await session.skills.list();
+    expect(skills.map(s => s.name)).toEqual(['shared', 'workspace-only']);
+    expect(skills[0]).toMatchObject({ name: 'shared', description: 'Code shared', instructions: 'Code body.' });
+    expect(await session.skills.get('shared')).toMatchObject({ description: 'Code shared' });
+  });
+
+  it('rejects duplicate code-registered skill names at construction', () => {
+    expect(
+      () =>
+        new Harness({
+          agents: { default: new MockAgent({ id: 'default' }) } as any,
+          modes: [{ id: 'm', agentId: 'default' }],
+          defaultModeId: 'm',
+          skills: [
+            { name: 'dupe', description: 'A', instructions: 'A' },
+            { name: 'dupe', description: 'B', instructions: 'B' },
+          ],
+        }),
+    ).toThrow(HarnessConfigError);
+  });
+
+  it('rejects malformed code-registered skill metadata at construction', () => {
+    expect(
+      () =>
+        new Harness({
+          agents: { default: new MockAgent({ id: 'default' }) } as any,
+          modes: [{ id: 'm', agentId: 'default' }],
+          defaultModeId: 'm',
+          skills: [
+            {
+              name: 'bad-metadata',
+              description: 'Bad metadata',
+              instructions: 'Body',
+              metadata: 'bad' as unknown as Record<string, unknown>,
+            },
+          ],
+        }),
+    ).toThrow(HarnessConfigError);
+
+    expect(
+      () =>
+        new Harness({
+          agents: { default: new MockAgent({ id: 'default' }) } as any,
+          modes: [{ id: 'm', agentId: 'default' }],
+          defaultModeId: 'm',
+          skills: [
+            {
+              name: 'bad-metadata-instance',
+              description: 'Bad metadata',
+              instructions: 'Body',
+              metadata: new Date() as unknown as Record<string, unknown>,
+            },
+          ],
+        }),
+    ).toThrow(HarnessConfigError);
+  });
+
+  it('rejects malformed code-registered skill categories at construction', () => {
+    expect(
+      () =>
+        new Harness({
+          agents: { default: new MockAgent({ id: 'default' }) } as any,
+          modes: [{ id: 'm', agentId: 'default' }],
+          defaultModeId: 'm',
+          skills: [
+            {
+              name: 'bad-category',
+              description: 'Bad category',
+              instructions: 'Body',
+              category: 123 as unknown as string,
+            },
+          ],
+        }),
+    ).toThrow(HarnessConfigError);
+  });
+
+  it('skills.get returns the matching descriptor or undefined', async () => {
     const fakeSkills = new FakeWorkspaceSkills([{ name: 'lint', description: 'Lint the repo' }]);
     const harness = makeHarnessWithSkills(fakeSkills);
     const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
@@ -161,7 +318,7 @@ describe('Session skill discovery (§4.6)', () => {
     expect(await session.skills.get('unknown')).toBeUndefined();
   });
 
-  it('getSkill rejects empty / non-string names', async () => {
+  it('skills.get rejects empty / non-string names', async () => {
     const harness = makeHarnessWithSkills(new FakeWorkspaceSkills([]));
     const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
     await expect(session.skills.get('')).rejects.toBeInstanceOf(HarnessValidationError);
@@ -187,7 +344,7 @@ describe('Session skill discovery (§4.6)', () => {
     expect(fakeSkills.listCallCount).toBe(1);
   });
 
-  it('refreshSkills clears the cache so the next read re-discovers', async () => {
+  it('skills.refresh clears the cache so the next read re-discovers', async () => {
     const fakeSkills = new FakeWorkspaceSkills([{ name: 'a', description: 'A' }]);
     const harness = makeHarnessWithSkills(fakeSkills);
     const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });

--- a/packages/core/src/harness/v1/session.skills.test.ts
+++ b/packages/core/src/harness/v1/session.skills.test.ts
@@ -287,6 +287,40 @@ describe('Session skill discovery (§4.6)', () => {
           ],
         }),
     ).toThrow(HarnessConfigError);
+
+    expect(
+      () =>
+        new Harness({
+          agents: { default: new MockAgent({ id: 'default' }) } as any,
+          modes: [{ id: 'm', agentId: 'default' }],
+          defaultModeId: 'm',
+          skills: [
+            {
+              name: 'bad-nested-metadata',
+              description: 'Bad metadata',
+              instructions: 'Body',
+              metadata: { nested: new Date() },
+            },
+          ],
+        }),
+    ).toThrow(HarnessConfigError);
+
+    expect(
+      () =>
+        new Harness({
+          agents: { default: new MockAgent({ id: 'default' }) } as any,
+          modes: [{ id: 'm', agentId: 'default' }],
+          defaultModeId: 'm',
+          skills: [
+            {
+              name: 'bad-function-metadata',
+              description: 'Bad metadata',
+              instructions: 'Body',
+              metadata: { nested: () => 'bad' },
+            },
+          ],
+        }),
+    ).toThrow(HarnessConfigError);
   });
 
   it('rejects malformed code-registered skill categories at construction', () => {

--- a/packages/core/src/harness/v1/session.skills.use.test.ts
+++ b/packages/core/src/harness/v1/session.skills.use.test.ts
@@ -1,12 +1,10 @@
 /**
  * Harness v1 — `session.skills.use()` (§4.6).
  *
- * Phase 2: programmatic skill execution against the workspace-discovered
- * catalog. Resolves by frontmatter name or workspace-relative path,
- * validates declared required args, appends a JSON code block carrying
- * validated args to the skill body, and dispatches as a single turn via
- * the signal-driven message path. Admission idempotency is deferred to a
- * follow-up slice.
+ * Programmatic skill execution against the code-registered and
+ * workspace-discovered catalogues. Code skills resolve by name first.
+ * Workspace skills resolve by frontmatter name or workspace-relative path
+ * unless a code skill owns the same name.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -23,6 +21,7 @@ import {
   HarnessValidationError,
 } from './errors';
 import { Harness } from './harness';
+import type { HarnessConfig, HarnessRequestContext } from './types';
 import type { WorkspaceProvider } from './workspace-provider';
 
 // ---------------------------------------------------------------------------
@@ -123,7 +122,10 @@ function resumableProviderFor(skills: FakeWorkspaceSkills | null): WorkspaceProv
   };
 }
 
-function makeHarnessWithSkills(skills: FakeWorkspaceSkills): {
+function makeHarnessWithSkills(
+  skills: FakeWorkspaceSkills,
+  codeSkills?: HarnessConfig['skills'],
+): {
   harness: Harness;
   agent: MockAgent;
 } {
@@ -136,6 +138,7 @@ function makeHarnessWithSkills(skills: FakeWorkspaceSkills): {
     defaultModeId: 'm',
     sessions: { storage },
     workspace: { kind: 'per-session', provider },
+    ...(codeSkills ? { skills: codeSkills } : {}),
   });
   return { harness, agent };
 }
@@ -158,6 +161,87 @@ describe('Session.skills.use() (§4.6)', () => {
     expect(agent.streamCalls).toHaveLength(1);
     expect(extractSignalContents(agent.streamCalls[0]!.messages)).toBe('Reproduce the bug step by step.');
     expect(fakeSkills.getCalls).toEqual(['reproduce-bug']);
+  });
+
+  it('runs a code-registered skill without a workspace', async () => {
+    const { harness, agent } = setupHarness({
+      skills: [{ name: 'code-only', description: 'Code only', instructions: 'Run the code skill.' }],
+    });
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await session.skills.use('code-only');
+
+    expect(agent.streamCalls).toHaveLength(1);
+    expect(extractSignalContents(agent.streamCalls[0]!.messages)).toBe('Run the code skill.');
+  });
+
+  it('prefers a code-registered skill when a workspace skill has the same name', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      {
+        name: 'shared',
+        description: 'Workspace shared',
+        path: 'skills/shared/SKILL.md',
+        instructions: 'Workspace body.',
+      },
+    ]);
+    const { harness, agent } = makeHarnessWithSkills(fakeSkills, [
+      { name: 'shared', description: 'Code shared', instructions: 'Code body.' },
+    ]);
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await session.skills.use('shared');
+
+    expect(agent.streamCalls).toHaveLength(1);
+    expect(extractSignalContents(agent.streamCalls[0]!.messages)).toBe('Code body.');
+    expect(fakeSkills.getCalls).toEqual([]);
+  });
+
+  it('does not allow a shadowed workspace skill to bypass code precedence by path', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      {
+        name: 'shared',
+        description: 'Workspace shared',
+        path: 'skills/shared/SKILL.md',
+        instructions: 'Workspace body.',
+      },
+    ]);
+    const { harness, agent } = makeHarnessWithSkills(fakeSkills, [
+      { name: 'shared', description: 'Code shared', instructions: 'Code body.' },
+    ]);
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(session.skills.use('skills/shared/SKILL.md')).rejects.toMatchObject({
+      searchedSources: ['code-registered', 'workspace'],
+    });
+
+    expect(agent.streamCalls).toHaveLength(0);
+    expect(fakeSkills.getCalls).toEqual(['skills/shared/SKILL.md']);
+  });
+
+  it('does not treat a code skill filePath as a use() alias', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      {
+        name: 'deploy',
+        description: 'Workspace deploy',
+        path: 'skills/deploy/SKILL.md',
+        instructions: 'Workspace deploy body.',
+      },
+    ]);
+    const { harness, agent } = makeHarnessWithSkills(fakeSkills, [
+      {
+        name: 'code-deploy',
+        description: 'Code deploy',
+        filePath: 'deploy',
+        instructions: 'Code deploy body.',
+      },
+    ]);
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await session.skills.use('deploy');
+
+    expect(agent.streamCalls).toHaveLength(1);
+    expect(extractSignalContents(agent.streamCalls[0]!.messages)).toBe('Workspace deploy body.');
+    expect(fakeSkills.getCalls).toEqual(['deploy']);
   });
 
   it('resolves a skill by workspace-relative path', async () => {
@@ -216,12 +300,15 @@ describe('Session.skills.use() (§4.6)', () => {
     expect(extractSignalContents(agent.streamCalls[0]!.messages)).toBe('Plain body.');
   });
 
-  it('throws HarnessSkillNotFoundError when no workspace skill matches the ref', async () => {
+  it('throws HarnessSkillNotFoundError when no skill matches the ref', async () => {
     const fakeSkills = new FakeWorkspaceSkills([{ name: 'exists', description: 'X', instructions: 'X.' }]);
     const { harness } = makeHarnessWithSkills(fakeSkills);
     const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
 
     await expect(session.skills.use('does-not-exist')).rejects.toBeInstanceOf(HarnessSkillNotFoundError);
+    await expect(session.skills.use('does-not-exist')).rejects.toMatchObject({
+      searchedSources: ['code-registered', 'workspace'],
+    });
   });
 
   it('throws HarnessSkillNotFoundError when the session has no workspace configured', async () => {
@@ -229,6 +316,7 @@ describe('Session.skills.use() (§4.6)', () => {
     const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
 
     await expect(session.skills.use('whatever')).rejects.toBeInstanceOf(HarnessSkillNotFoundError);
+    await expect(session.skills.use('whatever')).rejects.toMatchObject({ searchedSources: ['code-registered'] });
   });
 
   it('throws HarnessSkillArgsValidationError when required args are missing', async () => {
@@ -248,6 +336,295 @@ describe('Session.skills.use() (§4.6)', () => {
     );
 
     // No turn started.
+    expect(agent.streamCalls).toHaveLength(0);
+  });
+
+  it('rejects non-object args before dispatch', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      { name: 'object-args', description: 'Object args', instructions: 'Object args body.' },
+    ]);
+    const { harness, agent } = makeHarnessWithSkills(fakeSkills);
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(
+      session.skills.use('object-args', { args: [] as unknown as Record<string, unknown> }),
+    ).rejects.toMatchObject({
+      issues: ['args must be an object'],
+    });
+    expect(agent.streamCalls).toHaveLength(0);
+  });
+
+  it('validates type, enum, and additionalProperties before dispatch', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      {
+        name: 'typed',
+        description: 'Typed',
+        instructions: 'Typed body.',
+        metadata: {
+          args: {
+            required: ['ticketId'],
+            additionalProperties: false,
+            properties: {
+              ticketId: { type: 'string' },
+              priority: { enum: ['low', 'high'] },
+              count: { type: 'integer' },
+            },
+          },
+        },
+      },
+    ]);
+    const { harness, agent } = makeHarnessWithSkills(fakeSkills);
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(
+      session.skills.use('typed', { args: { ticketId: 123, priority: 'urgent', extra: true } }),
+    ).rejects.toMatchObject({
+      issues: ['ticketId must be string', 'priority must be one of ["low","high"]', 'unsupported arg: "extra"'],
+    });
+    expect(agent.streamCalls).toHaveLength(0);
+  });
+
+  it('accepts object enum values by structural equality', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      {
+        name: 'object-enum',
+        description: 'Object enum',
+        instructions: 'Object enum body.',
+        metadata: {
+          args: {
+            properties: {
+              target: { type: 'object', enum: [{ env: 'prod', flags: ['fast'] }] },
+            },
+          },
+        },
+      },
+    ]);
+    const { harness, agent } = makeHarnessWithSkills(fakeSkills);
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await session.skills.use('object-enum', { args: { target: { env: 'prod', flags: ['fast'] } } });
+
+    expect(agent.streamCalls).toHaveLength(1);
+  });
+
+  it('rejects undefined required and declared args', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      {
+        name: 'needs-defined',
+        description: 'Needs defined',
+        instructions: 'Defined body.',
+        metadata: { args: { required: ['ticketId'], properties: { ticketId: { type: 'string' } } } },
+      },
+    ]);
+    const { harness, agent } = makeHarnessWithSkills(fakeSkills);
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(session.skills.use('needs-defined', { args: { ticketId: undefined } })).rejects.toMatchObject({
+      issues: ['ticketId must be JSON-serializable', 'missing required arg: "ticketId"', 'ticketId must be string'],
+    });
+    expect(agent.streamCalls).toHaveLength(0);
+  });
+
+  it('does not let returned code skill descriptor mutation weaken validation', async () => {
+    const { harness, agent } = setupHarness({
+      skills: [
+        {
+          name: 'immutable',
+          description: 'Immutable',
+          instructions: 'Immutable body.',
+          metadata: { args: { required: ['ticketId'] } },
+        },
+      ],
+    });
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const descriptor = await session.skills.get('immutable');
+    (descriptor!.metadata!.args as { required: string[] }).required = [];
+
+    await expect(session.skills.use('immutable', { args: {} })).rejects.toMatchObject({
+      issues: ['missing required arg: "ticketId"'],
+    });
+    expect(agent.streamCalls).toHaveLength(0);
+  });
+
+  it('enforces additionalProperties false even without declared properties', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      {
+        name: 'closed',
+        description: 'Closed',
+        instructions: 'Closed body.',
+        metadata: { args: { additionalProperties: false } },
+      },
+    ]);
+    const { harness, agent } = makeHarnessWithSkills(fakeSkills);
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(session.skills.use('closed', { args: { extra: true } })).rejects.toMatchObject({
+      issues: ['unsupported arg: "extra"'],
+    });
+    expect(agent.streamCalls).toHaveLength(0);
+  });
+
+  it('rejects unsupported schema types before dispatch', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      {
+        name: 'unsupported-type',
+        description: 'Unsupported type',
+        instructions: 'Unsupported type body.',
+        metadata: { args: { type: 'date' } },
+      },
+    ]);
+    const { harness, agent } = makeHarnessWithSkills(fakeSkills);
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(session.skills.use('unsupported-type')).rejects.toMatchObject({
+      issues: ['$.type must be a supported JSON schema type'],
+    });
+    expect(agent.streamCalls).toHaveLength(0);
+  });
+
+  it('rejects non-plain args schema objects before dispatch', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      {
+        name: 'non-plain-schema',
+        description: 'Non-plain schema',
+        instructions: 'Non-plain schema body.',
+        metadata: { args: new Date() },
+      },
+    ]);
+    const { harness, agent } = makeHarnessWithSkills(fakeSkills);
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(session.skills.use('non-plain-schema')).rejects.toMatchObject({
+      issues: ['unsupported args schema: expected object'],
+    });
+    expect(agent.streamCalls).toHaveLength(0);
+  });
+
+  it('rejects circular args schemas before dispatch', async () => {
+    const argsSchema: Record<string, unknown> = { properties: {} };
+    (argsSchema.properties as Record<string, unknown>).self = argsSchema;
+    const { harness, agent } = setupHarness({
+      skills: [
+        {
+          name: 'circular-schema',
+          description: 'Circular schema',
+          instructions: 'Circular schema body.',
+          metadata: { args: argsSchema },
+        },
+      ],
+    });
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(session.skills.use('circular-schema', { args: {} })).rejects.toMatchObject({
+      issues: ['self must not contain circular args schema references'],
+    });
+    expect(agent.streamCalls).toHaveLength(0);
+  });
+
+  it('rejects unsupported top-level args schema fields before dispatch', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      {
+        name: 'minimum',
+        description: 'Minimum',
+        instructions: 'Minimum body.',
+        metadata: { args: { minimum: 1 } },
+      },
+    ]);
+    const { harness, agent } = makeHarnessWithSkills(fakeSkills);
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(session.skills.use('minimum')).rejects.toMatchObject({
+      issues: ['$.minimum is not a supported args schema field'],
+    });
+    expect(agent.streamCalls).toHaveLength(0);
+  });
+
+  it('rejects unsupported nested args schema fields even when args omit those properties', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      {
+        name: 'nested-shape',
+        description: 'Nested shape',
+        instructions: 'Nested shape body.',
+        metadata: {
+          args: {
+            properties: {
+              query: { type: 'string', pattern: '^PF-' },
+              tags: { type: 'array', items: { type: 'string', minLength: 1 } },
+            },
+          },
+        },
+      },
+    ]);
+    const { harness, agent } = makeHarnessWithSkills(fakeSkills);
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(session.skills.use('nested-shape', { args: {} })).rejects.toMatchObject({
+      issues: [
+        'query.pattern is not a supported args schema field',
+        'tags[].minLength is not a supported args schema field',
+      ],
+    });
+    expect(agent.streamCalls).toHaveLength(0);
+  });
+
+  it('rejects non-JSON enum schema values before dispatch', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      {
+        name: 'bad-enum',
+        description: 'Bad enum',
+        instructions: 'Bad enum body.',
+        metadata: { args: { properties: { value: { enum: [1n] } } } },
+      },
+    ]);
+    const { harness, agent } = makeHarnessWithSkills(fakeSkills);
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(session.skills.use('bad-enum', { args: {} })).rejects.toMatchObject({
+      issues: ['value.enum[0] must be JSON-serializable'],
+    });
+    expect(agent.streamCalls).toHaveLength(0);
+  });
+
+  it('rejects non-JSON args before dispatch', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      { name: 'json-only', description: 'JSON only', instructions: 'JSON only body.' },
+    ]);
+    const { harness, agent } = makeHarnessWithSkills(fakeSkills);
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(session.skills.use('json-only', { args: { bad: 1n } })).rejects.toMatchObject({
+      issues: ['bad must be JSON-serializable'],
+    });
+    expect(agent.streamCalls).toHaveLength(0);
+  });
+
+  it('rejects own toJSON args before dispatch', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      { name: 'no-to-json', description: 'No toJSON', instructions: 'No toJSON body.' },
+    ]);
+    const { harness, agent } = makeHarnessWithSkills(fakeSkills);
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(
+      session.skills.use('no-to-json', { args: { value: { toJSON: () => 'hidden' } } }),
+    ).rejects.toMatchObject({
+      issues: ['value.toJSON is not supported in skill args'],
+    });
+    expect(agent.streamCalls).toHaveLength(0);
+  });
+
+  it('rejects circular args before dispatch', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      { name: 'no-cycles', description: 'No cycles', instructions: 'No cycles body.' },
+    ]);
+    const { harness, agent } = makeHarnessWithSkills(fakeSkills);
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const args: Record<string, unknown> = {};
+    args.self = args;
+
+    await expect(session.skills.use('no-cycles', { args })).rejects.toMatchObject({
+      issues: ['self must not contain circular references'],
+    });
     expect(agent.streamCalls).toHaveLength(0);
   });
 
@@ -301,20 +678,16 @@ describe('Session.skills.use() (§4.6)', () => {
     expect(extractSignalContents(agent.streamCalls[0]!.messages)).toBe('body');
   });
 
-  it('is also reachable as ctx.useSkill from within a tool', async () => {
-    // This is a structural smoke test: the request context plumbed to the
-    // built-in tools exposes `useSkill` as a thin proxy onto
-    // `session.skills.use`. We assert the proxy exists and delegates by
-    // calling through it directly with the same harness.
+  it('exposes ctx.useSkill through the per-turn request context', async () => {
     const fakeSkills = new FakeWorkspaceSkills([{ name: 'callme', description: 'd', instructions: 'CALLED' }]);
     const { harness, agent } = makeHarnessWithSkills(fakeSkills);
     const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
 
-    // _buildRequestContext is internal; the test approximation is that
-    // session.skills.use exists, accepts a ref, and produces a turn — the
-    // delegation surface (ctx.useSkill) is a one-liner over the same code
-    // path.
-    await session.skills.use('callme');
-    expect(extractSignalContents(agent.streamCalls[0]!.messages)).toBe('CALLED');
+    await session.message({ content: 'prime context' });
+    const harnessContext = agent.streamCalls[0]!.options.requestContext.get('harness') as HarnessRequestContext;
+    await harnessContext.useSkill('callme');
+
+    expect(agent.streamCalls).toHaveLength(2);
+    expect(extractSignalContents(agent.streamCalls[1]!.messages)).toBe('CALLED');
   });
 });

--- a/packages/core/src/harness/v1/session.skills.use.test.ts
+++ b/packages/core/src/harness/v1/session.skills.use.test.ts
@@ -613,6 +613,19 @@ describe('Session.skills.use() (§4.6)', () => {
     expect(agent.streamCalls).toHaveLength(0);
   });
 
+  it('accepts JSON data fields named toJSON', async () => {
+    const fakeSkills = new FakeWorkspaceSkills([
+      { name: 'json-field', description: 'JSON field', instructions: 'JSON field body.' },
+    ]);
+    const { harness, agent } = makeHarnessWithSkills(fakeSkills);
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await session.skills.use('json-field', { args: { value: { toJSON: 'literal' } } });
+
+    expect(agent.streamCalls).toHaveLength(1);
+    expect(extractSignalContents(agent.streamCalls[0]!.messages)).toContain('"toJSON": "literal"');
+  });
+
   it('rejects circular args before dispatch', async () => {
     const fakeSkills = new FakeWorkspaceSkills([
       { name: 'no-cycles', description: 'No cycles', instructions: 'No cycles body.' },

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -1327,7 +1327,10 @@ export class Session {
       return;
     }
     if (typeof value !== 'object') return;
-    if (Object.prototype.hasOwnProperty.call(value, 'toJSON')) {
+    if (
+      Object.prototype.hasOwnProperty.call(value, 'toJSON') &&
+      typeof (value as { toJSON?: unknown }).toJSON === 'function'
+    ) {
       issues.push(`${path}.toJSON is not supported in skill args`);
       return;
     }

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -7,7 +7,7 @@
  *
  * The current local surface includes message/signal/queue turns, mode/model
  * and state mutation, display snapshots, message listing, pending inbox
- * responses, permissions, workspace-backed skills, subagents, goals, event
+ * responses, permissions, code/workspace skills, subagents, goals, event
  * forwarding, abort, and idle waiting. It is not yet the production remote or
  * recovery surface: durable admission/result rows, server routes, remote SDKs,
  * channels, wakeups, and request-context `registerQuestion` /
@@ -114,6 +114,14 @@ import type {
  */
 const ASK_USER_TOOL_NAME = ASK_USER_TOOL_ID;
 const SUBMIT_PLAN_TOOL_NAME = SUBMIT_PLAN_TOOL_ID;
+const SUPPORTED_SKILL_ARG_SCHEMA_KEYS = new Set([
+  'required',
+  'properties',
+  'type',
+  'enum',
+  'items',
+  'additionalProperties',
+]);
 
 export type SessionLifecycleState = 'live' | 'closed' | 'evicted';
 
@@ -422,15 +430,12 @@ export class Session {
   // -------------------------------------------------------------------------
   // Skill discovery cache (§4.6).
   //
-  // Workspace skill discovery is async and lazy. We cache the resolved
-  // catalog for the lifetime of this in-memory Session instance. Concurrent
-  // `listSkills` / `getSkill` calls during a generation build share the
-  // same in-flight promise (single-flight), avoiding duplicate discovery
-  // work. `refreshSkills()` clears the cache so the next read re-runs
-  // discovery through the workspace skill source.
-  //
-  // Phase 1 caches workspace-only generations. Phase 2 will layer the
-  // code-registered ∪ workspace merge on top.
+  // Workspace skill discovery is async and lazy. We cache the merged code +
+  // workspace catalog for the lifetime of this in-memory Session instance.
+  // Concurrent `skills.list` / `skills.get` calls during a generation build
+  // share the same in-flight promise (single-flight), avoiding duplicate
+  // discovery work. `skills.refresh()` clears the cache so the next read
+  // re-runs discovery through the workspace skill source.
   // -------------------------------------------------------------------------
   private _skillsCache?: HarnessSkill[];
   private _skillsResolving?: Promise<HarnessSkill[]>;
@@ -924,26 +929,26 @@ export class Session {
   // -------------------------------------------------------------------------
   // Skills — §4.6.
   //
-  // Workspace-discovered skills are projected from the configured
-  // `WorkspaceSkills` source into `HarnessSkill` descriptors. Discovery
-  // runs asynchronously on the first `list` / `get` / `use` call per
-  // in-memory Session instance and the result is cached for the session's
+  // Code-registered skills are merged ahead of workspace-discovered skills.
+  // Workspace-discovered entries are projected from the configured
+  // `WorkspaceSkills` source into `HarnessSkill` descriptors. Discovery runs
+  // asynchronously on the first `list` / `get` / `use` call per in-memory
+  // Session instance and the merged result is cached for the session's
   // lifetime. Concurrent calls during a generation share a single-flight
-  // promise. `refresh()` drops the cache so the next call re-runs
-  // discovery.
+  // promise. `refresh()` drops the cache so the next call re-runs discovery.
   //
-  // `use(ref, opts?)` resolves a skill by frontmatter name or relative
-  // path under the workspace skill source, validates declared required
-  // args, appends a JSON code block carrying the validated args to the
-  // skill body, and delegates to the signal-driven message path. The
-  // returned `AgentResult` is the underlying turn's result. Admission
-  // idempotency is deferred to a follow-up slice.
+  // `use(ref, opts?)` resolves a code-registered or workspace skill by name
+  // or relative path, validates declared args, appends a JSON code block
+  // carrying the validated args to the skill body, and delegates to the
+  // signal-driven message path. The returned `AgentResult` is the underlying
+  // turn's result.
   // -------------------------------------------------------------------------
 
   /**
    * Skill discovery, inspection, and programmatic execution — see §4.6
    * and §4.2c.
    *
+   * Code-registered skills are merged ahead of workspace-discovered skills.
    * Workspace-discovered skills are projected into `HarnessSkill`
    * descriptors. Discovery runs asynchronously on the first `list` /
    * `get` / `use` call per in-memory Session instance and is cached for
@@ -955,14 +960,14 @@ export class Session {
     /**
      * List skills available to this session.
      *
-     * Returns an empty array when the session has no workspace configured.
-     * Otherwise delegates to the resolved workspace's `WorkspaceSkills`
-     * surface and projects each entry into a `HarnessSkill`.
+     * Returns code-registered skills plus workspace-discovered skills.
+     * If the session has no workspace configured, only code-registered
+     * skills are returned.
      */
     list: (): Promise<HarnessSkill[]> => this._skillsList(),
     /**
      * Look up a skill by name. Returns `undefined` when the name does not
-     * resolve. The only source consulted is the session's workspace.
+     * resolve in the code or workspace catalogues.
      */
     get: (name: string): Promise<HarnessSkill | undefined> => this._skillsGet(name),
     /**
@@ -972,16 +977,16 @@ export class Session {
      */
     refresh: (): Promise<void> => this._skillsRefresh(),
     /**
-     * Resolve a workspace skill by name or relative path, optionally
-     * validate provided arguments against the skill's declared
-     * `args.required[]` frontmatter, append a JSON code block of the
-     * validated args to the skill instructions, and dispatch the result
+     * Resolve a code-registered skill by name, or a workspace skill by name
+     * or relative path, optionally validate provided arguments against the
+     * skill's declared args schema, append a JSON code block of the validated
+     * args to the skill instructions, and dispatch the result
      * through the signal-driven message path as a single turn. Resolves
      * to the underlying turn's `AgentResult`.
      *
      * Throws {@link HarnessSkillNotFoundError} when `ref` does not match
-     * any workspace skill, and {@link HarnessSkillArgsValidationError}
-     * when required args are missing.
+     * any skill, and {@link HarnessSkillArgsValidationError} when declared
+     * args are invalid.
      */
     use: (ref: string, opts?: UseSkillOptions): Promise<AgentResult> => this._skillsUse(ref, opts),
   });
@@ -996,6 +1001,8 @@ export class Session {
     if (typeof name !== 'string' || name.length === 0) {
       throw new HarnessValidationError('skills.get()', 'name must be a non-empty string');
     }
+    const codeSkill = this._harness._getCodeSkill(name);
+    if (codeSkill) return codeSkill;
     const skills = await this._resolveSkills();
     return skills.find(s => s.name === name);
   }
@@ -1012,14 +1019,16 @@ export class Session {
   }
 
   /**
-   * Resolve a workspace skill by name or relative path, validate any
-   * declared required args, inject the validated args as a JSON code
-   * block into the skill instructions, and dispatch the result through
-   * `message()` as a single turn. Returns the underlying `AgentResult`.
+   * Resolve a code-registered skill by name, or a workspace skill by name or
+   * relative path, validate any declared args schema, inject the validated
+   * args as a JSON code block into the skill instructions, and dispatch the
+   * result through `message()` as a single turn. Returns the underlying
+   * `AgentResult`.
    *
-   * Reference resolution mirrors Flue's `session.skill(ref, ...)` — either
-   * the frontmatter `name` or a relative path under the workspace skill
-   * source resolves. `WorkspaceSkills.get(ref)` already supports both.
+   * Reference resolution checks the static code registry first, then mirrors
+   * Flue's workspace `session.skill(ref, ...)` behavior — either the
+   * frontmatter `name` or a relative path under the workspace skill source
+   * resolves. `WorkspaceSkills.get(ref)` already supports both.
    */
   private async _skillsUse(ref: string, opts?: UseSkillOptions): Promise<AgentResult> {
     this._assertLive('skills.use()');
@@ -1027,38 +1036,37 @@ export class Session {
       throw new HarnessValidationError('skills.use()', 'ref must be a non-empty string');
     }
 
+    const codeSkill = this._harness._getCodeSkill(ref);
+    if (codeSkill) {
+      this._validateSkillArgs(codeSkill.name, codeSkill.metadata, opts?.args);
+      const expandedContent = this._buildSkillPrompt(codeSkill.instructions, opts?.args);
+      return this.message({
+        content: expandedContent,
+        ...(opts?.modelOverride ? { model: opts.modelOverride } : {}),
+      });
+    }
+
     // Force workspace materialization. Unlike `list` / `get`, `use` must
     // produce a definitive answer (start a turn or refuse with a typed
-    // not-found error); provisional code-only results are not acceptable.
+    // not-found error).
     const workspace = await this.getWorkspace();
     const workspaceSkills = workspace?.skills;
     if (!workspaceSkills) {
-      throw new HarnessSkillNotFoundError(ref, []);
+      throw new HarnessSkillNotFoundError(ref, ['code-registered']);
     }
 
     // `WorkspaceSkills.get` accepts either the frontmatter `name` or a
     // relative path under the configured skill source.
     const skill = await workspaceSkills.get(ref);
     if (!skill) {
-      throw new HarnessSkillNotFoundError(ref, ['workspace']);
+      throw new HarnessSkillNotFoundError(ref, ['code-registered', 'workspace']);
+    }
+    if (this._harness._getCodeSkill(skill.name)) {
+      throw new HarnessSkillNotFoundError(ref, ['code-registered', 'workspace']);
     }
 
     const args = opts?.args;
-
-    // Phase 2 args validation: only enforce `args.required[]` (if the
-    // skill frontmatter declares it). Full schema validation lands with
-    // admission idempotency in a follow-up slice.
-    const requiredKeys = this._extractRequiredArgKeys(skill.metadata);
-    if (requiredKeys.length > 0) {
-      const provided = args ?? {};
-      const missing = requiredKeys.filter(k => !(k in provided));
-      if (missing.length > 0) {
-        throw new HarnessSkillArgsValidationError(
-          skill.name,
-          missing.map(k => `missing required arg: "${k}"`),
-        );
-      }
-    }
+    this._validateSkillArgs(skill.name, skill.metadata, args);
 
     // Build the expanded prompt: skill instructions + (optional) JSON
     // code block carrying validated args. Skill authors reference the
@@ -1072,17 +1080,272 @@ export class Session {
   }
 
   /**
-   * Pull `args.required[]` (a string array) out of skill frontmatter
-   * metadata, if declared. Returns an empty array when the skill does not
-   * declare required args. Defensive against malformed metadata.
+   * Validate `metadata.args` as a small JSON-schema-ish object. The harness
+   * supports the common prompt-arg fields used by workspace frontmatter:
+   * `required`, `properties`, `type`, `enum`, `items`, and
+   * `additionalProperties`. Unsupported or malformed schema shapes fail
+   * before a skill turn starts.
    */
-  private _extractRequiredArgKeys(metadata: Record<string, unknown> | undefined): string[] {
-    if (!metadata || typeof metadata !== 'object') return [];
+  private _validateSkillArgs(
+    skillName: string,
+    metadata: Record<string, unknown> | undefined,
+    args: Record<string, unknown> | undefined,
+  ): void {
+    if (args !== undefined && (!args || typeof args !== 'object' || Array.isArray(args))) {
+      throw new HarnessSkillArgsValidationError(skillName, ['args must be an object']);
+    }
+
+    const issues: string[] = [];
+    if (args !== undefined) {
+      this._validateJsonSerializableSkillArg('$', args, new WeakSet(), issues);
+    }
+    if (!metadata || typeof metadata !== 'object') {
+      if (issues.length > 0) throw new HarnessSkillArgsValidationError(skillName, issues);
+      return;
+    }
     const argsField = (metadata as Record<string, unknown>).args;
-    if (!argsField || typeof argsField !== 'object') return [];
-    const required = (argsField as Record<string, unknown>).required;
-    if (!Array.isArray(required)) return [];
-    return required.filter((k): k is string => typeof k === 'string' && k.length > 0);
+    if (argsField === undefined) {
+      if (issues.length > 0) throw new HarnessSkillArgsValidationError(skillName, issues);
+      return;
+    }
+    if (!this._isPlainRecord(argsField)) {
+      throw new HarnessSkillArgsValidationError(skillName, ['unsupported args schema: expected object']);
+    }
+
+    const issueCountBeforeSchemaShape = issues.length;
+    this._validateSkillArgSchemaShape('$', argsField, issues, new WeakSet());
+    if (issues.length > issueCountBeforeSchemaShape) {
+      throw new HarnessSkillArgsValidationError(skillName, issues);
+    }
+
+    this._validateSkillArgSchemaValue('$', args ?? {}, argsField, issues);
+    if (issues.length > 0) {
+      throw new HarnessSkillArgsValidationError(skillName, issues);
+    }
+  }
+
+  private _validateSkillArgSchemaShape(
+    path: string,
+    schema: Record<string, unknown>,
+    issues: string[],
+    seen: WeakSet<object>,
+  ): void {
+    if (seen.has(schema)) {
+      issues.push(`${path} must not contain circular args schema references`);
+      return;
+    }
+    seen.add(schema);
+
+    for (const key of Object.keys(schema)) {
+      if (!SUPPORTED_SKILL_ARG_SCHEMA_KEYS.has(key)) {
+        issues.push(`${path}.${key} is not a supported args schema field`);
+      }
+    }
+
+    const required = schema.required;
+    if (
+      required !== undefined &&
+      (!Array.isArray(required) || required.some(k => typeof k !== 'string' || k.length === 0))
+    ) {
+      issues.push(`${path}.required must be an array of non-empty strings`);
+    }
+
+    const enumValues = schema.enum;
+    if (enumValues !== undefined) {
+      if (!Array.isArray(enumValues)) {
+        issues.push(`${path}.enum must be an array`);
+      } else {
+        enumValues.forEach((candidate, index) => {
+          this._validateJsonSerializableSkillArg(`${path}.enum[${index}]`, candidate, new WeakSet(), issues);
+        });
+      }
+    }
+
+    const declaredType = schema.type;
+    if (declaredType !== undefined) {
+      this._validateSkillArgDeclaredType(path, declaredType, issues);
+    }
+
+    const properties = schema.properties;
+    if (properties !== undefined) {
+      if (!this._isPlainRecord(properties)) {
+        issues.push(`${path}.properties must be an object`);
+      } else {
+        for (const [key, childSchema] of Object.entries(properties)) {
+          if (!this._isPlainRecord(childSchema)) {
+            issues.push(`${path}.properties.${key} must be an object`);
+            continue;
+          }
+          this._validateSkillArgSchemaShape(path === '$' ? key : `${path}.${key}`, childSchema, issues, seen);
+        }
+      }
+    }
+
+    const additionalProperties = schema.additionalProperties;
+    if (additionalProperties !== undefined && additionalProperties !== true && additionalProperties !== false) {
+      issues.push(`${path}.additionalProperties must be boolean`);
+    }
+
+    const items = schema.items;
+    if (items !== undefined) {
+      if (!this._isPlainRecord(items)) {
+        issues.push(`${path}.items must be an object`);
+      } else {
+        this._validateSkillArgSchemaShape(`${path}[]`, items, issues, seen);
+      }
+    }
+
+    seen.delete(schema);
+  }
+
+  private _validateSkillArgSchemaValue(
+    path: string,
+    value: unknown,
+    schema: Record<string, unknown>,
+    issues: string[],
+  ): void {
+    const required = schema.required;
+    if (Array.isArray(required) && this._isPlainRecord(value)) {
+      for (const key of required) {
+        if (!Object.prototype.hasOwnProperty.call(value, key) || value[key] === undefined) {
+          issues.push(`missing required arg: "${path === '$' ? key : `${path}.${key}`}"`);
+        }
+      }
+    }
+
+    const enumValues = schema.enum;
+    if (Array.isArray(enumValues) && !enumValues.some(candidate => this._skillArgValuesEqual(candidate, value))) {
+      issues.push(`${path} must be one of ${JSON.stringify(enumValues)}`);
+    }
+
+    const declaredType = schema.type;
+    if (declaredType !== undefined && !this._matchesSkillArgType(value, declaredType, path, issues)) return;
+
+    const properties = schema.properties;
+    const additionalProperties = schema.additionalProperties;
+    if (this._isPlainRecord(properties) && this._isPlainRecord(value)) {
+      for (const [key, childSchema] of Object.entries(properties)) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+        if (!this._isPlainRecord(childSchema)) continue;
+        this._validateSkillArgSchemaValue(path === '$' ? key : `${path}.${key}`, value[key], childSchema, issues);
+      }
+    }
+    if (additionalProperties === false && this._isPlainRecord(value)) {
+      const allowedKeys = this._isPlainRecord(properties) ? new Set(Object.keys(properties)) : new Set<string>();
+      for (const key of Object.keys(value)) {
+        if (!allowedKeys.has(key)) issues.push(`unsupported arg: "${path === '$' ? key : `${path}.${key}`}"`);
+      }
+    }
+
+    const items = schema.items;
+    if (this._isPlainRecord(items) && Array.isArray(value)) {
+      value.forEach((item, index) => {
+        this._validateSkillArgSchemaValue(`${path}[${index}]`, item, items, issues);
+      });
+    }
+  }
+
+  private _validateSkillArgDeclaredType(path: string, declaredType: unknown, issues: string[]): void {
+    const allowedTypes = Array.isArray(declaredType) ? declaredType : [declaredType];
+    const supported = new Set(['string', 'number', 'integer', 'boolean', 'object', 'array', 'null']);
+    if (allowedTypes.some(type => typeof type !== 'string' || !supported.has(type))) {
+      issues.push(`${path}.type must be a supported JSON schema type`);
+    }
+  }
+
+  private _matchesSkillArgType(value: unknown, declaredType: unknown, path: string, issues: string[]): boolean {
+    const allowedTypes = Array.isArray(declaredType) ? declaredType : [declaredType];
+    const supported = new Set(['string', 'number', 'integer', 'boolean', 'object', 'array', 'null']);
+    if (allowedTypes.some(type => typeof type !== 'string' || !supported.has(type))) {
+      issues.push(`${path}.type must be a supported JSON schema type`);
+      return false;
+    }
+
+    const actualMatches = allowedTypes.some(type => {
+      switch (type) {
+        case 'string':
+          return typeof value === 'string';
+        case 'number':
+          return typeof value === 'number' && Number.isFinite(value);
+        case 'integer':
+          return Number.isInteger(value);
+        case 'boolean':
+          return typeof value === 'boolean';
+        case 'object':
+          return this._isPlainRecord(value);
+        case 'array':
+          return Array.isArray(value);
+        case 'null':
+          return value === null;
+        default:
+          return false;
+      }
+    });
+    if (!actualMatches) {
+      issues.push(`${path} must be ${allowedTypes.join(' | ')}`);
+    }
+    return actualMatches;
+  }
+
+  private _isPlainRecord(value: unknown): value is Record<string, unknown> {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  }
+
+  private _skillArgValuesEqual(left: unknown, right: unknown): boolean {
+    if (Object.is(left, right)) return true;
+    if (Array.isArray(left) && Array.isArray(right)) {
+      return (
+        left.length === right.length && left.every((value, index) => this._skillArgValuesEqual(value, right[index]))
+      );
+    }
+    if (this._isPlainRecord(left) && this._isPlainRecord(right)) {
+      const leftKeys = Object.keys(left);
+      const rightKeys = Object.keys(right);
+      if (leftKeys.length !== rightKeys.length) return false;
+      return leftKeys.every(
+        key => Object.prototype.hasOwnProperty.call(right, key) && this._skillArgValuesEqual(left[key], right[key]),
+      );
+    }
+    return false;
+  }
+
+  private _validateJsonSerializableSkillArg(
+    path: string,
+    value: unknown,
+    seen: WeakSet<object>,
+    issues: string[],
+  ): void {
+    if (value === null || typeof value === 'string' || typeof value === 'boolean') return;
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value)) issues.push(`${path} must be JSON-serializable`);
+      return;
+    }
+    if (value === undefined || typeof value === 'bigint' || typeof value === 'function' || typeof value === 'symbol') {
+      issues.push(`${path} must be JSON-serializable`);
+      return;
+    }
+    if (typeof value !== 'object') return;
+    if (Object.prototype.hasOwnProperty.call(value, 'toJSON')) {
+      issues.push(`${path}.toJSON is not supported in skill args`);
+      return;
+    }
+    if (seen.has(value)) {
+      issues.push(`${path} must not contain circular references`);
+      return;
+    }
+    seen.add(value);
+    if (Array.isArray(value)) {
+      value.forEach((item, index) => this._validateJsonSerializableSkillArg(`${path}[${index}]`, item, seen, issues));
+    } else if (this._isPlainRecord(value)) {
+      for (const [key, child] of Object.entries(value)) {
+        this._validateJsonSerializableSkillArg(path === '$' ? key : `${path}.${key}`, child, seen, issues);
+      }
+    } else {
+      issues.push(`${path} must be JSON-serializable`);
+    }
+    seen.delete(value);
   }
 
   /**
@@ -1105,31 +1368,34 @@ export class Session {
     if (this._skillsResolving) return this._skillsResolving;
 
     const build = async (): Promise<HarnessSkill[]> => {
+      const codeSkills = this._harness._listCodeSkills();
       const workspace = await this.getWorkspace();
       const workspaceSkills = workspace?.skills;
       if (!workspaceSkills) {
         // No workspace, or workspace has no skill source configured.
-        // Phase 2 will union this with code-registered skills.
-        return [];
+        return codeSkills;
       }
       const entries = await workspaceSkills.list();
-      const projected: HarnessSkill[] = entries.map(meta => ({
-        name: meta.name,
-        description: meta.description,
-        // `list()` returns metadata only; the instructions body lives in
-        // the skill's SKILL.md and is fetched via
-        // `workspace.skills.get(name)`. `use()` materializes instructions
-        // lazily; for the inspection surface we surface an empty string so
-        // the descriptor shape stays uniform.
-        instructions: '',
-        ...(meta.path ? { filePath: meta.path } : {}),
-        // Pass through arbitrary skill frontmatter metadata so callers can
-        // discover skill-level flags (e.g. `metadata.goal === true` for
-        // goal-mode skills). Workspace's `SkillMetadata.metadata` is
-        // typed `Record<string, unknown>` and is already JSON-serialisable.
-        ...(meta.metadata ? { metadata: meta.metadata } : {}),
-      }));
-      return projected;
+      const codeNames = new Set(codeSkills.map(skill => skill.name));
+      const projected = await Promise.all(
+        entries
+          .filter(meta => !codeNames.has(meta.name))
+          .map(async meta => {
+            const skill = await workspaceSkills.get(meta.path ?? meta.name);
+            return {
+              name: meta.name,
+              description: meta.description,
+              instructions: skill?.instructions ?? '',
+              ...(meta.path ? { filePath: meta.path } : {}),
+              // Pass through arbitrary skill frontmatter metadata so callers can
+              // discover skill-level flags (e.g. `metadata.goal === true` for
+              // goal-mode skills). Workspace's `SkillMetadata.metadata` is
+              // typed `Record<string, unknown>` and is already JSON-serialisable.
+              ...(meta.metadata ? { metadata: meta.metadata } : {}),
+            };
+          }),
+      );
+      return [...codeSkills, ...projected];
     };
 
     const pending = build();
@@ -1137,7 +1403,7 @@ export class Session {
     try {
       const result = await pending;
       // Only populate the cache when our own promise is still the
-      // session-tracked one. If `refreshSkills()` ran while we were
+      // session-tracked one. If `skills.refresh()` ran while we were
       // resolving, `_skillsResolving` was cleared (or replaced by a
       // newer build) and we must not stomp it.
       if (this._skillsResolving === pending) {

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -154,20 +154,23 @@ export type ModelAuthStatus = 'authenticated' | 'needs_auth' | 'unknown';
 // HarnessSkill (§4.6).
 //
 // A skill is a named, parameterised prompt invoked via
-// `session.skills.use(ref, opts)`. Skills are sourced from the session's
-// configured `WorkspaceSkills` — there is no separate code-registered
-// catalogue.
+// `session.skills.use(ref, opts)`. Skills are sourced from the static
+// HarnessConfig registry and the session's configured `WorkspaceSkills`.
+// Static skills resolve by name; workspace skills resolve by name or path.
+// Static skills win on name conflicts so deployment-owned prompts can
+// intentionally override workspace-discovered prompts.
 // ---------------------------------------------------------------------------
 
 /**
  * Public skill descriptor. See §4.6.
  *
- * Projected from the workspace `WorkspaceSkills` source into this shape.
+ * Code-registered directly through {@link HarnessConfigCommon.skills} or
+ * projected from the workspace `WorkspaceSkills` source into this shape.
  * Workspace-internal fields (references, scripts, assets, license,
  * compatibility) remain owned by `WorkspaceSkills` and are not surfaced here.
  */
 export interface HarnessSkill {
-  /** Lookup key for `session.skills.use(name, ...)`. */
+  /** Lookup key for code skills and the primary `session.skills.use(name, ...)` path. */
   name: string;
 
   /** Shown in tool catalogues / UIs. */
@@ -190,8 +193,9 @@ export interface HarnessSkill {
   filePath?: string;
 
   /**
-   * Pass-through of workspace skill metadata (e.g. `goal: true` for skills
-   * that should appear under `/goal/<name>`). Opaque to the harness.
+   * Pass-through skill metadata (e.g. `goal: true` for skills that should
+   * appear under `/goal/<name>`). `session.skills.use()` validates the
+   * optional `args` schema before dispatch; other fields remain caller-owned.
    */
   metadata?: Record<string, unknown>;
 }
@@ -202,9 +206,10 @@ export interface HarnessSkill {
 export interface UseSkillOptions {
   /**
    * Arguments to inject into the skill prompt as a JSON code block. If the
-   * resolved skill declares required argument keys in its frontmatter
-   * (`args.required[]`), missing keys throw
-   * {@link HarnessSkillArgsValidationError} before any turn starts.
+   * resolved skill declares `metadata.args`, missing required keys,
+   * unsupported schema shapes, and supported type/enum/property validation
+   * failures throw {@link HarnessSkillArgsValidationError} before any turn
+   * starts.
    */
   args?: Record<string, unknown>;
 
@@ -420,6 +425,15 @@ export interface HarnessConfigCommon {
   models?: ModelInfo[];
 
   /**
+   * Static, code-registered skills. These are merged ahead of the session's
+   * workspace-discovered skills for `session.skills.list/get/use`.
+   *
+   * Each `name` must be unique within this array. When a workspace skill has
+   * the same `name`, this code-registered descriptor wins.
+   */
+  skills?: HarnessSkill[];
+
+  /**
    * Resolves a catalog model id to its current auth status. Called by
    * `harness.models.getAuthStatus(modelId)`. May return a `Promise`.
    *
@@ -452,8 +466,8 @@ export interface HarnessConfigCommon {
    */
   workspace?: HarnessWorkspaceConfig;
 
-  // Remaining fields (skills, files, intervals, observationalMemory) land here
-  // as we wire them up.
+  // Remaining fields (files, intervals, observationalMemory) land here as we
+  // wire them up.
 
   [key: string]: unknown;
 }
@@ -1084,11 +1098,10 @@ export interface HarnessRequestContext<TState = unknown> {
   workspace?: Workspace;
 
   /**
-   * Invoke a workspace skill programmatically from inside a tool. Resolves
-   * by frontmatter `name` or relative path under the workspace skill
-   * source. Delegates to `session.skills.use(ref, opts)` against the
-   * owning session, sharing its resolution, args validation, prompt
-   * construction, and turn dispatch. See spec §4.6.
+   * Invoke a skill programmatically from inside a tool. Delegates to
+   * `session.skills.use(ref, opts)` against the owning session, sharing its
+   * code/workspace resolution, args validation, prompt construction, and turn
+   * dispatch. See spec §4.6.
    */
   useSkill: (ref: string, opts?: UseSkillOptions) => Promise<AgentResult>;
 }

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -196,6 +196,9 @@ export interface HarnessSkill {
    * Pass-through skill metadata (e.g. `goal: true` for skills that should
    * appear under `/goal/<name>`). `session.skills.use()` validates the
    * optional `args` schema before dispatch; other fields remain caller-owned.
+   * Code-registered skills accept only primitives, arrays, and plain objects
+   * here so returned descriptors cannot share mutable class instances with
+   * the original config.
    */
   metadata?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary

Linear: PF-350

- Add code-registered Harness v1 skills via `new Harness({ skills: [...] })` with construction-time validation, clone isolation, and code-before-workspace precedence for `session.skills.list/get/use`.
- Harden `metadata.args` validation before dispatch for supported schema fields, JSON-serializable args, malformed schema shapes, circular refs, and non-JSON enum values.
- Align the §4.6 skills spec and add an `@mastra/core` major changeset because unsupported workspace skill arg schema fields now fail before execution.

## Scope / overlap

Fresh open PR scan before push:

- #69 broad core/runtime revert-shaped diff; no direct `packages/core/src/harness/v1/**` or PF-350 spec-file overlap. General merge-order risk only.
- #68 legacy `packages/core/src/harness/**` and shared agent/tool runtime paths; no direct v1 harness path overlap.
- #58 ClickHouse memory only; no overlap.

No storage/server/channel/R2/Cloudflare/prod-sensitive behavior touched.

## Validation

- `pnpm --filter @mastra/core test src/harness/v1/session.skills.test.ts src/harness/v1/session.skills.use.test.ts` — passed, 2 files / 49 tests, no type errors.
- `pnpm --filter @mastra/core typecheck` — passed.
- `pnpm --filter @mastra/core build:lib` — passed; only existing npm config warnings and Node DEP0190 warning.
- `pnpm exec prettier --check .changeset/pf-350-harness-code-skills.md harness-spec-brainstorming/sections/04-public-api/06-skills.md packages/core/src/harness/v1/__test-utils__/setup.ts packages/core/src/harness/v1/errors.ts packages/core/src/harness/v1/harness.ts packages/core/src/harness/v1/session.skills.test.ts packages/core/src/harness/v1/session.skills.use.test.ts packages/core/src/harness/v1/session.ts packages/core/src/harness/v1/types.ts` — passed.
- `git diff --check` — passed.

## Review evidence

- Local Codex review pass 1, current diff: No findings.
- Local Codex review pass 2, current diff: No findings.
- CodeRabbit CLI, current diff after PR review fixes: Review completed: No findings.
- Claude read-only council: no blockers; accepted findings for metadata consistency and stricter-schema changeset disclosure were fixed.
- PR review threads from CodeRabbit and Codex were patched in `be68e5e253` and replied to with source/check evidence.

Rejected one CodeRabbit suggestion to swallow workspace resolution failures in `skills.list()`: §4.6 says workspace resolution/provider/resume/loss/discovery failures surface through the workspace error boundary instead of degrading to a partial catalog. Code-only `skills.get/use` still short-circuit without materializing workspace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR lets you define "skills" (things the assistant can run) directly in code when creating a Harness. Those code-defined skills are validated at construction and before use, and they take precedence over workspace-defined skills with the same name.

## Summary of Changes
Adds first-class support for code-registered Harness v1 skills via HarnessConfig.skills (new Harness({ skills: [...] })) so skills can be provided at Harness construction and automatically available in every session without workspace setup. Code-registered skills are resolved by name, cloned to avoid shared mutable references, validated for shape/metadata, and take precedence over workspace-discovered skills with the same name. Argument schemas in skill metadata are strictly validated prior to dispatch and execution.

### Key Features
- New Harness config field: skills?: HarnessSkill[] and Harness constructor validation/cloning for configured skills; private _codeSkills storage plus accessors _listCodeSkills() and _getCodeSkill().
- Resolution chain: session.skills.use/get/list now check code-registered skills first (by name) and then delegate to workspace discovery; merged catalog caches code + workspace entries with code skills first; session.skills.refresh() clears local discovery cache.
- Pre-dispatch metadata.args validation with a limited JSON-schema-like subset: supported keys are required, properties, type, enum, items, and boolean additionalProperties. Validator enforces JSON-serializability, rejects unsupported/malformed schema fields, detects circular refs, rejects non-JSON enum values, validates required keys and declared types (string/number/integer/boolean/object/array/null), enforces additionalProperties=false, and validates nested properties/items.
- Clone isolation: deep-clone semantics for skill descriptors/metadata using safe cycle-aware cloning so runtime mutations cannot weaken validation or share mutable instances.
- Error semantics: HarnessSkillNotFoundError now reports searchedSources including 'code-registered' and 'workspace'; HarnessSkillArgsValidationError thrown on schema/args validation failures before any turn begins.
- Behavior: Code-only skills.resolve/use short-circuit without materializing a workspace; workspace resolution/provider/resume/discovery failures continue to surface through the workspace error boundary (no swallowing).

### Spec & Type Changes
- Skills spec (§4.6) updated to document session-scoped, combined code + workspace resolution, discovery/caching/refresh, and args prompt construction (args appended as JSON code block to instructions).
- HarnessSkill descriptor clarified to include optional category, filePath, and metadata.
- UseSkillOptions: renamed model? → modelOverride?.
- HarnessConfigCommon gains skills?: HarnessSkill[].
- HarnessSkillNotFoundError constructor/signature updated to include both 'code-registered' | 'workspace' in searchedSources union.
- .changeset marks @mastra/core as a major release due to stricter schema validation that can break existing workspace skills using unsupported constraint fields.

### Tests & Validation
- Unit tests updated/added for session.skills.* and session.skills.use behaviors (two test files referenced; 48 tests across them) covering code-skill precedence, workspace shadowing, discovery caching/coalescing/refresh, session lifecycle, and extensive args/schema validation cases (non-object args, unsupported schema fields, JSON-serializability, circular refs, non-JSON enum values, required/defined checks, prevention of descriptor mutation attacks).
- Local CI: tests, typecheck, build:lib, prettier checks, and git diff --check passed for the changed files.

### Breaking Changes / Migration Notes
- Major changeset: @mastra/core bumped due to stricter pre-dispatch validation. Workspace skill descriptors that rely on unsupported JSON-schema-like constraint fields (e.g., pattern, minimum, minLength, etc.) will now fail validation before execution; authors must move such validation into the prompt/runtime or adapt metadata to the supported subset.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/84)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/84)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->