### PR TITLE
[PF-351] Add Harness admission storage contract

### DIFF
--- a/.changeset/pf-351-harness-storage-contract.md
+++ b/.changeset/pf-351-harness-storage-contract.md
@@ -18,4 +18,4 @@ const result = await harnessStorage.createOrLoadActiveSession(
 );
 ```
 
-The in-memory and LibSQL adapters implement the new contract with namespace-aware keys and focused conformance coverage.
+Tests and projects can now use namespace-scoped Harness storage without key collisions, with in-memory and LibSQL backends covered by the same conformance behavior.

--- a/.changeset/pf-351-harness-storage-contract.md
+++ b/.changeset/pf-351-harness-storage-contract.md
@@ -1,0 +1,21 @@
+---
+'@mastra/core': minor
+'@mastra/libsql': minor
+---
+
+[PF-351] Add namespace-aware Harness v1 admission/result storage contracts.
+
+Added:
+
+- Namespace scoping for Harness session and attachment storage.
+- Atomic active-session create/load behavior for `(harnessName, resourceId, threadId)`.
+- Durable queue admission receipts, lifecycle timestamps, retained result/tombstone lookups, duplicate/conflict resolution, compaction, and session-scoped tombstone cleanup.
+
+```ts
+const result = await harnessStorage.createOrLoadActiveSession(
+  { ...record, harnessName: 'alpha' },
+  { initialLease: { ownerId: 'worker-1', ttlMs: 30000 } },
+);
+```
+
+The in-memory and LibSQL adapters implement the new contract with namespace-aware keys and focused conformance coverage.

--- a/packages/core/src/harness/v1/harness.test.ts
+++ b/packages/core/src/harness/v1/harness.test.ts
@@ -12,8 +12,10 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Agent } from '../../agent';
+import { Mastra } from '../../mastra';
 import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
 import { InMemoryDB } from '../../storage/domains/inmemory-db';
+import { InMemoryStore } from '../../storage/mock';
 
 import {
   HarnessConfigError,
@@ -172,6 +174,38 @@ describe('Harness v1 — session(...) by thread', () => {
     const rehydrated = await harness2.session({ threadId: 't1', resourceId: 'r1' });
     expect(rehydrated.id).toBe(id);
     expect(rehydrated).not.toBe(original);
+  });
+
+  it('uses the registered Mastra harness key as the storage namespace', async () => {
+    const storage = new InMemoryStore();
+    const alpha = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+    const beta = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+    new Mastra({
+      agents: { default: makeAgent() },
+      storage,
+      harnesses: { alpha, beta },
+    });
+
+    const a = await alpha.session({ threadId: 'shared-thread', resourceId: 'r1' });
+    const b = await beta.session({ threadId: 'shared-thread', resourceId: 'r1' });
+
+    expect(a.id).not.toBe(b.id);
+    expect(a.getRecord().harnessName).toBe('alpha');
+    expect(b.getRecord().harnessName).toBe('beta');
+    const harnessStore = await storage.getStore('harness');
+    expect(harnessStore).toBeDefined();
+    await expect(harnessStore!.loadSession({ harnessName: 'alpha', sessionId: a.id })).resolves.toMatchObject({
+      harnessName: 'alpha',
+    });
+    await expect(harnessStore!.loadSession({ harnessName: 'beta', sessionId: b.id })).resolves.toMatchObject({
+      harnessName: 'beta',
+    });
   });
 
   it('forces a brand-new thread when threadId is { fresh: true }', async () => {
@@ -418,12 +452,11 @@ describe('Harness v1 — deterministic-id branch (§5.3)', () => {
     expect(b).toBe(a);
   });
 
-  it('creates a fresh record when caller-supplied sessionId disagrees with the active one', async () => {
+  it('returns the active record when caller-supplied sessionId disagrees with the active one', async () => {
     const harness = makeHarness();
     const first = await harness.session({ threadId: 't1', resourceId: 'r1' });
     const second = await harness.session({ threadId: 't1', resourceId: 'r1', sessionId: 'sess-different' });
-    expect(second.id).toBe('sess-different');
-    expect(second.id).not.toBe(first.id);
+    expect(second.id).toBe(first.id);
     expect(second.threadId).toBe('t1');
   });
 });
@@ -469,9 +502,9 @@ describe('Harness v1 — crash recovery (lease TTL)', () => {
     // expiry by rewriting the lease window into the past directly in the
     // backing db (saveSession preserves lease metadata so we cannot do this
     // through the public storage API).
-    const stored = db.harnessSessions.get(id);
+    const stored = db.harnessSessions.get(`default\u0000${id}`);
     if (!stored) throw new Error('precondition: session must exist after crash');
-    db.harnessSessions.set(id, { ...stored, leaseExpiresAt: Date.now() - 60_000 });
+    db.harnessSessions.set(`default\u0000${id}`, { ...stored, leaseExpiresAt: Date.now() - 60_000 });
 
     const b = makeHarness({ sessions: { storage } });
     const taken = await b.session({ sessionId: id });

--- a/packages/core/src/harness/v1/harness.test.ts
+++ b/packages/core/src/harness/v1/harness.test.ts
@@ -208,6 +208,21 @@ describe('Harness v1 — session(...) by thread', () => {
     });
   });
 
+  it('rejects re-registering the same Mastra under a different harness key', async () => {
+    const storage = new InMemoryStore();
+    const alpha = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+    const mastra = new Mastra({
+      agents: { default: makeAgent() },
+      storage,
+      harnesses: { alpha },
+    });
+
+    expect(() => alpha.__registerMastra(mastra, 'renamed')).toThrow(HarnessConfigError);
+  });
+
   it('forces a brand-new thread when threadId is { fresh: true }', async () => {
     const a = await harness.session({ threadId: { fresh: true }, resourceId: 'r1' });
     const b = await harness.session({ threadId: { fresh: true }, resourceId: 'r1' });

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -175,6 +175,7 @@ export class Harness {
    * `harness.mastra`.
    */
   private _mastra?: Mastra;
+  private _harnessName = 'default';
   private readonly _storageOverride?: HarnessStorage;
   private readonly _modesById: Map<string, HarnessMode>;
   private readonly _defaultModeId?: string;
@@ -456,9 +457,12 @@ export class Harness {
    * harness is registered under `harnesses.<name>`. Idempotent for the
    * same parent; throws if called twice with different parents.
    */
-  __registerMastra(mastra: Mastra): void {
+  __registerMastra(mastra: Mastra, harnessName?: string): void {
     if (this._mastra && this._mastra !== mastra) {
       throw new HarnessConfigError('mastra', 'harness is already bound to a different Mastra instance');
+    }
+    if (harnessName !== undefined) {
+      this._harnessName = harnessName;
     }
     if (this._mastra === mastra) return;
     this._bindMastra(mastra);
@@ -702,7 +706,7 @@ export class Harness {
       return live;
     }
 
-    const stored = await storage.loadSession({ sessionId });
+    const stored = await storage.loadSession({ harnessName: this._harnessName, sessionId });
     if (!stored) throw new HarnessSessionNotFoundError(sessionId);
     if (resourceId !== undefined && stored.resourceId !== resourceId) {
       // Cross-tenant existence is never leaked.
@@ -743,33 +747,13 @@ export class Harness {
     // In-memory hit by (threadId, resourceId)?
     for (const live of this._liveSessions.values()) {
       if (live.threadId === threadId && live.resourceId === resourceId) {
-        // §5.3: deterministic-ID callers can pass `sessionId` alongside; if
-        // the live one has a different id, prefer the explicit id and treat
-        // the live one as a different session.
-        if (opts.sessionId && live.id !== opts.sessionId) continue;
         return live;
       }
     }
 
     // Storage lookup — adapters filter out closed records.
-    const stored = await storage.loadSessionByThread({ threadId, resourceId });
+    const stored = await storage.loadSessionByThread({ harnessName: this._harnessName, threadId, resourceId });
     if (stored) {
-      if (opts.sessionId && stored.id !== opts.sessionId) {
-        // Caller asked for a specific session id on this thread; the active
-        // one in storage doesn't match — fall through to deterministic-id
-        // create with the supplied id.
-        return this._createFresh(storage, {
-          resourceId,
-          threadId,
-          ownsThread: false,
-          sessionId: opts.sessionId,
-          parentSessionId: opts.parentSessionId,
-          origin: opts.origin ?? 'top-level',
-          modeId: opts.modeId,
-          modelId: opts.modelId,
-          subagentDepth: opts.subagentDepth,
-        });
-      }
       return this._hydrate(storage, stored);
     }
 
@@ -803,11 +787,11 @@ export class Harness {
     }
     if (liveCandidate) return liveCandidate;
 
-    const summaries = await storage.listSessions({ resourceId, includeClosed: false });
+    const summaries = await storage.listSessions({ harnessName: this._harnessName, resourceId, includeClosed: false });
     const head = summaries[0];
     if (head) {
       // listSessions returns newest-first by lastActivityAt.
-      const stored = await storage.loadSession({ sessionId: head.id });
+      const stored = await storage.loadSession({ harnessName: this._harnessName, sessionId: head.id });
       if (stored && stored.closedAt === undefined) {
         return this._hydrate(storage, stored);
       }
@@ -859,10 +843,9 @@ export class Harness {
       throw new HarnessConfigError('session().modeId', `unknown mode "${modeId}"`);
     }
 
-    // First-write inserts the row, then we acquire the lease against it.
-    // Lease + version both start at the values set here.
     const record: SessionRecord = {
       id: sessionId,
+      harnessName: this._harnessName,
       resourceId: init.resourceId,
       threadId: init.threadId,
       parentSessionId: init.parentSessionId,
@@ -884,9 +867,11 @@ export class Harness {
       leaseExpiresAt: now + this._leaseTtlMs,
     };
 
-    let saved;
+    let admitted;
     try {
-      saved = await storage.saveSession(record, { ownerId: this.ownerId, ifVersion: 0 });
+      admitted = await storage.createOrLoadActiveSession(record, {
+        initialLease: { ownerId: this.ownerId, ttlMs: this._leaseTtlMs },
+      });
     } catch (err) {
       // A version conflict on first insert means another writer beat us to
       // this id (only realistic for deterministic ids passed by the caller).
@@ -895,15 +880,12 @@ export class Harness {
       }
       throw new HarnessStorageError(sessionId, 'flush', err);
     }
-    record.version = saved.version;
 
-    // Acquire the lease atomically so renews/CAS use a known TTL.
-    const lease = await this._acquireLease(storage, sessionId);
-    record.ownerId = this.ownerId;
-    record.leaseExpiresAt = lease.expiresAt;
-    record.version = lease.version;
+    if (!admitted.created) {
+      return this._hydrate(storage, admitted.record);
+    }
 
-    return this._publish(storage, record);
+    return this._publish(storage, admitted.record);
   }
 
   private async _hydrate(storage: HarnessStorage, stored: SessionRecord): Promise<Session> {
@@ -980,6 +962,7 @@ export class Harness {
   private async _acquireLease(storage: HarnessStorage, sessionId: string) {
     try {
       return await storage.acquireSessionLease({
+        harnessName: this._harnessName,
         sessionId,
         ownerId: this.ownerId,
         ttlMs: this._leaseTtlMs,
@@ -1011,7 +994,7 @@ export class Harness {
       await this._closeSession(live);
       return;
     }
-    const stored = await storage.loadSession({ sessionId: opts.sessionId });
+    const stored = await storage.loadSession({ harnessName: this._harnessName, sessionId: opts.sessionId });
     if (!stored) throw new HarnessSessionNotFoundError(opts.sessionId);
     if (stored.closedAt !== undefined) return; // already closed → idempotent.
     // Hydrate so we have the lease, then close.
@@ -1037,6 +1020,7 @@ export class Harness {
     let saved;
     try {
       saved = await storage.saveSession(closed, {
+        harnessName: record.harnessName,
         ownerId: this.ownerId,
         ifVersion: record.version,
       });
@@ -1050,6 +1034,7 @@ export class Harness {
     // parent's lease — a crash in the middle leaves a partially-closed
     // tree and the next deleteSession on the original target completes.
     const children = await storage.listSessions({
+      harnessName: record.harnessName,
       resourceId: record.resourceId,
       includeClosed: false,
       parentSessionId: record.id,
@@ -1060,6 +1045,7 @@ export class Harness {
 
     try {
       await storage.releaseSessionLease({
+        harnessName: record.harnessName,
         sessionId: session.id,
         ownerId: this.ownerId,
       });
@@ -1103,6 +1089,7 @@ export class Harness {
   async listSessions(opts: SessionListOptions & { parentSessionId?: string }): Promise<SessionSummary[]> {
     const storage = this._requireStorage('listSessions()');
     return storage.listSessions({
+      harnessName: this._harnessName,
       resourceId: opts.resourceId,
       includeClosed: opts.includeClosed,
       parentSessionId: opts.parentSessionId,
@@ -1116,7 +1103,7 @@ export class Harness {
    */
   async loadSession(opts: SessionLoadByIdOptions): Promise<SessionRecord | null> {
     const storage = this._requireStorage('loadSession()');
-    const stored = await storage.loadSession({ sessionId: opts.sessionId });
+    const stored = await storage.loadSession({ harnessName: this._harnessName, sessionId: opts.sessionId });
     if (!stored) return null;
     if (stored.closedAt !== undefined && !opts.includeClosed) return null;
     return stored;
@@ -1145,6 +1132,7 @@ export class Harness {
     for (const session of sessions) {
       try {
         await storage.releaseSessionLease({
+          harnessName: session.getRecord().harnessName,
           sessionId: session.id,
           ownerId: this.ownerId,
         });
@@ -1323,6 +1311,7 @@ export class Harness {
       const storage = this._requireStorage('threads.delete()');
       let cascaded = false;
       const stored = await storage.loadSessionByThread({
+        harnessName: this._harnessName,
         threadId: opts.threadId,
         resourceId: opts.resourceId,
       });
@@ -1492,6 +1481,7 @@ export class Harness {
           : new Uint8Array(await new Response(opts.data).arrayBuffer());
       const attachmentId = `attachment-${randomUUID()}`;
       const saved = await storage.saveAttachment({
+        harnessName: session.getRecord().harnessName,
         sessionId: session.id,
         attachmentId,
         name: opts.filename,
@@ -1515,6 +1505,7 @@ export class Harness {
       );
       try {
         await storage.deleteAttachment({
+          harnessName: session.getRecord().harnessName,
           sessionId: session.id,
           attachmentId: opts.attachmentId,
         });

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -461,10 +461,15 @@ export class Harness {
     if (this._mastra && this._mastra !== mastra) {
       throw new HarnessConfigError('mastra', 'harness is already bound to a different Mastra instance');
     }
+    if (this._mastra === mastra) {
+      if (harnessName !== undefined && harnessName !== this._harnessName) {
+        throw new HarnessConfigError('mastra', 'harness is already registered under a different harness name');
+      }
+      return;
+    }
     if (harnessName !== undefined) {
       this._harnessName = harnessName;
     }
-    if (this._mastra === mastra) return;
     this._bindMastra(mastra);
   }
 

--- a/packages/core/src/harness/v1/session.queue.test.ts
+++ b/packages/core/src/harness/v1/session.queue.test.ts
@@ -262,7 +262,8 @@ describe('Session.queue() — crash replay', () => {
     const sessionId = 'sess-replay';
     const queuedItemId = 'q-survive';
     const now = Date.now();
-    db.harnessSessions.set(sessionId, {
+    db.harnessSessions.set(`default\u0000${sessionId}`, {
+      harnessName: 'default',
       id: sessionId,
       resourceId: 'u',
       threadId: 't-replay',

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -3592,6 +3592,7 @@ export class Session {
     for (const attachment of item.attachments) {
       if (attachment.kind !== 'ref') continue;
       const loaded = await this._storage.loadAttachment({
+        harnessName: this._record.harnessName,
         sessionId: attachment.ownerSessionId,
         attachmentId: attachment.attachmentId,
       });

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -3405,6 +3405,7 @@ export class Session {
     const attachmentReferences = attachments
       .filter((attachment): attachment is Extract<PersistedAttachment, { kind: 'ref' }> => attachment.kind === 'ref')
       .map(attachment => ({
+        harnessName: this._record.harnessName,
         sessionId: attachment.ownerSessionId,
         attachmentId: attachment.attachmentId,
         source: 'queued_item' as const,
@@ -3447,6 +3448,7 @@ export class Session {
         throw new HarnessValidationError(`${field}[${i}].ownerSessionId`, 'attachment must belong to this session');
       }
       const record = await this._storage.getAttachmentRecord({
+        harnessName: this._record.harnessName,
         sessionId: this.id,
         attachmentId: ref.attachmentId,
       });
@@ -3797,6 +3799,7 @@ export class Session {
         lastActivityAt: Date.now(),
       };
       const saveOpts = {
+        harnessName: this._record.harnessName,
         ownerId: this._ownerId,
         ifVersion: this._record.version,
       };

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -245,8 +245,8 @@ export interface UseSkillOptions {
  *   1. **Registered on a Mastra instance.** The Harness is created with no
  *      `mastra` / `agents` / `storage` of its own and is then registered as
  *      a child of a `Mastra` instance (`new Mastra({ harnesses: { ... } })`).
- *      The parent calls `harness.__registerMastra(mastra)` and the harness
- *      reads agents and storage from there.
+ *      The parent calls `harness.__registerMastra(mastra, name)` and the
+ *      harness reads agents and storage from there.
  *
  *   2. **Self-contained.** The Harness is constructed with `agents` (and
  *      optionally `storage`) and internally builds a private `Mastra`

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1243,7 +1243,7 @@ export class Mastra<
     if (config?.harnesses) {
       for (const [key, harness] of Object.entries(config.harnesses)) {
         if (harness == null) continue;
-        harness.__registerMastra(this);
+        harness.__registerMastra(this, key);
         this.#harnesses[key] = harness;
       }
     }

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -48,6 +48,7 @@ export const TABLE_CHANNEL_CONFIG = 'mastra_channel_config';
 export const TABLE_HARNESS_SESSIONS = 'mastra_harness_sessions';
 export const TABLE_HARNESS_ATTACHMENTS = 'mastra_harness_attachments';
 export const TABLE_HARNESS_ATTACHMENT_REFERENCES = 'mastra_harness_attachment_references';
+export const TABLE_HARNESS_OPERATION_TOMBSTONES = 'mastra_harness_operation_tombstones';
 
 /** Union of all core table name constants. */
 export type TABLE_NAMES =
@@ -85,7 +86,8 @@ export type TABLE_NAMES =
   | typeof TABLE_CHANNEL_CONFIG
   | typeof TABLE_HARNESS_SESSIONS
   | typeof TABLE_HARNESS_ATTACHMENTS
-  | typeof TABLE_HARNESS_ATTACHMENT_REFERENCES;
+  | typeof TABLE_HARNESS_ATTACHMENT_REFERENCES
+  | typeof TABLE_HARNESS_OPERATION_TOMBSTONES;
 
 export const SCORERS_SCHEMA: Record<string, StorageColumn> = {
   id: { type: 'text', nullable: false, primaryKey: true },
@@ -634,11 +636,13 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
   // shapes are defined by the harness layer and the adapter does not query
   // their internals.
   [TABLE_HARNESS_SESSIONS]: {
+    harness_name: { type: 'text', nullable: false },
     id: { type: 'text', nullable: false, primaryKey: true },
     resource_id: { type: 'text', nullable: false },
     thread_id: { type: 'text', nullable: false },
     parent_session_id: { type: 'text', nullable: true },
     origin: { type: 'text', nullable: false },
+    subagent_depth: { type: 'integer', nullable: true },
     owns_thread: { type: 'boolean', nullable: false },
     mode_id: { type: 'text', nullable: false },
     model_id: { type: 'text', nullable: false },
@@ -648,12 +652,15 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
     token_usage: { type: 'jsonb', nullable: false },
     pending_queue: { type: 'jsonb', nullable: false },
     pending_resume: { type: 'jsonb', nullable: true },
+    queue_admission_receipts: { type: 'jsonb', nullable: true },
     observational_memory: { type: 'jsonb', nullable: true },
     goal: { type: 'jsonb', nullable: true },
     workspace: { type: 'jsonb', nullable: true },
     state: { type: 'jsonb', nullable: false },
     created_at: { type: 'bigint', nullable: false },
     last_activity_at: { type: 'bigint', nullable: false },
+    closing_at: { type: 'bigint', nullable: true },
+    close_deadline_at: { type: 'bigint', nullable: true },
     closed_at: { type: 'bigint', nullable: true },
     version: { type: 'integer', nullable: false },
     owner_id: { type: 'text', nullable: true },
@@ -665,6 +672,7 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
   // 100 MiB) the 33% base64 overhead is acceptable; switching to a true
   // BLOB column is a lossless schema migration when we extend the union.
   [TABLE_HARNESS_ATTACHMENTS]: {
+    harness_name: { type: 'text', nullable: false },
     session_id: { type: 'text', nullable: false },
     attachment_id: { type: 'text', nullable: false },
     name: { type: 'text', nullable: false },
@@ -676,12 +684,29 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
     data_b64: { type: 'text', nullable: false },
   },
   [TABLE_HARNESS_ATTACHMENT_REFERENCES]: {
+    harness_name: { type: 'text', nullable: false },
     session_id: { type: 'text', nullable: false },
     attachment_id: { type: 'text', nullable: false },
     source: { type: 'text', nullable: false },
     source_id: { type: 'text', nullable: false },
     retained_until: { type: 'bigint', nullable: true },
     created_at: { type: 'bigint', nullable: false },
+  },
+  [TABLE_HARNESS_OPERATION_TOMBSTONES]: {
+    id: { type: 'text', nullable: false, primaryKey: true },
+    harness_name: { type: 'text', nullable: false },
+    session_id: { type: 'text', nullable: false },
+    kind: { type: 'text', nullable: false },
+    resource_id: { type: 'text', nullable: false },
+    thread_id: { type: 'text', nullable: false },
+    admission_id: { type: 'text', nullable: true },
+    admission_hash: { type: 'text', nullable: true },
+    queued_item_id: { type: 'text', nullable: true },
+    signal_id: { type: 'text', nullable: true },
+    run_id: { type: 'text', nullable: true },
+    terminal_at: { type: 'bigint', nullable: false },
+    compacted_at: { type: 'bigint', nullable: false },
+    expires_at: { type: 'bigint', nullable: false },
   },
 };
 
@@ -691,13 +716,20 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
  */
 export const TABLE_CONFIGS: Partial<Record<TABLE_NAMES, StorageTableConfig>> = {
   [TABLE_DATASET_ITEMS]: { columns: DATASET_ITEMS_SCHEMA, compositePrimaryKey: ['id', 'datasetVersion'] },
+  [TABLE_HARNESS_SESSIONS]: {
+    columns: TABLE_SCHEMAS[TABLE_HARNESS_SESSIONS],
+    compositePrimaryKey: ['harness_name', 'id'],
+  },
   [TABLE_HARNESS_ATTACHMENTS]: {
     columns: TABLE_SCHEMAS[TABLE_HARNESS_ATTACHMENTS],
-    compositePrimaryKey: ['session_id', 'attachment_id'],
+    compositePrimaryKey: ['harness_name', 'session_id', 'attachment_id'],
   },
   [TABLE_HARNESS_ATTACHMENT_REFERENCES]: {
     columns: TABLE_SCHEMAS[TABLE_HARNESS_ATTACHMENT_REFERENCES],
-    compositePrimaryKey: ['session_id', 'attachment_id', 'source', 'source_id'],
+    compositePrimaryKey: ['harness_name', 'session_id', 'attachment_id', 'source', 'source_id'],
+  },
+  [TABLE_HARNESS_OPERATION_TOMBSTONES]: {
+    columns: TABLE_SCHEMAS[TABLE_HARNESS_OPERATION_TOMBSTONES],
   },
 };
 

--- a/packages/core/src/storage/domains/harness/base.ts
+++ b/packages/core/src/storage/domains/harness/base.ts
@@ -1,10 +1,16 @@
 import { StorageDomain } from '../base';
 import type {
   AcquireSessionLeaseInput,
+  AgentSignalResultStatus,
   AttachmentReference,
   AttachmentRecord,
+  CreateOrLoadActiveSessionOptions,
+  CreateOrLoadActiveSessionResult,
   ListSessionsInput,
   LoadedAttachment,
+  OperationAdmissionEvidence,
+  OperationAdmissionTombstone,
+  QueueAdmissionReceipt,
   ReleaseSessionLeaseInput,
   RenewSessionLeaseInput,
   SaveAttachmentInput,
@@ -90,6 +96,18 @@ export class HarnessStorageSessionNotFoundError extends Error {
   }
 }
 
+export class HarnessStorageAdmissionConflictError extends Error {
+  readonly name = 'HarnessStorageAdmissionConflictError';
+  readonly code = 'harness.storage.admission_conflict' as const;
+  constructor(
+    public readonly sessionId: string,
+    public readonly kind: 'message' | 'queue',
+    public readonly admissionId: string,
+  ) {
+    super(`Admission "${admissionId}" for ${kind} in session "${sessionId}" conflicts with stored evidence`);
+  }
+}
+
 /**
  * Storage domain for the v1 Harness — see HARNESS_V1_SPEC.md §5.
  *
@@ -132,7 +150,7 @@ export abstract class HarnessStorage extends StorageDomain {
    * Resource scoping is NOT enforced here; the harness layer cross-checks
    * `resourceId` against the returned record before surfacing it.
    */
-  abstract loadSession(opts: { sessionId: string }): Promise<SessionRecord | null>;
+  abstract loadSession(opts: { harnessName?: string; sessionId: string }): Promise<SessionRecord | null>;
 
   /**
    * Lookup by (thread, resource). Returns only **active** records
@@ -140,10 +158,14 @@ export abstract class HarnessStorage extends StorageDomain {
    * even if one or more closed records match — close-then-reopen-by-thread
    * is guaranteed to create a fresh session (HARNESS_V1_SPEC.md §5.3).
    *
-   * If multiple active records match (a degenerate state), implementations
-   * return the most recent by `lastActivityAt`.
+   * Implementations reject new rows that would create a second active session
+   * for the same `(harnessName, resourceId, threadId)` admission key.
    */
-  abstract loadSessionByThread(opts: { threadId: string; resourceId: string }): Promise<SessionRecord | null>;
+  abstract loadSessionByThread(opts: {
+    harnessName?: string;
+    threadId: string;
+    resourceId: string;
+  }): Promise<SessionRecord | null>;
 
   /**
    * List session summaries for a resource. Closed records are excluded by
@@ -181,6 +203,17 @@ export abstract class HarnessStorage extends StorageDomain {
   ): Promise<SaveSessionResult>;
 
   /**
+   * Atomic active-session admission. Inserts `record` only when no active
+   * record exists for `(harnessName, resourceId, threadId)`; otherwise returns
+   * the existing active row without overwriting it. A created row also receives
+   * the caller's initial lease.
+   */
+  abstract createOrLoadActiveSession(
+    record: SessionRecord,
+    opts: CreateOrLoadActiveSessionOptions,
+  ): Promise<CreateOrLoadActiveSessionResult>;
+
+  /**
    * Hard-delete of a single session record. The harness layer's
    * `harness.deleteSession(...)` walks the `parentSessionId` chain and
    * calls this method once per descendant — adapters do NOT implement
@@ -189,7 +222,7 @@ export abstract class HarnessStorage extends StorageDomain {
    * Implementations should also delete attachments owned by the session
    * (equivalent to `deleteAttachmentsForSession`) to keep the index clean.
    */
-  abstract deleteSession(opts: { sessionId: string }): Promise<void>;
+  abstract deleteSession(opts: { harnessName?: string; sessionId: string }): Promise<void>;
 
   // -------------------------------------------------------------------------
   // Session leases (HARNESS_V1_SPEC.md §5.8)
@@ -248,13 +281,17 @@ export abstract class HarnessStorage extends StorageDomain {
    * Load an attachment by (sessionId, attachmentId). Returns null when the
    * row is missing.
    */
-  abstract loadAttachment(opts: { sessionId: string; attachmentId: string }): Promise<LoadedAttachment | null>;
+  abstract loadAttachment(opts: {
+    harnessName?: string;
+    sessionId: string;
+    attachmentId: string;
+  }): Promise<LoadedAttachment | null>;
 
   /**
    * Delete a single attachment. No-op when the row is missing.
    * Throws `HarnessStorageAttachmentInUseError` while references remain.
    */
-  abstract deleteAttachment(opts: { sessionId: string; attachmentId: string }): Promise<void>;
+  abstract deleteAttachment(opts: { harnessName?: string; sessionId: string; attachmentId: string }): Promise<void>;
 
   /**
    * Delete all attachments owned by a session. Called from `deleteSession`
@@ -262,13 +299,17 @@ export abstract class HarnessStorage extends StorageDomain {
    * down. Referenced rows are skipped; force cleanup belongs to the lifecycle
    * delete lane.
    */
-  abstract deleteAttachmentsForSession(opts: { sessionId: string }): Promise<void>;
+  abstract deleteAttachmentsForSession(opts: { harnessName?: string; sessionId: string }): Promise<void>;
 
   /**
    * Look up the index row only (without bytes). Useful for attachment
    * metadata listings (e.g. message rendering).
    */
-  abstract getAttachmentRecord(opts: { sessionId: string; attachmentId: string }): Promise<AttachmentRecord | null>;
+  abstract getAttachmentRecord(opts: {
+    harnessName?: string;
+    sessionId: string;
+    attachmentId: string;
+  }): Promise<AttachmentRecord | null>;
 
   /**
    * Register durable references to attachment bytes. Source ids are scoped by
@@ -280,7 +321,61 @@ export abstract class HarnessStorage extends StorageDomain {
 
   abstract deleteAttachmentReferences(references: SaveAttachmentReferenceInput[]): Promise<void>;
 
-  abstract listAttachmentReferences(opts: { sessionId: string; attachmentId: string }): Promise<AttachmentReference[]>;
+  abstract listAttachmentReferences(opts: {
+    harnessName?: string;
+    sessionId: string;
+    attachmentId: string;
+  }): Promise<AttachmentReference[]>;
+
+  // -------------------------------------------------------------------------
+  // Admission/result evidence
+  // -------------------------------------------------------------------------
+
+  abstract loadMessageResultEvidence(opts: {
+    harnessName?: string;
+    sessionId: string;
+    resourceId: string;
+    threadId: string;
+    signalId: string;
+  }): Promise<AgentSignalResultStatus | OperationAdmissionTombstone | null>;
+
+  abstract loadQueueResultEvidence(opts: {
+    harnessName?: string;
+    sessionId: string;
+    resourceId: string;
+    queuedItemId: string;
+  }): Promise<QueueAdmissionReceipt | OperationAdmissionTombstone | null>;
+
+  abstract resolveOperationAdmissionEvidence(opts: {
+    harnessName?: string;
+    sessionId: string;
+    resourceId: string;
+    kind: 'message' | 'queue';
+    admissionId: string;
+    attemptedAdmissionHash: string;
+  }): Promise<{
+    status: 'none' | 'duplicate' | 'conflict';
+    evidence?: OperationAdmissionEvidence;
+    storedAdmissionHash?: string;
+  }>;
+
+  abstract writeOperationAdmissionTombstone(record: OperationAdmissionTombstone): Promise<void>;
+
+  abstract compactOperationResultEvidence(opts: {
+    harnessName?: string;
+    sessionId: string;
+    resourceId: string;
+    kind: 'message' | 'queue';
+    signalId?: string;
+    queuedItemId?: string;
+    now: number;
+  }): Promise<OperationAdmissionTombstone | null>;
+
+  abstract deleteOperationAdmissionTombstonesForSession(opts: {
+    harnessName?: string;
+    sessionId: string;
+    resourceId: string;
+  }): Promise<void>;
 
   // -------------------------------------------------------------------------
   // Test-only

--- a/packages/core/src/storage/domains/harness/inmemory.test.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+
+import { InMemoryDB } from '../inmemory-db';
+import { HarnessStorageVersionConflictError } from './base';
+import { InMemoryHarness } from './inmemory';
+import type { SessionRecord } from './types';
+
+describe('InMemoryHarness admission storage contract', () => {
+  it('creates or returns one active session for a namespace/resource/thread key', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    const first = await storage.createOrLoadActiveSession(sampleSession({ id: 'first' }), {
+      initialLease: { ownerId: 'h-1', ttlMs: 30_000 },
+    });
+    const second = await storage.createOrLoadActiveSession(sampleSession({ id: 'second' }), {
+      initialLease: { ownerId: 'h-2', ttlMs: 30_000 },
+    });
+
+    expect(first).toMatchObject({ created: true, leaseAcquired: true, version: 1 });
+    expect(second).toMatchObject({
+      created: false,
+      leaseAcquired: false,
+      record: expect.objectContaining({ id: 'first', ownerId: 'h-1' }),
+    });
+    await expect(storage.loadSession({ sessionId: 'second' })).resolves.toBeNull();
+  });
+
+  it('rejects direct first writes that would create duplicate active sessions', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    await storage.saveSession(sampleSession({ id: 'first' }), { ownerId: 'h-1', ifVersion: 0 });
+
+    await expect(
+      storage.saveSession(sampleSession({ id: 'second' }), { ownerId: 'h-2', ifVersion: 0 }),
+    ).rejects.toBeInstanceOf(HarnessStorageVersionConflictError);
+    await expect(storage.loadSession({ sessionId: 'second' })).resolves.toBeNull();
+  });
+
+  it('isolates sessions by harness namespace', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+
+    await storage.saveSession(sampleSession({ harnessName: 'harness-a', modeId: 'build' }), {
+      harnessName: 'harness-a',
+      ownerId: 'h',
+      ifVersion: 0,
+    });
+    await storage.saveSession(sampleSession({ harnessName: 'harness-b', modeId: 'review' }), {
+      harnessName: 'harness-b',
+      ownerId: 'h',
+      ifVersion: 0,
+    });
+
+    await expect(storage.loadSession({ harnessName: 'harness-a', sessionId: 'session-1' })).resolves.toMatchObject({
+      harnessName: 'harness-a',
+      modeId: 'build',
+    });
+    await expect(storage.loadSession({ harnessName: 'harness-b', sessionId: 'session-1' })).resolves.toMatchObject({
+      harnessName: 'harness-b',
+      modeId: 'review',
+    });
+  });
+
+  it('compacts terminal queue receipts into namespace-scoped tombstones', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    await storage.saveSession(
+      sampleSession({
+        queueAdmissionReceipts: {
+          'queued-1': {
+            admissionId: 'admission-1',
+            admissionHash: 'hash-1',
+            queuedItemId: 'queued-1',
+            status: 'completed',
+            attempts: 1,
+            enqueuedAt: 1000,
+            completedAt: 2000,
+            updatedAt: 2000,
+            runId: 'run-1',
+            signalId: 'signal-1',
+          },
+        },
+      }),
+      { ownerId: 'h', ifVersion: 0 },
+    );
+
+    const tombstone = await storage.compactOperationResultEvidence({
+      sessionId: 'session-1',
+      resourceId: 'resource-1',
+      kind: 'queue',
+      queuedItemId: 'queued-1',
+      now: 3000,
+    });
+
+    expect(tombstone).toMatchObject({
+      harnessName: 'default',
+      admissionId: 'admission-1',
+      admissionHash: 'hash-1',
+      queuedItemId: 'queued-1',
+      terminalAt: 2000,
+      compactedAt: 3000,
+    });
+    await expect(
+      storage.loadQueueResultEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        queuedItemId: 'queued-1',
+      }),
+    ).resolves.toEqual(tombstone);
+  });
+});
+
+function sampleSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    harnessName: 'default',
+    id: 'session-1',
+    resourceId: 'resource-1',
+    threadId: 'thread-1',
+    origin: 'top-level',
+    ownsThread: false,
+    modeId: 'build',
+    modelId: 'model-1',
+    subagentModelOverrides: {},
+    permissionRules: { categories: {}, tools: {} },
+    sessionGrants: { categories: [], tools: [] },
+    tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    pendingQueue: [],
+    state: {},
+    createdAt: 1000,
+    lastActivityAt: 1000,
+    version: 0,
+    ...overrides,
+  };
+}

--- a/packages/core/src/storage/domains/harness/inmemory.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.ts
@@ -169,8 +169,10 @@ export class InMemoryHarness extends HarnessStorage {
     }
 
     for (const ref of references) {
-      const refHarnessName = resolveHarnessName(ref.harnessName, harnessName);
-      if (!this.db.harnessAttachmentRecords.has(attachmentKey(refHarnessName, ref.sessionId, ref.attachmentId))) {
+      if (ref.harnessName !== undefined && resolveHarnessName(ref.harnessName, harnessName) !== harnessName) {
+        throw new HarnessStorageAttachmentUnavailableError(ref.sessionId, ref.attachmentId);
+      }
+      if (!this.db.harnessAttachmentRecords.has(attachmentKey(harnessName, ref.sessionId, ref.attachmentId))) {
         throw new HarnessStorageAttachmentUnavailableError(ref.sessionId, ref.attachmentId);
       }
     }
@@ -185,8 +187,7 @@ export class InMemoryHarness extends HarnessStorage {
     };
     this.db.harnessSessions.set(sessionKey(harnessName, record.id), cloneSessionRecord(stored));
     for (const ref of references) {
-      const refHarnessName = resolveHarnessName(ref.harnessName, harnessName);
-      this.db.harnessAttachmentReferences.set(attachmentReferenceKey({ ...ref, harnessName: refHarnessName }), {
+      this.db.harnessAttachmentReferences.set(attachmentReferenceKey({ ...ref, harnessName }), {
         source: ref.source,
         sourceId: ref.sourceId,
         ...(ref.retainedUntil !== undefined ? { retainedUntil: ref.retainedUntil } : {}),
@@ -249,6 +250,12 @@ export class InMemoryHarness extends HarnessStorage {
         sessionId,
         resourceId: existing.resourceId,
       });
+    }
+    const refPrefix = `${namespace}\u0000${sessionId}\u0000`;
+    for (const key of this.db.harnessAttachmentReferences.keys()) {
+      if (key.startsWith(refPrefix)) {
+        this.db.harnessAttachmentReferences.delete(key);
+      }
     }
     this.db.harnessSessions.delete(sessionKey(namespace, sessionId));
     await this.deleteAttachmentsForSession({ harnessName: namespace, sessionId });

--- a/packages/core/src/storage/domains/harness/inmemory.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.ts
@@ -46,6 +46,7 @@ import type {
 export class InMemoryHarness extends HarnessStorage {
   private db: InMemoryDB;
   private readonly harnessName: string;
+  private readonly compactionLocks = new Map<string, Promise<void>>();
 
   constructor({ db, harnessName = 'default' }: { db: InMemoryDB; harnessName?: string }) {
     super();
@@ -625,34 +626,37 @@ export class InMemoryHarness extends HarnessStorage {
       );
     }
 
-    const session = this.db.harnessSessions.get(sessionKey(namespace, sessionId));
-    if (session && session.resourceId !== resourceId) return null;
-    const receipt = queuedItemId ? session?.queueAdmissionReceipts?.[queuedItemId] : undefined;
-    if (!session || !receipt) return null;
-    if (!isTerminalQueueReceipt(receipt)) return null;
-    const tombstone: OperationAdmissionTombstone = {
-      kind: 'queue',
-      harnessName: namespace,
-      sessionId,
-      resourceId,
-      threadId: session.threadId,
-      admissionId: receipt.admissionId,
-      admissionHash: receipt.admissionHash,
-      queuedItemId: receipt.queuedItemId,
-      ...(receipt.signalId !== undefined ? { signalId: receipt.signalId } : {}),
-      ...(receipt.runId !== undefined ? { runId: receipt.runId } : {}),
-      terminalAt: receipt.completedAt ?? receipt.failedAt ?? receipt.deadAt ?? now,
-      compactedAt: now,
-      expiresAt: now,
-    };
-    await this.writeOperationAdmissionTombstone(tombstone);
-    const nextReceipts = { ...(session.queueAdmissionReceipts ?? {}) };
-    delete nextReceipts[queuedItemId!];
-    this.db.harnessSessions.set(sessionKey(namespace, sessionId), {
-      ...session,
-      queueAdmissionReceipts: Object.keys(nextReceipts).length > 0 ? nextReceipts : undefined,
+    const key = sessionKey(namespace, sessionId);
+    return this.withCompactionLock(key, async () => {
+      const session = this.db.harnessSessions.get(key);
+      if (session && session.resourceId !== resourceId) return null;
+      const receipt = queuedItemId ? session?.queueAdmissionReceipts?.[queuedItemId] : undefined;
+      if (!session || !receipt) return null;
+      if (!isTerminalQueueReceipt(receipt)) return null;
+      const tombstone: OperationAdmissionTombstone = {
+        kind: 'queue',
+        harnessName: namespace,
+        sessionId,
+        resourceId,
+        threadId: session.threadId,
+        admissionId: receipt.admissionId,
+        admissionHash: receipt.admissionHash,
+        queuedItemId: receipt.queuedItemId,
+        ...(receipt.signalId !== undefined ? { signalId: receipt.signalId } : {}),
+        ...(receipt.runId !== undefined ? { runId: receipt.runId } : {}),
+        terminalAt: receipt.completedAt ?? receipt.failedAt ?? receipt.deadAt ?? now,
+        compactedAt: now,
+        expiresAt: now,
+      };
+      await this.writeOperationAdmissionTombstone(tombstone);
+      const nextReceipts = { ...(session.queueAdmissionReceipts ?? {}) };
+      delete nextReceipts[queuedItemId!];
+      this.db.harnessSessions.set(key, {
+        ...session,
+        queueAdmissionReceipts: Object.keys(nextReceipts).length > 0 ? nextReceipts : undefined,
+      });
+      return cloneJson(tombstone);
     });
-    return cloneJson(tombstone);
   }
 
   async deleteOperationAdmissionTombstonesForSession({
@@ -683,6 +687,25 @@ export class InMemoryHarness extends HarnessStorage {
       if (predicate(tombstone)) return tombstone;
     }
     return null;
+  }
+
+  private async withCompactionLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const previous = this.compactionLocks.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    const queued = previous.catch(() => undefined).then(() => current);
+    this.compactionLocks.set(key, queued);
+    await previous.catch(() => undefined);
+    try {
+      return await fn();
+    } finally {
+      release();
+      if (this.compactionLocks.get(key) === queued) {
+        this.compactionLocks.delete(key);
+      }
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/packages/core/src/storage/domains/harness/inmemory.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 import type { InMemoryDB } from '../inmemory-db';
 import {
   HarnessStorage,
+  HarnessStorageAdmissionConflictError,
   HarnessStorageAttachmentInUseError,
   HarnessStorageAttachmentUnavailableError,
   HarnessStorageLeaseConflictError,
@@ -11,10 +12,16 @@ import {
 } from './base';
 import type {
   AcquireSessionLeaseInput,
+  AgentSignalResultStatus,
   AttachmentReference,
   AttachmentRecord,
+  CreateOrLoadActiveSessionOptions,
+  CreateOrLoadActiveSessionResult,
   ListSessionsInput,
   LoadedAttachment,
+  OperationAdmissionEvidence,
+  OperationAdmissionTombstone,
+  QueueAdmissionReceipt,
   ReleaseSessionLeaseInput,
   RenewSessionLeaseInput,
   SaveAttachmentReferenceInput,
@@ -38,45 +45,63 @@ import type {
  */
 export class InMemoryHarness extends HarnessStorage {
   private db: InMemoryDB;
+  private readonly harnessName: string;
 
-  constructor({ db }: { db: InMemoryDB }) {
+  constructor({ db, harnessName = 'default' }: { db: InMemoryDB; harnessName?: string }) {
     super();
     this.db = db;
+    this.harnessName = harnessName;
   }
 
   // -------------------------------------------------------------------------
   // Session records
   // -------------------------------------------------------------------------
 
-  async loadSession({ sessionId }: { sessionId: string }): Promise<SessionRecord | null> {
-    return this.db.harnessSessions.get(sessionId) ?? null;
+  async loadSession({
+    sessionId,
+    harnessName,
+  }: {
+    sessionId: string;
+    harnessName?: string;
+  }): Promise<SessionRecord | null> {
+    const record = this.db.harnessSessions.get(
+      sessionKey(resolveHarnessName(harnessName, this.harnessName), sessionId),
+    );
+    return record ? cloneSessionRecord(record) : null;
   }
 
   async loadSessionByThread({
     threadId,
     resourceId,
+    harnessName,
   }: {
     threadId: string;
     resourceId: string;
+    harnessName?: string;
   }): Promise<SessionRecord | null> {
     let candidate: SessionRecord | null = null;
+    const namespace = resolveHarnessName(harnessName, this.harnessName);
     for (const record of this.db.harnessSessions.values()) {
+      if (record.harnessName !== namespace) continue;
       if (record.threadId !== threadId || record.resourceId !== resourceId) continue;
       if (record.closedAt !== undefined) continue;
       if (candidate === null || record.lastActivityAt > candidate.lastActivityAt) {
         candidate = record;
       }
     }
-    return candidate;
+    return candidate ? cloneSessionRecord(candidate) : null;
   }
 
   async listSessions({
     resourceId,
     includeClosed = false,
     parentSessionId,
+    harnessName,
   }: ListSessionsInput): Promise<SessionSummary[]> {
     const matched: SessionRecord[] = [];
+    const namespace = resolveHarnessName(harnessName, this.harnessName);
     for (const record of this.db.harnessSessions.values()) {
+      if (record.harnessName !== namespace) continue;
       if (record.resourceId !== resourceId) continue;
       if (!includeClosed && record.closedAt !== undefined) continue;
       if (parentSessionId !== undefined && record.parentSessionId !== parentSessionId) continue;
@@ -87,7 +112,8 @@ export class InMemoryHarness extends HarnessStorage {
   }
 
   async saveSession(record: SessionRecord, opts: SaveSessionOptions): Promise<SaveSessionResult> {
-    const existing = this.db.harnessSessions.get(record.id);
+    const harnessName = opts.harnessName ?? record.harnessName ?? this.harnessName;
+    const existing = this.db.harnessSessions.get(sessionKey(harnessName, record.id));
 
     if (existing) {
       // Lease check first — the lease is the authoritative ownership token.
@@ -101,18 +127,25 @@ export class InMemoryHarness extends HarnessStorage {
       if (opts.ifVersion !== 0) {
         throw new HarnessStorageVersionConflictError(record.id, opts.ifVersion, 0);
       }
+      for (const active of this.db.harnessSessions.values()) {
+        if (active.harnessName !== harnessName) continue;
+        if (active.resourceId !== record.resourceId || active.threadId !== record.threadId) continue;
+        if (active.closedAt !== undefined) continue;
+        throw new HarnessStorageVersionConflictError(record.id, opts.ifVersion, active.version);
+      }
     }
 
     const nextVersion = opts.ifVersion + 1;
     const stored: SessionRecord = {
       ...record,
+      harnessName,
       version: nextVersion,
       // Preserve current lease metadata — `saveSession` does not mutate it.
       ownerId: existing?.ownerId,
       leaseExpiresAt: existing?.leaseExpiresAt,
     };
 
-    this.db.harnessSessions.set(record.id, stored);
+    this.db.harnessSessions.set(sessionKey(harnessName, record.id), cloneSessionRecord(stored));
     return { version: nextVersion };
   }
 
@@ -121,7 +154,8 @@ export class InMemoryHarness extends HarnessStorage {
     opts: SaveSessionOptions,
     references: SaveAttachmentReferenceInput[],
   ): Promise<SaveSessionResult> {
-    const existing = this.db.harnessSessions.get(record.id);
+    const harnessName = opts.harnessName ?? record.harnessName ?? this.harnessName;
+    const existing = this.db.harnessSessions.get(sessionKey(harnessName, record.id));
 
     if (existing) {
       assertLeaseHolder(existing, opts.ownerId);
@@ -134,7 +168,8 @@ export class InMemoryHarness extends HarnessStorage {
     }
 
     for (const ref of references) {
-      if (!this.db.harnessAttachmentRecords.has(attachmentKey(ref.sessionId, ref.attachmentId))) {
+      const refHarnessName = resolveHarnessName(ref.harnessName, harnessName);
+      if (!this.db.harnessAttachmentRecords.has(attachmentKey(refHarnessName, ref.sessionId, ref.attachmentId))) {
         throw new HarnessStorageAttachmentUnavailableError(ref.sessionId, ref.attachmentId);
       }
     }
@@ -142,13 +177,15 @@ export class InMemoryHarness extends HarnessStorage {
     const nextVersion = opts.ifVersion + 1;
     const stored: SessionRecord = {
       ...record,
+      harnessName,
       version: nextVersion,
       ownerId: existing.ownerId,
       leaseExpiresAt: existing.leaseExpiresAt,
     };
-    this.db.harnessSessions.set(record.id, stored);
+    this.db.harnessSessions.set(sessionKey(harnessName, record.id), cloneSessionRecord(stored));
     for (const ref of references) {
-      this.db.harnessAttachmentReferences.set(attachmentReferenceKey(ref), {
+      const refHarnessName = resolveHarnessName(ref.harnessName, harnessName);
+      this.db.harnessAttachmentReferences.set(attachmentReferenceKey({ ...ref, harnessName: refHarnessName }), {
         source: ref.source,
         sourceId: ref.sourceId,
         ...(ref.retainedUntil !== undefined ? { retainedUntil: ref.retainedUntil } : {}),
@@ -157,17 +194,77 @@ export class InMemoryHarness extends HarnessStorage {
     return { version: nextVersion };
   }
 
-  async deleteSession({ sessionId }: { sessionId: string }): Promise<void> {
-    this.db.harnessSessions.delete(sessionId);
-    await this.deleteAttachmentsForSession({ sessionId });
+  async createOrLoadActiveSession(
+    record: SessionRecord,
+    opts: CreateOrLoadActiveSessionOptions,
+  ): Promise<CreateOrLoadActiveSessionResult> {
+    const namespace = resolveHarnessName(record.harnessName, this.harnessName);
+    const storageNow = Date.now();
+    for (const existing of this.db.harnessSessions.values()) {
+      if (existing.harnessName !== namespace) continue;
+      if (existing.resourceId !== record.resourceId || existing.threadId !== record.threadId) continue;
+      if (existing.closedAt !== undefined) continue;
+      return {
+        record: cloneSessionRecord(existing),
+        created: false,
+        leaseAcquired: false,
+        version: existing.version,
+        expiresAt: existing.leaseExpiresAt,
+        storageNow,
+      };
+    }
+
+    const key = sessionKey(namespace, record.id);
+    const existingById = this.db.harnessSessions.get(key);
+    if (existingById) {
+      throw new HarnessStorageVersionConflictError(record.id, 0, existingById.version);
+    }
+
+    const expiresAt = storageNow + opts.initialLease.ttlMs;
+    const stored: SessionRecord = {
+      ...record,
+      harnessName: namespace,
+      version: 1,
+      ownerId: opts.initialLease.ownerId,
+      leaseExpiresAt: expiresAt,
+    };
+    this.db.harnessSessions.set(key, cloneSessionRecord(stored));
+    return {
+      record: cloneSessionRecord(stored),
+      created: true,
+      leaseAcquired: true,
+      version: 1,
+      expiresAt,
+      storageNow,
+    };
+  }
+
+  async deleteSession({ sessionId, harnessName }: { sessionId: string; harnessName?: string }): Promise<void> {
+    const namespace = resolveHarnessName(harnessName, this.harnessName);
+    const existing = this.db.harnessSessions.get(sessionKey(namespace, sessionId));
+    if (existing) {
+      await this.deleteOperationAdmissionTombstonesForSession({
+        harnessName: namespace,
+        sessionId,
+        resourceId: existing.resourceId,
+      });
+    }
+    this.db.harnessSessions.delete(sessionKey(namespace, sessionId));
+    await this.deleteAttachmentsForSession({ harnessName: namespace, sessionId });
   }
 
   // -------------------------------------------------------------------------
   // Session leases
   // -------------------------------------------------------------------------
 
-  async acquireSessionLease({ sessionId, ownerId, ttlMs }: AcquireSessionLeaseInput): Promise<SessionLeaseResult> {
-    const existing = this.db.harnessSessions.get(sessionId);
+  async acquireSessionLease({
+    sessionId,
+    ownerId,
+    ttlMs,
+    harnessName,
+  }: AcquireSessionLeaseInput): Promise<SessionLeaseResult> {
+    const namespace = resolveHarnessName(harnessName, this.harnessName);
+    const existing = this.db.harnessSessions.get(sessionKey(namespace, sessionId));
     if (!existing) throw new HarnessStorageSessionNotFoundError(sessionId);
 
     const now = Date.now();
@@ -184,12 +281,18 @@ export class InMemoryHarness extends HarnessStorage {
       ownerId,
       leaseExpiresAt: expiresAt,
     };
-    this.db.harnessSessions.set(sessionId, updated);
+    this.db.harnessSessions.set(sessionKey(namespace, sessionId), cloneSessionRecord(updated));
     return { version: existing.version, expiresAt };
   }
 
-  async renewSessionLease({ sessionId, ownerId, ttlMs }: RenewSessionLeaseInput): Promise<SessionLeaseResult> {
-    const existing = this.db.harnessSessions.get(sessionId);
+  async renewSessionLease({
+    sessionId,
+    ownerId,
+    ttlMs,
+    harnessName,
+  }: RenewSessionLeaseInput): Promise<SessionLeaseResult> {
+    const namespace = resolveHarnessName(harnessName, this.harnessName);
+    const existing = this.db.harnessSessions.get(sessionKey(namespace, sessionId));
     if (!existing) throw new HarnessStorageSessionNotFoundError(sessionId);
 
     const now = Date.now();
@@ -206,12 +309,13 @@ export class InMemoryHarness extends HarnessStorage {
 
     const expiresAt = now + ttlMs;
     const updated: SessionRecord = { ...existing, leaseExpiresAt: expiresAt };
-    this.db.harnessSessions.set(sessionId, updated);
+    this.db.harnessSessions.set(sessionKey(namespace, sessionId), cloneSessionRecord(updated));
     return { version: existing.version, expiresAt };
   }
 
-  async releaseSessionLease({ sessionId, ownerId }: ReleaseSessionLeaseInput): Promise<void> {
-    const existing = this.db.harnessSessions.get(sessionId);
+  async releaseSessionLease({ sessionId, ownerId, harnessName }: ReleaseSessionLeaseInput): Promise<void> {
+    const namespace = resolveHarnessName(harnessName, this.harnessName);
+    const existing = this.db.harnessSessions.get(sessionKey(namespace, sessionId));
     if (!existing) throw new HarnessStorageSessionNotFoundError(sessionId);
 
     // No-op if we're not the current owner — the spec calls this out:
@@ -220,7 +324,7 @@ export class InMemoryHarness extends HarnessStorage {
     if (existing.ownerId !== ownerId) return;
 
     const updated: SessionRecord = { ...existing, ownerId: undefined, leaseExpiresAt: undefined };
-    this.db.harnessSessions.set(sessionId, updated);
+    this.db.harnessSessions.set(sessionKey(namespace, sessionId), cloneSessionRecord(updated));
   }
 
   // -------------------------------------------------------------------------
@@ -230,12 +334,14 @@ export class InMemoryHarness extends HarnessStorage {
   async saveAttachment({
     sessionId,
     attachmentId,
+    harnessName,
     name,
     mimeType,
     source,
     data,
   }: SaveAttachmentInput): Promise<SaveAttachmentResult> {
-    const key = attachmentKey(sessionId, attachmentId);
+    const namespace = resolveHarnessName(harnessName, this.harnessName);
+    const key = attachmentKey(namespace, sessionId, attachmentId);
     const bytes = data.byteLength;
     const sha256 = sha256Hex(data);
     const record: AttachmentRecord = {
@@ -257,11 +363,13 @@ export class InMemoryHarness extends HarnessStorage {
   async loadAttachment({
     sessionId,
     attachmentId,
+    harnessName,
   }: {
     sessionId: string;
     attachmentId: string;
+    harnessName?: string;
   }): Promise<LoadedAttachment | null> {
-    const key = attachmentKey(sessionId, attachmentId);
+    const key = attachmentKey(resolveHarnessName(harnessName, this.harnessName), sessionId, attachmentId);
     const record = this.db.harnessAttachmentRecords.get(key);
     const bytes = this.db.harnessAttachmentBytes.get(key);
     if (!record || !bytes) return null;
@@ -274,22 +382,38 @@ export class InMemoryHarness extends HarnessStorage {
     };
   }
 
-  async deleteAttachment({ sessionId, attachmentId }: { sessionId: string; attachmentId: string }): Promise<void> {
-    const references = await this.listAttachmentReferences({ sessionId, attachmentId });
+  async deleteAttachment({
+    sessionId,
+    attachmentId,
+    harnessName,
+  }: {
+    sessionId: string;
+    attachmentId: string;
+    harnessName?: string;
+  }): Promise<void> {
+    const namespace = resolveHarnessName(harnessName, this.harnessName);
+    const references = await this.listAttachmentReferences({ harnessName: namespace, sessionId, attachmentId });
     if (references.length > 0) {
       throw new HarnessStorageAttachmentInUseError(sessionId, attachmentId, references);
     }
-    const key = attachmentKey(sessionId, attachmentId);
+    const key = attachmentKey(namespace, sessionId, attachmentId);
     this.db.harnessAttachmentRecords.delete(key);
     this.db.harnessAttachmentBytes.delete(key);
   }
 
-  async deleteAttachmentsForSession({ sessionId }: { sessionId: string }): Promise<void> {
-    const prefix = `${sessionId}\u0000`;
+  async deleteAttachmentsForSession({
+    sessionId,
+    harnessName,
+  }: {
+    sessionId: string;
+    harnessName?: string;
+  }): Promise<void> {
+    const namespace = resolveHarnessName(harnessName, this.harnessName);
+    const prefix = `${namespace}\u0000${sessionId}\u0000`;
     for (const key of this.db.harnessAttachmentRecords.keys()) {
       if (key.startsWith(prefix)) {
-        const [, attachmentId] = splitAttachmentKey(key);
-        const references = await this.listAttachmentReferences({ sessionId, attachmentId });
+        const [, , attachmentId] = splitAttachmentKey(key);
+        const references = await this.listAttachmentReferences({ harnessName: namespace, sessionId, attachmentId });
         if (references.length > 0) continue;
         this.db.harnessAttachmentRecords.delete(key);
         this.db.harnessAttachmentBytes.delete(key);
@@ -300,16 +424,23 @@ export class InMemoryHarness extends HarnessStorage {
   async getAttachmentRecord({
     sessionId,
     attachmentId,
+    harnessName,
   }: {
     sessionId: string;
     attachmentId: string;
+    harnessName?: string;
   }): Promise<AttachmentRecord | null> {
-    return this.db.harnessAttachmentRecords.get(attachmentKey(sessionId, attachmentId)) ?? null;
+    return (
+      this.db.harnessAttachmentRecords.get(
+        attachmentKey(resolveHarnessName(harnessName, this.harnessName), sessionId, attachmentId),
+      ) ?? null
+    );
   }
 
   async recordAttachmentReferences(references: SaveAttachmentReferenceInput[]): Promise<void> {
     for (const ref of references) {
-      this.db.harnessAttachmentReferences.set(attachmentReferenceKey(ref), {
+      const harnessName = resolveHarnessName(ref.harnessName, this.harnessName);
+      this.db.harnessAttachmentReferences.set(attachmentReferenceKey({ ...ref, harnessName }), {
         source: ref.source,
         sourceId: ref.sourceId,
         ...(ref.retainedUntil !== undefined ? { retainedUntil: ref.retainedUntil } : {}),
@@ -319,23 +450,239 @@ export class InMemoryHarness extends HarnessStorage {
 
   async deleteAttachmentReferences(references: SaveAttachmentReferenceInput[]): Promise<void> {
     for (const ref of references) {
-      this.db.harnessAttachmentReferences.delete(attachmentReferenceKey(ref));
+      const harnessName = resolveHarnessName(ref.harnessName, this.harnessName);
+      this.db.harnessAttachmentReferences.delete(attachmentReferenceKey({ ...ref, harnessName }));
     }
   }
 
   async listAttachmentReferences({
     sessionId,
     attachmentId,
+    harnessName,
   }: {
     sessionId: string;
     attachmentId: string;
+    harnessName?: string;
   }): Promise<AttachmentReference[]> {
-    const prefix = `${sessionId}\u0000${attachmentId}\u0000`;
+    const prefix = `${resolveHarnessName(harnessName, this.harnessName)}\u0000${sessionId}\u0000${attachmentId}\u0000`;
     const refs: AttachmentReference[] = [];
     for (const [key, ref] of this.db.harnessAttachmentReferences) {
       if (key.startsWith(prefix)) refs.push({ ...ref });
     }
     return refs.sort((a, b) => a.source.localeCompare(b.source) || a.sourceId.localeCompare(b.sourceId));
+  }
+
+  // -------------------------------------------------------------------------
+  // Admission/result evidence
+  // -------------------------------------------------------------------------
+
+  async loadMessageResultEvidence({
+    harnessName,
+    sessionId,
+    resourceId,
+    threadId,
+    signalId,
+  }: {
+    harnessName?: string;
+    sessionId: string;
+    resourceId: string;
+    threadId: string;
+    signalId: string;
+  }): Promise<AgentSignalResultStatus | OperationAdmissionTombstone | null> {
+    const namespace = resolveHarnessName(harnessName, this.harnessName);
+    const tombstone = this.findTombstone(
+      t =>
+        t.harnessName === namespace &&
+        t.kind === 'message' &&
+        t.sessionId === sessionId &&
+        t.resourceId === resourceId &&
+        t.threadId === threadId &&
+        t.signalId === signalId,
+    );
+    return tombstone ? cloneJson(tombstone) : null;
+  }
+
+  async loadQueueResultEvidence({
+    harnessName,
+    sessionId,
+    resourceId,
+    queuedItemId,
+  }: {
+    harnessName?: string;
+    sessionId: string;
+    resourceId: string;
+    queuedItemId: string;
+  }): Promise<QueueAdmissionReceipt | OperationAdmissionTombstone | null> {
+    const namespace = resolveHarnessName(harnessName, this.harnessName);
+    const session = this.db.harnessSessions.get(sessionKey(namespace, sessionId));
+    if (session && session.resourceId !== resourceId) return null;
+    const receipt = session?.queueAdmissionReceipts?.[queuedItemId];
+    if (receipt) return cloneJson(receipt);
+    const tombstone = this.findTombstone(
+      t =>
+        t.harnessName === namespace &&
+        t.kind === 'queue' &&
+        t.sessionId === sessionId &&
+        t.resourceId === resourceId &&
+        t.queuedItemId === queuedItemId,
+    );
+    return tombstone ? cloneJson(tombstone) : null;
+  }
+
+  async resolveOperationAdmissionEvidence({
+    harnessName,
+    sessionId,
+    resourceId,
+    kind,
+    admissionId,
+    attemptedAdmissionHash,
+  }: {
+    harnessName?: string;
+    sessionId: string;
+    resourceId: string;
+    kind: 'message' | 'queue';
+    admissionId: string;
+    attemptedAdmissionHash: string;
+  }): Promise<{
+    status: 'none' | 'duplicate' | 'conflict';
+    evidence?: OperationAdmissionEvidence;
+    storedAdmissionHash?: string;
+  }> {
+    const namespace = resolveHarnessName(harnessName, this.harnessName);
+    if (kind === 'queue') {
+      const session = this.db.harnessSessions.get(sessionKey(namespace, sessionId));
+      if (session && session.resourceId !== resourceId) return { status: 'none' };
+      for (const receipt of Object.values(session?.queueAdmissionReceipts ?? {})) {
+        if (receipt.admissionId !== admissionId) continue;
+        if (receipt.admissionHash !== attemptedAdmissionHash) {
+          return { status: 'conflict', evidence: cloneJson(receipt), storedAdmissionHash: receipt.admissionHash };
+        }
+        return { status: 'duplicate', evidence: cloneJson(receipt), storedAdmissionHash: receipt.admissionHash };
+      }
+    }
+
+    const tombstone = this.findTombstone(
+      t =>
+        t.harnessName === namespace &&
+        t.sessionId === sessionId &&
+        t.resourceId === resourceId &&
+        t.kind === kind &&
+        t.admissionId === admissionId,
+    );
+    if (!tombstone) return { status: 'none' };
+    if (tombstone.admissionHash !== attemptedAdmissionHash) {
+      return {
+        status: 'conflict',
+        evidence: cloneJson(tombstone),
+        storedAdmissionHash: tombstone.admissionHash,
+      };
+    }
+    return {
+      status: 'duplicate',
+      evidence: cloneJson(tombstone),
+      storedAdmissionHash: tombstone.admissionHash,
+    };
+  }
+
+  async writeOperationAdmissionTombstone(record: OperationAdmissionTombstone): Promise<void> {
+    const key = tombstoneKey(record);
+    const existing = this.db.harnessOperationTombstones.get(key);
+    if (existing && !sameTombstoneIdentity(existing, record)) {
+      throw new HarnessStorageAdmissionConflictError(record.sessionId, record.kind, record.admissionId ?? key);
+    }
+    this.db.harnessOperationTombstones.set(key, cloneJson(record));
+  }
+
+  async compactOperationResultEvidence({
+    harnessName,
+    sessionId,
+    resourceId,
+    kind,
+    signalId,
+    queuedItemId,
+    now,
+  }: {
+    harnessName?: string;
+    sessionId: string;
+    resourceId: string;
+    kind: 'message' | 'queue';
+    signalId?: string;
+    queuedItemId?: string;
+    now: number;
+  }): Promise<OperationAdmissionTombstone | null> {
+    const namespace = resolveHarnessName(harnessName, this.harnessName);
+    if (kind === 'message') {
+      return (
+        this.findTombstone(
+          t =>
+            t.harnessName === namespace &&
+            t.sessionId === sessionId &&
+            t.resourceId === resourceId &&
+            t.kind === 'message' &&
+            t.signalId === signalId &&
+            t.compactedAt <= now,
+        ) ?? null
+      );
+    }
+
+    const session = this.db.harnessSessions.get(sessionKey(namespace, sessionId));
+    if (session && session.resourceId !== resourceId) return null;
+    const receipt = queuedItemId ? session?.queueAdmissionReceipts?.[queuedItemId] : undefined;
+    if (!session || !receipt) return null;
+    if (!isTerminalQueueReceipt(receipt)) return null;
+    const tombstone: OperationAdmissionTombstone = {
+      kind: 'queue',
+      harnessName: namespace,
+      sessionId,
+      resourceId,
+      threadId: session.threadId,
+      admissionId: receipt.admissionId,
+      admissionHash: receipt.admissionHash,
+      queuedItemId: receipt.queuedItemId,
+      ...(receipt.signalId !== undefined ? { signalId: receipt.signalId } : {}),
+      ...(receipt.runId !== undefined ? { runId: receipt.runId } : {}),
+      terminalAt: receipt.completedAt ?? receipt.failedAt ?? receipt.deadAt ?? now,
+      compactedAt: now,
+      expiresAt: now,
+    };
+    await this.writeOperationAdmissionTombstone(tombstone);
+    const nextReceipts = { ...(session.queueAdmissionReceipts ?? {}) };
+    delete nextReceipts[queuedItemId!];
+    this.db.harnessSessions.set(sessionKey(namespace, sessionId), {
+      ...session,
+      queueAdmissionReceipts: Object.keys(nextReceipts).length > 0 ? nextReceipts : undefined,
+    });
+    return cloneJson(tombstone);
+  }
+
+  async deleteOperationAdmissionTombstonesForSession({
+    harnessName,
+    sessionId,
+    resourceId,
+  }: {
+    harnessName?: string;
+    sessionId: string;
+    resourceId: string;
+  }): Promise<void> {
+    const namespace = resolveHarnessName(harnessName, this.harnessName);
+    for (const [key, tombstone] of this.db.harnessOperationTombstones) {
+      if (
+        tombstone.harnessName === namespace &&
+        tombstone.sessionId === sessionId &&
+        tombstone.resourceId === resourceId
+      ) {
+        this.db.harnessOperationTombstones.delete(key);
+      }
+    }
+  }
+
+  private findTombstone(
+    predicate: (tombstone: OperationAdmissionTombstone) => boolean,
+  ): OperationAdmissionTombstone | null {
+    for (const tombstone of this.db.harnessOperationTombstones.values()) {
+      if (predicate(tombstone)) return tombstone;
+    }
+    return null;
   }
 
   // -------------------------------------------------------------------------
@@ -347,6 +694,7 @@ export class InMemoryHarness extends HarnessStorage {
     this.db.harnessAttachmentRecords.clear();
     this.db.harnessAttachmentBytes.clear();
     this.db.harnessAttachmentReferences.clear();
+    this.db.harnessOperationTombstones.clear();
   }
 }
 
@@ -359,17 +707,57 @@ export class InMemoryHarness extends HarnessStorage {
  * separator means session-prefix scans for `deleteAttachmentsForSession` are
  * unambiguous regardless of the contents of the ids.
  */
-function attachmentKey(ownerSessionId: string, attachmentId: string): string {
-  return `${ownerSessionId}\u0000${attachmentId}`;
+function sessionKey(harnessName: string, sessionId: string): string {
+  return `${harnessName}\u0000${sessionId}`;
 }
 
-function splitAttachmentKey(key: string): [string, string] {
-  const [ownerSessionId = '', attachmentId = ''] = key.split('\u0000');
-  return [ownerSessionId, attachmentId];
+function attachmentKey(harnessName: string, ownerSessionId: string, attachmentId: string): string {
+  return `${harnessName}\u0000${ownerSessionId}\u0000${attachmentId}`;
 }
 
 function attachmentReferenceKey(ref: SaveAttachmentReferenceInput): string {
-  return `${ref.sessionId}\u0000${ref.attachmentId}\u0000${ref.source}\u0000${ref.sourceId}`;
+  return `${resolveHarnessName(ref.harnessName, 'default')}\u0000${ref.sessionId}\u0000${ref.attachmentId}\u0000${ref.source}\u0000${ref.sourceId}`;
+}
+
+function splitAttachmentKey(key: string): [string, string, string] {
+  const [harnessName = '', ownerSessionId = '', attachmentId = ''] = key.split('\u0000');
+  return [harnessName, ownerSessionId, attachmentId];
+}
+
+function tombstoneKey(record: OperationAdmissionTombstone): string {
+  const publicId = record.kind === 'message' ? record.signalId : record.queuedItemId;
+  return `${record.harnessName}\u0000${record.sessionId}\u0000${record.kind}\u0000${publicId ?? record.admissionId ?? record.compactedAt}`;
+}
+
+function resolveHarnessName(input: string | undefined, fallback: string): string {
+  return input ?? fallback;
+}
+
+function cloneSessionRecord(record: SessionRecord): SessionRecord {
+  return cloneJson(record);
+}
+
+function cloneJson<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function sameTombstoneIdentity(a: OperationAdmissionTombstone, b: OperationAdmissionTombstone): boolean {
+  return (
+    a.kind === b.kind &&
+    a.harnessName === b.harnessName &&
+    a.sessionId === b.sessionId &&
+    a.resourceId === b.resourceId &&
+    a.threadId === b.threadId &&
+    a.admissionId === b.admissionId &&
+    a.admissionHash === b.admissionHash &&
+    a.queuedItemId === b.queuedItemId &&
+    a.signalId === b.signalId &&
+    a.runId === b.runId
+  );
+}
+
+function isTerminalQueueReceipt(receipt: QueueAdmissionReceipt): boolean {
+  return receipt.status === 'completed' || receipt.status === 'failed' || receipt.status === 'dead';
 }
 
 function sha256Hex(bytes: Uint8Array): string {
@@ -391,6 +779,7 @@ function assertLeaseHolder(existing: SessionRecord, ownerId: string): void {
 
 function toSummary(record: SessionRecord): SessionSummary {
   return {
+    harnessName: record.harnessName,
     id: record.id,
     resourceId: record.resourceId,
     threadId: record.threadId,
@@ -399,6 +788,8 @@ function toSummary(record: SessionRecord): SessionSummary {
     modeId: record.modeId,
     modelId: record.modelId,
     lastActivityAt: record.lastActivityAt,
+    closingAt: record.closingAt,
+    closeDeadlineAt: record.closeDeadlineAt,
     closedAt: record.closedAt,
   };
 }

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -75,9 +75,20 @@ export type PersistedAttachment =
  */
 export interface QueuedItem {
   id: string;
+  /**
+   * Idempotency key for this queue admission. Older local-only queue items may
+   * not have one yet; durable remote/channel/wakeup admissions must set it.
+   */
+  admissionId?: string;
+  /**
+   * Stable hash of the admitted queue inputs. Used with `admissionId` to
+   * distinguish exact retries from same-key/different-payload conflicts.
+   */
+  admissionHash?: string;
   enqueuedAt: number;
   content: string;
   attachments: PersistedAttachment[];
+  requestContext?: unknown;
   model?: string;
   mode?: string;
   yolo?: boolean;
@@ -205,6 +216,11 @@ export type AttachmentReferenceSource =
  * write lease (see HARNESS_V1_SPEC.md §5.8).
  */
 export interface SessionRecord {
+  /**
+   * Immutable Harness namespace. The runtime writes `default` for single
+   * harness/local storage and the registered Mastra harness key when known.
+   */
+  harnessName: string;
   id: string;
   resourceId: string;
   threadId: string;
@@ -250,6 +266,7 @@ export interface SessionRecord {
   // At most one outstanding agent suspension per session (see PendingResume).
   pendingQueue: QueuedItem[];
   pendingResume?: PendingResume;
+  queueAdmissionReceipts?: Record<string, QueueAdmissionReceipt>;
 
   // Observational memory config (per-session override)
   observationalMemory?: {
@@ -269,6 +286,8 @@ export interface SessionRecord {
   // Lifecycle
   createdAt: number;
   lastActivityAt: number;
+  closingAt?: number;
+  closeDeadlineAt?: number;
   closedAt?: number;
 
   // Write-concurrency — see HARNESS_V1_SPEC.md §5.8.
@@ -284,6 +303,7 @@ export interface SessionRecord {
  * Lightweight projection of `SessionRecord`, used by `listSessions(...)`.
  */
 export interface SessionSummary {
+  harnessName: string;
   id: string;
   resourceId: string;
   threadId: string;
@@ -292,8 +312,72 @@ export interface SessionSummary {
   modeId: string;
   modelId: string;
   lastActivityAt: number;
+  closingAt?: number;
+  closeDeadlineAt?: number;
   closedAt?: number;
 }
+
+export type HarnessOperationKind = 'message' | 'queue';
+
+export interface HarnessStoredPublicError {
+  code: string;
+  message: string;
+}
+
+export type AgentSignalResultStatus =
+  | { status: 'pending'; signalId: string; runId?: string }
+  | { status: 'completed'; signalId: string; runId: string; result: unknown }
+  | { status: 'failed'; signalId: string; runId?: string; error: HarnessStoredPublicError };
+
+export interface AgentSignalAccepted {
+  runId: string;
+  signalId: string;
+  duplicate: boolean;
+  admissionId?: string;
+  admissionHash?: string;
+}
+
+export interface QueueAdmissionReceipt {
+  admissionId: string;
+  admissionHash: string;
+  queuedItemId: string;
+  status: 'queued' | 'admitting' | 'accepted' | 'completed' | 'admission_failed' | 'failed' | 'dead';
+  runId?: string;
+  signalId?: string;
+  result?: unknown;
+  error?: HarnessStoredPublicError;
+  attempts: number;
+  enqueuedAt: number;
+  admittingAt?: number;
+  acceptedAt?: number;
+  completedAt?: number;
+  failedAt?: number;
+  deadAt?: number;
+  nextAttemptAt?: number;
+  updatedAt: number;
+}
+
+export interface OperationAdmissionTombstone {
+  kind: HarnessOperationKind;
+  harnessName: string;
+  sessionId: string;
+  resourceId: string;
+  threadId: string;
+  admissionId?: string;
+  admissionHash?: string;
+  queuedItemId?: string;
+  signalId?: string;
+  runId?: string;
+  terminalAt: number;
+  compactedAt: number;
+  expiresAt: number;
+}
+
+export type OperationAdmissionEvidence =
+  | AgentSignalAccepted
+  | AgentSignalResultStatus
+  | QueueAdmissionReceipt
+  | OperationAdmissionTombstone;
 
 // ---------------------------------------------------------------------------
 // Attachment metadata
@@ -328,6 +412,7 @@ export interface AttachmentRecord {
 // ---------------------------------------------------------------------------
 
 export interface ListSessionsInput {
+  harnessName?: string;
   resourceId: string;
   /** When true, includes records with `closedAt` set. */
   includeClosed?: boolean;
@@ -336,6 +421,7 @@ export interface ListSessionsInput {
 }
 
 export interface SaveSessionOptions {
+  harnessName?: string;
   /** The Harness instance currently holding the lease. */
   ownerId: string;
   /**
@@ -350,19 +436,38 @@ export interface SaveSessionResult {
   version: number;
 }
 
+export interface CreateOrLoadActiveSessionOptions {
+  initialLease: {
+    ownerId: string;
+    ttlMs: number;
+  };
+}
+
+export interface CreateOrLoadActiveSessionResult {
+  record: SessionRecord;
+  created: boolean;
+  leaseAcquired: boolean;
+  version: number;
+  expiresAt?: number;
+  storageNow: number;
+}
+
 export interface AcquireSessionLeaseInput {
+  harnessName?: string;
   sessionId: string;
   ownerId: string;
   ttlMs: number;
 }
 
 export interface RenewSessionLeaseInput {
+  harnessName?: string;
   sessionId: string;
   ownerId: string;
   ttlMs: number;
 }
 
 export interface ReleaseSessionLeaseInput {
+  harnessName?: string;
   sessionId: string;
   ownerId: string;
 }
@@ -375,6 +480,7 @@ export interface SessionLeaseResult {
 }
 
 export interface SaveAttachmentInput {
+  harnessName?: string;
   sessionId: string;
   attachmentId: string;
   name: string;
@@ -404,6 +510,7 @@ export interface AttachmentReference {
 }
 
 export interface SaveAttachmentReferenceInput extends AttachmentReference {
+  harnessName?: string;
   /** Session that owns the referenced attachment bytes. */
   sessionId: string;
   attachmentId: string;

--- a/packages/core/src/storage/domains/inmemory-db.ts
+++ b/packages/core/src/storage/domains/inmemory-db.ts
@@ -20,7 +20,12 @@ import type {
   ExperimentResult,
 } from '../types';
 import type { AgentVersion } from './agents';
-import type { AttachmentRecord, AttachmentReference, SessionRecord } from './harness/types';
+import type {
+  AttachmentRecord,
+  AttachmentReference,
+  OperationAdmissionTombstone,
+  SessionRecord,
+} from './harness/types';
 import type { MCPClientVersion } from './mcp-clients';
 import type { MCPServerVersion } from './mcp-servers';
 import type { TraceEntry } from './observability';
@@ -90,6 +95,7 @@ export class InMemoryDB {
   readonly harnessAttachmentRecords = new Map<string, AttachmentRecord>();
   readonly harnessAttachmentBytes = new Map<string, Uint8Array>();
   readonly harnessAttachmentReferences = new Map<string, AttachmentReference>();
+  readonly harnessOperationTombstones = new Map<string, OperationAdmissionTombstone>();
 
   /**
    * Clears all data from all collections.
@@ -133,5 +139,6 @@ export class InMemoryDB {
     this.harnessAttachmentRecords.clear();
     this.harnessAttachmentBytes.clear();
     this.harnessAttachmentReferences.clear();
+    this.harnessOperationTombstones.clear();
   }
 }

--- a/packages/core/src/storage/domains/operations/inmemory.ts
+++ b/packages/core/src/storage/domains/operations/inmemory.ts
@@ -48,6 +48,7 @@ export class StoreOperationsInMemory extends StoreOperations {
       mastra_harness_sessions: new Map(),
       mastra_harness_attachments: new Map(),
       mastra_harness_attachment_references: new Map(),
+      mastra_harness_operation_tombstones: new Map(),
     };
   }
 

--- a/stores/_test-utils/src/domains/harness/data.ts
+++ b/stores/_test-utils/src/domains/harness/data.ts
@@ -8,6 +8,7 @@ export function createSampleSessionRecord(overrides: Partial<SessionRecord> = {}
   const now = Date.now();
   return {
     id: 'session-1',
+    harnessName: 'default',
     resourceId: 'resource-1',
     threadId: 'thread-1',
     origin: 'top-level',

--- a/stores/_test-utils/src/domains/harness/index.ts
+++ b/stores/_test-utils/src/domains/harness/index.ts
@@ -1,4 +1,5 @@
 import {
+  HarnessStorageAdmissionConflictError,
   HarnessStorageLeaseConflictError,
   HarnessStorageSessionNotFoundError,
   HarnessStorageVersionConflictError,
@@ -158,6 +159,74 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
         const loaded = await harness.loadSession({ sessionId: 'session-1' });
         expect(loaded?.ownsThread).toBe(true);
       });
+
+      it('isolates session rows by harnessName namespace', async () => {
+        if (!harness) return;
+        await harness.saveSession(
+          createSampleSessionRecord({ harnessName: 'harness-a', modeId: 'build', lastActivityAt: 1000 }),
+          { harnessName: 'harness-a', ownerId: 'h', ifVersion: 0 },
+        );
+        await harness.saveSession(
+          createSampleSessionRecord({ harnessName: 'harness-b', modeId: 'review', lastActivityAt: 2000 }),
+          { harnessName: 'harness-b', ownerId: 'h', ifVersion: 0 },
+        );
+
+        await expect(harness.loadSession({ harnessName: 'missing', sessionId: 'session-1' })).resolves.toBeNull();
+        await expect(harness.loadSession({ harnessName: 'harness-a', sessionId: 'session-1' })).resolves.toMatchObject({
+          harnessName: 'harness-a',
+          modeId: 'build',
+        });
+        await expect(harness.loadSession({ harnessName: 'harness-b', sessionId: 'session-1' })).resolves.toMatchObject({
+          harnessName: 'harness-b',
+          modeId: 'review',
+        });
+        await expect(harness.listSessions({ harnessName: 'harness-a', resourceId: 'resource-1' })).resolves.toEqual([
+          expect.objectContaining({ harnessName: 'harness-a', modeId: 'build' }),
+        ]);
+      });
+
+      it('round-trips durable queue admission and lifecycle metadata', async () => {
+        if (!harness) return;
+        const record = createSampleSessionRecord({
+          subagentDepth: 2,
+          closingAt: 3000,
+          closeDeadlineAt: 4000,
+          pendingQueue: [
+            {
+              id: 'queued-1',
+              admissionId: 'admission-1',
+              admissionHash: 'hash-1',
+              enqueuedAt: 1000,
+              content: 'queued',
+              attachments: [],
+              requestContext: { userId: 'user-1' },
+            },
+          ],
+          queueAdmissionReceipts: {
+            'queued-1': {
+              admissionId: 'admission-1',
+              admissionHash: 'hash-1',
+              queuedItemId: 'queued-1',
+              status: 'accepted',
+              attempts: 1,
+              enqueuedAt: 1000,
+              acceptedAt: 1100,
+              updatedAt: 1100,
+              runId: 'run-1',
+              signalId: 'signal-1',
+            },
+          },
+        });
+
+        await harness.saveSession(record, { ownerId: 'h', ifVersion: 0 });
+
+        const loaded = await harness.loadSession({ sessionId: 'session-1' });
+        expect(loaded?.subagentDepth).toBe(2);
+        expect(loaded?.closingAt).toBe(3000);
+        expect(loaded?.closeDeadlineAt).toBe(4000);
+        expect(loaded?.pendingQueue).toEqual(record.pendingQueue);
+        expect(loaded?.queueAdmissionReceipts).toEqual(record.queueAdmissionReceipts);
+      });
     });
 
     describe('loadSessionByThread', () => {
@@ -189,22 +258,83 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
         expect(await harness.loadSessionByThread({ threadId: 'thread-1', resourceId: 'other-resource' })).toBeNull();
       });
 
-      it('returns the most recent active record when multiple match', async () => {
+      it('rejects a second active record for the same admission key', async () => {
         if (!harness) return;
         await harness.saveSession(createSampleSessionRecord({ id: 'a', lastActivityAt: 1000 }), {
           ownerId: 'h-1',
           ifVersion: 0,
         });
-        await harness.saveSession(createSampleSessionRecord({ id: 'b', lastActivityAt: 2000 }), {
-          ownerId: 'h-1',
-          ifVersion: 0,
-        });
+        await expect(
+          harness.saveSession(createSampleSessionRecord({ id: 'b', lastActivityAt: 2000 }), {
+            ownerId: 'h-1',
+            ifVersion: 0,
+          }),
+        ).rejects.toBeInstanceOf(HarnessStorageVersionConflictError);
 
         const loaded = await harness.loadSessionByThread({
           threadId: 'thread-1',
           resourceId: 'resource-1',
         });
-        expect(loaded?.id).toBe('b');
+        expect(loaded?.id).toBe('a');
+      });
+    });
+
+    describe('createOrLoadActiveSession', () => {
+      it('creates a leased active session when none exists', async () => {
+        if (!harness) return;
+        const result = await harness.createOrLoadActiveSession(createSampleSessionRecord(), {
+          initialLease: { ownerId: 'h', ttlMs: 30_000 },
+        });
+
+        expect(result).toMatchObject({
+          created: true,
+          leaseAcquired: true,
+          version: 1,
+          record: expect.objectContaining({ id: 'session-1', ownerId: 'h', version: 1 }),
+        });
+        expect(result.expiresAt).toBeGreaterThanOrEqual(result.storageNow);
+        await expect(harness.loadSession({ sessionId: 'session-1' })).resolves.toMatchObject({
+          ownerId: 'h',
+          version: 1,
+        });
+      });
+
+      it('returns the existing active session for the same namespace/resource/thread', async () => {
+        if (!harness) return;
+        await harness.createOrLoadActiveSession(createSampleSessionRecord({ id: 'first' }), {
+          initialLease: { ownerId: 'h-1', ttlMs: 30_000 },
+        });
+
+        const result = await harness.createOrLoadActiveSession(createSampleSessionRecord({ id: 'second' }), {
+          initialLease: { ownerId: 'h-2', ttlMs: 30_000 },
+        });
+
+        expect(result).toMatchObject({
+          created: false,
+          leaseAcquired: false,
+          record: expect.objectContaining({ id: 'first', ownerId: 'h-1' }),
+        });
+        await expect(harness.loadSession({ sessionId: 'second' })).resolves.toBeNull();
+      });
+
+      it('allows the same resource/thread active key in a different harness namespace', async () => {
+        if (!harness) return;
+        await harness.createOrLoadActiveSession(createSampleSessionRecord({ harnessName: 'harness-a', id: 'same' }), {
+          initialLease: { ownerId: 'h-a', ttlMs: 30_000 },
+        });
+
+        const result = await harness.createOrLoadActiveSession(
+          createSampleSessionRecord({ harnessName: 'harness-b', id: 'same' }),
+          {
+            initialLease: { ownerId: 'h-b', ttlMs: 30_000 },
+          },
+        );
+
+        expect(result).toMatchObject({
+          created: true,
+          leaseAcquired: true,
+          record: expect.objectContaining({ harnessName: 'harness-b', id: 'same', ownerId: 'h-b' }),
+        });
       });
     });
 
@@ -642,6 +772,188 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
 
         expect(await harness.loadAttachment({ sessionId: 'session-a', attachmentId: 'a1' })).not.toBeNull();
         expect(await harness.loadAttachment({ sessionId: 'session-b', attachmentId: 'a2' })).not.toBeNull();
+      });
+    });
+
+    describe('admission/result evidence', () => {
+      it('loads queue admission receipts and resolves duplicate/conflict attempts', async () => {
+        if (!harness) return;
+        await harness.saveSession(
+          createSampleSessionRecord({
+            queueAdmissionReceipts: {
+              'queued-1': {
+                admissionId: 'admission-1',
+                admissionHash: 'hash-1',
+                queuedItemId: 'queued-1',
+                status: 'accepted',
+                attempts: 1,
+                enqueuedAt: 1000,
+                acceptedAt: 1100,
+                updatedAt: 1100,
+                runId: 'run-1',
+                signalId: 'signal-1',
+              },
+            },
+          }),
+          { ownerId: 'h', ifVersion: 0 },
+        );
+
+        await expect(
+          harness.loadQueueResultEvidence({
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            queuedItemId: 'queued-1',
+          }),
+        ).resolves.toMatchObject({ status: 'accepted', admissionId: 'admission-1' });
+        await expect(
+          harness.loadQueueResultEvidence({
+            sessionId: 'session-1',
+            resourceId: 'other-resource',
+            queuedItemId: 'queued-1',
+          }),
+        ).resolves.toBeNull();
+        await expect(
+          harness.resolveOperationAdmissionEvidence({
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            kind: 'queue',
+            admissionId: 'admission-1',
+            attemptedAdmissionHash: 'hash-1',
+          }),
+        ).resolves.toMatchObject({ status: 'duplicate', storedAdmissionHash: 'hash-1' });
+        await expect(
+          harness.resolveOperationAdmissionEvidence({
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            kind: 'queue',
+            admissionId: 'admission-1',
+            attemptedAdmissionHash: 'different-hash',
+          }),
+        ).resolves.toMatchObject({ status: 'conflict', storedAdmissionHash: 'hash-1' });
+        await expect(
+          harness.resolveOperationAdmissionEvidence({
+            sessionId: 'session-1',
+            resourceId: 'other-resource',
+            kind: 'queue',
+            admissionId: 'admission-1',
+            attemptedAdmissionHash: 'hash-1',
+          }),
+        ).resolves.toMatchObject({ status: 'none' });
+      });
+
+      it('writes, loads, conflicts, and deletes operation tombstones', async () => {
+        if (!harness) return;
+        const tombstone = {
+          kind: 'message' as const,
+          harnessName: 'default',
+          sessionId: 'session-1',
+          resourceId: 'resource-1',
+          threadId: 'thread-1',
+          admissionId: 'admission-1',
+          admissionHash: 'hash-1',
+          signalId: 'signal-1',
+          runId: 'run-1',
+          terminalAt: 2000,
+          compactedAt: 3000,
+          expiresAt: 4000,
+        };
+
+        await harness.writeOperationAdmissionTombstone(tombstone);
+        await harness.writeOperationAdmissionTombstone(tombstone);
+
+        await expect(
+          harness.loadMessageResultEvidence({
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            threadId: 'thread-1',
+            signalId: 'signal-1',
+          }),
+        ).resolves.toEqual(tombstone);
+        await expect(
+          harness.resolveOperationAdmissionEvidence({
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            kind: 'message',
+            admissionId: 'admission-1',
+            attemptedAdmissionHash: 'hash-1',
+          }),
+        ).resolves.toMatchObject({ status: 'duplicate', storedAdmissionHash: 'hash-1' });
+        await expect(
+          harness.writeOperationAdmissionTombstone({ ...tombstone, admissionHash: 'different-hash' }),
+        ).rejects.toBeInstanceOf(HarnessStorageAdmissionConflictError);
+
+        await harness.deleteOperationAdmissionTombstonesForSession({
+          sessionId: 'session-1',
+          resourceId: 'resource-1',
+        });
+        await expect(
+          harness.loadMessageResultEvidence({
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            threadId: 'thread-1',
+            signalId: 'signal-1',
+          }),
+        ).resolves.toBeNull();
+      });
+
+      it('compacts terminal queue receipts into tombstones', async () => {
+        if (!harness) return;
+        await harness.saveSession(
+          createSampleSessionRecord({
+            queueAdmissionReceipts: {
+              'queued-1': {
+                admissionId: 'admission-1',
+                admissionHash: 'hash-1',
+                queuedItemId: 'queued-1',
+                status: 'completed',
+                attempts: 1,
+                enqueuedAt: 1000,
+                acceptedAt: 1100,
+                completedAt: 2000,
+                updatedAt: 2000,
+                runId: 'run-1',
+                signalId: 'signal-1',
+                result: { ok: true },
+              },
+            },
+          }),
+          { ownerId: 'h', ifVersion: 0 },
+        );
+
+        const tombstone = await harness.compactOperationResultEvidence({
+          sessionId: 'session-1',
+          resourceId: 'other-resource',
+          kind: 'queue',
+          queuedItemId: 'queued-1',
+          now: 3000,
+        });
+        expect(tombstone).toBeNull();
+
+        const compacted = await harness.compactOperationResultEvidence({
+          sessionId: 'session-1',
+          resourceId: 'resource-1',
+          kind: 'queue',
+          queuedItemId: 'queued-1',
+          now: 3000,
+        });
+        expect(compacted).toMatchObject({
+          kind: 'queue',
+          admissionId: 'admission-1',
+          admissionHash: 'hash-1',
+          queuedItemId: 'queued-1',
+          terminalAt: 2000,
+          compactedAt: 3000,
+        });
+        await expect(
+          harness.loadQueueResultEvidence({
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            queuedItemId: 'queued-1',
+          }),
+        ).resolves.toEqual(compacted);
+        await expect(harness.loadSession({ sessionId: 'session-1' })).resolves.toMatchObject({
+          queueAdmissionReceipts: undefined,
+        });
       });
     });
 

--- a/stores/_test-utils/src/domains/harness/index.ts
+++ b/stores/_test-utils/src/domains/harness/index.ts
@@ -1,5 +1,6 @@
 import {
   HarnessStorageAdmissionConflictError,
+  HarnessStorageAttachmentUnavailableError,
   HarnessStorageLeaseConflictError,
   HarnessStorageSessionNotFoundError,
   HarnessStorageVersionConflictError,
@@ -427,6 +428,34 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
 
         expect(await harness.loadAttachment({ sessionId: 'session-1', attachmentId: 'a1' })).toBeNull();
       });
+
+      it('clears attachment references before cascading owned attachments', async () => {
+        if (!harness) return;
+        await harness.saveSession(createSampleSessionRecord(), { ownerId: 'h', ifVersion: 0 });
+        await harness.saveAttachment({
+          sessionId: 'session-1',
+          attachmentId: 'a1',
+          name: 'note.txt',
+          mimeType: 'text/plain',
+          source: 'preupload',
+          data: new Uint8Array([1, 2, 3]),
+        });
+        await harness.recordAttachmentReferences([
+          {
+            sessionId: 'session-1',
+            attachmentId: 'a1',
+            source: 'queued_item',
+            sourceId: 'q1',
+          },
+        ]);
+
+        await harness.deleteSession({ sessionId: 'session-1' });
+
+        await expect(harness.listAttachmentReferences({ sessionId: 'session-1', attachmentId: 'a1' })).resolves.toEqual(
+          [],
+        );
+        await expect(harness.loadAttachment({ sessionId: 'session-1', attachmentId: 'a1' })).resolves.toBeNull();
+      });
     });
 
     describe('leases', () => {
@@ -772,6 +801,43 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
 
         expect(await harness.loadAttachment({ sessionId: 'session-a', attachmentId: 'a1' })).not.toBeNull();
         expect(await harness.loadAttachment({ sessionId: 'session-b', attachmentId: 'a2' })).not.toBeNull();
+      });
+
+      it('keeps transactional attachment references in the session harness namespace', async () => {
+        if (!harness) return;
+        await harness.saveSession(createSampleSessionRecord({ harnessName: 'harness-a', id: 'session-a' }), {
+          harnessName: 'harness-a',
+          ownerId: 'h',
+          ifVersion: 0,
+        });
+        await harness.saveAttachment({
+          harnessName: 'harness-b',
+          sessionId: 'session-a',
+          attachmentId: 'a1',
+          name: 'n',
+          mimeType: 'text/plain',
+          source: 'preupload',
+          data: new Uint8Array([1]),
+        });
+
+        await expect(
+          harness.saveSessionWithAttachmentReferences(
+            createSampleSessionRecord({ harnessName: 'harness-a', id: 'session-a', version: 1 }),
+            { harnessName: 'harness-a', ownerId: 'h', ifVersion: 1 },
+            [
+              {
+                harnessName: 'harness-b',
+                sessionId: 'session-a',
+                attachmentId: 'a1',
+                source: 'queued_item',
+                sourceId: 'q1',
+              },
+            ],
+          ),
+        ).rejects.toBeInstanceOf(HarnessStorageAttachmentUnavailableError);
+        await expect(
+          harness.listAttachmentReferences({ harnessName: 'harness-b', sessionId: 'session-a', attachmentId: 'a1' }),
+        ).resolves.toEqual([]);
       });
     });
 

--- a/stores/_test-utils/src/domains/harness/index.ts
+++ b/stores/_test-utils/src/domains/harness/index.ts
@@ -955,6 +955,88 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           queueAdmissionReceipts: undefined,
         });
       });
+
+      it('compacts concurrent terminal queue receipts without losing survivors', async () => {
+        if (!harness) return;
+        await harness.saveSession(
+          createSampleSessionRecord({
+            queueAdmissionReceipts: {
+              'queued-1': {
+                admissionId: 'admission-1',
+                admissionHash: 'hash-1',
+                queuedItemId: 'queued-1',
+                status: 'completed',
+                attempts: 1,
+                enqueuedAt: 1000,
+                acceptedAt: 1100,
+                completedAt: 2000,
+                updatedAt: 2000,
+              },
+              'queued-2': {
+                admissionId: 'admission-2',
+                admissionHash: 'hash-2',
+                queuedItemId: 'queued-2',
+                status: 'failed',
+                attempts: 1,
+                enqueuedAt: 1000,
+                acceptedAt: 1100,
+                failedAt: 2100,
+                updatedAt: 2100,
+              },
+              'queued-3': {
+                admissionId: 'admission-3',
+                admissionHash: 'hash-3',
+                queuedItemId: 'queued-3',
+                status: 'accepted',
+                attempts: 1,
+                enqueuedAt: 1000,
+                acceptedAt: 1100,
+                updatedAt: 1100,
+              },
+            },
+          }),
+          { ownerId: 'h', ifVersion: 0 },
+        );
+
+        const [first, second] = await Promise.all([
+          harness.compactOperationResultEvidence({
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            kind: 'queue',
+            queuedItemId: 'queued-1',
+            now: 3000,
+          }),
+          harness.compactOperationResultEvidence({
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            kind: 'queue',
+            queuedItemId: 'queued-2',
+            now: 3000,
+          }),
+        ]);
+
+        expect(first).toMatchObject({ queuedItemId: 'queued-1', admissionHash: 'hash-1' });
+        expect(second).toMatchObject({ queuedItemId: 'queued-2', admissionHash: 'hash-2' });
+        await expect(
+          harness.loadQueueResultEvidence({
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            queuedItemId: 'queued-1',
+          }),
+        ).resolves.toMatchObject({ queuedItemId: 'queued-1', admissionHash: 'hash-1' });
+        await expect(
+          harness.loadQueueResultEvidence({
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            queuedItemId: 'queued-2',
+          }),
+        ).resolves.toMatchObject({ queuedItemId: 'queued-2', admissionHash: 'hash-2' });
+        await expect(harness.loadSession({ sessionId: 'session-1' })).resolves.toMatchObject({
+          queueAdmissionReceipts: {
+            'queued-3': expect.objectContaining({ status: 'accepted' }),
+          },
+        });
+      });
     });
 
     describe('dangerouslyClearAll', () => {

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -323,12 +323,15 @@ export class HarnessLibSQL extends HarnessStorage {
 
       const createdAt = Date.now();
       for (const ref of references) {
+        if (ref.harnessName !== undefined && this.#resolveHarnessName(ref.harnessName) !== harnessName) {
+          throw new HarnessStorageAttachmentUnavailableError(ref.sessionId, ref.attachmentId);
+        }
         const attachment = await tx.execute({
           sql: `SELECT attachment_id
                 FROM ${TABLE_HARNESS_ATTACHMENTS}
                 WHERE harness_name = ? AND session_id = ? AND attachment_id = ?
                 LIMIT 1`,
-          args: [this.#resolveHarnessName(ref.harnessName ?? harnessName), ref.sessionId, ref.attachmentId],
+          args: [harnessName, ref.sessionId, ref.attachmentId],
         });
         if (attachment.rows.length === 0) {
           throw new HarnessStorageAttachmentUnavailableError(ref.sessionId, ref.attachmentId);
@@ -340,7 +343,7 @@ export class HarnessLibSQL extends HarnessStorage {
             ON CONFLICT DO UPDATE SET
                   retained_until = excluded.retained_until`,
           args: [
-            this.#resolveHarnessName(ref.harnessName ?? harnessName),
+            harnessName,
             ref.sessionId,
             ref.attachmentId,
             ref.source,
@@ -475,6 +478,11 @@ export class HarnessLibSQL extends HarnessStorage {
         resourceId: existing.resourceId,
       });
     }
