### PR TITLE
[PF-352] Add Harness message admission idempotency

### DIFF
--- a/.changeset/pf-352-harness-message-admission.md
+++ b/.changeset/pf-352-harness-message-admission.md
@@ -3,4 +3,9 @@
 "@mastra/libsql": patch
 ---
 
-Added Harness v1 message admission idempotency with retained result evidence for duplicate retry handling.
+Added retry-safe `session.message()` admission for Harness v1 using the `admissionId` parameter.
+
+```ts
+await session.message({ content: 'Summarize this issue', admissionId: 'msg-123' });
+await session.message({ content: 'Summarize this issue', admissionId: 'msg-123' }); // duplicate retry
+```

--- a/.changeset/pf-352-harness-message-admission.md
+++ b/.changeset/pf-352-harness-message-admission.md
@@ -1,0 +1,6 @@
+---
+"@mastra/core": patch
+"@mastra/libsql": patch
+---
+
+Added Harness v1 message admission idempotency with retained result evidence for duplicate retry handling.

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -17,6 +17,19 @@ import type {
 
 const AGENT_THREAD_KEY_SEPARATOR = '\u0000';
 
+function callerSignalPayloadKey(signal: AgentSignal): string | undefined {
+  try {
+    return JSON.stringify({
+      type: signal.type,
+      contents: signal.contents,
+      attributes: signal.attributes,
+      metadata: signal.metadata,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
 function withThreadMemory(memory: unknown, resourceId: string, threadId: string) {
   return {
     ...((memory && typeof memory === 'object' ? memory : {}) as Record<string, unknown>),
@@ -320,6 +333,7 @@ export class AgentThreadStreamRuntime {
     } catch {
       this.#threadKeysByRunId.delete(pendingIdle.runId);
       this.#cleanupPreparedRun(pendingIdle.runId);
+      this.#forgetCallerSignalsForRun(pendingIdle.runId);
       if (this.#activeThreadRunIds.get(key) === pendingIdle.runId) {
         this.#activeThreadRunIds.delete(key);
       }
@@ -475,14 +489,24 @@ export class AgentThreadStreamRuntime {
       }
     }
 
+    if (runId && !activeRecord) {
+      activeRecord = this.#threadRunsById.get(runId);
+    }
+    if (!key && activeRecord) {
+      key = this.#threadKey(activeRecord.resourceId, activeRecord.threadId);
+    }
     const isActiveTarget = Boolean(
       runId && (activeRecord?.output.status === 'running' || (key && this.#activeThreadRunIds.get(key) === runId)),
     );
     const resourceId = target.resourceId ?? activeRecord?.resourceId;
     const threadId = target.threadId ?? activeRecord?.threadId;
+    const scopedRunId = target.runId;
+    const signalPayloadKey = callerSignalPayloadKey(signalInput);
     const callerSignalKey =
-      callerSignalId !== undefined
-        ? [agent.id, resourceId ?? '', threadId ?? '', callerSignalId].join('\u0000')
+      callerSignalId !== undefined && signalPayloadKey !== undefined
+        ? [agent.id, resourceId ?? '', threadId ?? '', scopedRunId ?? '', callerSignalId, signalPayloadKey].join(
+            '\u0000',
+          )
         : undefined;
     if (callerSignalKey) {
       const accepted = this.#acceptedCallerSignals.get(callerSignalKey);
@@ -511,9 +535,9 @@ export class AgentThreadStreamRuntime {
           target.ifIdle?.streamOptions?.requestContext,
         );
         void persisted.catch(() => {});
-        return { accepted: true, runId: runId!, signal, persisted };
+        return acceptSignal({ accepted: true, runId: runId!, signal, persisted });
       }
-      return { accepted: true, runId: runId!, signal };
+      return acceptSignal({ accepted: true, runId: runId!, signal });
     }
 
     if (runId) {
@@ -556,9 +580,9 @@ export class AgentThreadStreamRuntime {
           target.ifIdle?.streamOptions?.requestContext,
         );
         void persisted.catch(() => {});
-        return { accepted: true, runId, signal, persisted };
+        return acceptSignal({ accepted: true, runId, signal, persisted });
       }
-      return { accepted: true, runId, signal };
+      return acceptSignal({ accepted: true, runId, signal });
     }
 
     key ??= this.#threadKey(resourceId, threadId);
@@ -578,22 +602,24 @@ export class AgentThreadStreamRuntime {
     // the idle stream so concurrent callers do not launch duplicate runs.
     this.#activeThreadRunIds.set(key, runId);
     this.#threadKeysByRunId.set(runId, key);
-    void agent
+    const output = agent
       .stream(signal, {
         ...(target.ifIdle?.streamOptions as any),
         runId,
         memory: withThreadMemory(target.ifIdle?.streamOptions?.memory, resourceId, threadId),
       })
-      .catch(() => {
+      .catch(err => {
         this.#threadKeysByRunId.delete(runId);
         this.#cleanupPreparedRun(runId);
         this.#forgetCallerSignalsForRun(runId);
         if (this.#activeThreadRunIds.get(key) === runId) {
           this.#activeThreadRunIds.delete(key);
         }
-      });
+        throw err;
+      }) as Promise<MastraModelOutput<unknown>>;
+    void output.catch(() => {});
 
-    return acceptSignal({ accepted: true, runId, signal });
+    return acceptSignal({ accepted: true, runId, signal, output });
   }
 }
 

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -58,6 +58,8 @@ export class AgentThreadStreamRuntime {
   #watchedThreadRunIds = new Set<string>();
   #preparedRunsById = new Map<string, PreparedThreadRun>();
   #abortedRunIds = new Set<string>();
+  #acceptedCallerSignals = new Map<string, SendAgentSignalResult>();
+  #callerSignalIdsByRunId = new Map<string, Set<string>>();
   /**
    * Per-run resolvers used by `waitForRunOutput()`. Populated lazily on the
    * first `waitForRunOutput()` call and cleared when `registerRun()` resolves
@@ -177,12 +179,21 @@ export class AgentThreadStreamRuntime {
     this.#watchedThreadRunIds.clear();
     this.#preparedRunsById.clear();
     this.#abortedRunIds.clear();
+    this.#acceptedCallerSignals.clear();
+    this.#callerSignalIdsByRunId.clear();
   }
 
   #cleanupPreparedRun(runId: string) {
     this.#preparedRunsById.get(runId)?.cleanup();
     this.#preparedRunsById.delete(runId);
     this.#abortedRunIds.delete(runId);
+  }
+
+  #forgetCallerSignalsForRun(runId: string) {
+    const callerSignalIds = this.#callerSignalIdsByRunId.get(runId);
+    if (!callerSignalIds) return;
+    this.#callerSignalIdsByRunId.delete(runId);
+    for (const callerSignalId of callerSignalIds) this.#acceptedCallerSignals.delete(callerSignalId);
   }
 
   #notifyThreadRun(record: AgentThreadRunRecord<any>) {
@@ -243,6 +254,7 @@ export class AgentThreadStreamRuntime {
       this.#threadRunsById.delete(record.runId);
       this.#threadKeysByRunId.delete(record.runId);
       this.#cleanupPreparedRun(record.runId);
+      this.#forgetCallerSignalsForRun(record.runId);
       if (this.#activeThreadRunIds.get(key) === record.runId) {
         this.#activeThreadRunIds.delete(key);
       }
@@ -436,6 +448,7 @@ export class AgentThreadStreamRuntime {
     target: SendAgentSignalOptions<OUTPUT>,
   ): SendAgentSignalResult {
     const signal = createSignal(signalInput);
+    const callerSignalId = signalInput.id;
     let key: string | undefined;
     let runId = target.runId;
     const activeBehavior = target.ifActive?.behavior ?? 'deliver';
@@ -467,6 +480,23 @@ export class AgentThreadStreamRuntime {
     );
     const resourceId = target.resourceId ?? activeRecord?.resourceId;
     const threadId = target.threadId ?? activeRecord?.threadId;
+    const callerSignalKey =
+      callerSignalId !== undefined
+        ? [agent.id, resourceId ?? '', threadId ?? '', callerSignalId].join('\u0000')
+        : undefined;
+    if (callerSignalKey) {
+      const accepted = this.#acceptedCallerSignals.get(callerSignalKey);
+      if (accepted) return accepted;
+    }
+    const acceptSignal = (result: SendAgentSignalResult): SendAgentSignalResult => {
+      if (callerSignalKey) {
+        this.#acceptedCallerSignals.set(callerSignalKey, result);
+        const signalIds = this.#callerSignalIdsByRunId.get(result.runId) ?? new Set<string>();
+        signalIds.add(callerSignalKey);
+        this.#callerSignalIdsByRunId.set(result.runId, signalIds);
+      }
+      return result;
+    };
 
     if (isActiveTarget && activeBehavior !== 'deliver') {
       if (activeBehavior === 'persist') {
@@ -497,7 +527,7 @@ export class AgentThreadStreamRuntime {
           queue.push(signal);
           this.#pendingSignalsByThread.set(key, queue);
           this.#watchThreadRunCompletion(key, activeRecord);
-          return { accepted: true, runId, signal };
+          return acceptSignal({ accepted: true, runId, signal });
         }
       }
 
@@ -507,7 +537,7 @@ export class AgentThreadStreamRuntime {
         const queue = this.#pendingSignalsByThread.get(key) ?? [];
         queue.push(signal);
         this.#pendingSignalsByThread.set(key, queue);
-        return { accepted: true, runId, signal };
+        return acceptSignal({ accepted: true, runId, signal });
       }
     }
 
@@ -515,7 +545,7 @@ export class AgentThreadStreamRuntime {
       throw new Error('No active agent run found for signal target');
     }
 
-    runId = randomUUID();
+    runId ??= randomUUID();
     if (idleBehavior !== 'wake') {
       if (idleBehavior === 'persist') {
         const persisted = this.#persistSignal(
@@ -541,7 +571,7 @@ export class AgentThreadStreamRuntime {
       if (activeRecord) {
         this.#watchThreadRunCompletion(key, activeRecord);
       }
-      return { accepted: true, runId, signal };
+      return acceptSignal({ accepted: true, runId, signal });
     }
 
     // No active same-agent run accepted the signal. Reserve the thread before starting
@@ -557,12 +587,13 @@ export class AgentThreadStreamRuntime {
       .catch(() => {
         this.#threadKeysByRunId.delete(runId);
         this.#cleanupPreparedRun(runId);
+        this.#forgetCallerSignalsForRun(runId);
         if (this.#activeThreadRunIds.get(key) === runId) {
           this.#activeThreadRunIds.delete(key);
         }
       });
 
-    return { accepted: true, runId, signal };
+    return acceptSignal({ accepted: true, runId, signal });
   }
 }
 

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -123,6 +123,8 @@ export interface SendAgentSignalResult {
   accepted: true;
   runId: string;
   signal: CreatedAgentSignal;
+  /** Resolves with the stream output when this signal starts an idle thread run. */
+  output?: Promise<MastraModelOutput<unknown>>;
   /** Resolves when a `persist` behavior finishes writing the signal to memory. */
   persisted?: Promise<void>;
 }

--- a/packages/core/src/harness/v1/errors.ts
+++ b/packages/core/src/harness/v1/errors.ts
@@ -96,6 +96,18 @@ export class HarnessQueueFullError extends Error {
   }
 }
 
+export class HarnessAdmissionConflictError extends Error {
+  readonly name = 'HarnessAdmissionConflictError';
+  constructor(
+    public readonly sessionId: string,
+    public readonly admissionId: string,
+    public readonly storedAdmissionHash: string,
+    public readonly attemptedAdmissionHash: string,
+  ) {
+    super(`Admission "${admissionId}" for session "${sessionId}" conflicts with stored evidence`);
+  }
+}
+
 export class HarnessAttachmentInUseError extends Error {
   readonly name = 'HarnessAttachmentInUseError';
   constructor(

--- a/packages/core/src/harness/v1/index.ts
+++ b/packages/core/src/harness/v1/index.ts
@@ -50,6 +50,7 @@ export type {
 
 export {
   HarnessConfigError,
+  HarnessAdmissionConflictError,
   HarnessQueueFullError,
   HarnessSessionClosedError,
   HarnessSessionLockedError,

--- a/packages/core/src/harness/v1/session.message.test.ts
+++ b/packages/core/src/harness/v1/session.message.test.ts
@@ -15,6 +15,7 @@ import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
 import { InMemoryDB } from '../../storage/domains/inmemory-db';
 
 import { buildFakeOutput, extractSignalContents } from './__test-utils__/fake-output';
+import { HarnessAdmissionConflictError, HarnessValidationError } from './errors';
 import { Harness } from './harness';
 
 // ---------------------------------------------------------------------------
@@ -148,6 +149,86 @@ describe('Session.message() — default path', () => {
     expect(turnSignal.aborted).toBe(true);
     expect((turnSignal as { reason?: unknown }).reason).toBe('caller-cancelled');
   });
+
+  it('deduplicates an exact admissionId retry without accepting a second signal', async () => {
+    const { harness, agent } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    const first = await session.message({ content: 'hi', admissionId: 'admission-1' });
+    const second = await session.message({ content: 'hi', admissionId: 'admission-1' });
+
+    expect(first.text).toBe('hello back');
+    expect(second.text).toBe('hello back');
+    expect(agent.calls).toHaveLength(1);
+  });
+
+  it('deduplicates concurrent exact admissionId retries before dispatching a second signal', async () => {
+    const { harness, agent } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    const [first, second] = await Promise.all([
+      session.message({ content: 'hi', admissionId: 'admission-1' }),
+      session.message({ content: 'hi', admissionId: 'admission-1' }),
+    ]);
+
+    expect(first.text).toBe('hello back');
+    expect(second.text).toBe('hello back');
+    expect(agent.calls).toHaveLength(1);
+  });
+
+  it('rejects a same admissionId retry with different message inputs before a second signal', async () => {
+    const { harness, agent } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await session.message({ content: 'hi', admissionId: 'admission-1' });
+    await expect(session.message({ content: 'changed', admissionId: 'admission-1' })).rejects.toBeInstanceOf(
+      HarnessAdmissionConflictError,
+    );
+    expect(agent.calls).toHaveLength(1);
+  });
+
+  it('rejects concurrent conflicting admissionId retries without dispatching a second signal', async () => {
+    const { harness, agent } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    const results = await Promise.allSettled([
+      session.message({ content: 'hi', admissionId: 'admission-1' }),
+      session.message({ content: 'changed', admissionId: 'admission-1' }),
+    ]);
+
+    expect(results.filter(result => result.status === 'fulfilled')).toHaveLength(1);
+    const rejected = results.find(result => result.status === 'rejected');
+    expect(rejected?.reason).toBeInstanceOf(HarnessAdmissionConflictError);
+    expect(agent.calls).toHaveLength(1);
+  });
+
+  it('rejects admissionId with non-hash-safe additionalTools', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(
+      session.message({ content: 'hi', admissionId: 'admission-1', additionalTools: { local: {} as any } }),
+    ).rejects.toBeInstanceOf(HarnessValidationError);
+  });
+
+  it('rejects an empty admissionId', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(session.message({ content: 'hi', admissionId: '' })).rejects.toBeInstanceOf(HarnessValidationError);
+  });
+
+  it('rejects a stream retry after a completed admissionId result', async () => {
+    const { harness, agent } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await session.message({ content: 'hi', admissionId: 'admission-1' });
+
+    await expect(session.message({ content: 'hi', admissionId: 'admission-1', stream: true })).rejects.toBeInstanceOf(
+      HarnessValidationError,
+    );
+    expect(agent.calls).toHaveLength(1);
+  });
 });
 
 describe('Session.message() — streaming path', () => {
@@ -194,6 +275,15 @@ describe('Session.message() — structured + sync path', () => {
     await expect(session.message({ content: 'go', stream: true, output: Schema, sync: true } as any)).rejects.toThrow(
       /mutually exclusive/,
     );
+  });
+
+  it('rejects admissionId on the sync structured-output path', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(
+      session.message({ content: 'compute', admissionId: 'admission-1', output: Schema, sync: true } as any),
+    ).rejects.toBeInstanceOf(HarnessValidationError);
   });
 });
 

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -135,6 +135,8 @@ type MessageAdmissionStart = {
  */
 const ASK_USER_TOOL_NAME = ASK_USER_TOOL_ID;
 const SUBMIT_PLAN_TOOL_NAME = SUBMIT_PLAN_TOOL_ID;
+const MESSAGE_ADMISSION_DURABLE_WAIT_TIMEOUT_MS = 30_000;
+const MESSAGE_ADMISSION_DURABLE_WAIT_INTERVAL_MS = 100;
 const SUPPORTED_SKILL_ARG_SCHEMA_KEYS = new Set([
   'required',
   'properties',
@@ -1445,9 +1447,9 @@ export class Session {
   // Signal-routing helpers (§4.2). One long-lived thread subscription per
   // Session multiplexes every run on the thread into a single chunk
   // stream. `message()` calls `agent.sendSignal()`, gets a `runId` back,
-  // and awaits the matching entry in `_runCompletionPromises`. The drain
-  // loop resolves that entry when a terminal chunk (`finish` / `error` /
-  // `abort` / `tool-call-suspended`) for the run arrives.
+  // and awaits the matching entry in `_runCompletionPromises`. Completion
+  // settlement is handled by `_watchRunCompletion()`; the drain loop only
+  // emits harness events from stream chunks.
   // -------------------------------------------------------------------------
 
   /**
@@ -2019,23 +2021,62 @@ export class Session {
     // loop is responsible for harness events; we still keep the turn
     // in-flight (so `isRunning()` reports true) until the run completes.
     if (opts.stream === true) {
-      const out = agent.getRunOutput(signal.runId) as MastraModelOutput<unknown> | undefined;
+      let out = agent.getRunOutput(signal.runId) as MastraModelOutput<unknown> | undefined;
+      if (!out && (signal.output || admissionIdentity !== undefined)) {
+        await pendingEvidenceWrite;
+        try {
+          out = signal.output
+            ? ((await signal.output) as MastraModelOutput<unknown>)
+            : ((await Promise.race([
+                agent.waitForRunOutput(signal.runId) as Promise<MastraModelOutput<unknown>>,
+                completion.then(
+                  () => undefined,
+                  () => undefined,
+                ),
+                delay(MESSAGE_ADMISSION_DURABLE_WAIT_TIMEOUT_MS).then(() => undefined),
+              ])) as MastraModelOutput<unknown> | undefined);
+        } catch (err) {
+          this._endTurn(turnAbortController);
+          void completion.catch(() => {});
+          const waiter = this._runCompletionPromises.get(signal.runId);
+          this._runCompletionPromises.delete(signal.runId);
+          this._rememberCompletedRun(signal.runId, { ok: false, err });
+          waiter?.reject(err);
+          if (admissionIdentity !== undefined) {
+            await this._writeMessageResultEvidence({
+              status: 'failed',
+              signalId: signal.signal.id,
+              runId: signal.runId,
+              error: projectHarnessPublicError(err),
+              admissionId: opts.admissionId!,
+              admissionHash: admissionHash!,
+            });
+          }
+          if (opts.admissionId !== undefined) this._messageAdmissionStarts.delete(opts.admissionId);
+          void this._maybeDrainQueue();
+          throw err;
+        }
+      }
       if (!out) {
         this._endTurn(turnAbortController);
-        // Drop the completion waiter so the drain doesn't try to resolve into
-        // a dead listener.
-        this._runCompletionPromises.delete(signal.runId);
         void pendingEvidenceWrite.catch(() => {});
         const err = new HarnessConfigError('message()', 'agent did not register a run for the dispatched signal');
+        // Drop the completion waiter so duplicate retries do not treat an
+        // unregistered run as live forever.
+        void completion.catch(() => {});
+        const waiter = this._runCompletionPromises.get(signal.runId);
+        this._runCompletionPromises.delete(signal.runId);
+        this._rememberCompletedRun(signal.runId, { ok: false, err });
+        waiter?.reject(err);
         if (admissionIdentity !== undefined) {
           await this._writeMessageResultEvidence({
             status: 'failed',
             signalId: signal.signal.id,
             runId: signal.runId,
             error: projectHarnessPublicError(err),
-            ...(opts.admissionId !== undefined ? { admissionId: opts.admissionId } : {}),
-            ...(admissionHash !== undefined ? { admissionHash } : {}),
-          }).catch(() => {});
+            admissionId: opts.admissionId!,
+            admissionHash: admissionHash!,
+          });
         }
         throw err;
       }
@@ -2084,10 +2125,15 @@ export class Session {
       return out;
     }
 
-    // Default path: wait for the drain to deliver this run's terminal
-    // chunk and bundled `FullOutput`, then run post-turn bookkeeping.
+    // Default path: wait for stream startup and the completion watcher to
+    // deliver this run's bundled `FullOutput`, then run post-turn bookkeeping.
+    let streamStarted = signal.output === undefined;
     try {
       await pendingEvidenceWrite;
+      if (signal.output) {
+        await signal.output;
+        streamStarted = true;
+      }
       const full = await completion;
       this._recordTurnCompletion(full);
       if (admissionIdentity !== undefined) {
@@ -2109,6 +2155,13 @@ export class Session {
       await this._runGoalJudge(full, false);
       return full;
     } catch (err) {
+      if (!streamStarted) {
+        void completion.catch(() => {});
+        const waiter = this._runCompletionPromises.get(signal.runId);
+        this._runCompletionPromises.delete(signal.runId);
+        this._rememberCompletedRun(signal.runId, { ok: false, err });
+        waiter?.reject(err);
+      }
       if (admissionIdentity !== undefined) {
         await this._writeMessageResultEvidence({
           status: 'failed',
@@ -2185,7 +2238,7 @@ export class Session {
         const agent = this._harness.getAgentForMode(opts.mode ?? this._record.modeId);
         await this._ensureThreadSubscription(agent);
         if (!this._hasLiveMessageRun(agent, runId)) {
-          throw new HarnessValidationError('message().admissionId', 'pending message admission is not live');
+          return this._awaitDurableMessageResult(evidence, opts);
         }
         return this._awaitRunCompletion(runId);
       }
@@ -2208,6 +2261,36 @@ export class Session {
     return Boolean(
       agent.getRunOutput(runId) || this._runCompletionPromises.has(runId) || this._completedRuns.has(runId),
     );
+  }
+
+  private async _awaitDurableMessageResult(
+    evidence: AgentSignalResultEvidence,
+    opts: MessageOptions,
+  ): Promise<AgentResult> {
+    const deadline = Date.now() + MESSAGE_ADMISSION_DURABLE_WAIT_TIMEOUT_MS;
+    while (true) {
+      throwIfAborted(opts.abortSignal, 'message().admissionId');
+      const latest = await this._storage.loadMessageResultEvidence({
+        harnessName: this._record.harnessName,
+        sessionId: this.id,
+        resourceId: this.resourceId,
+        threadId: this.threadId,
+        signalId: evidence.signalId,
+      });
+      if (!latest) {
+        throw new HarnessValidationError('message().admissionId', 'duplicate message result evidence has expired');
+      }
+      if ('status' in latest) {
+        if (latest.status === 'completed') return latest.result as AgentResult;
+        if (latest.status === 'failed') throw publicErrorProjectionToError(latest.error);
+      } else {
+        throw new HarnessValidationError('message().admissionId', 'duplicate message result evidence has expired');
+      }
+      if (Date.now() >= deadline) {
+        throw new HarnessValidationError('message().admissionId', 'pending message admission is not live');
+      }
+      await delay(MESSAGE_ADMISSION_DURABLE_WAIT_INTERVAL_MS, opts.abortSignal);
+    }
   }
 
   private _messageAdmissionIdentity(admissionId: string): MessageAdmissionIdentity {
@@ -4399,7 +4482,29 @@ function projectHarnessPublicError(err: unknown): { code: string; message: strin
 function publicErrorProjectionToError(error: { code: string; message: string }): Error {
   const projected = new Error(error.message);
   projected.name = error.code;
+  (projected as Error & { code: string }).code = error.code;
   return projected;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined, path: string): void {
+  if (!signal?.aborted) return;
+  throw signal.reason ?? new HarnessValidationError(path, 'operation aborted');
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  throwIfAborted(signal, 'delay()');
+  return new Promise((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout>;
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new HarnessValidationError('delay()', 'operation aborted'));
+    };
+    timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
 }
 
 function createDeferred<T>(): Deferred<T> {

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -24,7 +24,7 @@
  * Callers must re-resolve via `harness.session(...)` to get a fresh instance.
  */
 
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { z } from 'zod';
 
 import { Agent } from '../../agent';
@@ -33,14 +33,18 @@ import type { AgentThreadSubscription, ToolsInput } from '../../agent/types';
 import { ModelRouterLanguageModel } from '../../llm/model/router';
 import { PrefillErrorHandler, ProviderHistoryCompat, StreamErrorRetryProcessor } from '../../processors';
 import { RequestContext } from '../../request-context';
+import { HarnessStorageAdmissionConflictError } from '../../storage/domains/harness';
 import type {
   GoalJudgeDecision,
   GoalState,
+  AgentSignalResultEvidence,
+  AgentSignalResultStatus,
   HarnessStorage,
   HarnessStorageAttachmentUnavailableError,
   PendingResume,
   PermissionRules,
   PersistedAttachment,
+  OperationAdmissionTombstone,
   QueuedItem,
   SaveAttachmentReferenceInput,
   SessionGrants,
@@ -55,6 +59,7 @@ import type { StoredMessageRow } from '../_shared/message-conversion';
 import type { HarnessMessage } from '../types';
 
 import {
+  HarnessAdmissionConflictError,
   HarnessAttachmentUnavailableError,
   HarnessConfigError,
   HarnessOverrideConflictError,
@@ -105,6 +110,22 @@ import type {
   SessionSignalResult,
   ToolCategory,
 } from './types';
+
+type MessageAdmissionIdentity = {
+  signalId: string;
+  runId: string;
+};
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+};
+
+type MessageAdmissionStart = {
+  admissionHash: string;
+  promise: Promise<string>;
+};
 
 /**
  * Tool IDs the harness translates from `tool-call-approval` /
@@ -466,10 +487,9 @@ export class Session {
    *  Guards re-opens and re-entrant teardown. */
   private _threadSubscriptionClosed = false;
   /**
-   * Per-run completion promises, keyed by `runId`. The drain loop resolves
-   * (or rejects) the matching entry on a terminal chunk (`finish` / `error` /
-   * `abort` / `tool-call-suspended`). `_awaitRunCompletion(runId)` reads
-   * here. Entries left over on `close()` are rejected so callers don't hang.
+   * Per-run completion promises, keyed by `runId`. `_watchRunCompletion()`
+   * resolves or rejects the matching entry after the runtime output finishes.
+   * Entries left over on `close()` are rejected so callers don't hang.
    */
   private readonly _runCompletionPromises = new Map<
     string,
@@ -484,13 +504,14 @@ export class Session {
    * to register a waiter. `sendSignal()` returns synchronously and the runtime
    * can drive the entire run to completion in the same microtask tick, so by
    * the time `_awaitRunCompletion(runId)` runs the terminal chunk may already
-   * have been processed. Entries are consumed by the first matching
-   * `_awaitRunCompletion` call.
+   * have been processed. Entries are retained so duplicate admission waiters
+   * that converge on the same run can all observe the terminal result.
    */
   private readonly _completedRuns = new Map<
     string,
     { ok: true; full: FullOutput<unknown> } | { ok: false; err: unknown }
   >();
+  private readonly _messageAdmissionStarts = new Map<string, MessageAdmissionStart>();
 
   /** @internal — constructed by the Harness, not directly. */
   constructor(internals: SessionInternals) {
@@ -1475,10 +1496,11 @@ export class Session {
    */
   private _awaitRunCompletion(runId: string): Promise<FullOutput<unknown>> {
     // Fast path: the run may have already terminated before this call ran.
-    // Consume the cached result.
+    // Keep the cached result reusable so duplicate admission callers that
+    // converge on the same runId can still observe the terminal output even
+    // if another waiter arrived first.
     const cached = this._completedRuns.get(runId);
     if (cached) {
-      this._completedRuns.delete(runId);
       return cached.ok ? Promise.resolve(cached.full) : Promise.reject(cached.err);
     }
     // Multiple callers can await the same run (e.g. `message()` followed by
@@ -1575,19 +1597,31 @@ export class Session {
    * already dropped it from `getRunOutput()` by now).
    *
    * If no waiter is registered yet (very fast run), the result is stashed
-   * in `_completedRuns` so the next `_awaitRunCompletion(runId)` call can
-   * consume it.
+   * in `_completedRuns` so later `_awaitRunCompletion(runId)` calls can
+   * observe it.
    */
   private async _handleRunTerminal(runId: string, out: MastraModelOutput<unknown>): Promise<void> {
     const waiter = this._runCompletionPromises.get(runId);
     this._runCompletionPromises.delete(runId);
     try {
       const full = (await out.getFullOutput()) as FullOutput<unknown>;
+      this._rememberCompletedRun(runId, { ok: true, full });
       if (waiter) waiter.resolve(full);
-      else this._completedRuns.set(runId, { ok: true, full });
     } catch (err) {
+      this._rememberCompletedRun(runId, { ok: false, err });
       if (waiter) waiter.reject(err);
-      else this._completedRuns.set(runId, { ok: false, err });
+    }
+  }
+
+  private _rememberCompletedRun(
+    runId: string,
+    entry: { ok: true; full: FullOutput<unknown> } | { ok: false; err: unknown },
+  ): void {
+    this._completedRuns.set(runId, entry);
+    while (this._completedRuns.size > 64) {
+      const oldest = this._completedRuns.keys().next().value;
+      if (oldest === undefined) return;
+      this._completedRuns.delete(oldest);
     }
   }
 
@@ -1770,14 +1804,79 @@ export class Session {
     if (opts.output !== undefined && opts.sync !== true) {
       throw new HarnessConfigError('message()', 'structured `output` requires `sync: true` (typed turn boundary)');
     }
+    if (opts.admissionId !== undefined && opts.output !== undefined) {
+      throw new HarnessValidationError(
+        'message().admissionId',
+        'admissionId is not supported with sync structured output',
+      );
+    }
+    if (opts.admissionId !== undefined && opts.additionalTools !== undefined) {
+      throw new HarnessValidationError('message().admissionId', 'admissionId cannot be combined with additionalTools');
+    }
+    if (opts.admissionId !== undefined && opts.admissionId.length === 0) {
+      throw new HarnessValidationError('message().admissionId', 'admissionId must be a non-empty string');
+    }
 
     // Resolve the effective mode (per-call override wins, else session's).
     const effectiveModeId = opts.mode ?? this._record.modeId;
     const mode = this._harness._getMode(effectiveModeId);
     const agent = this._harness.getAgentForMode(effectiveModeId);
+    const admissionHash =
+      opts.admissionId !== undefined
+        ? this._computeMessageAdmissionHash(opts, {
+            modeId: effectiveModeId,
+            modelId: opts.model ?? this._record.modelId,
+          })
+        : undefined;
+    const duplicate =
+      opts.admissionId !== undefined
+        ? await this._resolveMessageAdmissionDuplicate({
+            admissionId: opts.admissionId,
+            admissionHash: admissionHash!,
+          })
+        : undefined;
+    if (duplicate) {
+      return this._returnDuplicateMessageResult(duplicate, opts);
+    }
+    const admissionIdentity =
+      opts.admissionId !== undefined ? this._messageAdmissionIdentity(opts.admissionId) : undefined;
 
     // Per-turn additionalTools merge with the mode's surface, never replace.
     const toolsets = this._buildToolsets(mode, opts.additionalTools);
+
+    const admissionStart = opts.admissionId !== undefined ? createDeferred<string>() : undefined;
+    if (admissionStart) void admissionStart.promise.catch(() => {});
+    if (admissionIdentity !== undefined && admissionHash !== undefined && admissionStart !== undefined) {
+      const existingStart = this._messageAdmissionStarts.get(opts.admissionId!);
+      if (existingStart) {
+        if (existingStart.admissionHash !== admissionHash) {
+          throw new HarnessAdmissionConflictError(
+            this.id,
+            opts.admissionId!,
+            existingStart.admissionHash,
+            admissionHash,
+          );
+        }
+        const runId = await existingStart.promise;
+        return this._returnDuplicateMessageResult(
+          {
+            status: 'pending',
+            harnessName: this._record.harnessName,
+            sessionId: this.id,
+            resourceId: this.resourceId,
+            threadId: this.threadId,
+            signalId: admissionIdentity.signalId,
+            runId,
+            admissionId: opts.admissionId!,
+            admissionHash,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
+          opts,
+        );
+      }
+      this._messageAdmissionStarts.set(opts.admissionId!, { admissionHash, promise: admissionStart.promise });
+    }
 
     // Every turn runs under a session-owned AbortController so
     // `session.abort()` can cancel the in-flight run. If the caller passes
@@ -1837,19 +1936,84 @@ export class Session {
     // paths surface chunks through the same subscription stream.
     await this._ensureThreadSubscription(agent);
 
-    const signal = agent.sendSignal(
-      { type: 'user-message', contents: opts.content as never },
-      {
-        resourceId: this.resourceId,
-        threadId: this.threadId,
-        ifIdle: { behavior: 'wake', streamOptions: baseExecOptions as never },
-      },
-    );
+    if (admissionIdentity !== undefined && admissionHash !== undefined && admissionStart !== undefined) {
+      try {
+        const reservation = await this._writeMessageResultEvidence({
+          status: 'pending',
+          signalId: admissionIdentity.signalId,
+          runId: admissionIdentity.runId,
+          admissionId: opts.admissionId!,
+          admissionHash,
+        });
+        if (!reservation.created) {
+          this._messageAdmissionStarts.delete(opts.admissionId!);
+          admissionStart.resolve(admissionIdentity.runId);
+          const existing = await this._resolveMessageAdmissionDuplicate({
+            admissionId: opts.admissionId!,
+            admissionHash,
+          });
+          if (existing) {
+            try {
+              return await this._returnDuplicateMessageResult(existing, opts);
+            } finally {
+              this._endTurn(turnAbortController);
+            }
+          }
+        }
+      } catch (err) {
+        this._messageAdmissionStarts.delete(opts.admissionId!);
+        admissionStart.reject(err);
+        throw err;
+      }
+    }
+
+    let signal;
+    try {
+      signal = agent.sendSignal(
+        {
+          ...(admissionIdentity ? { id: admissionIdentity.signalId } : {}),
+          type: 'user-message',
+          contents: opts.content as never,
+        },
+        {
+          ...(admissionIdentity ? { runId: admissionIdentity.runId } : {}),
+          resourceId: this.resourceId,
+          threadId: this.threadId,
+          ifIdle: { behavior: 'wake', streamOptions: baseExecOptions as never },
+        },
+      );
+    } catch (err) {
+      admissionStart?.reject(err);
+      if (opts.admissionId !== undefined) this._messageAdmissionStarts.delete(opts.admissionId);
+      if (admissionIdentity !== undefined && admissionHash !== undefined) {
+        await this._writeMessageResultEvidence({
+          status: 'failed',
+          signalId: admissionIdentity.signalId,
+          runId: admissionIdentity.runId,
+          admissionId: opts.admissionId!,
+          admissionHash,
+          error: projectHarnessPublicError(err),
+        }).catch(() => {});
+      }
+      throw err;
+    }
 
     // Register the completion waiter BEFORE the drain has a chance to see
     // a terminal chunk for this runId (the run can start synchronously on
     // the wake path).
     const completion = this._awaitRunCompletion(signal.runId);
+    admissionStart?.resolve(signal.runId);
+
+    const pendingEvidenceWrite =
+      admissionIdentity !== undefined
+        ? this._writeMessageResultEvidence({
+            status: 'pending',
+            signalId: signal.signal.id,
+            runId: signal.runId,
+            ...(opts.admissionId !== undefined ? { admissionId: opts.admissionId } : {}),
+            ...(admissionHash !== undefined ? { admissionHash } : {}),
+          })
+        : Promise.resolve();
 
     // Streaming path: hand the live `MastraModelOutput` back. The drain
     // loop is responsible for harness events; we still keep the turn
@@ -1861,11 +2025,35 @@ export class Session {
         // Drop the completion waiter so the drain doesn't try to resolve into
         // a dead listener.
         this._runCompletionPromises.delete(signal.runId);
-        throw new HarnessConfigError('message()', 'agent did not register a run for the dispatched signal');
+        void pendingEvidenceWrite.catch(() => {});
+        const err = new HarnessConfigError('message()', 'agent did not register a run for the dispatched signal');
+        if (admissionIdentity !== undefined) {
+          await this._writeMessageResultEvidence({
+            status: 'failed',
+            signalId: signal.signal.id,
+            runId: signal.runId,
+            error: projectHarnessPublicError(err),
+            ...(opts.admissionId !== undefined ? { admissionId: opts.admissionId } : {}),
+            ...(admissionHash !== undefined ? { admissionHash } : {}),
+          }).catch(() => {});
+        }
+        throw err;
       }
+      await pendingEvidenceWrite;
       void completion
         .then(full => {
           this._recordTurnCompletion(full);
+          if (admissionIdentity === undefined) return full;
+          return this._writeMessageResultEvidence({
+            status: 'completed',
+            signalId: signal.signal.id,
+            runId: signal.runId,
+            result: full,
+            admissionId: opts.admissionId!,
+            admissionHash: admissionHash!,
+          }).then(() => full);
+        })
+        .then(full => {
           return this._maybeCaptureSuspend(full).then(() => {
             this._emitTurnEvent({
               type: 'agent_end',
@@ -1875,10 +2063,21 @@ export class Session {
             return this._runGoalJudge(full, false);
           });
         })
-        .catch(() => {
+        .catch(err => {
+          if (admissionIdentity !== undefined) {
+            void this._writeMessageResultEvidence({
+              status: 'failed',
+              signalId: signal.signal.id,
+              runId: signal.runId,
+              error: projectHarnessPublicError(err),
+              admissionId: opts.admissionId!,
+              admissionHash: admissionHash!,
+            }).catch(() => {});
+          }
           // The caller owns the visible stream; swallow drain-side errors.
         })
         .finally(() => {
+          if (opts.admissionId !== undefined) this._messageAdmissionStarts.delete(opts.admissionId);
           this._endTurn(turnAbortController);
           void this._maybeDrainQueue();
         });
@@ -1888,8 +2087,19 @@ export class Session {
     // Default path: wait for the drain to deliver this run's terminal
     // chunk and bundled `FullOutput`, then run post-turn bookkeeping.
     try {
+      await pendingEvidenceWrite;
       const full = await completion;
       this._recordTurnCompletion(full);
+      if (admissionIdentity !== undefined) {
+        await this._writeMessageResultEvidence({
+          status: 'completed',
+          signalId: signal.signal.id,
+          runId: signal.runId,
+          result: full,
+          admissionId: opts.admissionId!,
+          admissionHash: admissionHash!,
+        });
+      }
       await this._maybeCaptureSuspend(full);
       this._emitTurnEvent({
         type: 'agent_end',
@@ -1898,12 +2108,164 @@ export class Session {
       });
       await this._runGoalJudge(full, false);
       return full;
+    } catch (err) {
+      if (admissionIdentity !== undefined) {
+        await this._writeMessageResultEvidence({
+          status: 'failed',
+          signalId: signal.signal.id,
+          runId: signal.runId,
+          error: projectHarnessPublicError(err),
+          admissionId: opts.admissionId!,
+          admissionHash: admissionHash!,
+        }).catch(() => {});
+      }
+      throw err;
     } finally {
+      if (opts.admissionId !== undefined) this._messageAdmissionStarts.delete(opts.admissionId);
       this._endTurn(turnAbortController);
       // Now that the manual turn has cleared the in-flight guard, kick
       // the queue drain so any item that was admitted mid-turn can run.
       void this._maybeDrainQueue();
     }
+  }
+
+  private async _resolveMessageAdmissionDuplicate({
+    admissionId,
+    admissionHash,
+  }: {
+    admissionId: string;
+    admissionHash: string;
+  }): Promise<AgentSignalResultEvidence | OperationAdmissionTombstone | undefined> {
+    const resolved = await this._storage.resolveOperationAdmissionEvidence({
+      harnessName: this._record.harnessName,
+      sessionId: this.id,
+      resourceId: this.resourceId,
+      kind: 'message',
+      admissionId,
+      attemptedAdmissionHash: admissionHash,
+    });
+    if (resolved.status === 'none') return undefined;
+    if (resolved.status === 'conflict') {
+      throw new HarnessAdmissionConflictError(this.id, admissionId, resolved.storedAdmissionHash ?? '', admissionHash);
+    }
+    return resolved.evidence as AgentSignalResultEvidence | OperationAdmissionTombstone | undefined;
+  }
+
+  private async _returnDuplicateMessageResult(
+    evidence: AgentSignalResultEvidence | OperationAdmissionTombstone,
+    opts: MessageOptions,
+  ): Promise<AgentResult | AgentStream | unknown> {
+    if ('status' in evidence) {
+      if (opts.stream === true) {
+        if (evidence.status === 'pending') {
+          const agent = this._harness.getAgentForMode(opts.mode ?? this._record.modeId);
+          await this._ensureThreadSubscription(agent);
+          const runId = await this._pendingMessageRunId(evidence);
+          if (runId && !this._hasLiveMessageRun(agent, runId)) {
+            throw new HarnessValidationError('message().admissionId', 'pending message admission is not live');
+          }
+          const output = runId
+            ? ((agent.getRunOutput(runId) as AgentStream | undefined) ??
+              (await Promise.race([
+                agent.waitForRunOutput(runId) as Promise<AgentStream>,
+                this._awaitRunCompletion(runId).then(
+                  () => undefined,
+                  () => undefined,
+                ),
+              ])))
+            : undefined;
+          if (output) return output;
+        }
+        throw new HarnessValidationError('message().admissionId', 'duplicate stream is no longer live');
+      }
+      if (evidence.status === 'completed') return evidence.result as AgentResult;
+      if (evidence.status === 'failed') throw publicErrorProjectionToError(evidence.error);
+      const runId = await this._pendingMessageRunId(evidence);
+      if (runId) {
+        const agent = this._harness.getAgentForMode(opts.mode ?? this._record.modeId);
+        await this._ensureThreadSubscription(agent);
+        if (!this._hasLiveMessageRun(agent, runId)) {
+          throw new HarnessValidationError('message().admissionId', 'pending message admission is not live');
+        }
+        return this._awaitRunCompletion(runId);
+      }
+    }
+    throw new HarnessValidationError('message().admissionId', 'duplicate message result evidence has expired');
+  }
+
+  private async _pendingMessageRunId(evidence: AgentSignalResultEvidence): Promise<string | undefined> {
+    if (evidence.status !== 'pending') return evidence.runId;
+    const starting = evidence.admissionId ? this._messageAdmissionStarts.get(evidence.admissionId) : undefined;
+    if (!starting) return evidence.runId;
+    try {
+      return await starting.promise;
+    } catch {
+      return evidence.runId;
+    }
+  }
+
+  private _hasLiveMessageRun(agent: Agent, runId: string): boolean {
+    return Boolean(
+      agent.getRunOutput(runId) || this._runCompletionPromises.has(runId) || this._completedRuns.has(runId),
+    );
+  }
+
+  private _messageAdmissionIdentity(admissionId: string): MessageAdmissionIdentity {
+    const digest = sha256CanonicalJson({
+      kind: 'message-admission',
+      harnessName: this._record.harnessName,
+      sessionId: this.id,
+      resourceId: this.resourceId,
+      threadId: this.threadId,
+      admissionId,
+    });
+    return {
+      signalId: `harness-message-${digest.slice(0, 32)}`,
+      runId: `harness-message-${digest.slice(32, 64)}`,
+    };
+  }
+
+  private async _writeMessageResultEvidence(
+    status: AgentSignalResultStatus & { admissionId?: string; admissionHash?: string },
+  ): Promise<{ created: boolean }> {
+    const now = Date.now();
+    try {
+      return await this._storage.writeMessageResultEvidence({
+        ...status,
+        harnessName: this._record.harnessName,
+        sessionId: this.id,
+        resourceId: this.resourceId,
+        threadId: this.threadId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    } catch (err) {
+      if (err instanceof HarnessStorageAdmissionConflictError && status.admissionId && status.admissionHash) {
+        await this._resolveMessageAdmissionDuplicate({
+          admissionId: status.admissionId,
+          admissionHash: status.admissionHash,
+        });
+        throw new HarnessAdmissionConflictError(this.id, status.admissionId, '', status.admissionHash);
+      }
+      throw err;
+    }
+  }
+
+  private _computeMessageAdmissionHash(opts: MessageOptions, stable: { modeId: string; modelId: string }): string {
+    return sha256CanonicalJson({
+      kind: 'message',
+      content: opts.content,
+      mode: stable.modeId,
+      model: stable.modelId,
+      attachments: (opts.attachments ?? []).map(attachment => ({
+        attachmentId: attachment.attachmentId,
+        resourceId: attachment.resourceId,
+        ...(attachment.ownerSessionId !== undefined ? { ownerSessionId: attachment.ownerSessionId } : {}),
+        ...(attachment.bytes !== undefined ? { bytes: attachment.bytes } : {}),
+        ...(attachment.sha256 !== undefined ? { sha256: attachment.sha256 } : {}),
+        ...(attachment.source !== undefined ? { source: attachment.source } : {}),
+      })),
+    });
   }
 
   // -------------------------------------------------------------------------
@@ -3977,4 +4339,75 @@ export class Session {
   get _internalStorage(): HarnessStorage {
     return this._storage;
   }
+}
+
+type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+
+function sha256CanonicalJson(value: unknown): string {
+  return createHash('sha256')
+    .update(canonicalJson(assertJsonValue(value)), 'utf8')
+    .digest('hex');
+}
+
+function assertJsonValue(value: unknown, path = 'value'): JsonValue {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || Object.is(value, -0)) {
+      throw new HarnessValidationError(path, 'must be a finite JSON number');
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    const out: JsonValue[] = [];
+    for (let index = 0; index < value.length; index += 1) {
+      if (!(index in value)) throw new HarnessValidationError(`${path}[${index}]`, 'sparse arrays are not allowed');
+      out.push(assertJsonValue(value[index], `${path}[${index}]`));
+    }
+    return out;
+  }
+  if (typeof value === 'object' && value !== null && isPlainJsonObject(value)) {
+    const out: Record<string, JsonValue> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      if (entry !== undefined) out[key] = assertJsonValue(entry, `${path}.${key}`);
+    }
+    return out;
+  }
+  throw new HarnessValidationError(path, 'must be JSON-serializable for admission hashing');
+}
+
+function isPlainJsonObject(value: object): value is Record<string, unknown> {
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function canonicalJson(value: JsonValue): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  return `{${Object.keys(value)
+    .sort()
+    .map(key => `${JSON.stringify(key)}:${canonicalJson(value[key]!)}`)
+    .join(',')}}`;
+}
+
+function projectHarnessPublicError(err: unknown): { code: string; message: string } {
+  if (err instanceof Error) {
+    return { code: (err as { code?: string }).code ?? err.name ?? 'harness.message_failed', message: err.message };
+  }
+  return { code: 'harness.message_failed', message: String(err) };
+}
+
+function publicErrorProjectionToError(error: { code: string; message: string }): Error {
+  const projected = new Error(error.message);
+  projected.name = error.code;
+  return projected;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -799,6 +799,9 @@ interface MessageOptionsBase extends MessageOverrides {
   /** Free-form user content. The only required field. */
   content: string;
 
+  /** Optional idempotency key for retry-safe signal-driven messages. */
+  admissionId?: string;
+
   /** Optional pre-uploaded attachments to include with the user message. */
   attachments?: AttachmentRef[];
 

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -48,6 +48,7 @@ export const TABLE_CHANNEL_CONFIG = 'mastra_channel_config';
 export const TABLE_HARNESS_SESSIONS = 'mastra_harness_sessions';
 export const TABLE_HARNESS_ATTACHMENTS = 'mastra_harness_attachments';
 export const TABLE_HARNESS_ATTACHMENT_REFERENCES = 'mastra_harness_attachment_references';
+export const TABLE_HARNESS_MESSAGE_RESULTS = 'mastra_harness_message_results';
 export const TABLE_HARNESS_OPERATION_TOMBSTONES = 'mastra_harness_operation_tombstones';
 
 /** Union of all core table name constants. */
@@ -87,6 +88,7 @@ export type TABLE_NAMES =
   | typeof TABLE_HARNESS_SESSIONS
   | typeof TABLE_HARNESS_ATTACHMENTS
   | typeof TABLE_HARNESS_ATTACHMENT_REFERENCES
+  | typeof TABLE_HARNESS_MESSAGE_RESULTS
   | typeof TABLE_HARNESS_OPERATION_TOMBSTONES;
 
 export const SCORERS_SCHEMA: Record<string, StorageColumn> = {
@@ -692,6 +694,22 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
     retained_until: { type: 'bigint', nullable: true },
     created_at: { type: 'bigint', nullable: false },
   },
+  [TABLE_HARNESS_MESSAGE_RESULTS]: {
+    id: { type: 'text', nullable: false, primaryKey: true },
+    harness_name: { type: 'text', nullable: false },
+    session_id: { type: 'text', nullable: false },
+    resource_id: { type: 'text', nullable: false },
+    thread_id: { type: 'text', nullable: false },
+    signal_id: { type: 'text', nullable: false },
+    run_id: { type: 'text', nullable: true },
+    admission_id: { type: 'text', nullable: true },
+    admission_hash: { type: 'text', nullable: true },
+    status: { type: 'text', nullable: false },
+    result: { type: 'jsonb', nullable: true },
+    error: { type: 'jsonb', nullable: true },
+    created_at: { type: 'bigint', nullable: false },
+    updated_at: { type: 'bigint', nullable: false },
+  },
   [TABLE_HARNESS_OPERATION_TOMBSTONES]: {
     id: { type: 'text', nullable: false, primaryKey: true },
     harness_name: { type: 'text', nullable: false },
@@ -727,6 +745,9 @@ export const TABLE_CONFIGS: Partial<Record<TABLE_NAMES, StorageTableConfig>> = {
   [TABLE_HARNESS_ATTACHMENT_REFERENCES]: {
     columns: TABLE_SCHEMAS[TABLE_HARNESS_ATTACHMENT_REFERENCES],
     compositePrimaryKey: ['harness_name', 'session_id', 'attachment_id', 'source', 'source_id'],
+  },
+  [TABLE_HARNESS_MESSAGE_RESULTS]: {
+    columns: TABLE_SCHEMAS[TABLE_HARNESS_MESSAGE_RESULTS],
   },
   [TABLE_HARNESS_OPERATION_TOMBSTONES]: {
     columns: TABLE_SCHEMAS[TABLE_HARNESS_OPERATION_TOMBSTONES],

--- a/packages/core/src/storage/domains/harness/base.ts
+++ b/packages/core/src/storage/domains/harness/base.ts
@@ -1,6 +1,7 @@
 import { StorageDomain } from '../base';
 import type {
   AcquireSessionLeaseInput,
+  AgentSignalResultEvidence,
   AgentSignalResultStatus,
   AttachmentReference,
   AttachmentRecord,
@@ -338,6 +339,8 @@ export abstract class HarnessStorage extends StorageDomain {
     threadId: string;
     signalId: string;
   }): Promise<AgentSignalResultStatus | OperationAdmissionTombstone | null>;
+
+  abstract writeMessageResultEvidence(record: AgentSignalResultEvidence): Promise<{ created: boolean }>;
 
   abstract loadQueueResultEvidence(opts: {
     harnessName?: string;

--- a/packages/core/src/storage/domains/harness/inmemory.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.ts
@@ -12,6 +12,7 @@ import {
 } from './base';
 import type {
   AcquireSessionLeaseInput,
+  AgentSignalResultEvidence,
   AgentSignalResultStatus,
   AttachmentReference,
   AttachmentRecord,
@@ -498,6 +499,10 @@ export class InMemoryHarness extends HarnessStorage {
     signalId: string;
   }): Promise<AgentSignalResultStatus | OperationAdmissionTombstone | null> {
     const namespace = resolveHarnessName(harnessName, this.harnessName);
+    const retained = this.db.harnessMessageResultEvidence.get(messageEvidenceKey(namespace, sessionId, signalId));
+    if (retained && retained.resourceId === resourceId && retained.threadId === threadId) {
+      return cloneJson(retained);
+    }
     const tombstone = this.findTombstone(
       t =>
         t.harnessName === namespace &&
@@ -508,6 +513,30 @@ export class InMemoryHarness extends HarnessStorage {
         t.signalId === signalId,
     );
     return tombstone ? cloneJson(tombstone) : null;
+  }
+
+  async writeMessageResultEvidence(record: AgentSignalResultEvidence): Promise<{ created: boolean }> {
+    const namespacedRecord = {
+      ...record,
+      harnessName: resolveHarnessName(record.harnessName, this.harnessName),
+    };
+    const key = messageEvidenceKey(namespacedRecord.harnessName, namespacedRecord.sessionId, namespacedRecord.signalId);
+    const existing = this.db.harnessMessageResultEvidence.get(key);
+    if (existing && !sameMessageEvidenceIdentity(existing, namespacedRecord)) {
+      throw new HarnessStorageAdmissionConflictError(
+        namespacedRecord.sessionId,
+        'message',
+        namespacedRecord.admissionId ?? namespacedRecord.signalId,
+      );
+    }
+    this.db.harnessMessageResultEvidence.set(
+      key,
+      cloneJson({
+        ...namespacedRecord,
+        createdAt: existing?.createdAt ?? namespacedRecord.createdAt,
+      }),
+    );
+    return { created: existing === undefined };
   }
 
   async loadQueueResultEvidence({
@@ -557,6 +586,22 @@ export class InMemoryHarness extends HarnessStorage {
     storedAdmissionHash?: string;
   }> {
     const namespace = resolveHarnessName(harnessName, this.harnessName);
+    if (kind === 'message') {
+      for (const evidence of this.db.harnessMessageResultEvidence.values()) {
+        if (
+          evidence.harnessName !== namespace ||
+          evidence.sessionId !== sessionId ||
+          evidence.resourceId !== resourceId ||
+          evidence.admissionId !== admissionId
+        ) {
+          continue;
+        }
+        if (evidence.admissionHash !== attemptedAdmissionHash) {
+          return { status: 'conflict', evidence: cloneJson(evidence), storedAdmissionHash: evidence.admissionHash };
+        }
+        return { status: 'duplicate', evidence: cloneJson(evidence), storedAdmissionHash: evidence.admissionHash };
+      }
+    }
     if (kind === 'queue') {
       const session = this.db.harnessSessions.get(sessionKey(namespace, sessionId));
       if (session && session.resourceId !== resourceId) return { status: 'none' };
@@ -620,17 +665,26 @@ export class InMemoryHarness extends HarnessStorage {
   }): Promise<OperationAdmissionTombstone | null> {
     const namespace = resolveHarnessName(harnessName, this.harnessName);
     if (kind === 'message') {
-      return (
-        this.findTombstone(
-          t =>
-            t.harnessName === namespace &&
-            t.sessionId === sessionId &&
-            t.resourceId === resourceId &&
-            t.kind === 'message' &&
-            t.signalId === signalId &&
-            t.compactedAt <= now,
-        ) ?? null
-      );
+      const key = signalId ? messageEvidenceKey(namespace, sessionId, signalId) : undefined;
+      const retained = key ? this.db.harnessMessageResultEvidence.get(key) : undefined;
+      if (!retained || retained.resourceId !== resourceId || retained.status === 'pending') return null;
+      const tombstone: OperationAdmissionTombstone = {
+        kind: 'message',
+        harnessName: namespace,
+        sessionId,
+        resourceId,
+        threadId: retained.threadId,
+        ...(retained.admissionId !== undefined ? { admissionId: retained.admissionId } : {}),
+        ...(retained.admissionHash !== undefined ? { admissionHash: retained.admissionHash } : {}),
+        signalId: retained.signalId,
+        ...(retained.runId !== undefined ? { runId: retained.runId } : {}),
+        terminalAt: retained.updatedAt,
+        compactedAt: now,
+        expiresAt: now,
+      };
+      await this.writeOperationAdmissionTombstone(tombstone);
+      this.db.harnessMessageResultEvidence.delete(messageEvidenceKey(namespace, sessionId, retained.signalId));
+      return cloneJson(tombstone);
     }
 
     const key = sessionKey(namespace, sessionId);
@@ -676,6 +730,15 @@ export class InMemoryHarness extends HarnessStorage {
     resourceId: string;
   }): Promise<void> {
     const namespace = resolveHarnessName(harnessName, this.harnessName);
+    for (const [key, evidence] of this.db.harnessMessageResultEvidence) {
+      if (
+        evidence.harnessName === namespace &&
+        evidence.sessionId === sessionId &&
+        evidence.resourceId === resourceId
+      ) {
+        this.db.harnessMessageResultEvidence.delete(key);
+      }
+    }
     for (const [key, tombstone] of this.db.harnessOperationTombstones) {
       if (
         tombstone.harnessName === namespace &&
@@ -724,6 +787,7 @@ export class InMemoryHarness extends HarnessStorage {
     this.db.harnessAttachmentRecords.clear();
     this.db.harnessAttachmentBytes.clear();
     this.db.harnessAttachmentReferences.clear();
+    this.db.harnessMessageResultEvidence.clear();
     this.db.harnessOperationTombstones.clear();
   }
 }
@@ -759,6 +823,10 @@ function tombstoneKey(record: OperationAdmissionTombstone): string {
   return `${record.harnessName}\u0000${record.sessionId}\u0000${record.kind}\u0000${publicId ?? record.admissionId ?? record.compactedAt}`;
 }
 
+function messageEvidenceKey(harnessName: string, sessionId: string, signalId: string): string {
+  return `${harnessName}\u0000${sessionId}\u0000${signalId}`;
+}
+
 function resolveHarnessName(input: string | undefined, fallback: string): string {
   return input ?? fallback;
 }
@@ -783,6 +851,18 @@ function sameTombstoneIdentity(a: OperationAdmissionTombstone, b: OperationAdmis
     a.queuedItemId === b.queuedItemId &&
     a.signalId === b.signalId &&
     a.runId === b.runId
+  );
+}
+
+function sameMessageEvidenceIdentity(a: AgentSignalResultEvidence, b: AgentSignalResultEvidence): boolean {
+  return (
+    a.harnessName === b.harnessName &&
+    a.sessionId === b.sessionId &&
+    a.resourceId === b.resourceId &&
+    a.threadId === b.threadId &&
+    a.signalId === b.signalId &&
+    a.admissionId === b.admissionId &&
+    a.admissionHash === b.admissionHash
   );
 }
 

--- a/packages/core/src/storage/domains/harness/inmemory.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.ts
@@ -529,6 +529,9 @@ export class InMemoryHarness extends HarnessStorage {
         namespacedRecord.admissionId ?? namespacedRecord.signalId,
       );
     }
+    if (existing && isTerminalMessageEvidence(existing)) {
+      return { created: false };
+    }
     this.db.harnessMessageResultEvidence.set(
       key,
       cloneJson({
@@ -864,6 +867,10 @@ function sameMessageEvidenceIdentity(a: AgentSignalResultEvidence, b: AgentSigna
     a.admissionId === b.admissionId &&
     a.admissionHash === b.admissionHash
   );
+}
+
+function isTerminalMessageEvidence(record: AgentSignalResultEvidence): boolean {
+  return record.status === 'completed' || record.status === 'failed';
 }
 
 function isTerminalQueueReceipt(receipt: QueueAdmissionReceipt): boolean {

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -337,6 +337,17 @@ export interface AgentSignalAccepted {
   admissionHash?: string;
 }
 
+export type AgentSignalResultEvidence = AgentSignalResultStatus & {
+  harnessName: string;
+  sessionId: string;
+  resourceId: string;
+  threadId: string;
+  admissionId?: string;
+  admissionHash?: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
 export interface QueueAdmissionReceipt {
   admissionId: string;
   admissionHash: string;
@@ -375,6 +386,7 @@ export interface OperationAdmissionTombstone {
 
 export type OperationAdmissionEvidence =
   | AgentSignalAccepted
+  | AgentSignalResultEvidence
   | AgentSignalResultStatus
   | QueueAdmissionReceipt
   | OperationAdmissionTombstone;

--- a/packages/core/src/storage/domains/inmemory-db.ts
+++ b/packages/core/src/storage/domains/inmemory-db.ts
@@ -21,6 +21,7 @@ import type {
 } from '../types';
 import type { AgentVersion } from './agents';
 import type {
+  AgentSignalResultEvidence,
   AttachmentRecord,
   AttachmentReference,
   OperationAdmissionTombstone,
@@ -95,6 +96,7 @@ export class InMemoryDB {
   readonly harnessAttachmentRecords = new Map<string, AttachmentRecord>();
   readonly harnessAttachmentBytes = new Map<string, Uint8Array>();
   readonly harnessAttachmentReferences = new Map<string, AttachmentReference>();
+  readonly harnessMessageResultEvidence = new Map<string, AgentSignalResultEvidence>();
   readonly harnessOperationTombstones = new Map<string, OperationAdmissionTombstone>();
 
   /**
@@ -139,6 +141,7 @@ export class InMemoryDB {
     this.harnessAttachmentRecords.clear();
     this.harnessAttachmentBytes.clear();
     this.harnessAttachmentReferences.clear();
+    this.harnessMessageResultEvidence.clear();
     this.harnessOperationTombstones.clear();
   }
 }

--- a/packages/core/src/storage/domains/operations/inmemory.ts
+++ b/packages/core/src/storage/domains/operations/inmemory.ts
@@ -48,6 +48,7 @@ export class StoreOperationsInMemory extends StoreOperations {
       mastra_harness_sessions: new Map(),
       mastra_harness_attachments: new Map(),
       mastra_harness_attachment_references: new Map(),
+      mastra_harness_message_results: new Map(),
       mastra_harness_operation_tombstones: new Map(),
     };
   }

--- a/stores/_test-utils/src/domains/harness/index.ts
+++ b/stores/_test-utils/src/domains/harness/index.ts
@@ -962,6 +962,94 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
         ).resolves.toBeNull();
       });
 
+      it('writes retained message result evidence and resolves duplicate/conflict attempts', async () => {
+        if (!harness) return;
+        await harness.writeMessageResultEvidence({
+          harnessName: 'default',
+          sessionId: 'session-1',
+          resourceId: 'resource-1',
+          threadId: 'thread-1',
+          signalId: 'signal-1',
+          runId: 'run-1',
+          admissionId: 'admission-1',
+          admissionHash: 'hash-1',
+          status: 'completed',
+          result: { text: 'done' },
+          createdAt: 1000,
+          updatedAt: 2000,
+        });
+
+        await expect(
+          harness.loadMessageResultEvidence({
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            threadId: 'thread-1',
+            signalId: 'signal-1',
+          }),
+        ).resolves.toMatchObject({ status: 'completed', result: { text: 'done' } });
+        await expect(
+          harness.resolveOperationAdmissionEvidence({
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            kind: 'message',
+            admissionId: 'admission-1',
+            attemptedAdmissionHash: 'hash-1',
+          }),
+        ).resolves.toMatchObject({ status: 'duplicate', storedAdmissionHash: 'hash-1' });
+        await expect(
+          harness.resolveOperationAdmissionEvidence({
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            kind: 'message',
+            admissionId: 'admission-1',
+            attemptedAdmissionHash: 'different-hash',
+          }),
+        ).resolves.toMatchObject({ status: 'conflict', storedAdmissionHash: 'hash-1' });
+      });
+
+      it('compacts terminal message evidence into tombstones', async () => {
+        if (!harness) return;
+        await harness.writeMessageResultEvidence({
+          harnessName: 'default',
+          sessionId: 'session-1',
+          resourceId: 'resource-1',
+          threadId: 'thread-1',
+          signalId: 'signal-1',
+          runId: 'run-1',
+          admissionId: 'admission-1',
+          admissionHash: 'hash-1',
+          status: 'failed',
+          error: { code: 'harness.test', message: 'failed' },
+          createdAt: 1000,
+          updatedAt: 2000,
+        });
+
+        const compacted = await harness.compactOperationResultEvidence({
+          sessionId: 'session-1',
+          resourceId: 'resource-1',
+          kind: 'message',
+          signalId: 'signal-1',
+          now: 3000,
+        });
+
+        expect(compacted).toMatchObject({
+          kind: 'message',
+          admissionId: 'admission-1',
+          admissionHash: 'hash-1',
+          signalId: 'signal-1',
+          terminalAt: 2000,
+          compactedAt: 3000,
+        });
+        await expect(
+          harness.loadMessageResultEvidence({
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            threadId: 'thread-1',
+            signalId: 'signal-1',
+          }),
+        ).resolves.toEqual(compacted);
+      });
+
       it('compacts terminal queue receipts into tombstones', async () => {
         if (!harness) return;
         await harness.saveSession(

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 
 import { createClient } from '@libsql/client';
 import { TABLE_HARNESS_ATTACHMENTS } from '@mastra/core/storage';
@@ -6,11 +6,20 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { HarnessLibSQL } from './index';
 
+let harnessDbCounter = 0;
+
+function createHarnessTestClient() {
+  harnessDbCounter += 1;
+  return createClient({
+    url: `file:/tmp/mastra-harness-libsql-${process.pid}-${harnessDbCounter}-${randomUUID()}.db`,
+  });
+}
+
 describe('HarnessLibSQL attachments', () => {
   let storage: HarnessLibSQL;
 
   beforeEach(async () => {
-    const client = createClient({ url: ':memory:' });
+    const client = createHarnessTestClient();
     storage = new HarnessLibSQL({ client });
     await storage.init();
   });
@@ -98,5 +107,101 @@ describe('HarnessLibSQL attachments', () => {
       bytes: 3,
       sha256: expectedSha256,
     });
+  });
+});
+
+describe('HarnessLibSQL message result evidence', () => {
+  let storage: HarnessLibSQL;
+
+  beforeEach(async () => {
+    const client = createHarnessTestClient();
+    storage = new HarnessLibSQL({ client });
+    await storage.init();
+  });
+
+  it('stores retained message evidence and resolves duplicate/conflict admissions', async () => {
+    await storage.writeMessageResultEvidence({
+      harnessName: 'default',
+      sessionId: 'session-1',
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      signalId: 'signal-1',
+      runId: 'run-1',
+      admissionId: 'admission-1',
+      admissionHash: 'hash-1',
+      status: 'completed',
+      result: { text: 'done' },
+      createdAt: 1000,
+      updatedAt: 2000,
+    });
+
+    await expect(
+      storage.loadMessageResultEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        signalId: 'signal-1',
+      }),
+    ).resolves.toMatchObject({ status: 'completed', result: { text: 'done' } });
+    await expect(
+      storage.resolveOperationAdmissionEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        kind: 'message',
+        admissionId: 'admission-1',
+        attemptedAdmissionHash: 'hash-1',
+      }),
+    ).resolves.toMatchObject({ status: 'duplicate', storedAdmissionHash: 'hash-1' });
+    await expect(
+      storage.resolveOperationAdmissionEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        kind: 'message',
+        admissionId: 'admission-1',
+        attemptedAdmissionHash: 'different-hash',
+      }),
+    ).resolves.toMatchObject({ status: 'conflict', storedAdmissionHash: 'hash-1' });
+  });
+
+  it('compacts terminal message evidence into tombstones', async () => {
+    await storage.writeMessageResultEvidence({
+      harnessName: 'default',
+      sessionId: 'session-1',
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      signalId: 'signal-1',
+      runId: 'run-1',
+      admissionId: 'admission-1',
+      admissionHash: 'hash-1',
+      status: 'failed',
+      error: { code: 'harness.test', message: 'failed' },
+      createdAt: 1000,
+      updatedAt: 2000,
+    });
+
+    const compacted = await storage.compactOperationResultEvidence({
+      sessionId: 'session-1',
+      resourceId: 'resource-1',
+      kind: 'message',
+      signalId: 'signal-1',
+      now: 3000,
+    });
+
+    expect(compacted).toMatchObject({
+      kind: 'message',
+      admissionId: 'admission-1',
+      admissionHash: 'hash-1',
+      signalId: 'signal-1',
+      terminalAt: 2000,
+      compactedAt: 3000,
+    });
+    await expect(
+      storage.loadMessageResultEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        signalId: 'signal-1',
+      }),
+    ).resolves.toEqual(compacted);
   });
 });

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -120,20 +120,55 @@ describe('HarnessLibSQL message result evidence', () => {
   });
 
   it('stores retained message evidence and resolves duplicate/conflict admissions', async () => {
-    await storage.writeMessageResultEvidence({
-      harnessName: 'default',
-      sessionId: 'session-1',
-      resourceId: 'resource-1',
-      threadId: 'thread-1',
-      signalId: 'signal-1',
-      runId: 'run-1',
-      admissionId: 'admission-1',
-      admissionHash: 'hash-1',
-      status: 'completed',
-      result: { text: 'done' },
-      createdAt: 1000,
-      updatedAt: 2000,
-    });
+    await expect(
+      storage.writeMessageResultEvidence({
+        harnessName: 'default',
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        signalId: 'signal-1',
+        runId: 'run-1',
+        admissionId: 'admission-1',
+        admissionHash: 'hash-1',
+        status: 'completed',
+        result: { text: 'done' },
+        createdAt: 1000,
+        updatedAt: 2000,
+      }),
+    ).resolves.toEqual({ created: true });
+
+    await expect(
+      storage.writeMessageResultEvidence({
+        harnessName: 'default',
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        signalId: 'signal-1',
+        runId: 'run-1',
+        admissionId: 'admission-1',
+        admissionHash: 'hash-1',
+        status: 'completed',
+        result: { text: 'done' },
+        createdAt: 1000,
+        updatedAt: 2000,
+      }),
+    ).resolves.toEqual({ created: false });
+
+    await expect(
+      storage.writeMessageResultEvidence({
+        harnessName: 'default',
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        signalId: 'signal-1',
+        runId: 'run-1',
+        admissionId: 'admission-1',
+        admissionHash: 'hash-1',
+        status: 'pending',
+        createdAt: 3000,
+        updatedAt: 3000,
+      }),
+    ).resolves.toEqual({ created: false });
 
     await expect(
       storage.loadMessageResultEvidence({

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -12,12 +12,14 @@ import {
   TABLE_CONFIGS,
   TABLE_HARNESS_ATTACHMENT_REFERENCES,
   TABLE_HARNESS_ATTACHMENTS,
+  TABLE_HARNESS_MESSAGE_RESULTS,
   TABLE_HARNESS_OPERATION_TOMBSTONES,
   TABLE_HARNESS_SESSIONS,
   TABLE_SCHEMAS,
 } from '@mastra/core/storage';
 import type {
   AcquireSessionLeaseInput,
+  AgentSignalResultEvidence,
   AgentSignalResultStatus,
   AttachmentReference,
   AttachmentRecord,
@@ -92,6 +94,7 @@ export class HarnessLibSQL extends HarnessStorage {
       schema: TABLE_SCHEMAS[TABLE_HARNESS_ATTACHMENT_REFERENCES],
       compositePrimaryKey: attachmentRefsConfig?.compositePrimaryKey,
     });
+    await this.#ensureMessageResultsTable();
     const tombstonesConfig = TABLE_CONFIGS[TABLE_HARNESS_OPERATION_TOMBSTONES];
     await this.#db.createTable({
       tableName: TABLE_HARNESS_OPERATION_TOMBSTONES,
@@ -125,8 +128,10 @@ export class HarnessLibSQL extends HarnessStorage {
   }
 
   async dangerouslyClearAll(): Promise<void> {
+    await this.#ensureMessageResultsTable();
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_ATTACHMENT_REFERENCES}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_ATTACHMENTS}`);
+    await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_MESSAGE_RESULTS}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_OPERATION_TOMBSTONES}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_SESSIONS}`);
   }
@@ -799,6 +804,16 @@ export class HarnessLibSQL extends HarnessStorage {
     signalId: string;
   }): Promise<AgentSignalResultStatus | OperationAdmissionTombstone | null> {
     const namespace = this.#resolveHarnessName(harnessName);
+    await this.#ensureMessageResultsTable();
+    const retainedResult = await this.#client.execute({
+      sql: `SELECT * FROM ${TABLE_HARNESS_MESSAGE_RESULTS}
+            WHERE harness_name = ? AND session_id = ? AND resource_id = ? AND thread_id = ?
+              AND signal_id = ?
+            LIMIT 1`,
+      args: [namespace, sessionId, resourceId, threadId, signalId],
+    });
+    const retained = retainedResult.rows[0];
+    if (retained) return rowToMessageResultEvidence(retained as Record<string, unknown>);
     const result = await this.#client.execute({
       sql: `SELECT * FROM ${TABLE_HARNESS_OPERATION_TOMBSTONES}
             WHERE harness_name = ? AND session_id = ? AND resource_id = ? AND thread_id = ?
@@ -808,6 +823,72 @@ export class HarnessLibSQL extends HarnessStorage {
     });
     const row = result.rows[0];
     return row ? rowToTombstone(row as Record<string, unknown>) : null;
+  }
+
+  async writeMessageResultEvidence(record: AgentSignalResultEvidence): Promise<{ created: boolean }> {
+    await this.#ensureMessageResultsTable();
+    const namespacedRecord = { ...record, harnessName: this.#resolveHarnessName(record.harnessName) };
+    const id = messageEvidenceId(namespacedRecord);
+    const tx = await this.#client.transaction('write');
+    let created = false;
+    try {
+      const existing = await tx.execute({
+        sql: `SELECT * FROM ${TABLE_HARNESS_MESSAGE_RESULTS} WHERE id = ? LIMIT 1`,
+        args: [id],
+      });
+      if (existing.rows[0]) {
+        const current = rowToMessageResultEvidence(existing.rows[0] as Record<string, unknown>);
+        if (!sameMessageEvidenceIdentity(current, namespacedRecord)) {
+          throw new HarnessStorageAdmissionConflictError(
+            namespacedRecord.sessionId,
+            'message',
+            namespacedRecord.admissionId ?? namespacedRecord.signalId,
+          );
+        }
+        await tx.execute({
+          sql: `UPDATE ${TABLE_HARNESS_MESSAGE_RESULTS}
+                SET run_id = ?, status = ?, result = ?, error = ?, updated_at = ?
+                WHERE id = ?`,
+          args: [
+            namespacedRecord.runId ?? null,
+            namespacedRecord.status,
+            'result' in namespacedRecord ? JSON.stringify(namespacedRecord.result) : null,
+            'error' in namespacedRecord ? JSON.stringify(namespacedRecord.error) : null,
+            namespacedRecord.updatedAt,
+            id,
+          ],
+        });
+      } else {
+        created = true;
+        await tx.execute({
+          sql: `INSERT INTO ${TABLE_HARNESS_MESSAGE_RESULTS}
+                (id, harness_name, session_id, resource_id, thread_id, signal_id, run_id,
+                 admission_id, admission_hash, status, result, error, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          args: [
+            id,
+            namespacedRecord.harnessName,
+            namespacedRecord.sessionId,
+            namespacedRecord.resourceId,
+            namespacedRecord.threadId,
+            namespacedRecord.signalId,
+            namespacedRecord.runId ?? null,
+            namespacedRecord.admissionId ?? null,
+            namespacedRecord.admissionHash ?? null,
+            namespacedRecord.status,
+            'result' in namespacedRecord ? JSON.stringify(namespacedRecord.result) : null,
+            'error' in namespacedRecord ? JSON.stringify(namespacedRecord.error) : null,
+            namespacedRecord.createdAt,
+            namespacedRecord.updatedAt,
+          ],
+        });
+      }
+      await tx.commit();
+      return { created };
+    } catch (err) {
+      if (!tx.closed) await tx.rollback();
+      throw err;
+    }
   }
 
   async loadQueueResultEvidence({
@@ -857,6 +938,25 @@ export class HarnessLibSQL extends HarnessStorage {
     storedAdmissionHash?: string;
   }> {
     const namespace = this.#resolveHarnessName(harnessName);
+    if (kind === 'message') await this.#ensureMessageResultsTable();
+    if (kind === 'message') {
+      const retained = await this.#client.execute({
+        sql: `SELECT * FROM ${TABLE_HARNESS_MESSAGE_RESULTS}
+              WHERE harness_name = ? AND session_id = ? AND resource_id = ?
+                AND admission_id = ?
+              LIMIT 1`,
+        args: [namespace, sessionId, resourceId, admissionId],
+      });
+      const row = retained.rows[0];
+      if (row) {
+        const evidence = rowToMessageResultEvidence(row as Record<string, unknown>);
+        return {
+          status: evidence.admissionHash === attemptedAdmissionHash ? 'duplicate' : 'conflict',
+          evidence,
+          storedAdmissionHash: evidence.admissionHash,
+        };
+      }
+    }
     if (kind === 'queue') {
       const session = await this.loadSession({ harnessName: namespace, sessionId });
       if (session && session.resourceId !== resourceId) return { status: 'none' };
@@ -947,6 +1047,7 @@ export class HarnessLibSQL extends HarnessStorage {
     sessionId,
     resourceId,
     kind,
+    signalId,
     queuedItemId,
     now,
   }: {
@@ -958,8 +1059,41 @@ export class HarnessLibSQL extends HarnessStorage {
     queuedItemId?: string;
     now: number;
   }): Promise<OperationAdmissionTombstone | null> {
-    if (kind === 'message') return null;
     const namespace = this.#resolveHarnessName(harnessName);
+    if (kind === 'message') {
+      await this.#ensureMessageResultsTable();
+      const result = await this.#client.execute({
+        sql: `SELECT * FROM ${TABLE_HARNESS_MESSAGE_RESULTS}
+              WHERE harness_name = ? AND session_id = ? AND resource_id = ?
+                AND signal_id = ?
+              LIMIT 1`,
+        args: [namespace, sessionId, resourceId, signalId ?? ''],
+      });
+      const row = result.rows[0];
+      if (!row) return null;
+      const retained = rowToMessageResultEvidence(row as Record<string, unknown>);
+      if (retained.status === 'pending') return null;
+      const tombstone: OperationAdmissionTombstone = {
+        kind: 'message',
+        harnessName: namespace,
+        sessionId,
+        resourceId,
+        threadId: retained.threadId,
+        ...(retained.admissionId !== undefined ? { admissionId: retained.admissionId } : {}),
+        ...(retained.admissionHash !== undefined ? { admissionHash: retained.admissionHash } : {}),
+        signalId: retained.signalId,
+        ...(retained.runId !== undefined ? { runId: retained.runId } : {}),
+        terminalAt: retained.updatedAt,
+        compactedAt: now,
+        expiresAt: now,
+      };
+      await this.writeOperationAdmissionTombstone(tombstone);
+      await this.#client.execute({
+        sql: `DELETE FROM ${TABLE_HARNESS_MESSAGE_RESULTS} WHERE id = ?`,
+        args: [messageEvidenceId(retained)],
+      });
+      return tombstone;
+    }
     return this.#withCompactionLock(`${namespace}\0${sessionId}`, async () => {
       for (let attempt = 0; attempt < 3; attempt += 1) {
         const result = await this.#client.execute({
@@ -1017,6 +1151,12 @@ export class HarnessLibSQL extends HarnessStorage {
     sessionId: string;
     resourceId: string;
   }): Promise<void> {
+    await this.#ensureMessageResultsTable();
+    await this.#client.execute({
+      sql: `DELETE FROM ${TABLE_HARNESS_MESSAGE_RESULTS}
+            WHERE harness_name = ? AND session_id = ? AND resource_id = ?`,
+      args: [this.#resolveHarnessName(harnessName), sessionId, resourceId],
+    });
     await this.#client.execute({
       sql: `DELETE FROM ${TABLE_HARNESS_OPERATION_TOMBSTONES}
             WHERE harness_name = ? AND session_id = ? AND resource_id = ?`,
@@ -1047,6 +1187,15 @@ export class HarnessLibSQL extends HarnessStorage {
 
   #resolveHarnessName(input?: string): string {
     return input ?? this.#harnessName;
+  }
+
+  async #ensureMessageResultsTable(): Promise<void> {
+    const messageResultsConfig = TABLE_CONFIGS[TABLE_HARNESS_MESSAGE_RESULTS];
+    await this.#db.createTable({
+      tableName: TABLE_HARNESS_MESSAGE_RESULTS,
+      schema: TABLE_SCHEMAS[TABLE_HARNESS_MESSAGE_RESULTS],
+      compositePrimaryKey: messageResultsConfig?.compositePrimaryKey,
+    });
   }
 
   async #backfillAttachmentMetadata(): Promise<void> {
@@ -1325,9 +1474,45 @@ function rowToTombstone(row: Record<string, unknown>): OperationAdmissionTombsto
   };
 }
 
+function rowToMessageResultEvidence(row: Record<string, unknown>): AgentSignalResultEvidence {
+  const base = {
+    harnessName: String(row.harness_name),
+    sessionId: String(row.session_id),
+    resourceId: String(row.resource_id),
+    threadId: String(row.thread_id),
+    signalId: String(row.signal_id),
+    ...(row.run_id == null ? {} : { runId: String(row.run_id) }),
+    ...(row.admission_id == null ? {} : { admissionId: String(row.admission_id) }),
+    ...(row.admission_hash == null ? {} : { admissionHash: String(row.admission_hash) }),
+    createdAt: Number(row.created_at),
+    updatedAt: Number(row.updated_at),
+  };
+  const status = String(row.status);
+  if (status === 'completed') {
+    return {
+      ...base,
+      status: 'completed',
+      runId: base.runId ?? '',
+      result: parseJson(row.result),
+    };
+  }
+  if (status === 'failed') {
+    return {
+      ...base,
+      status: 'failed',
+      error: parseJson(row.error) ?? { code: 'harness.message_failed', message: 'Message failed' },
+    };
+  }
+  return { ...base, status: 'pending' };
+}
+
 function tombstoneId(record: OperationAdmissionTombstone): string {
   const publicId = record.kind === 'message' ? record.signalId : record.queuedItemId;
   return `${record.harnessName}\u0000${record.sessionId}\u0000${record.kind}\u0000${publicId ?? record.admissionId ?? record.compactedAt}`;
+}
+
+function messageEvidenceId(record: Pick<AgentSignalResultEvidence, 'harnessName' | 'sessionId' | 'signalId'>): string {
+  return `${record.harnessName}\u0000${record.sessionId}\u0000${record.signalId}`;
 }
 
 function sameTombstoneIdentity(a: OperationAdmissionTombstone, b: OperationAdmissionTombstone): boolean {
@@ -1342,6 +1527,18 @@ function sameTombstoneIdentity(a: OperationAdmissionTombstone, b: OperationAdmis
     a.queuedItemId === b.queuedItemId &&
     a.signalId === b.signalId &&
     a.runId === b.runId
+  );
+}
+
+function sameMessageEvidenceIdentity(a: AgentSignalResultEvidence, b: AgentSignalResultEvidence): boolean {
+  return (
+    a.harnessName === b.harnessName &&
+    a.sessionId === b.sessionId &&
+    a.resourceId === b.resourceId &&
+    a.threadId === b.threadId &&
+    a.signalId === b.signalId &&
+    a.admissionId === b.admissionId &&
+    a.admissionHash === b.admissionHash
   );
 }
 

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -829,6 +829,16 @@ export class HarnessLibSQL extends HarnessStorage {
     await this.#ensureMessageResultsTable();
     const namespacedRecord = { ...record, harnessName: this.#resolveHarnessName(record.harnessName) };
     const id = messageEvidenceId(namespacedRecord);
+    const loadCurrent = async () => {
+      const current = await this.loadMessageResultEvidence({
+        harnessName: namespacedRecord.harnessName,
+        sessionId: namespacedRecord.sessionId,
+        resourceId: namespacedRecord.resourceId,
+        threadId: namespacedRecord.threadId,
+        signalId: namespacedRecord.signalId,
+      });
+      return current && 'status' in current ? current : null;
+    };
     const tx = await this.#client.transaction('write');
     let created = false;
     try {
@@ -844,6 +854,10 @@ export class HarnessLibSQL extends HarnessStorage {
             'message',
             namespacedRecord.admissionId ?? namespacedRecord.signalId,
           );
+        }
+        if (isTerminalMessageEvidence(current)) {
+          await tx.commit();
+          return { created: false };
         }
         await tx.execute({
           sql: `UPDATE ${TABLE_HARNESS_MESSAGE_RESULTS}
@@ -887,6 +901,17 @@ export class HarnessLibSQL extends HarnessStorage {
       return { created };
     } catch (err) {
       if (!tx.closed) await tx.rollback();
+      if (isUniqueConstraintError(err)) {
+        const current = await loadCurrent();
+        if (current && sameMessageEvidenceIdentity(current as AgentSignalResultEvidence, namespacedRecord)) {
+          return { created: false };
+        }
+        throw new HarnessStorageAdmissionConflictError(
+          namespacedRecord.sessionId,
+          'message',
+          namespacedRecord.admissionId ?? namespacedRecord.signalId,
+        );
+      }
       throw err;
     }
   }
@@ -1540,6 +1565,10 @@ function sameMessageEvidenceIdentity(a: AgentSignalResultEvidence, b: AgentSigna
     a.admissionId === b.admissionId &&
     a.admissionHash === b.admissionHash
   );
+}
+
+function isTerminalMessageEvidence(record: AgentSignalResultEvidence): boolean {
+  return record.status === 'completed' || record.status === 'failed';
 }
 
 function isTerminalQueueReceipt(receipt: QueueAdmissionReceipt): boolean {


### PR DESCRIPTION
## Linear

PF-352

## Summary

- Add Harness v1 admission hashing, duplicate replay, and conflict handling for message calls with admission IDs.
- Add retained message result evidence to Harness storage, in-memory storage, and LibSQL storage.
- Add deterministic signal/run routing and scoped caller-signal de-dupe for concurrent admission retries.
- Add focused message and storage tests plus a changeset for @mastra/core and @mastra/libsql.

## Validation

- pnpm --filter @mastra/core test src/harness/v1/session.message.test.ts src/storage/domains/harness/inmemory.test.ts
- timeout 60s pnpm exec vitest run src/storage/domains/harness/index.test.ts --reporter dot from stores/libsql
- pnpm --filter @mastra/core typecheck
- pnpm --filter @mastra/core build:lib
- pnpm --filter @mastra/libsql build:lib
- Local Codex review pass 1: blockers found and fixed; final focused blocker review reported no blockers.
- Local Codex review pass 2: no blockers; review/nit cleanup applied where scoped.
- coderabbit review --plain: valid in-scope findings fixed; out-of-scope compaction/namespace notes recorded in Linear.

## Notes

- Wakeup/background recovery for stale durable pending message evidence remains in PF-374/PF-375.
- RequestContext is intentionally not included in the message admission hash until PF-348 defines the request-context option surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes Harness message calls retry-safe by letting callers attach an admissionId (a stable receipt). Re-sending the same admissionId returns the original result; sending the same admissionId with different inputs is rejected.

## Summary

Adds idempotent message admission to Harness v1 so signal-driven message calls with an admissionId are deduplicated, persisted, and conflict-checked across concurrent retries and storage backends.

Core admission and API changes
- Add optional admissionId?: string to MessageOptionsBase for session.message().
- Compute deterministic admission hash using canonical JSON + sha256 to detect identical vs conflicting admissions.
- Reject admissionId + sync structured-output and non-hash-safe additionalTools combinations; reject empty admissionId.
- Introduce HarnessAdmissionConflictError to report sessionId/admissionId conflicts (includes stored vs attempted hashes).

Message admission flow and runtime
- session.message() coordinates concurrent admission waiters via a deferred start registry, writes pending evidence before returning live streaming output, and persists completed/failed evidence on completion or error.
- Adds helpers: canonical JSON hashing, public error projection/unprojection, and createDeferred() utility.

Signal deduplication
- AgentThreadStreamRuntime deduplicates caller-scoped sendSignal() calls by building a callerSignalKey (agent/thread targeting + signalInput.id + serialized payload signature). Previously accepted results are returned from an internal cache; bookkeeping is cleaned up on run completion and tests reset.

Evidence model and storage contract
- New AgentSignalResultEvidence type extends result status with harness/session/resource/thread identifiers, admissionId/admissionHash, and timestamps.
- Add TABLE_HARNESS_MESSAGE_RESULTS and register it in storage constants.
- Extend HarnessStorage domain with writeMessageResultEvidence(record) → { created: boolean }.

In-memory storage changes
- InMemoryHarness and InMemoryDB add harnessMessageResultEvidence retention map; implement writeMessageResultEvidence with conflict detection and terminal-preservation semantics.
- resolveOperationAdmissionEvidence gains a 'message' path to return duplicate vs conflict by comparing admission hashes.
- compactOperationResultEvidence can compact retained message evidence into tombstones; session cleanup deletes retained message evidence.

LibSQL storage changes
- HarnessLibSQL persists message-result evidence to TABLE_HARNESS_MESSAGE_RESULTS with transactional upsert semantics, identity/conflict checks, and terminal-row short-circuiting.
- loadMessageResultEvidence reads retained message rows before falling back to tombstones.
- resolveOperationAdmissionEvidence and compactOperationResultEvidence now support kind === 'message'; compacting writes a tombstone and deletes the retained row.
- deleteOperationAdmissionTombstonesForSession removes message-results rows for the session/resource.

Tests and validation
- Tests added/expanded:
  - Session.message() tests: dedup concurrent admissionId retries, conflict detection for same admissionId with different inputs, rejection of non-hash-safe additionalTools and empty admissionId, rejection of admissionId on sync structured-output, and stream-retry semantics.
  - Harness storage conformance tests: writeMessageResultEvidence persistence, resolveAdmission duplicate/conflict behavior, and compaction into tombstones for both in-memory and LibSQL backends.
  - LibSQL tests use unique file-based DB per test suite run.
- Ran targeted vitest suites for @mastra/core and Harness/libsql storage tests with specified timeouts.
- Typechecking and library builds for @mastra/core and @mastra/libsql passed.
- Local Codex and coderabbit reviews applied in-scope fixes; out-of-scope notes recorded.
- Deferred work: wakeup/background recovery for stale pending message evidence (tracked in PF-374/PF-375); RequestContext excluded from admission hash pending PF-348.

No public API signatures were removed; a new error class and storage method were added and a message options field was introduced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/86)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->