### PR TITLE
[PF-440] Prepare PapersFlow Mastra artifacts after PF-352

### DIFF
--- a/client-sdks/ai-sdk/package.json
+++ b/client-sdks/ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/ai-sdk",
-  "version": "1.4.2",
+  "version": "1.4.2-papersflow.sha.4177781.0",
   "description": "Adds custom API routes to be compatible with the AI SDK UI parts",
   "type": "module",
   "main": "dist/index.js",

--- a/observability/mastra/package.json
+++ b/observability/mastra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/observability",
-  "version": "1.12.0",
+  "version": "1.12.0-papersflow.sha.4177781.0",
   "description": "Core observability package for Mastra - includes tracing and scoring features",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/agent-builder/package.json
+++ b/packages/agent-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/agent-builder",
-  "version": "1.0.35-alpha.0",
+  "version": "1.0.35-papersflow.sha.4177781.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/core",
-  "version": "1.34.0-alpha.2",
+  "version": "1.34.0-papersflow.sha.4177781.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "dist/index.js",
@@ -249,6 +249,16 @@
       "require": {
         "types": "./dist/harness/index.d.ts",
         "default": "./dist/harness/index.cjs"
+      }
+    },
+    "./harness/v1": {
+      "import": {
+        "types": "./dist/harness/v1/index.d.ts",
+        "default": "./dist/harness/v1/index.js"
+      },
+      "require": {
+        "types": "./dist/harness/v1/index.d.ts",
+        "default": "./dist/harness/v1/index.cjs"
       }
     },
     "./hooks": {

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/memory",
-  "version": "1.18.1-alpha.0",
+  "version": "1.18.1-papersflow.sha.4177781.0",
   "description": "",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/schema-compat/package.json
+++ b/packages/schema-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/schema-compat",
-  "version": "1.2.10",
+  "version": "1.2.10-papersflow.sha.4177781.0",
   "description": "Tool schema compatibility layer for Mastra.ai",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/server",
-  "version": "1.34.0-alpha.2",
+  "version": "1.34.0-papersflow.sha.4177781.0",
   "description": "",
   "type": "module",
   "files": [

--- a/server-adapters/fastify/package.json
+++ b/server-adapters/fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/fastify",
-  "version": "1.3.21-alpha.2",
+  "version": "1.3.21-papersflow.sha.4177781.0",
   "description": "Mastra Fastify adapter for the server",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Prepare the PapersFlow Mastra artifact source after PF-352 merged.

Changes:
- add PapersFlow-visible package versions with suffix `papersflow.sha.4177781.0`
- export `@mastra/core/harness/v1` from `@mastra/core/package.json`
- keep runtime source behavior from PF-352 merge commit `41777812ee16eb1534f3501672be1da0c3dc2410`
- artifact-prep commit: `e628848b01c82b410c88efa86bbddec8ade55abc`

## Local validation

From `/tmp/mastra-fork-pf-440-artifacts-4177781`:
- `pnpm install`
- `pnpm build:core`
- `pnpm --filter @mastra/core test -- --run src/harness/v1/session.message.test.ts src/harness/v1/session.queue.test.ts src/storage/domains/harness/inmemory.test.ts`
- `pnpm --filter @mastra/memory run build:lib`
- `pnpm --filter @mastra/ai-sdk run build:lib`
- `pnpm --filter @mastra/observability run build`
- `pnpm --filter @mastra/agent-builder run build`
- `pnpm --filter @mastra/server run build:lib`
- `pnpm --filter @mastra/fastify run build`
- `pnpm --filter @mastra/schema-compat pack --pack-destination /tmp/pf-440-mastra-artifacts-4177781`
- `pnpm --filter @mastra/core pack --pack-destination /tmp/pf-440-mastra-artifacts-4177781`
- `pnpm --filter @mastra/memory pack --pack-destination /tmp/pf-440-mastra-artifacts-4177781`
- `pnpm --filter @mastra/ai-sdk pack --pack-destination /tmp/pf-440-mastra-artifacts-4177781`
- `pnpm --filter @mastra/observability pack --pack-destination /tmp/pf-440-mastra-artifacts-4177781`
- `pnpm --filter @mastra/agent-builder pack --pack-destination /tmp/pf-440-mastra-artifacts-4177781`
- `pnpm --filter @mastra/server pack --pack-destination /tmp/pf-440-mastra-artifacts-4177781`
- `pnpm --filter @mastra/fastify pack --pack-destination /tmp/pf-440-mastra-artifacts-4177781`
- smoke install in `/tmp/pf-440-mastra-smoke-4177781` with `file:` deps plus `pnpm.overrides` for all eight tarballs
- Node import smoke: `@mastra/core/harness/v1`, `@mastra/core/storage`, `@mastra/core`, `@mastra/ai-sdk`, `@mastra/fastify`, `@mastra/observability`
- verified storage exports include `TABLE_HARNESS_MESSAGE_RESULTS` and `TABLE_HARNESS_OPERATION_TOMBSTONES`
- `git diff --check`

Smoke install completed with zod peer dependency warnings from AI SDK packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR updates the version numbers for 8 Mastra packages to include a special "PapersFlow" label (with a unique identifier), making them ready to be used by the PapersFlow project. It's like putting special stickers on packages to say "this version is customized for PapersFlow." One package also gets a new way to import a new feature.

## Changes

**Package Version Updates (PapersFlow-suffixed)**

Seven packages had their versions updated to include the `-papersflow.sha.4177781.0` suffix:

- `client-sdks/ai-sdk/package.json`: `1.4.2` → `1.4.2-papersflow.sha.4177781.0`
- `observability/mastra/package.json`: `1.12.0` → `1.12.0-papersflow.sha.4177781.0`
- `packages/agent-builder/package.json`: `1.0.35-alpha.0` → `1.0.35-papersflow.sha.4177781.0`
- `packages/core/package.json`: `1.34.0-alpha.2` → `1.34.0-papersflow.sha.4177781.0`
- `packages/memory/package.json`: `1.18.1-alpha.0` → `1.18.1-papersflow.sha.4177781.0`
- `packages/schema-compat/package.json`: `1.2.10` → `1.2.10-papersflow.sha.4177781.0`
- `packages/server/package.json`: `1.34.0-alpha.2` → `1.34.0-papersflow.sha.4177781.0`
- `server-adapters/fastify/package.json`: `1.3.21-alpha.2` → `1.3.21-papersflow.sha.4177781.0`

**New Export Path**

`packages/core/package.json` added a new export subpath `./harness/v1` that maps to the built harness module:
- `import`: `./dist/harness/v1/index.js` (with types at `./dist/harness/v1/index.d.ts`)
- `require`: `./dist/harness/v1/index.cjs` (with types at `./dist/harness/v1/index.d.ts`)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/87)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->