+    await this.#client.execute({
+      sql: `DELETE FROM ${TABLE_HARNESS_ATTACHMENT_REFERENCES}
+            WHERE harness_name = ? AND session_id = ?`,
+      args: [namespace, sessionId],
+    });
     // Cascade attachments first; we don't rely on FK cascades because the
     // schema deliberately doesn't declare a FK (sessions can be hard-deleted
     // independently of how attachments were uploaded).

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -59,6 +59,7 @@ export class HarnessLibSQL extends HarnessStorage {
   #db: LibSQLDB;
   #client: Client;
   #harnessName: string;
+  #compactionLocks = new Map<string, Promise<void>>();
 
   constructor(config: LibSQLDomainConfig) {
     super();
@@ -114,6 +115,7 @@ export class HarnessLibSQL extends HarnessStorage {
     });
     await this.#backfillHarnessNamespace();
     await this.#backfillAttachmentMetadata();
+    await this.#assertNoDuplicateActiveSessions();
     await this.#client.execute({
       sql: `CREATE UNIQUE INDEX IF NOT EXISTS idx_harness_sessions_active_key
             ON "${TABLE_HARNESS_SESSIONS}" ("harness_name", "resource_id", "thread_id")
@@ -950,35 +952,52 @@ export class HarnessLibSQL extends HarnessStorage {
   }): Promise<OperationAdmissionTombstone | null> {
     if (kind === 'message') return null;
     const namespace = this.#resolveHarnessName(harnessName);
-    const session = await this.loadSession({ harnessName: namespace, sessionId });
-    if (session && session.resourceId !== resourceId) return null;
-    const receipt = queuedItemId ? session?.queueAdmissionReceipts?.[queuedItemId] : undefined;
-    if (!session || !receipt || !isTerminalQueueReceipt(receipt)) return null;
-    const tombstone: OperationAdmissionTombstone = {
-      kind: 'queue',
-      harnessName: namespace,
-      sessionId,
-      resourceId,
-      threadId: session.threadId,
-      admissionId: receipt.admissionId,
-      admissionHash: receipt.admissionHash,
-      queuedItemId: receipt.queuedItemId,
-      ...(receipt.signalId !== undefined ? { signalId: receipt.signalId } : {}),
-      ...(receipt.runId !== undefined ? { runId: receipt.runId } : {}),
-      terminalAt: receipt.completedAt ?? receipt.failedAt ?? receipt.deadAt ?? now,
-      compactedAt: now,
-      expiresAt: now,
-    };
-    await this.writeOperationAdmissionTombstone(tombstone);
-    const nextReceipts = { ...(session.queueAdmissionReceipts ?? {}) };
-    delete nextReceipts[queuedItemId!];
-    await this.#client.execute({
-      sql: `UPDATE ${TABLE_HARNESS_SESSIONS}
-            SET queue_admission_receipts = ?
-            WHERE harness_name = ? AND id = ?`,
-      args: [Object.keys(nextReceipts).length > 0 ? JSON.stringify(nextReceipts) : null, namespace, sessionId],
+    return this.#withCompactionLock(`${namespace}\0${sessionId}`, async () => {
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        const result = await this.#client.execute({
+          sql: `SELECT * FROM ${TABLE_HARNESS_SESSIONS} WHERE harness_name = ? AND id = ?`,
+          args: [namespace, sessionId],
+        });
+        const row = result.rows[0] as Record<string, unknown> | undefined;
+        if (!row) return null;
+        const session = rowToSession(row);
+        if (session.resourceId !== resourceId) return null;
+        const receipt = queuedItemId ? session.queueAdmissionReceipts?.[queuedItemId] : undefined;
+        if (!receipt || !isTerminalQueueReceipt(receipt)) return null;
+        const tombstone: OperationAdmissionTombstone = {
+          kind: 'queue',
+          harnessName: namespace,
+          sessionId,
+          resourceId,
+          threadId: session.threadId,
+          admissionId: receipt.admissionId,
+          admissionHash: receipt.admissionHash,
+          queuedItemId: receipt.queuedItemId,
+          ...(receipt.signalId !== undefined ? { signalId: receipt.signalId } : {}),
+          ...(receipt.runId !== undefined ? { runId: receipt.runId } : {}),
+          terminalAt: receipt.completedAt ?? receipt.failedAt ?? receipt.deadAt ?? now,
+          compactedAt: now,
+          expiresAt: now,
+        };
+        await this.writeOperationAdmissionTombstone(tombstone);
+        const nextReceipts = { ...(session.queueAdmissionReceipts ?? {}) };
+        delete nextReceipts[queuedItemId!];
+        const nextReceiptJson = Object.keys(nextReceipts).length > 0 ? JSON.stringify(nextReceipts) : null;
+        const originalReceiptJson = row.queue_admission_receipts == null ? null : String(row.queue_admission_receipts);
+        const updateResult = await this.#client.execute({
+          sql: `UPDATE ${TABLE_HARNESS_SESSIONS}
+                SET queue_admission_receipts = ?
+                WHERE harness_name = ? AND id = ?
+                  AND ${originalReceiptJson === null ? 'queue_admission_receipts IS NULL' : 'queue_admission_receipts = ?'}`,
+          args:
+            originalReceiptJson === null
+              ? [nextReceiptJson, namespace, sessionId]
+              : [nextReceiptJson, namespace, sessionId, originalReceiptJson],
+        });
+        if (updateResult.rowsAffected > 0) return tombstone;
+      }
+      throw new Error(`Harness LibSQL compaction for session "${sessionId}" conflicted after retries`);
     });
-    return tombstone;
   }
 
   async deleteOperationAdmissionTombstonesForSession({
@@ -1053,6 +1072,50 @@ export class HarnessLibSQL extends HarnessStorage {
             String(row.attachment_id),
           ],
         });
+      }
+    }
+  }
+
+  async #assertNoDuplicateActiveSessions(): Promise<void> {
+    const result = await this.#client.execute({
+      sql: `SELECT harness_name, resource_id, thread_id, COUNT(*) AS duplicate_count
+            FROM ${TABLE_HARNESS_SESSIONS}
+            WHERE closed_at IS NULL
+            GROUP BY harness_name, resource_id, thread_id
+            HAVING COUNT(*) > 1
+            LIMIT 5`,
+      args: [],
+    });
+    if (result.rows.length === 0) return;
+
+    const examples = result.rows
+      .map(row => {
+        const record = row as Record<string, unknown>;
+        return `${String(record.harness_name)}:${String(record.resource_id)}:${String(record.thread_id)} (${String(
+          record.duplicate_count,
+        )})`;
+      })
+      .join(', ');
+    throw new Error(
+      `Cannot create Harness active-session uniqueness index while duplicate active rows exist. Close or migrate duplicate active rows for: ${examples}`,
+    );
+  }
+
+  async #withCompactionLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const previous = this.#compactionLocks.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    const queued = previous.catch(() => undefined).then(() => current);
+    this.#compactionLocks.set(key, queued);
+    await previous.catch(() => undefined);
+    try {
+      return await fn();
+    } finally {
+      release();
+      if (this.#compactionLocks.get(key) === queued) {
+        this.#compactionLocks.delete(key);
       }
     }
   }

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 import type { Client } from '@libsql/client';
 import {
   HarnessStorage,
+  HarnessStorageAdmissionConflictError,
   HarnessStorageAttachmentInUseError,
   HarnessStorageAttachmentUnavailableError,
   HarnessStorageLeaseConflictError,
@@ -11,15 +12,22 @@ import {
   TABLE_CONFIGS,
   TABLE_HARNESS_ATTACHMENT_REFERENCES,
   TABLE_HARNESS_ATTACHMENTS,
+  TABLE_HARNESS_OPERATION_TOMBSTONES,
   TABLE_HARNESS_SESSIONS,
   TABLE_SCHEMAS,
 } from '@mastra/core/storage';
 import type {
   AcquireSessionLeaseInput,
+  AgentSignalResultStatus,
   AttachmentReference,
   AttachmentRecord,
+  CreateOrLoadActiveSessionOptions,
+  CreateOrLoadActiveSessionResult,
   ListSessionsInput,
   LoadedAttachment,
+  OperationAdmissionEvidence,
+  OperationAdmissionTombstone,
+  QueueAdmissionReceipt,
   ReleaseSessionLeaseInput,
   RenewSessionLeaseInput,
   SaveAttachmentReferenceInput,
@@ -43,18 +51,20 @@ import type { LibSQLDomainConfig } from '../../db';
  * two writers cannot both observe the same predecessor.
  *
  * Attachments live in `mastra_harness_attachments` with a composite primary
- * key on `(session_id, attachment_id)`. Bytes are stored base64-encoded in
- * `data_b64` for now and the digest/source metadata is stored alongside the
- * byte payload.
+ * key on `(harness_name, session_id, attachment_id)`. Bytes are stored
+ * base64-encoded in `data_b64` for now and the digest/source metadata is
+ * stored alongside the byte payload.
  */
 export class HarnessLibSQL extends HarnessStorage {
   #db: LibSQLDB;
   #client: Client;
+  #harnessName: string;
 
   constructor(config: LibSQLDomainConfig) {
     super();
     const client = resolveClient(config);
     this.#client = client;
+    this.#harnessName = (config as LibSQLDomainConfig & { harnessName?: string }).harnessName ?? 'default';
     this.#db = new LibSQLDB({
       client,
       maxRetries: config.maxRetries,
@@ -63,9 +73,11 @@ export class HarnessLibSQL extends HarnessStorage {
   }
 
   async init(): Promise<void> {
+    const sessionsConfig = TABLE_CONFIGS[TABLE_HARNESS_SESSIONS];
     await this.#db.createTable({
       tableName: TABLE_HARNESS_SESSIONS,
       schema: TABLE_SCHEMAS[TABLE_HARNESS_SESSIONS],
+      compositePrimaryKey: sessionsConfig?.compositePrimaryKey,
     });
     const attachmentsConfig = TABLE_CONFIGS[TABLE_HARNESS_ATTACHMENTS];
     await this.#db.createTable({
@@ -79,17 +91,41 @@ export class HarnessLibSQL extends HarnessStorage {
       schema: TABLE_SCHEMAS[TABLE_HARNESS_ATTACHMENT_REFERENCES],
       compositePrimaryKey: attachmentRefsConfig?.compositePrimaryKey,
     });
+    const tombstonesConfig = TABLE_CONFIGS[TABLE_HARNESS_OPERATION_TOMBSTONES];
+    await this.#db.createTable({
+      tableName: TABLE_HARNESS_OPERATION_TOMBSTONES,
+      schema: TABLE_SCHEMAS[TABLE_HARNESS_OPERATION_TOMBSTONES],
+      compositePrimaryKey: tombstonesConfig?.compositePrimaryKey,
+    });
+    await this.#db.alterTable({
+      tableName: TABLE_HARNESS_SESSIONS,
+      schema: TABLE_SCHEMAS[TABLE_HARNESS_SESSIONS],
+      ifNotExists: ['harness_name', 'subagent_depth', 'queue_admission_receipts', 'closing_at', 'close_deadline_at'],
+    });
     await this.#db.alterTable({
       tableName: TABLE_HARNESS_ATTACHMENTS,
       schema: TABLE_SCHEMAS[TABLE_HARNESS_ATTACHMENTS],
-      ifNotExists: ['sha256', 'source'],
+      ifNotExists: ['harness_name', 'sha256', 'source'],
     });
+    await this.#db.alterTable({
+      tableName: TABLE_HARNESS_ATTACHMENT_REFERENCES,
+      schema: TABLE_SCHEMAS[TABLE_HARNESS_ATTACHMENT_REFERENCES],
+      ifNotExists: ['harness_name'],
+    });
+    await this.#backfillHarnessNamespace();
     await this.#backfillAttachmentMetadata();
+    await this.#client.execute({
+      sql: `CREATE UNIQUE INDEX IF NOT EXISTS idx_harness_sessions_active_key
+            ON "${TABLE_HARNESS_SESSIONS}" ("harness_name", "resource_id", "thread_id")
+            WHERE "closed_at" IS NULL`,
+      args: [],
+    });
   }
 
   async dangerouslyClearAll(): Promise<void> {
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_ATTACHMENT_REFERENCES}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_ATTACHMENTS}`);
+    await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_OPERATION_TOMBSTONES}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_SESSIONS}`);
   }
 
@@ -97,10 +133,17 @@ export class HarnessLibSQL extends HarnessStorage {
   // Session records
   // -------------------------------------------------------------------------
 
-  async loadSession({ sessionId }: { sessionId: string }): Promise<SessionRecord | null> {
+  async loadSession({
+    sessionId,
+    harnessName,
+  }: {
+    sessionId: string;
+    harnessName?: string;
+  }): Promise<SessionRecord | null> {
+    const namespace = this.#resolveHarnessName(harnessName);
     const result = await this.#client.execute({
-      sql: `SELECT * FROM ${TABLE_HARNESS_SESSIONS} WHERE id = ?`,
-      args: [sessionId],
+      sql: `SELECT * FROM ${TABLE_HARNESS_SESSIONS} WHERE harness_name = ? AND id = ?`,
+      args: [namespace, sessionId],
     });
     const row = result.rows[0];
     return row ? rowToSession(row as Record<string, unknown>) : null;
@@ -109,16 +152,19 @@ export class HarnessLibSQL extends HarnessStorage {
   async loadSessionByThread({
     threadId,
     resourceId,
+    harnessName,
   }: {
     threadId: string;
     resourceId: string;
+    harnessName?: string;
   }): Promise<SessionRecord | null> {
+    const namespace = this.#resolveHarnessName(harnessName);
     const result = await this.#client.execute({
       sql: `SELECT * FROM ${TABLE_HARNESS_SESSIONS}
-            WHERE thread_id = ? AND resource_id = ? AND closed_at IS NULL
+            WHERE harness_name = ? AND thread_id = ? AND resource_id = ? AND closed_at IS NULL
             ORDER BY last_activity_at DESC
             LIMIT 1`,
-      args: [threadId, resourceId],
+      args: [namespace, threadId, resourceId],
     });
     const row = result.rows[0];
     return row ? rowToSession(row as Record<string, unknown>) : null;
@@ -128,9 +174,10 @@ export class HarnessLibSQL extends HarnessStorage {
     resourceId,
     includeClosed = false,
     parentSessionId,
+    harnessName,
   }: ListSessionsInput): Promise<SessionSummary[]> {
-    const conditions: string[] = ['resource_id = ?'];
-    const args: (string | number)[] = [resourceId];
+    const conditions: string[] = ['harness_name = ?', 'resource_id = ?'];
+    const args: (string | number)[] = [this.#resolveHarnessName(harnessName), resourceId];
 
     if (!includeClosed) conditions.push('closed_at IS NULL');
     if (parentSessionId !== undefined) {
@@ -139,8 +186,8 @@ export class HarnessLibSQL extends HarnessStorage {
     }
 
     const result = await this.#client.execute({
-      sql: `SELECT id, resource_id, thread_id, parent_session_id, origin, mode_id, model_id,
-                   last_activity_at, closed_at
+      sql: `SELECT harness_name, id, resource_id, thread_id, parent_session_id, origin, mode_id, model_id,
+                   last_activity_at, closing_at, close_deadline_at, closed_at
             FROM ${TABLE_HARNESS_SESSIONS}
             WHERE ${conditions.join(' AND ')}
             ORDER BY last_activity_at DESC`,
@@ -151,8 +198,10 @@ export class HarnessLibSQL extends HarnessStorage {
   }
 
   async saveSession(record: SessionRecord, opts: SaveSessionOptions): Promise<SaveSessionResult> {
+    const harnessName = this.#resolveHarnessName(opts.harnessName ?? record.harnessName);
+    const namespacedRecord: SessionRecord = { ...record, harnessName };
     const nextVersion = opts.ifVersion + 1;
-    const cols = sessionColumnValues(record, nextVersion);
+    const cols = sessionColumnValues(namespacedRecord, nextVersion);
 
     if (opts.ifVersion === 0) {
       // First insert. Race with another writer is caught by the PRIMARY KEY
@@ -166,8 +215,17 @@ export class HarnessLibSQL extends HarnessStorage {
         });
       } catch (err) {
         if (isUniqueConstraintError(err)) {
-          const existing = await this.loadSession({ sessionId: record.id });
-          throw new HarnessStorageVersionConflictError(record.id, opts.ifVersion, existing?.version ?? 0);
+          const existing = await this.loadSession({ harnessName, sessionId: record.id });
+          const active = await this.loadSessionByThread({
+            harnessName,
+            resourceId: record.resourceId,
+            threadId: record.threadId,
+          });
+          throw new HarnessStorageVersionConflictError(
+            record.id,
+            opts.ifVersion,
+            existing?.version ?? active?.version ?? 0,
+          );
         }
         throw err;
       }
@@ -178,14 +236,17 @@ export class HarnessLibSQL extends HarnessStorage {
     // two concurrent writers cannot both succeed on the same predecessor.
     // We exclude owner_id and lease_expires_at from the update set — those
     // belong to the lease lifecycle methods.
-    const updateNames = cols.names.filter(n => n !== 'owner_id' && n !== 'lease_expires_at' && n !== 'id');
+    const updateNames = cols.names.filter(
+      n => n !== 'owner_id' && n !== 'lease_expires_at' && n !== 'id' && n !== 'harness_name',
+    );
     const updateValues = updateNames.map(n => cols.values[cols.names.indexOf(n)]);
 
     const setClause = updateNames.map(n => `${n} = ?`).join(', ');
     const updateResult = await this.#client.execute({
       sql: `UPDATE ${TABLE_HARNESS_SESSIONS}
             SET ${setClause}
-            WHERE id = ?
+            WHERE harness_name = ?
+              AND id = ?
               AND version = ?
               AND (
                 owner_id IS NULL
@@ -193,12 +254,12 @@ export class HarnessLibSQL extends HarnessStorage {
                 OR lease_expires_at <= ?
                 OR owner_id = ?
               )`,
-      args: [...updateValues, record.id, opts.ifVersion, Date.now(), opts.ownerId],
+      args: [...updateValues, harnessName, record.id, opts.ifVersion, Date.now(), opts.ownerId],
     });
 
     if (updateResult.rowsAffected === 0) {
       // Distinguish lease conflict from version conflict by re-reading the row.
-      const existing = await this.loadSession({ sessionId: record.id });
+      const existing = await this.loadSession({ harnessName, sessionId: record.id });
       if (!existing) {
         throw new HarnessStorageVersionConflictError(record.id, opts.ifVersion, 0);
       }
@@ -226,9 +287,13 @@ export class HarnessLibSQL extends HarnessStorage {
       throw new HarnessStorageVersionConflictError(record.id, opts.ifVersion, 0);
     }
 
+    const harnessName = this.#resolveHarnessName(opts.harnessName ?? record.harnessName);
+    const namespacedRecord: SessionRecord = { ...record, harnessName };
     const nextVersion = opts.ifVersion + 1;
-    const cols = sessionColumnValues(record, nextVersion);
-    const updateNames = cols.names.filter(n => n !== 'owner_id' && n !== 'lease_expires_at' && n !== 'id');
+    const cols = sessionColumnValues(namespacedRecord, nextVersion);
+    const updateNames = cols.names.filter(
+      n => n !== 'owner_id' && n !== 'lease_expires_at' && n !== 'id' && n !== 'harness_name',
+    );
     const updateValues = updateNames.map(n => cols.values[cols.names.indexOf(n)]);
     const setClause = updateNames.map(n => `${n} = ?`).join(', ');
 
@@ -237,7 +302,8 @@ export class HarnessLibSQL extends HarnessStorage {
       const updateResult = await tx.execute({
         sql: `UPDATE ${TABLE_HARNESS_SESSIONS}
               SET ${setClause}
-              WHERE id = ?
+              WHERE harness_name = ?
+                AND id = ?
                 AND version = ?
                 AND (
                   owner_id IS NULL
@@ -245,12 +311,12 @@ export class HarnessLibSQL extends HarnessStorage {
                   OR lease_expires_at <= ?
                   OR owner_id = ?
                 )`,
-        args: [...updateValues, record.id, opts.ifVersion, Date.now(), opts.ownerId],
+        args: [...updateValues, harnessName, record.id, opts.ifVersion, Date.now(), opts.ownerId],
       });
 
       if (updateResult.rowsAffected === 0) {
         await tx.rollback();
-        await this.#throwSaveSessionConflict(record, opts);
+        await this.#throwSaveSessionConflict(namespacedRecord, opts);
       }
 
       const createdAt = Date.now();
@@ -258,20 +324,28 @@ export class HarnessLibSQL extends HarnessStorage {
         const attachment = await tx.execute({
           sql: `SELECT attachment_id
                 FROM ${TABLE_HARNESS_ATTACHMENTS}
-                WHERE session_id = ? AND attachment_id = ?
+                WHERE harness_name = ? AND session_id = ? AND attachment_id = ?
                 LIMIT 1`,
-          args: [ref.sessionId, ref.attachmentId],
+          args: [this.#resolveHarnessName(ref.harnessName ?? harnessName), ref.sessionId, ref.attachmentId],
         });
         if (attachment.rows.length === 0) {
           throw new HarnessStorageAttachmentUnavailableError(ref.sessionId, ref.attachmentId);
         }
         await tx.execute({
           sql: `INSERT INTO ${TABLE_HARNESS_ATTACHMENT_REFERENCES}
-                (session_id, attachment_id, source, source_id, retained_until, created_at)
-                VALUES (?, ?, ?, ?, ?, ?)
-                ON CONFLICT(session_id, attachment_id, source, source_id) DO UPDATE SET
+                (harness_name, session_id, attachment_id, source, source_id, retained_until, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT DO UPDATE SET
                   retained_until = excluded.retained_until`,
-          args: [ref.sessionId, ref.attachmentId, ref.source, ref.sourceId, ref.retainedUntil ?? null, createdAt],
+          args: [
+            this.#resolveHarnessName(ref.harnessName ?? harnessName),
+            ref.sessionId,
+            ref.attachmentId,
+            ref.source,
+            ref.sourceId,
+            ref.retainedUntil ?? null,
+            createdAt,
+          ],
         });
       }
 
@@ -284,7 +358,7 @@ export class HarnessLibSQL extends HarnessStorage {
   }
 
   async #throwSaveSessionConflict(record: SessionRecord, opts: SaveSessionOptions): Promise<never> {
-    const existing = await this.loadSession({ sessionId: record.id });
+    const existing = await this.loadSession({ harnessName: record.harnessName, sessionId: record.id });
     if (!existing) {
       throw new HarnessStorageVersionConflictError(record.id, opts.ifVersion, 0);
     }
@@ -300,14 +374,112 @@ export class HarnessLibSQL extends HarnessStorage {
     throw new HarnessStorageVersionConflictError(record.id, opts.ifVersion, existing.version);
   }
 
-  async deleteSession({ sessionId }: { sessionId: string }): Promise<void> {
+  async createOrLoadActiveSession(
+    record: SessionRecord,
+    opts: CreateOrLoadActiveSessionOptions,
+  ): Promise<CreateOrLoadActiveSessionResult> {
+    const harnessName = this.#resolveHarnessName(record.harnessName);
+    const storageNow = Date.now();
+    const tx = await this.#client.transaction('write');
+    try {
+      const active = await tx.execute({
+        sql: `SELECT * FROM ${TABLE_HARNESS_SESSIONS}
+              WHERE harness_name = ? AND resource_id = ? AND thread_id = ? AND closed_at IS NULL
+              ORDER BY last_activity_at DESC
+              LIMIT 1`,
+        args: [harnessName, record.resourceId, record.threadId],
+      });
+      const activeRow = active.rows[0];
+      if (activeRow) {
+        await tx.commit();
+        const existing = rowToSession(activeRow as Record<string, unknown>);
+        return {
+          record: existing,
+          created: false,
+          leaseAcquired: false,
+          version: existing.version,
+          expiresAt: existing.leaseExpiresAt,
+          storageNow,
+        };
+      }
+
+      const existingById = await tx.execute({
+        sql: `SELECT version FROM ${TABLE_HARNESS_SESSIONS}
+              WHERE harness_name = ? AND id = ?
+              LIMIT 1`,
+        args: [harnessName, record.id],
+      });
+      if (existingById.rows[0]) {
+        await tx.rollback();
+        throw new HarnessStorageVersionConflictError(record.id, 0, Number(existingById.rows[0]!.version));
+      }
+
+      const expiresAt = storageNow + opts.initialLease.ttlMs;
+      const namespacedRecord: SessionRecord = {
+        ...record,
+        harnessName,
+        ownerId: opts.initialLease.ownerId,
+        leaseExpiresAt: expiresAt,
+      };
+      const cols = sessionColumnValues(namespacedRecord, 1);
+      await tx.execute({
+        sql: `INSERT INTO ${TABLE_HARNESS_SESSIONS}
+              (${cols.names.join(', ')})
+              VALUES (${cols.names.map(() => '?').join(', ')})`,
+        args: cols.values,
+      });
+      await tx.commit();
+      const created = rowToSession(Object.fromEntries(cols.names.map((name, index) => [name, cols.values[index]])));
+      return {
+        record: created,
+        created: true,
+        leaseAcquired: true,
+        version: 1,
+        expiresAt,
+        storageNow,
+      };
+    } catch (err) {
+      if (!tx.closed) await tx.rollback();
+      if (isUniqueConstraintError(err)) {
+        const active = await this.loadSessionByThread({
+          harnessName,
+          resourceId: record.resourceId,
+          threadId: record.threadId,
+        });
+        if (active) {
+          return {
+            record: active,
+            created: false,
+            leaseAcquired: false,
+            version: active.version,
+            expiresAt: active.leaseExpiresAt,
+            storageNow,
+          };
+        }
+        const existingById = await this.loadSession({ harnessName, sessionId: record.id });
+        if (existingById) throw new HarnessStorageVersionConflictError(record.id, 0, existingById.version);
+      }
+      throw err;
+    }
+  }
+
+  async deleteSession({ sessionId, harnessName }: { sessionId: string; harnessName?: string }): Promise<void> {
+    const namespace = this.#resolveHarnessName(harnessName);
+    const existing = await this.loadSession({ harnessName: namespace, sessionId });
+    if (existing) {
+      await this.deleteOperationAdmissionTombstonesForSession({
+        harnessName: namespace,
+        sessionId,
+        resourceId: existing.resourceId,
+      });
+    }
     // Cascade attachments first; we don't rely on FK cascades because the
     // schema deliberately doesn't declare a FK (sessions can be hard-deleted
     // independently of how attachments were uploaded).
-    await this.deleteAttachmentsForSession({ sessionId });
+    await this.deleteAttachmentsForSession({ harnessName: namespace, sessionId });
     await this.#client.execute({
-      sql: `DELETE FROM ${TABLE_HARNESS_SESSIONS} WHERE id = ?`,
-      args: [sessionId],
+      sql: `DELETE FROM ${TABLE_HARNESS_SESSIONS} WHERE harness_name = ? AND id = ?`,
+      args: [namespace, sessionId],
     });
   }
 
@@ -315,14 +487,21 @@ export class HarnessLibSQL extends HarnessStorage {
   // Session leases
   // -------------------------------------------------------------------------
 
-  async acquireSessionLease({ sessionId, ownerId, ttlMs }: AcquireSessionLeaseInput): Promise<SessionLeaseResult> {
+  async acquireSessionLease({
+    sessionId,
+    ownerId,
+    ttlMs,
+    harnessName,
+  }: AcquireSessionLeaseInput): Promise<SessionLeaseResult> {
+    const namespace = this.#resolveHarnessName(harnessName);
     const now = Date.now();
     const expiresAt = now + ttlMs;
 
     const result = await this.#client.execute({
       sql: `UPDATE ${TABLE_HARNESS_SESSIONS}
             SET owner_id = ?, lease_expires_at = ?
-            WHERE id = ?
+            WHERE harness_name = ?
+              AND id = ?
               AND (
                 owner_id IS NULL
                 OR lease_expires_at IS NULL
@@ -330,11 +509,11 @@ export class HarnessLibSQL extends HarnessStorage {
                 OR owner_id = ?
               )
             RETURNING version`,
-      args: [ownerId, expiresAt, sessionId, now, ownerId],
+      args: [ownerId, expiresAt, namespace, sessionId, now, ownerId],
     });
 
     if (result.rows.length === 0) {
-      const existing = await this.loadSession({ sessionId });
+      const existing = await this.loadSession({ harnessName: namespace, sessionId });
       if (!existing) throw new HarnessStorageSessionNotFoundError(sessionId);
       throw new HarnessStorageLeaseConflictError(
         sessionId,
@@ -346,23 +525,30 @@ export class HarnessLibSQL extends HarnessStorage {
     return { version: Number(result.rows[0]!.version), expiresAt };
   }
 
-  async renewSessionLease({ sessionId, ownerId, ttlMs }: RenewSessionLeaseInput): Promise<SessionLeaseResult> {
+  async renewSessionLease({
+    sessionId,
+    ownerId,
+    ttlMs,
+    harnessName,
+  }: RenewSessionLeaseInput): Promise<SessionLeaseResult> {
+    const namespace = this.#resolveHarnessName(harnessName);
     const now = Date.now();
     const expiresAt = now + ttlMs;
 
     const result = await this.#client.execute({
       sql: `UPDATE ${TABLE_HARNESS_SESSIONS}
             SET lease_expires_at = ?
-            WHERE id = ?
+            WHERE harness_name = ?
+              AND id = ?
               AND owner_id = ?
               AND lease_expires_at IS NOT NULL
               AND lease_expires_at > ?
             RETURNING version`,
-      args: [expiresAt, sessionId, ownerId, now],
+      args: [expiresAt, namespace, sessionId, ownerId, now],
     });
 
     if (result.rows.length === 0) {
-      const existing = await this.loadSession({ sessionId });
+      const existing = await this.loadSession({ harnessName: namespace, sessionId });
       if (!existing) throw new HarnessStorageSessionNotFoundError(sessionId);
       throw new HarnessStorageLeaseConflictError(
         sessionId,
@@ -374,10 +560,11 @@ export class HarnessLibSQL extends HarnessStorage {
     return { version: Number(result.rows[0]!.version), expiresAt };
   }
 
-  async releaseSessionLease({ sessionId, ownerId }: ReleaseSessionLeaseInput): Promise<void> {
+  async releaseSessionLease({ sessionId, ownerId, harnessName }: ReleaseSessionLeaseInput): Promise<void> {
+    const namespace = this.#resolveHarnessName(harnessName);
     const exists = await this.#client.execute({
-      sql: `SELECT 1 FROM ${TABLE_HARNESS_SESSIONS} WHERE id = ? LIMIT 1`,
-      args: [sessionId],
+      sql: `SELECT 1 FROM ${TABLE_HARNESS_SESSIONS} WHERE harness_name = ? AND id = ? LIMIT 1`,
+      args: [namespace, sessionId],
     });
     if (exists.rows.length === 0) {
       throw new HarnessStorageSessionNotFoundError(sessionId);
@@ -387,8 +574,8 @@ export class HarnessLibSQL extends HarnessStorage {
     await this.#client.execute({
       sql: `UPDATE ${TABLE_HARNESS_SESSIONS}
             SET owner_id = NULL, lease_expires_at = NULL
-            WHERE id = ? AND owner_id = ?`,
-      args: [sessionId, ownerId],
+            WHERE harness_name = ? AND id = ? AND owner_id = ?`,
+      args: [namespace, sessionId, ownerId],
     });
   }
 
@@ -399,19 +586,21 @@ export class HarnessLibSQL extends HarnessStorage {
   async saveAttachment({
     sessionId,
     attachmentId,
+    harnessName,
     name,
     mimeType,
     source,
     data,
   }: SaveAttachmentInput): Promise<SaveAttachmentResult> {
+    const namespace = this.#resolveHarnessName(harnessName);
     const sha256 = sha256Hex(data);
     const bytes = data.byteLength;
     const dataB64 = bytesToBase64(data);
     await this.#client.execute({
       sql: `INSERT INTO ${TABLE_HARNESS_ATTACHMENTS}
-            (session_id, attachment_id, name, mime_type, size_bytes, sha256, source, created_at, data_b64)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(session_id, attachment_id) DO UPDATE SET
+            (harness_name, session_id, attachment_id, name, mime_type, size_bytes, sha256, source, created_at, data_b64)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT DO UPDATE SET
               name = excluded.name,
               mime_type = excluded.mime_type,
               size_bytes = excluded.size_bytes,
@@ -419,7 +608,7 @@ export class HarnessLibSQL extends HarnessStorage {
               source = excluded.source,
               created_at = excluded.created_at,
               data_b64 = excluded.data_b64`,
-      args: [sessionId, attachmentId, name, mimeType, bytes, sha256, source, Date.now(), dataB64],
+      args: [namespace, sessionId, attachmentId, name, mimeType, bytes, sha256, source, Date.now(), dataB64],
     });
     return { attachmentId, bytes, sha256 };
   }
@@ -427,14 +616,17 @@ export class HarnessLibSQL extends HarnessStorage {
   async loadAttachment({
     sessionId,
     attachmentId,
+    harnessName,
   }: {
     sessionId: string;
     attachmentId: string;
+    harnessName?: string;
   }): Promise<LoadedAttachment | null> {
+    const namespace = this.#resolveHarnessName(harnessName);
     const result = await this.#client.execute({
       sql: `SELECT name, mime_type, size_bytes, sha256, data_b64 FROM ${TABLE_HARNESS_ATTACHMENTS}
-            WHERE session_id = ? AND attachment_id = ?`,
-      args: [sessionId, attachmentId],
+            WHERE harness_name = ? AND session_id = ? AND attachment_id = ?`,
+      args: [namespace, sessionId, attachmentId],
     });
     const row = result.rows[0];
     if (!row) return null;
@@ -447,50 +639,71 @@ export class HarnessLibSQL extends HarnessStorage {
     };
   }
 
-  async deleteAttachment({ sessionId, attachmentId }: { sessionId: string; attachmentId: string }): Promise<void> {
+  async deleteAttachment({
+    sessionId,
+    attachmentId,
+    harnessName,
+  }: {
+    sessionId: string;
+    attachmentId: string;
+    harnessName?: string;
+  }): Promise<void> {
+    const namespace = this.#resolveHarnessName(harnessName);
     const result = await this.#client.execute({
       sql: `DELETE FROM ${TABLE_HARNESS_ATTACHMENTS}
-            WHERE session_id = ? AND attachment_id = ?
+            WHERE harness_name = ? AND session_id = ? AND attachment_id = ?
               AND NOT EXISTS (
                 SELECT 1 FROM ${TABLE_HARNESS_ATTACHMENT_REFERENCES} refs
-                WHERE refs.session_id = ${TABLE_HARNESS_ATTACHMENTS}.session_id
+                WHERE refs.harness_name = ${TABLE_HARNESS_ATTACHMENTS}.harness_name
+                  AND refs.session_id = ${TABLE_HARNESS_ATTACHMENTS}.session_id
                   AND refs.attachment_id = ${TABLE_HARNESS_ATTACHMENTS}.attachment_id
               )`,
-      args: [sessionId, attachmentId],
+      args: [namespace, sessionId, attachmentId],
     });
     if (result.rowsAffected === 0) {
-      const references = await this.listAttachmentReferences({ sessionId, attachmentId });
+      const references = await this.listAttachmentReferences({ harnessName: namespace, sessionId, attachmentId });
       if (references.length > 0) {
         throw new HarnessStorageAttachmentInUseError(sessionId, attachmentId, references);
       }
     }
   }
 
-  async deleteAttachmentsForSession({ sessionId }: { sessionId: string }): Promise<void> {
+  async deleteAttachmentsForSession({
+    sessionId,
+    harnessName,
+  }: {
+    sessionId: string;
+    harnessName?: string;
+  }): Promise<void> {
+    const namespace = this.#resolveHarnessName(harnessName);
     await this.#client.execute({
       sql: `DELETE FROM ${TABLE_HARNESS_ATTACHMENTS}
-            WHERE session_id = ?
+            WHERE harness_name = ? AND session_id = ?
               AND NOT EXISTS (
                 SELECT 1 FROM ${TABLE_HARNESS_ATTACHMENT_REFERENCES} refs
-                WHERE refs.session_id = ${TABLE_HARNESS_ATTACHMENTS}.session_id
+                WHERE refs.harness_name = ${TABLE_HARNESS_ATTACHMENTS}.harness_name
+                  AND refs.session_id = ${TABLE_HARNESS_ATTACHMENTS}.session_id
                   AND refs.attachment_id = ${TABLE_HARNESS_ATTACHMENTS}.attachment_id
               )`,
-      args: [sessionId],
+      args: [namespace, sessionId],
     });
   }
 
   async getAttachmentRecord({
     sessionId,
     attachmentId,
+    harnessName,
   }: {
     sessionId: string;
     attachmentId: string;
+    harnessName?: string;
   }): Promise<AttachmentRecord | null> {
+    const namespace = this.#resolveHarnessName(harnessName);
     const result = await this.#client.execute({
       sql: `SELECT session_id, attachment_id, name, mime_type, size_bytes, sha256, source, created_at
             FROM ${TABLE_HARNESS_ATTACHMENTS}
-            WHERE session_id = ? AND attachment_id = ?`,
-      args: [sessionId, attachmentId],
+            WHERE harness_name = ? AND session_id = ? AND attachment_id = ?`,
+      args: [namespace, sessionId, attachmentId],
     });
     const row = result.rows[0];
     if (!row) return null;
@@ -511,11 +724,19 @@ export class HarnessLibSQL extends HarnessStorage {
     for (const ref of references) {
       await this.#client.execute({
         sql: `INSERT INTO ${TABLE_HARNESS_ATTACHMENT_REFERENCES}
-              (session_id, attachment_id, source, source_id, retained_until, created_at)
-              VALUES (?, ?, ?, ?, ?, ?)
-              ON CONFLICT(session_id, attachment_id, source, source_id) DO UPDATE SET
+              (harness_name, session_id, attachment_id, source, source_id, retained_until, created_at)
+              VALUES (?, ?, ?, ?, ?, ?, ?)
+              ON CONFLICT DO UPDATE SET
                 retained_until = excluded.retained_until`,
-        args: [ref.sessionId, ref.attachmentId, ref.source, ref.sourceId, ref.retainedUntil ?? null, createdAt],
+        args: [
+          this.#resolveHarnessName(ref.harnessName),
+          ref.sessionId,
+          ref.attachmentId,
+          ref.source,
+          ref.sourceId,
+          ref.retainedUntil ?? null,
+          createdAt,
+        ],
       });
     }
   }
@@ -524,8 +745,8 @@ export class HarnessLibSQL extends HarnessStorage {
     for (const ref of references) {
       await this.#client.execute({
         sql: `DELETE FROM ${TABLE_HARNESS_ATTACHMENT_REFERENCES}
-              WHERE session_id = ? AND attachment_id = ? AND source = ? AND source_id = ?`,
-        args: [ref.sessionId, ref.attachmentId, ref.source, ref.sourceId],
+              WHERE harness_name = ? AND session_id = ? AND attachment_id = ? AND source = ? AND source_id = ?`,
+        args: [this.#resolveHarnessName(ref.harnessName), ref.sessionId, ref.attachmentId, ref.source, ref.sourceId],
       });
     }
   }
@@ -533,24 +754,278 @@ export class HarnessLibSQL extends HarnessStorage {
   async listAttachmentReferences({
     sessionId,
     attachmentId,
+    harnessName,
   }: {
     sessionId: string;
     attachmentId: string;
+    harnessName?: string;
   }): Promise<AttachmentReference[]> {
+    const namespace = this.#resolveHarnessName(harnessName);
     const result = await this.#client.execute({
       sql: `SELECT source, source_id, retained_until
             FROM ${TABLE_HARNESS_ATTACHMENT_REFERENCES}
-            WHERE session_id = ? AND attachment_id = ?
+            WHERE harness_name = ? AND session_id = ? AND attachment_id = ?
             ORDER BY source ASC, source_id ASC`,
-      args: [sessionId, attachmentId],
+      args: [namespace, sessionId, attachmentId],
     });
     return result.rows.map(rowToAttachmentReference);
+  }
+
+  // -------------------------------------------------------------------------
+  // Admission/result evidence
+  // -------------------------------------------------------------------------
+
+  async loadMessageResultEvidence({
+    harnessName,
+    sessionId,
+    resourceId,
+    threadId,
+    signalId,
+  }: {
+    harnessName?: string;
+    sessionId: string;
+    resourceId: string;
+    threadId: string;
+    signalId: string;
+  }): Promise<AgentSignalResultStatus | OperationAdmissionTombstone | null> {
+    const namespace = this.#resolveHarnessName(harnessName);
+    const result = await this.#client.execute({
+      sql: `SELECT * FROM ${TABLE_HARNESS_OPERATION_TOMBSTONES}
+            WHERE harness_name = ? AND session_id = ? AND resource_id = ? AND thread_id = ?
+              AND kind = 'message' AND signal_id = ?
+            LIMIT 1`,
+      args: [namespace, sessionId, resourceId, threadId, signalId],
+    });
+    const row = result.rows[0];
+    return row ? rowToTombstone(row as Record<string, unknown>) : null;
+  }
+
+  async loadQueueResultEvidence({
+    harnessName,
+    sessionId,
+    resourceId,
+    queuedItemId,
+  }: {
+    harnessName?: string;
+    sessionId: string;
+    resourceId: string;
+    queuedItemId: string;
+  }): Promise<QueueAdmissionReceipt | OperationAdmissionTombstone | null> {
+    const namespace = this.#resolveHarnessName(harnessName);
+    const session = await this.loadSession({ harnessName: namespace, sessionId });
+    if (session && session.resourceId !== resourceId) return null;
+    const receipt = session?.queueAdmissionReceipts?.[queuedItemId];
+    if (receipt) return receipt;
+    const result = await this.#client.execute({
+      sql: `SELECT * FROM ${TABLE_HARNESS_OPERATION_TOMBSTONES}
+            WHERE harness_name = ? AND session_id = ? AND resource_id = ?
+              AND kind = 'queue' AND queued_item_id = ?
+            LIMIT 1`,
+      args: [namespace, sessionId, resourceId, queuedItemId],
+    });
+    const row = result.rows[0];
+    return row ? rowToTombstone(row as Record<string, unknown>) : null;
+  }
+
+  async resolveOperationAdmissionEvidence({
+    harnessName,
+    sessionId,
+    resourceId,
+    kind,
+    admissionId,
+    attemptedAdmissionHash,
+  }: {
+    harnessName?: string;
+    sessionId: string;
+    resourceId: string;
+    kind: 'message' | 'queue';
+    admissionId: string;
+    attemptedAdmissionHash: string;
+  }): Promise<{
+    status: 'none' | 'duplicate' | 'conflict';
+    evidence?: OperationAdmissionEvidence;
+    storedAdmissionHash?: string;
+  }> {
+    const namespace = this.#resolveHarnessName(harnessName);
+    if (kind === 'queue') {
+      const session = await this.loadSession({ harnessName: namespace, sessionId });
+      if (session && session.resourceId !== resourceId) return { status: 'none' };
+      for (const receipt of Object.values(session?.queueAdmissionReceipts ?? {})) {
+        if (receipt.admissionId !== admissionId) continue;
+        return {
+          status: receipt.admissionHash === attemptedAdmissionHash ? 'duplicate' : 'conflict',
+          evidence: receipt,
+          storedAdmissionHash: receipt.admissionHash,
+        };
+      }
+    }
+
+    const result = await this.#client.execute({
+      sql: `SELECT * FROM ${TABLE_HARNESS_OPERATION_TOMBSTONES}
+            WHERE harness_name = ? AND session_id = ? AND resource_id = ?
+              AND kind = ? AND admission_id = ?
+            LIMIT 1`,
+      args: [namespace, sessionId, resourceId, kind, admissionId],
+    });
+    const row = result.rows[0];
+    if (!row) return { status: 'none' };
+    const tombstone = rowToTombstone(row as Record<string, unknown>);
+    return {
+      status: tombstone.admissionHash === attemptedAdmissionHash ? 'duplicate' : 'conflict',
+      evidence: tombstone,
+      storedAdmissionHash: tombstone.admissionHash,
+    };
+  }
+
+  async writeOperationAdmissionTombstone(record: OperationAdmissionTombstone): Promise<void> {
+    const namespacedRecord = { ...record, harnessName: this.#resolveHarnessName(record.harnessName) };
+    const id = tombstoneId(namespacedRecord);
+    const tx = await this.#client.transaction('write');
+    try {
+      const existing = await tx.execute({
+        sql: `SELECT * FROM ${TABLE_HARNESS_OPERATION_TOMBSTONES} WHERE id = ? LIMIT 1`,
+        args: [id],
+      });
+      if (existing.rows[0]) {
+        const current = rowToTombstone(existing.rows[0] as Record<string, unknown>);
+        if (!sameTombstoneIdentity(current, namespacedRecord)) {
+          throw new HarnessStorageAdmissionConflictError(
+            namespacedRecord.sessionId,
+            namespacedRecord.kind,
+            namespacedRecord.admissionId ?? id,
+          );
+        }
+        await tx.execute({
+          sql: `UPDATE ${TABLE_HARNESS_OPERATION_TOMBSTONES}
+                SET expires_at = ?
+                WHERE id = ?`,
+          args: [namespacedRecord.expiresAt, id],
+        });
+      } else {
+        await tx.execute({
+          sql: `INSERT INTO ${TABLE_HARNESS_OPERATION_TOMBSTONES}
+                (id, harness_name, session_id, kind, resource_id, thread_id, admission_id, admission_hash,
+                 queued_item_id, signal_id, run_id, terminal_at, compacted_at, expires_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          args: [
+            id,
+            namespacedRecord.harnessName,
+            namespacedRecord.sessionId,
+            namespacedRecord.kind,
+            namespacedRecord.resourceId,
+            namespacedRecord.threadId,
+            namespacedRecord.admissionId ?? null,
+            namespacedRecord.admissionHash ?? null,
+            namespacedRecord.queuedItemId ?? null,
+            namespacedRecord.signalId ?? null,
+            namespacedRecord.runId ?? null,
+            namespacedRecord.terminalAt,
+            namespacedRecord.compactedAt,
+            namespacedRecord.expiresAt,
+          ],
+        });
+      }
+      await tx.commit();
+    } catch (err) {
+      if (!tx.closed) await tx.rollback();
+      throw err;
+    }
+  }
+
+  async compactOperationResultEvidence({
+    harnessName,
+    sessionId,
+    resourceId,
+    kind,
+    queuedItemId,
+    now,
+  }: {
+    harnessName?: string;
+    sessionId: string;
+    resourceId: string;
+    kind: 'message' | 'queue';
+    signalId?: string;
+    queuedItemId?: string;
+    now: number;
+  }): Promise<OperationAdmissionTombstone | null> {
+    if (kind === 'message') return null;
+    const namespace = this.#resolveHarnessName(harnessName);
+    const session = await this.loadSession({ harnessName: namespace, sessionId });
+    if (session && session.resourceId !== resourceId) return null;
+    const receipt = queuedItemId ? session?.queueAdmissionReceipts?.[queuedItemId] : undefined;
+    if (!session || !receipt || !isTerminalQueueReceipt(receipt)) return null;
+    const tombstone: OperationAdmissionTombstone = {
+      kind: 'queue',
+      harnessName: namespace,
+      sessionId,
+      resourceId,
+      threadId: session.threadId,
+      admissionId: receipt.admissionId,
+      admissionHash: receipt.admissionHash,
+      queuedItemId: receipt.queuedItemId,
+      ...(receipt.signalId !== undefined ? { signalId: receipt.signalId } : {}),
+      ...(receipt.runId !== undefined ? { runId: receipt.runId } : {}),
+      terminalAt: receipt.completedAt ?? receipt.failedAt ?? receipt.deadAt ?? now,
+      compactedAt: now,
+      expiresAt: now,
+    };
+    await this.writeOperationAdmissionTombstone(tombstone);
+    const nextReceipts = { ...(session.queueAdmissionReceipts ?? {}) };
+    delete nextReceipts[queuedItemId!];
+    await this.#client.execute({
+      sql: `UPDATE ${TABLE_HARNESS_SESSIONS}
+            SET queue_admission_receipts = ?
+            WHERE harness_name = ? AND id = ?`,
+      args: [Object.keys(nextReceipts).length > 0 ? JSON.stringify(nextReceipts) : null, namespace, sessionId],
+    });
+    return tombstone;
+  }
+
+  async deleteOperationAdmissionTombstonesForSession({
+    harnessName,
+    sessionId,
+    resourceId,
+  }: {
+    harnessName?: string;
+    sessionId: string;
+    resourceId: string;
+  }): Promise<void> {
+    await this.#client.execute({
+      sql: `DELETE FROM ${TABLE_HARNESS_OPERATION_TOMBSTONES}
+            WHERE harness_name = ? AND session_id = ? AND resource_id = ?`,
+      args: [this.#resolveHarnessName(harnessName), sessionId, resourceId],
+    });
+  }
+
+  async #backfillHarnessNamespace(): Promise<void> {
+    await this.#client.execute({
+      sql: `UPDATE ${TABLE_HARNESS_SESSIONS}
+            SET harness_name = ?
+            WHERE harness_name IS NULL OR harness_name = ''`,
+      args: [this.#harnessName],
+    });
+    await this.#client.execute({
+      sql: `UPDATE ${TABLE_HARNESS_ATTACHMENTS}
+            SET harness_name = ?
+            WHERE harness_name IS NULL OR harness_name = ''`,
+      args: [this.#harnessName],
+    });
+    await this.#client.execute({
+      sql: `UPDATE ${TABLE_HARNESS_ATTACHMENT_REFERENCES}
+            SET harness_name = ?
+            WHERE harness_name IS NULL OR harness_name = ''`,
+      args: [this.#harnessName],
+    });
+  }
+
+  #resolveHarnessName(input?: string): string {
+    return input ?? this.#harnessName;
   }
 
   async #backfillAttachmentMetadata(): Promise<void> {
     for (;;) {
       const result = await this.#client.execute({
-        sql: `SELECT session_id, attachment_id, data_b64, sha256, source
+        sql: `SELECT harness_name, session_id, attachment_id, data_b64, sha256, source
               FROM ${TABLE_HARNESS_ATTACHMENTS}
               WHERE sha256 IS NULL OR sha256 = '' OR source IS NULL OR source = ''
               LIMIT 100`,
@@ -569,8 +1044,14 @@ export class HarnessLibSQL extends HarnessStorage {
         await this.#client.execute({
           sql: `UPDATE ${TABLE_HARNESS_ATTACHMENTS}
                 SET sha256 = ?, source = ?
-                WHERE session_id = ? AND attachment_id = ?`,
-          args: [sha256, source, String(row.session_id), String(row.attachment_id)],
+                WHERE harness_name = ? AND session_id = ? AND attachment_id = ?`,
+          args: [
+            sha256,
+            source,
+            String(row.harness_name ?? this.#harnessName),
+            String(row.session_id),
+            String(row.attachment_id),
+          ],
         });
       }
     }
@@ -582,11 +1063,13 @@ export class HarnessLibSQL extends HarnessStorage {
 // ---------------------------------------------------------------------------
 
 const SESSION_COLUMN_NAMES = [
+  'harness_name',
   'id',
   'resource_id',
   'thread_id',
   'parent_session_id',
   'origin',
+  'subagent_depth',
   'owns_thread',
   'mode_id',
   'model_id',
@@ -596,23 +1079,30 @@ const SESSION_COLUMN_NAMES = [
   'token_usage',
   'pending_queue',
   'pending_resume',
+  'queue_admission_receipts',
   'observational_memory',
   'goal',
   'workspace',
   'state',
   'created_at',
   'last_activity_at',
+  'closing_at',
+  'close_deadline_at',
   'closed_at',
   'version',
+  'owner_id',
+  'lease_expires_at',
 ] as const;
 
 function sessionColumnValues(record: SessionRecord, version: number): { names: string[]; values: any[] } {
   const values = [
+    record.harnessName,
     record.id,
     record.resourceId,
     record.threadId,
     record.parentSessionId ?? null,
     record.origin,
+    record.subagentDepth ?? null,
     record.ownsThread ? 1 : 0,
     record.modeId,
     record.modelId,
@@ -622,25 +1112,32 @@ function sessionColumnValues(record: SessionRecord, version: number): { names: s
     JSON.stringify(record.tokenUsage),
     JSON.stringify(record.pendingQueue),
     record.pendingResume ? JSON.stringify(record.pendingResume) : null,
+    record.queueAdmissionReceipts ? JSON.stringify(record.queueAdmissionReceipts) : null,
     record.observationalMemory ? JSON.stringify(record.observationalMemory) : null,
     record.goal ? JSON.stringify(record.goal) : null,
     record.workspace ? JSON.stringify(record.workspace) : null,
     JSON.stringify(record.state ?? {}),
     record.createdAt,
     record.lastActivityAt,
+    record.closingAt ?? null,
+    record.closeDeadlineAt ?? null,
     record.closedAt ?? null,
     version,
+    record.ownerId ?? null,
+    record.leaseExpiresAt ?? null,
   ];
   return { names: [...SESSION_COLUMN_NAMES], values };
 }
 
 function rowToSession(row: Record<string, unknown>): SessionRecord {
   return {
+    harnessName: String(row.harness_name ?? 'default'),
     id: String(row.id),
     resourceId: String(row.resource_id),
     threadId: String(row.thread_id),
     parentSessionId: row.parent_session_id != null ? String(row.parent_session_id) : undefined,
     origin: String(row.origin) as SessionRecord['origin'],
+    subagentDepth: row.subagent_depth != null ? Number(row.subagent_depth) : undefined,
     ownsThread: Number(row.owns_thread) === 1,
     modeId: String(row.mode_id),
     modelId: String(row.model_id),
@@ -650,12 +1147,15 @@ function rowToSession(row: Record<string, unknown>): SessionRecord {
     tokenUsage: parseJson(row.token_usage) ?? { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
     pendingQueue: parseJson(row.pending_queue) ?? [],
     pendingResume: parseJson(row.pending_resume) ?? undefined,
+    queueAdmissionReceipts: parseJson(row.queue_admission_receipts) ?? undefined,
     observationalMemory: parseJson(row.observational_memory) ?? undefined,
     goal: parseJson(row.goal) ?? undefined,
     workspace: parseJson(row.workspace) ?? undefined,
     state: parseJson(row.state) ?? {},
     createdAt: Number(row.created_at),
     lastActivityAt: Number(row.last_activity_at),
+    closingAt: row.closing_at != null ? Number(row.closing_at) : undefined,
+    closeDeadlineAt: row.close_deadline_at != null ? Number(row.close_deadline_at) : undefined,
     closedAt: row.closed_at != null ? Number(row.closed_at) : undefined,
     version: Number(row.version),
     ownerId: row.owner_id != null ? String(row.owner_id) : undefined,
@@ -665,6 +1165,7 @@ function rowToSession(row: Record<string, unknown>): SessionRecord {
 
 function rowToSummary(row: Record<string, unknown>): SessionSummary {
   return {
+    harnessName: String(row.harness_name ?? 'default'),
     id: String(row.id),
     resourceId: String(row.resource_id),
     threadId: String(row.thread_id),
@@ -673,6 +1174,8 @@ function rowToSummary(row: Record<string, unknown>): SessionSummary {
     modeId: String(row.mode_id),
     modelId: String(row.model_id),
     lastActivityAt: Number(row.last_activity_at),
+    closingAt: row.closing_at != null ? Number(row.closing_at) : undefined,
+    closeDeadlineAt: row.close_deadline_at != null ? Number(row.close_deadline_at) : undefined,
     closedAt: row.closed_at != null ? Number(row.closed_at) : undefined,
   };
 }
@@ -731,6 +1234,48 @@ function rowToAttachmentReference(row: Record<string, unknown>): AttachmentRefer
     sourceId: String(row.source_id),
     ...(row.retained_until == null ? {} : { retainedUntil: Number(row.retained_until) }),
   };
+}
+
+function rowToTombstone(row: Record<string, unknown>): OperationAdmissionTombstone {
+  return {
+    kind: String(row.kind) as OperationAdmissionTombstone['kind'],
+    harnessName: String(row.harness_name),
+    sessionId: String(row.session_id),
+    resourceId: String(row.resource_id),
+    threadId: String(row.thread_id),
+    admissionId: row.admission_id == null ? undefined : String(row.admission_id),
+    admissionHash: row.admission_hash == null ? undefined : String(row.admission_hash),
+    queuedItemId: row.queued_item_id == null ? undefined : String(row.queued_item_id),
+    signalId: row.signal_id == null ? undefined : String(row.signal_id),
+    runId: row.run_id == null ? undefined : String(row.run_id),
+    terminalAt: Number(row.terminal_at),
+    compactedAt: Number(row.compacted_at),
+    expiresAt: Number(row.expires_at),
+  };
+}
+
+function tombstoneId(record: OperationAdmissionTombstone): string {
+  const publicId = record.kind === 'message' ? record.signalId : record.queuedItemId;
+  return `${record.harnessName}\u0000${record.sessionId}\u0000${record.kind}\u0000${publicId ?? record.admissionId ?? record.compactedAt}`;
+}
+
+function sameTombstoneIdentity(a: OperationAdmissionTombstone, b: OperationAdmissionTombstone): boolean {
+  return (
+    a.kind === b.kind &&
+    a.harnessName === b.harnessName &&
+    a.sessionId === b.sessionId &&
+    a.resourceId === b.resourceId &&
+    a.threadId === b.threadId &&
+    a.admissionId === b.admissionId &&
+    a.admissionHash === b.admissionHash &&
+    a.queuedItemId === b.queuedItemId &&
+    a.signalId === b.signalId &&
+    a.runId === b.runId
+  );
+}
+
+function isTerminalQueueReceipt(receipt: QueueAdmissionReceipt): boolean {
+  return receipt.status === 'completed' || receipt.status === 'failed' || receipt.status === 'dead';
 }
 
 function toAttachmentReferenceSource(value: unknown): AttachmentReference['source'] {


### PR DESCRIPTION
## Linear

PF-351

## Summary

- Adds namespace-aware Harness storage records and adapter APIs for active-session admission, queue admission receipts, operation result/tombstone evidence, compaction, and session-scoped tombstone cleanup.
- Implements the contract for in-memory and LibSQL storage, including namespace-aware session/attachment/reference keys and a LibSQL active-session uniqueness index.
- Wires registered `Mastra({ harnesses: { key } })` names into Harness storage namespaces so parallel harnesses do not collide.
- Expands shared Harness storage conformance tests and adds direct in-memory admission tests.

## Open PR overlap checked

Fresh open PR scan before opening this PR:

- #69 `revert/fork-main-to-9c0fce1`: broad core/runtime revert-shaped diff, no direct Harness v1 storage-domain overlap; general merge-order risk only.
- #68 `pf-harness-authored-tool-gate`: legacy `packages/core/src/harness/**` and agent/tool runtime paths, no direct v1 Harness storage-domain overlap.
- #58 ClickHouse memory batching only, no overlap.
- #84 / PF-350 is now merged into `main` (`8e2eb0d`) and this branch was rebased onto that main before validation.

## Validation

- `pnpm --filter @mastra/core test src/storage/domains/harness/inmemory.test.ts src/harness/v1/harness.test.ts src/harness/v1/session.queue.test.ts` - 63 passed, 1 todo.
- `pnpm --filter @mastra/libsql test src/storage/index.test.ts -t Harness` - 49 passed, 465 skipped.
- `pnpm --filter @mastra/core typecheck` - passed.
- `pnpm --filter @mastra/core build:lib` - passed.
- `pnpm --filter @mastra/libsql build:lib` - passed.
- `git diff --check` - passed.
- Local Codex review pass 1 ran and blockers were fixed; pass 2 could not run because the local Codex CLI token was revoked (`refresh_token_invalidated`).
- `coderabbit review --plain` ran locally. PF-351 changeset finding was fixed. Out-of-scope skills finding recorded as PF-441. LibSQL migration-hardening follow-up recorded as PF-442.

## Notes

- This PR does not implement server routes, channel ingress/outbox, background recovery, Cloudflare/R2 attachment storage, or production/release actions.
- Attachment primitives/elements/R2 work remains in the attachment lanes (PF-345/PF-347) and is related from PF-351 for parallel coordination with dev7.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5: This makes Harness storage namespace-aware so multiple test harnesses can run in parallel without mixing data. It defines an atomic active-session admission API, durable queue/message admission evidence with compaction/tombstones, and wires harness registration keys into storage namespaces; implementations and tests for InMemory and LibSQL are included.

What this PR does
- Introduces namespace-aware Harness storage: session, attachment, attachment-reference, and operation-tombstone keys now include harnessName to isolate parallel harnesses.
- Adds an atomic active-session admission API: createOrLoadActiveSession(record, opts) with deterministic uniqueness on (harnessName, resourceId, threadId) and returns { created, admitted } semantics including initial lease acquisition.
- Adds durable admission/result evidence and tombstone model:
  - New types: QueueAdmissionReceipt, OperationAdmissionTombstone, OperationAdmissionEvidence, and related enums/structures.
  - APIs for loading message/queue evidence, resolving admission evidence (duplicate vs conflict vs none), writing tombstones, compacting terminal receipts into tombstones, and deleting session-scoped tombstones.
  - New error: HarnessStorageAdmissionConflictError for admission/evidence conflicts.
- Wires Mastra registration keys into harness namespaces: Mastra now calls harness.__registerMastra(this, key) so harnesses registered under different Mastra keys are isolated.
- Implements the contract in adapters:
  - InMemory: full harnessName scoping across sessions/leases/attachments/references/admission evidence, createOrLoadActiveSession, compaction/ tombstone handling, namespace-scoped conflict checks; added in-memory admission tests and conformance coverage.
  - LibSQL: schema additions (mastra_harness_operation_tombstones), harness_name column/backfill, uniqueness enforcement on (harness_name, resource_id, thread_id), harness-scoped SQL for sessions/attachments/tombstones, transactional createOrLoadActiveSession with unique-constraint-to-conflict mapping, and backfill/init logic.
- Threads harnessName through core: Harness/Session now propagate harnessName into storage operations and use createOrLoadActiveSession in session creation/hydration flows; __registerMastra signature extended to accept optional harnessName.
- Extends tests and conformance:
  - Expanded shared harness storage conformance suite to cover namespace isolation, admission/evidence semantics, compaction, tombstone lifecycle, and cross-namespace reference rejection.
  - Added direct InMemory admission tests and Mastra/harness registration tests validating namespace isolation and registration errors.
- Schema/constants/types changes:
  - New constant TABLE_HARNESS_OPERATION_TOMBSTONES and updated TABLE_SCHEMAS/TABLE_CONFIGS to include harness_name and operation tombstone schema.
  - SessionRecord gained harnessName and new session lifecycle fields (queueAdmissionReceipts, closingAt, closeDeadlineAt, subagent_depth projections); SessionSummary projects harnessName.
  - Many HarnessStorage method signatures updated to accept optional harnessName; CreateOrLoadActiveSession options/result types added; attachment/lease/save/list inputs extended with harnessName?.
- Minor developer-facing breaking/signature changes:
  - harness.__registerMastra(mastra) → harness.__registerMastra(mastra, harnessName?)
  - Multiple HarnessStorage abstract methods updated to accept optional harnessName; createOrLoadActiveSession and operation-evidence methods added.
  - InMemory and LibSQL constructors/methods updated to accept/resolve harnessName.

Validation performed
- Core tests: pnpm --filter @mastra/core test — 63 passed, 1 todo.
- LibSQL Harness tests: 49 passed, 465 skipped.
- Core typecheck/builds passed; git diff --check passed.
- Local automated reviews (Codex/coderabbit) run; blockers fixed; follow-ups PF-441 and PF-442 recorded.

Not in scope / known omissions
- Does not add server routes, channel ingress/outbox, background recovery, Cloudflare/R2 attachment storage, or production/release automation.
- Attachment primitives/elements and R2 storage remain in related PF-345/PF-347 PRs and are coordinated with this work.

Files / surface area (high level)
- Core: harness classes/tests (harness.ts, session.ts, tests), Mastra registration change, storage constants/types, base harness storage domain (APIs/errors).
- Stores: InMemory DB + InMemoryHarness (implementation + tests), LibSQL harness adapter (schema, SQL, backfill, uniqueness), shared test utils and conformance suite updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/85)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->