### PR TITLE
[PF-354] Add queue admission idempotency

### DIFF
--- a/.changeset/pf-354-queue-admission-idempotency.md
+++ b/.changeset/pf-354-queue-admission-idempotency.md
@@ -1,0 +1,11 @@
+---
+'@mastra/core': patch
+'@mastra/libsql': patch
+---
+
+Added retry-safe Harness v1 queue admission through `session.queue({ admissionId })`.
+
+```ts
+await session.queue({ content: 'Process this later', admissionId: 'queue-123' });
+await session.queue({ content: 'Process this later', admissionId: 'queue-123' }); // duplicate retry
+```

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -579,6 +579,24 @@ Send a message to the current agent. Creates a thread if none exists, builds a `
 await harness.sendMessage({ content: 'Explain the authentication flow' })
 ```
 
+#### `session.queue({ content, admissionId?, attachments?, mode?, model?, yolo? })`
+
+Queue a Harness v1 session turn so it runs after the current turn reaches an idle boundary. Use `admissionId` when a caller may retry the same queue request after a network, process, or storage interruption.
+
+```typescript
+const session = await harness.session({
+  resourceId: 'project-xyz',
+  threadId: { fresh: true },
+})
+
+const result = await session.queue({
+  content: 'Summarize the latest findings',
+  admissionId: 'queue-123',
+})
+```
+
+When a later `session.queue()` call uses the same `admissionId` and the same queue payload, the session returns the retained result, joins the live in-process queued turn, or waits briefly for durable terminal evidence from the original queued turn. If the payload differs, the call fails with an admission conflict.
+
 #### `listMessages(options?)`
 
 Retrieve messages for the current thread.

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -953,11 +953,16 @@ export class Harness {
       { sessionId: record.id },
     );
 
-    // If the hydrated record has queued items waiting and no live
-    // suspension blocking them, kick the drain. Items recovered this way
-    // emit `queue_item_replayed` instead of `queue_item_started` because
-    // the original `queue()` caller's resolver is gone.
-    if ((record.pendingQueue?.length ?? 0) > 0 && record.pendingResume === undefined) {
+    // If the hydrated record has queued items waiting and no live suspension
+    // blocking them, kick the drain. A `pendingResume` with `resumedAt` is
+    // also kicked so stale queued-resume recovery can clear/fail it instead
+    // of leaving the queue permanently busy. Items recovered this way emit
+    // `queue_item_replayed` instead of `queue_item_started` because the
+    // original `queue()` caller's resolver is gone.
+    if (
+      (record.pendingQueue?.length ?? 0) > 0 &&
+      (record.pendingResume === undefined || record.pendingResume.resumedAt !== undefined)
+    ) {
       void session._kickQueueDrain();
     }
 

--- a/packages/core/src/harness/v1/session.queue.test.ts
+++ b/packages/core/src/harness/v1/session.queue.test.ts
@@ -417,6 +417,45 @@ describe('Session.queue() — suspension', () => {
     expect(session.getRecord().pendingResume).toBeUndefined();
   });
 
+  it('keeps queued context while queued resume post-run side effects finish', async () => {
+    const { harness, agent } = setupHarness();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'r1',
+      suspendPayload: { toolCallId: 'tc-1', toolName: 'shell', args: { cmd: 'approve' } },
+    });
+    agent.enqueueRun({ finishReason: 'stop', runId: 'r1', text: 'resumed done' });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const runGoalJudge = (session as any)._runGoalJudge.bind(session);
+    let releaseGoalJudge!: () => void;
+    const goalJudgeGate = new Promise<void>(resolve => {
+      releaseGoalJudge = resolve;
+    });
+    let goalJudgeStarted = false;
+    (session as any)._runGoalJudge = async (...args: unknown[]) => {
+      goalJudgeStarted = true;
+      await goalJudgeGate;
+      return runGoalJudge(...args);
+    };
+
+    const first = session.queue({ content: 'first' });
+    await new Promise(resolve => setImmediate(resolve));
+    const queuedItemId = session.getRecord().pendingQueue[0]!.id;
+    const resumed = session.respondToToolApproval({ approved: true });
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(goalJudgeStarted).toBe(true);
+    expect(session.getDisplayState().currentQueuedItemId).toBe(queuedItemId);
+
+    releaseGoalJudge();
+    const [resumeResult, firstResult] = await Promise.all([resumed, first]);
+
+    expect(resumeResult.text).toBe('resumed done');
+    expect(firstResult.text).toBe('resumed done');
+    expect(session.getDisplayState().currentQueuedItemId).toBeUndefined();
+    await session.close();
+  });
+
   it('resumes a suspended queued mode override through the queued mode agent', async () => {
     const agentA = new MockAgent({ id: 'agentA' });
     const agentB = new MockAgent({ id: 'agentB' });
@@ -670,11 +709,17 @@ describe('Session.queue() — suspension', () => {
       modes: [{ id: 'default', agentId: 'default' }],
       defaultModeId: 'default',
     });
+    const events: HarnessEvent[] = [];
+    replayHarness.subscribe(e => events.push(e));
 
     const replaySession = await replayHarness.session({ sessionId });
     await replaySession.waitForIdle({ timeoutMs: 1000 });
 
     expect(replayAgent.streamCalls).toHaveLength(0);
+    expect(replayAgent.resumeCalls).toHaveLength(0);
+    expect(events.find(e => e.type === 'queue_item_started')).toBeUndefined();
+    expect(events.find(e => e.type === 'queue_item_replayed')).toMatchObject({ queuedItemId });
+    expect(events.find(e => e.type === 'agent_end')).toMatchObject({ queuedItemId });
     expect(replaySession.getRecord().pendingResume).toBeUndefined();
     expect(replaySession.getRecord().pendingQueue).toEqual([]);
     expect(replaySession.getRecord().queueAdmissionReceipts?.[queuedItemId]).toMatchObject({
@@ -818,11 +863,18 @@ describe('Session.queue() — suspension', () => {
       modes: [{ id: 'default', agentId: 'default' }],
       defaultModeId: 'default',
     });
+    const events: HarnessEvent[] = [];
+    replayHarness.subscribe(e => events.push(e));
     const replaySession = await replayHarness.session({ sessionId });
 
     const result = await replaySession.respondToToolApproval({ approved: true });
 
     expect(result.text).toBe('resumed done');
+    expect(events.find(e => e.type === 'suspension_resolved')).toMatchObject({ queuedItemId });
+    expect(events.find(e => e.type === 'agent_end')).toMatchObject({ queuedItemId });
+    expect(events.findIndex(e => e.type === 'agent_end')).toBeGreaterThan(
+      events.findIndex(e => e.type === 'suspension_resolved'),
+    );
     expect(replaySession.getRecord().pendingResume).toBeUndefined();
     expect(replaySession.getRecord().pendingQueue).toEqual([]);
     expect(replaySession.getRecord().queueAdmissionReceipts?.[queuedItemId]).toMatchObject({
@@ -904,10 +956,14 @@ describe('Session.queue() — suspension', () => {
       modes: [{ id: 'default', agentId: 'default' }],
       defaultModeId: 'default',
     });
+    const events: HarnessEvent[] = [];
+    replayHarness.subscribe(e => events.push(e));
     const replaySession = await replayHarness.session({ sessionId });
     await replaySession.waitForIdle({ timeoutMs: 1000 });
 
     expect(replayAgent.resumeCalls).toHaveLength(0);
+    expect(events.find(e => e.type === 'queue_item_started')).toBeUndefined();
+    expect(events.find(e => e.type === 'queue_item_replayed')).toMatchObject({ queuedItemId });
     expect(replaySession.getRecord().pendingResume).toBeUndefined();
     expect(replaySession.getRecord().pendingQueue).toEqual([]);
     expect(replaySession.getRecord().queueAdmissionReceipts?.[queuedItemId]).toMatchObject({

--- a/packages/core/src/harness/v1/session.queue.test.ts
+++ b/packages/core/src/harness/v1/session.queue.test.ts
@@ -6,7 +6,8 @@
  *     content validation, unknown-mode rejection
  *   - durable FIFO: items run head-of-line, persisted to `pendingQueue`,
  *     removed only after the turn completes
- *   - per-turn overrides: `mode` and `model` flow through to the stream call
+ *   - per-turn overrides: `mode` flows through to the stream call and `model`
+ *     persists on the queued item
  *   - events: `queue_item_started` on live drain, `queue_item_replayed` on
  *     hydration recovery, `agent_*` events carry `queuedItemId`
  *   - suspension mid-turn: drain parks on suspend, item stays in queue,
@@ -21,9 +22,10 @@ import { describe, expect, it } from 'vitest';
 
 import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
 import { InMemoryDB } from '../../storage/domains/inmemory-db';
+import { InMemoryStore } from '../../storage/mock';
 
 import { extractSignalContents, MockAgent, setupHarness } from './__test-utils__';
-import { HarnessQueueFullError, HarnessValidationError } from './errors';
+import { HarnessAdmissionConflictError, HarnessQueueFullError, HarnessValidationError } from './errors';
 import type { HarnessEvent } from './events';
 import { Harness } from './harness';
 
@@ -45,6 +47,7 @@ describe('Session.queue() — admission', () => {
     // The agent saw a single stream call carrying the queued content.
     expect(agent.streamCalls).toHaveLength(1);
     expect(extractSignalContents(agent.streamCalls[0]!.messages)).toBe('do work');
+    await session.close();
   });
 
   it('rejects when content is empty', async () => {
@@ -52,6 +55,7 @@ describe('Session.queue() — admission', () => {
     const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
 
     await expect(session.queue({ content: '' })).rejects.toBeInstanceOf(HarnessValidationError);
+    await session.close();
   });
 
   it('rejects an unknown mode override at admission', async () => {
@@ -59,6 +63,7 @@ describe('Session.queue() — admission', () => {
     const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
 
     await expect(session.queue({ content: 'hi', mode: 'nope' })).rejects.toThrow(/unknown mode/);
+    await session.close();
   });
 
   it('throws HarnessQueueFullError once pendingQueue reaches sessions.maxQueueDepth', async () => {
@@ -80,11 +85,179 @@ describe('Session.queue() — admission', () => {
       runId: 'r1',
       suspendPayload: { toolCallId: 'tc-1', toolName: 'shell', args: { cmd: 'ls' } },
     });
-    void session.queue({ content: 'first' });
+    const first = session.queue({ content: 'first' });
     // Yield so the drain has a chance to start the first item.
     await new Promise(resolve => setImmediate(resolve));
 
     await expect(session.queue({ content: 'second' })).rejects.toBeInstanceOf(HarnessQueueFullError);
+    agent.enqueueRun({ finishReason: 'stop', runId: 'r1', text: 'done' });
+    await session.respondToToolApproval({ approved: true });
+    await first;
+    await session.close();
+  });
+
+  it('dedupes exact admissionId retries without appending another item', async () => {
+    const { harness, agent } = setupHarness();
+    let release!: () => void;
+    const holdUntil = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    agent.enqueueRun({ finishReason: 'stop', text: 'queued reply', holdUntil });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const first = session.queue({ content: 'do work', admissionId: 'queue-1' });
+    await new Promise(resolve => setImmediate(resolve));
+    const second = session.queue({ content: 'do work', admissionId: 'queue-1' });
+
+    expect(session.getRecord().pendingQueue).toHaveLength(1);
+    release();
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult.text).toBe('queued reply');
+    expect(secondResult.text).toBe('queued reply');
+    expect(agent.streamCalls).toHaveLength(1);
+    const receipt = Object.values(session.getRecord().queueAdmissionReceipts ?? {})[0];
+    expect(receipt).toMatchObject({
+      admissionId: 'queue-1',
+      modeId: 'default',
+      status: 'completed',
+      postRunFinalizedAt: expect.any(Number),
+      result: expect.objectContaining({ text: 'queued reply' }),
+      signalId: expect.any(String),
+      runId: expect.any(String),
+    });
+    await session.close();
+  });
+
+  it('keeps a completed admission receipt if completed signal evidence cannot be written', async () => {
+    const { harness, agent, storage } = setupHarness();
+    const writeMessageResultEvidence = storage.writeMessageResultEvidence.bind(storage);
+    let completedEvidenceAttempts = 0;
+    storage.writeMessageResultEvidence = async record => {
+      if (record.status === 'completed') {
+        completedEvidenceAttempts++;
+        throw new Error('completed signal evidence unavailable');
+      }
+      return writeMessageResultEvidence(record);
+    };
+    agent.enqueueRun({ finishReason: 'stop', text: 'queued reply' });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const result = await session.queue({ content: 'do work', admissionId: 'queue-evidence-failure' });
+
+    expect(result.text).toBe('queued reply');
+    expect(completedEvidenceAttempts).toBe(1);
+    expect(session.getRecord().pendingQueue).toEqual([]);
+    const receipt = Object.values(session.getRecord().queueAdmissionReceipts ?? {})[0];
+    expect(receipt).toMatchObject({
+      admissionId: 'queue-evidence-failure',
+      status: 'completed',
+      postRunFinalizedAt: expect.any(Number),
+      result: expect.objectContaining({ text: 'queued reply' }),
+    });
+    expect(receipt?.error).toBeUndefined();
+    await session.close();
+  });
+
+  it('retries post-run finalization without removing a completed queued item', async () => {
+    const { harness, agent } = setupHarness();
+    agent.enqueueRun({ finishReason: 'stop', text: 'queued reply' });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const markQueuedPostRunFinalized = (session as any)._markQueuedPostRunFinalized.bind(session);
+    const runGoalJudge = (session as any)._runGoalJudge.bind(session);
+    let markerAttempts = 0;
+    let goalJudgeAttempts = 0;
+    (session as any)._markQueuedPostRunFinalized = async (...args: unknown[]) => {
+      markerAttempts++;
+      if (markerAttempts === 1) {
+        throw new Error('post-run finalization marker unavailable');
+      }
+      return markQueuedPostRunFinalized(...args);
+    };
+    (session as any)._runGoalJudge = async (...args: unknown[]) => {
+      goalJudgeAttempts++;
+      return runGoalJudge(...args);
+    };
+
+    const queued = session.queue({ content: 'do work', admissionId: 'queue-finalization-retry' });
+    await new Promise(resolve => setImmediate(resolve));
+    expect(session.getRecord().pendingQueue).toHaveLength(1);
+    const pendingReceipt = Object.values(session.getRecord().queueAdmissionReceipts ?? {})[0];
+    expect(pendingReceipt).toMatchObject({
+      status: 'completed',
+    });
+    expect(pendingReceipt?.postRunFinalizedAt).toBeUndefined();
+
+    const duplicate = session.queue({ content: 'do work', admissionId: 'queue-finalization-retry' });
+    await (session as any)._kickQueueDrain();
+    const [result, duplicateResult] = await Promise.all([queued, duplicate]);
+
+    expect(result.text).toBe('queued reply');
+    expect(duplicateResult.text).toBe('queued reply');
+    expect(markerAttempts).toBe(2);
+    expect(goalJudgeAttempts).toBe(1);
+    expect(session.getRecord().pendingQueue).toEqual([]);
+    const receipt = Object.values(session.getRecord().queueAdmissionReceipts ?? {})[0];
+    expect(receipt).toMatchObject({
+      admissionId: 'queue-finalization-retry',
+      status: 'completed',
+      postRunFinalizedAt: expect.any(Number),
+      result: expect.objectContaining({ text: 'queued reply' }),
+    });
+    await session.close();
+  });
+
+  it('conflicts on same admissionId with different queue payload', async () => {
+    const { harness, agent } = setupHarness();
+    agent.enqueueRun({ finishReason: 'stop', text: 'first reply' });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await session.queue({ content: 'first', admissionId: 'queue-conflict' });
+
+    await expect(session.queue({ content: 'second', admissionId: 'queue-conflict' })).rejects.toBeInstanceOf(
+      HarnessAdmissionConflictError,
+    );
+    expect(agent.streamCalls).toHaveLength(1);
+    await session.close();
+  });
+
+  it('replays a completed admissionId result from retained queue receipt', async () => {
+    const { harness, agent } = setupHarness();
+    agent.enqueueRun({ finishReason: 'stop', text: 'first reply' });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const first = await session.queue({ content: 'first', admissionId: 'queue-completed' });
+    const duplicate = await session.queue({ content: 'first', admissionId: 'queue-completed' });
+
+    expect(first.text).toBe('first reply');
+    expect(duplicate.text).toBe('first reply');
+    expect(agent.streamCalls).toHaveLength(1);
+    await session.close();
+  });
+
+  it('does not treat a later default mode switch as a conflicting duplicate admission', async () => {
+    const defaultAgent = new MockAgent({ id: 'default' });
+    const otherAgent = new MockAgent({ id: 'other' });
+    const { harness } = setupHarness({
+      agents: { default: defaultAgent, other: otherAgent },
+      modes: [
+        { id: 'default', agentId: 'default' },
+        { id: 'other', agentId: 'other' },
+      ],
+      defaultModeId: 'default',
+    });
+    defaultAgent.enqueueRun({ finishReason: 'stop', text: 'first reply' });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const first = await session.queue({ content: 'same', admissionId: 'queue-default-mode' });
+    await session.switchMode({ mode: 'other' });
+    const duplicate = await session.queue({ content: 'same', admissionId: 'queue-default-mode' });
+
+    expect(first.text).toBe('first reply');
+    expect(duplicate.text).toBe('first reply');
+    expect(defaultAgent.streamCalls).toHaveLength(1);
+    expect(otherAgent.streamCalls).toHaveLength(0);
+    await session.close();
   });
 });
 
@@ -146,13 +319,15 @@ describe('Session.queue() — FIFO + per-turn overrides', () => {
     });
     const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
 
-    void session.queue({ content: 'go', model: 'override-model' });
+    const queued = session.queue({ content: 'go', model: 'override-model' });
+    void queued.catch(() => {});
     await new Promise(resolve => setImmediate(resolve));
 
     const head = session.getRecord().pendingQueue?.[0];
     expect(head).toBeDefined();
     expect(head!.content).toBe('go');
     expect(head!.model).toBe('override-model');
+    await session.close();
   });
 });
 
@@ -196,7 +371,7 @@ describe('Session.queue() — events', () => {
 
 describe('Session.queue() — suspension', () => {
   it('parks the drain on suspend, leaves the item at the head, and resumes after respondTo*', async () => {
-    const { harness, agent } = setupHarness();
+    const { harness, agent, storage } = setupHarness();
     agent.enqueueRun({
       finishReason: 'suspended',
       runId: 'r1',
@@ -210,6 +385,26 @@ describe('Session.queue() — suspension', () => {
     // Mid-flight: item still in the queue, suspension captured.
     expect(session.getRecord().pendingQueue?.length).toBe(1);
     expect(session.getRecord().pendingResume?.kind).toBe('tool-approval');
+    const receipt = Object.values(session.getRecord().queueAdmissionReceipts ?? {})[0];
+    expect(receipt?.signalId).toBeDefined();
+    let signalEvidence = await storage.loadMessageResultEvidence({
+      harnessName: 'default',
+      sessionId: session.id,
+      resourceId: 'u',
+      threadId: session.threadId,
+      signalId: receipt!.signalId!,
+    });
+    for (let attempt = 0; !signalEvidence && attempt < 10; attempt++) {
+      await new Promise(resolve => setImmediate(resolve));
+      signalEvidence = await storage.loadMessageResultEvidence({
+        harnessName: 'default',
+        sessionId: session.id,
+        resourceId: 'u',
+        threadId: session.threadId,
+        signalId: receipt!.signalId!,
+      });
+    }
+    expect(signalEvidence).toMatchObject({ status: 'pending' });
 
     // Stage the resumed run, then approve.
     agent.enqueueRun({ finishReason: 'stop', runId: 'r1', text: 'done' });
@@ -220,6 +415,505 @@ describe('Session.queue() — suspension', () => {
     expect(result.finishReason).toBe('stop');
     expect(session.getRecord().pendingQueue).toEqual([]);
     expect(session.getRecord().pendingResume).toBeUndefined();
+  });
+
+  it('resumes a suspended queued mode override through the queued mode agent', async () => {
+    const agentA = new MockAgent({ id: 'agentA' });
+    const agentB = new MockAgent({ id: 'agentB' });
+    agentB.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'mode-b-run',
+      suspendPayload: { toolCallId: 'tc-mode-b', toolName: 'shell', args: { cmd: 'ls' } },
+    });
+    const { harness } = setupHarness({
+      agents: { agentA, agentB },
+      modes: [
+        { id: 'modeA', agentId: 'agentA' },
+        { id: 'modeB', agentId: 'agentB' },
+      ],
+      defaultModeId: 'modeA',
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const queued = session.queue({ content: 'use mode b', mode: 'modeB', admissionId: 'queue-mode-b-suspend' });
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(session.getRecord().pendingResume).toMatchObject({
+      queuedItemId: expect.any(String),
+      modeId: 'modeB',
+    });
+    expect(agentB.streamCalls).toHaveLength(1);
+    expect(agentA.streamCalls).toHaveLength(0);
+
+    agentB.enqueueRun({ finishReason: 'stop', runId: 'mode-b-run', text: 'done from mode b' });
+    await session.respondToToolApproval({ approved: true });
+    const result = await queued;
+
+    expect(result.text).toBe('done from mode b');
+    expect(agentB.resumeCalls).toHaveLength(1);
+    expect(agentA.resumeCalls).toHaveLength(0);
+    expect(session.getRecord().pendingResume).toBeUndefined();
+    await session.close();
+  });
+
+  it('resumes a hydrated queued mode override from receipt mode when pendingResume has no mode', async () => {
+    const storage = new InMemoryStore();
+    const harnessStore = await storage.getStore('harness');
+    if (!harnessStore) throw new Error('expected harness storage');
+    const sessionId = 'sess-hydrated-queued-resume-mode-fallback';
+    const queuedItemId = 'q-hydrated-queued-resume-mode-fallback';
+    const now = Date.now();
+    await harnessStore.saveSession(
+      {
+        harnessName: 'default',
+        id: sessionId,
+        resourceId: 'u',
+        threadId: 't-hydrated-queued-resume-mode-fallback',
+        origin: 'top-level',
+        ownsThread: false,
+        modeId: 'modeA',
+        modelId: 'default',
+        subagentModelOverrides: {},
+        permissionRules: { categories: {}, tools: {} },
+        sessionGrants: { categories: [], tools: [] },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        pendingQueue: [
+          {
+            id: queuedItemId,
+            admissionId: 'queue-hydrated-resume-mode-fallback',
+            admissionHash: 'hash-hydrated-resume-mode-fallback',
+            enqueuedAt: now,
+            content: 'resume mode b',
+            attachments: [],
+            mode: 'modeB',
+          },
+        ],
+        pendingResume: {
+          kind: 'tool-approval',
+          itemId: 'tool-approval:tc-mode-b',
+          runId: 'mode-b-run',
+          toolCallId: 'tc-mode-b',
+          toolName: 'shell',
+          source: 'parent',
+          requestedAt: now,
+          queuedItemId,
+          payload: { input: { cmd: 'echo ok' } },
+        },
+        queueAdmissionReceipts: {
+          [queuedItemId]: {
+            admissionId: 'queue-hydrated-resume-mode-fallback',
+            admissionHash: 'hash-hydrated-resume-mode-fallback',
+            queuedItemId,
+            modeId: 'modeB',
+            status: 'accepted',
+            runId: 'mode-b-run',
+            signalId: 'signal-mode-b',
+            attempts: 1,
+            enqueuedAt: now,
+            acceptedAt: now,
+            updatedAt: now,
+          },
+        },
+        state: undefined,
+        createdAt: now,
+        lastActivityAt: now,
+        version: 0,
+      },
+      { harnessName: 'default', ifVersion: 0 },
+    );
+
+    const agentA = new MockAgent({ id: 'agentA' });
+    const agentB = new MockAgent({ id: 'agentB' });
+    agentB.enqueueRun({ finishReason: 'stop', runId: 'mode-b-run', text: 'resumed on mode b' });
+    const replayHarness = new Harness({
+      agents: { agentA, agentB } as any,
+      storage,
+      modes: [
+        { id: 'modeA', agentId: 'agentA' },
+        { id: 'modeB', agentId: 'agentB' },
+      ],
+      defaultModeId: 'modeA',
+    });
+    const replaySession = await replayHarness.session({ sessionId });
+
+    const result = await replaySession.respondToToolApproval({ approved: true });
+
+    expect(result.text).toBe('resumed on mode b');
+    expect(agentB.resumeCalls).toHaveLength(1);
+    expect(agentA.resumeCalls).toHaveLength(0);
+    expect(replaySession.getRecord().pendingResume).toBeUndefined();
+    expect(replaySession.getRecord().queueAdmissionReceipts?.[queuedItemId]).toMatchObject({
+      status: 'completed',
+      modeId: 'modeB',
+    });
+  });
+
+  it('does not fail a queued resume as stale while the local resume call is still running', async () => {
+    const { harness, agent } = setupHarness();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'r1',
+      suspendPayload: { toolCallId: 'tc-1', toolName: 'shell', args: { cmd: 'ls' } },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const queued = session.queue({ content: 'sensitive', admissionId: 'queue-long-resume' });
+    await new Promise(resolve => setImmediate(resolve));
+
+    let release!: () => void;
+    const holdUntil = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    agent.enqueueRun({ finishReason: 'stop', runId: 'r1', text: 'done', holdUntil });
+    const approving = session.respondToToolApproval({ approved: true });
+    await new Promise(resolve => setImmediate(resolve));
+
+    await (session as any)._flushUpdate((prev: any) => ({
+      ...prev,
+      pendingResume: {
+        ...prev.pendingResume,
+        resumedAt: Date.now() - 60_000,
+      },
+    }));
+
+    await expect(session.respondToToolApproval({ approved: true })).rejects.toBeInstanceOf(HarnessValidationError);
+    const inFlightReceipt = Object.values(session.getRecord().queueAdmissionReceipts ?? {})[0];
+    expect(inFlightReceipt).not.toMatchObject({
+      status: 'failed',
+    });
+
+    release();
+    await approving;
+    const result = await queued;
+    expect(result.text).toBe('done');
+    expect(session.getRecord().pendingQueue).toEqual([]);
+    const receipt = Object.values(session.getRecord().queueAdmissionReceipts ?? {})[0];
+    expect(receipt).toMatchObject({
+      status: 'completed',
+    });
+    await session.close();
+  });
+
+  it('cleans up a completed queued resume receipt on hydration before the stale timeout', async () => {
+    const storage = new InMemoryStore();
+    const harnessStore = await storage.getStore('harness');
+    if (!harnessStore) throw new Error('expected harness storage');
+    const sessionId = 'sess-completed-resume-before-timeout';
+    const queuedItemId = 'q-completed-resume-before-timeout';
+    const now = Date.now();
+    await harnessStore.saveSession(
+      {
+        harnessName: 'default',
+        id: sessionId,
+        resourceId: 'u',
+        threadId: 't-completed-resume-before-timeout',
+        origin: 'top-level',
+        ownsThread: false,
+        modeId: 'default',
+        modelId: 'default',
+        subagentModelOverrides: {},
+        permissionRules: { categories: {}, tools: {} },
+        sessionGrants: { categories: [], tools: [] },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        pendingQueue: [
+          {
+            id: queuedItemId,
+            admissionId: 'queue-completed-resume-before-timeout',
+            admissionHash: 'hash-completed-resume-before-timeout',
+            enqueuedAt: now,
+            content: 'already resumed',
+            attachments: [],
+            mode: 'default',
+          },
+        ],
+        pendingResume: {
+          kind: 'tool-approval',
+          itemId: 'tc-completed',
+          runId: 'completed-resume-run',
+          toolCallId: 'tc-completed',
+          toolName: 'shell',
+          source: 'parent',
+          requestedAt: now,
+          queuedItemId,
+          modeId: 'default',
+          resumedAt: now,
+          payload: { toolName: 'shell', args: { cmd: 'ls' } },
+        },
+        queueAdmissionReceipts: {
+          [queuedItemId]: {
+            admissionId: 'queue-completed-resume-before-timeout',
+            admissionHash: 'hash-completed-resume-before-timeout',
+            queuedItemId,
+            modeId: 'default',
+            status: 'completed',
+            runId: 'completed-resume-run',
+            signalId: 'completed-resume-signal',
+            attempts: 1,
+            enqueuedAt: now,
+            acceptedAt: now,
+            completedAt: now,
+            updatedAt: now,
+            result: { text: 'already done', finishReason: 'stop', runId: 'completed-resume-run' },
+          },
+        },
+        state: undefined,
+        createdAt: now,
+        lastActivityAt: now,
+        version: 0,
+      },
+      { harnessName: 'default', ifVersion: 0 },
+    );
+
+    const replayAgent = new MockAgent({ id: 'default' });
+    replayAgent.enqueueRun({ finishReason: 'stop', text: 'must not run' });
+    const replayHarness = new Harness({
+      agents: { default: replayAgent } as any,
+      storage,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+
+    const replaySession = await replayHarness.session({ sessionId });
+    await replaySession.waitForIdle({ timeoutMs: 1000 });
+
+    expect(replayAgent.streamCalls).toHaveLength(0);
+    expect(replaySession.getRecord().pendingResume).toBeUndefined();
+    expect(replaySession.getRecord().pendingQueue).toEqual([]);
+    expect(replaySession.getRecord().queueAdmissionReceipts?.[queuedItemId]).toMatchObject({
+      status: 'completed',
+      postRunFinalizedAt: expect.any(Number),
+      result: expect.objectContaining({ text: 'already done' }),
+    });
+  });
+
+  it('returns a completed queued resume result on direct duplicate respond retry', async () => {
+    const { harness, agent } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const queuedItemId = 'q-completed-resume-direct-retry';
+    const now = Date.now();
+    await (session as any)._flushUpdate((prev: any) => ({
+      ...prev,
+      pendingQueue: [
+        {
+          id: queuedItemId,
+          admissionId: 'queue-completed-resume-direct-retry',
+          admissionHash: 'hash-completed-resume-direct-retry',
+          enqueuedAt: now,
+          content: 'already resumed',
+          attachments: [],
+          mode: 'default',
+        },
+      ],
+      pendingResume: {
+        kind: 'tool-approval',
+        itemId: 'tc-completed-direct',
+        runId: 'completed-direct-run',
+        toolCallId: 'tc-completed-direct',
+        toolName: 'shell',
+        source: 'parent',
+        requestedAt: now,
+        queuedItemId,
+        modeId: 'default',
+        resumedAt: now,
+        payload: { input: { cmd: 'ls' } },
+      },
+      queueAdmissionReceipts: {
+        [queuedItemId]: {
+          admissionId: 'queue-completed-resume-direct-retry',
+          admissionHash: 'hash-completed-resume-direct-retry',
+          queuedItemId,
+          modeId: 'default',
+          status: 'completed',
+          runId: 'completed-direct-run',
+          signalId: 'completed-direct-signal',
+          attempts: 1,
+          enqueuedAt: now,
+          acceptedAt: now,
+          completedAt: now,
+          updatedAt: now,
+          result: { text: 'already done', finishReason: 'stop', runId: 'completed-direct-run' },
+        },
+      },
+    }));
+
+    const result = await session.respondToToolApproval({ approved: true });
+
+    expect(result.text).toBe('already done');
+    expect(agent.resumeCalls).toHaveLength(0);
+    expect(session.getRecord().pendingResume).toBeUndefined();
+    expect(session.getRecord().pendingQueue).toEqual([]);
+    expect(session.getRecord().queueAdmissionReceipts?.[queuedItemId]).toMatchObject({
+      status: 'completed',
+      postRunFinalizedAt: expect.any(Number),
+    });
+    await session.close();
+  });
+
+  it('completes a rehydrated suspended queued item when respondTo* resumes it', async () => {
+    const storage = new InMemoryStore();
+    const harnessStore = await storage.getStore('harness');
+    if (!harnessStore) throw new Error('expected harness storage');
+    const sessionId = 'sess-rehydrated-queued-suspend';
+    const queuedItemId = 'q-rehydrated-queued-suspend';
+    const now = Date.now();
+    await harnessStore.saveSession(
+      {
+        harnessName: 'default',
+        id: sessionId,
+        resourceId: 'u',
+        threadId: 't-rehydrated-queued-suspend',
+        origin: 'top-level',
+        ownsThread: false,
+        modeId: 'default',
+        modelId: 'default',
+        subagentModelOverrides: {},
+        permissionRules: { categories: {}, tools: {} },
+        sessionGrants: { categories: [], tools: [] },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        pendingQueue: [
+          {
+            id: queuedItemId,
+            admissionId: 'queue-rehydrated-suspend',
+            admissionHash: 'hash-rehydrated-suspend',
+            enqueuedAt: now,
+            content: 'resume me',
+            attachments: [],
+          },
+        ],
+        pendingResume: {
+          kind: 'tool-approval',
+          itemId: 'tool-approval:tc-1',
+          runId: 'r1',
+          toolCallId: 'tc-1',
+          toolName: 'shell',
+          source: 'parent',
+          requestedAt: now,
+          payload: { input: { cmd: 'echo ok' } },
+        },
+        queueAdmissionReceipts: {
+          [queuedItemId]: {
+            admissionId: 'queue-rehydrated-suspend',
+            admissionHash: 'hash-rehydrated-suspend',
+            queuedItemId,
+            status: 'accepted',
+            runId: 'r1',
+            signalId: 'signal-1',
+            attempts: 1,
+            enqueuedAt: now,
+            acceptedAt: now,
+            updatedAt: now,
+          },
+        },
+        state: undefined,
+        createdAt: now,
+        lastActivityAt: now,
+        version: 0,
+      },
+      { harnessName: 'default', ifVersion: 0 },
+    );
+
+    const replayAgent = new MockAgent({ id: 'default' });
+    replayAgent.enqueueRun({ finishReason: 'stop', runId: 'r1', text: 'resumed done' });
+    const replayHarness = new Harness({
+      agents: { default: replayAgent } as any,
+      storage,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+    const replaySession = await replayHarness.session({ sessionId });
+
+    const result = await replaySession.respondToToolApproval({ approved: true });
+
+    expect(result.text).toBe('resumed done');
+    expect(replaySession.getRecord().pendingResume).toBeUndefined();
+    expect(replaySession.getRecord().pendingQueue).toEqual([]);
+    expect(replaySession.getRecord().queueAdmissionReceipts?.[queuedItemId]).toMatchObject({
+      status: 'completed',
+      result: expect.objectContaining({ text: 'resumed done' }),
+    });
+  });
+
+  it('fails a stale rehydrated queued resume instead of stranding pendingResume', async () => {
+    const storage = new InMemoryStore();
+    const harnessStore = await storage.getStore('harness');
+    if (!harnessStore) throw new Error('expected harness storage');
+    const sessionId = 'sess-stale-queued-resume';
+    const queuedItemId = 'q-stale-queued-resume';
+    const now = Date.now();
+    const staleAt = now - 31_000;
+    await harnessStore.saveSession(
+      {
+        harnessName: 'default',
+        id: sessionId,
+        resourceId: 'u',
+        threadId: 't-stale-queued-resume',
+        origin: 'top-level',
+        ownsThread: false,
+        modeId: 'default',
+        modelId: 'default',
+        subagentModelOverrides: {},
+        permissionRules: { categories: {}, tools: {} },
+        sessionGrants: { categories: [], tools: [] },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        pendingQueue: [
+          {
+            id: queuedItemId,
+            admissionId: 'queue-stale-resume',
+            admissionHash: 'hash-stale-resume',
+            enqueuedAt: now,
+            content: 'resume was in flight',
+            attachments: [],
+          },
+        ],
+        pendingResume: {
+          kind: 'tool-approval',
+          itemId: 'tool-approval:tc-1',
+          runId: 'r1',
+          toolCallId: 'tc-1',
+          toolName: 'shell',
+          source: 'parent',
+          requestedAt: staleAt,
+          resumedAt: staleAt,
+          queuedItemId,
+          payload: { input: { cmd: 'echo ok' } },
+        },
+        queueAdmissionReceipts: {
+          [queuedItemId]: {
+            admissionId: 'queue-stale-resume',
+            admissionHash: 'hash-stale-resume',
+            queuedItemId,
+            status: 'accepted',
+            runId: 'r1',
+            signalId: 'signal-1',
+            attempts: 1,
+            enqueuedAt: now,
+            acceptedAt: now,
+            updatedAt: now,
+          },
+        },
+        state: undefined,
+        createdAt: now,
+        lastActivityAt: now,
+        version: 0,
+      },
+      { harnessName: 'default', ifVersion: 0 },
+    );
+
+    const replayAgent = new MockAgent({ id: 'default' });
+    const replayHarness = new Harness({
+      agents: { default: replayAgent } as any,
+      storage,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+    const replaySession = await replayHarness.session({ sessionId });
+    await replaySession.waitForIdle({ timeoutMs: 1000 });
+
+    expect(replayAgent.resumeCalls).toHaveLength(0);
+    expect(replaySession.getRecord().pendingResume).toBeUndefined();
+    expect(replaySession.getRecord().pendingQueue).toEqual([]);
+    expect(replaySession.getRecord().queueAdmissionReceipts?.[queuedItemId]).toMatchObject({
+      status: 'failed',
+      error: { code: 'harness.queue_resume_recovery_stale' },
+    });
   });
 });
 
@@ -316,5 +1010,528 @@ describe('Session.queue() — crash replay', () => {
     expect(started).toBeUndefined();
     // Item drained off the queue successfully.
     expect(replayAgent.streamCalls).toHaveLength(1);
+  });
+
+  it('replays an accepted receipt when no durable signal was persisted before hydration', async () => {
+    const storage = new InMemoryStore();
+    const harnessStore = await storage.getStore('harness');
+    if (!harnessStore) throw new Error('expected harness storage');
+    const sessionId = 'sess-accepted-replay';
+    const queuedItemId = 'q-accepted';
+    const now = Date.now();
+    await harnessStore.saveSession(
+      {
+        harnessName: 'default',
+        id: sessionId,
+        resourceId: 'u',
+        threadId: 't-accepted-replay',
+        origin: 'top-level',
+        ownsThread: false,
+        modeId: 'default',
+        modelId: 'default',
+        subagentModelOverrides: {},
+        permissionRules: { categories: {}, tools: {} },
+        sessionGrants: { categories: [], tools: [] },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        pendingQueue: [
+          {
+            id: queuedItemId,
+            admissionId: 'queue-accepted',
+            admissionHash: 'hash-accepted',
+            enqueuedAt: now,
+            content: 'recover accepted',
+            attachments: [],
+          },
+        ],
+        queueAdmissionReceipts: {
+          [queuedItemId]: {
+            admissionId: 'queue-accepted',
+            admissionHash: 'hash-accepted',
+            queuedItemId,
+            status: 'accepted',
+            runId: 'stale-run',
+            signalId: 'stale-signal',
+            attempts: 1,
+            enqueuedAt: now,
+            acceptedAt: now,
+            updatedAt: now,
+          },
+        },
+        state: undefined,
+        createdAt: now,
+        lastActivityAt: now,
+        version: 0,
+      },
+      { harnessName: 'default', ifVersion: 0 },
+    );
+
+    const replayAgent = new MockAgent({ id: 'default' });
+    replayAgent.enqueueRun({ finishReason: 'stop', text: 'accepted recovered' });
+    const replayHarness = new Harness({
+      agents: { default: replayAgent } as any,
+      storage,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+
+    const replaySession = await replayHarness.session({ sessionId });
+    await replaySession.waitForIdle({ timeoutMs: 1000 });
+
+    expect(replayAgent.streamCalls.map(c => extractSignalContents(c.messages))).toEqual(['recover accepted']);
+    expect(replaySession.getRecord().pendingQueue).toEqual([]);
+    const receipt = replaySession.getRecord().queueAdmissionReceipts?.[queuedItemId];
+    expect(receipt).toMatchObject({
+      status: 'completed',
+      result: expect.objectContaining({ text: 'accepted recovered' }),
+    });
+    expect(receipt?.runId).not.toBe('stale-run');
+  });
+
+  it('recovers an accepted receipt using its persisted mode after the session default mode changes', async () => {
+    const storage = new InMemoryStore();
+    const harnessStore = await storage.getStore('harness');
+    if (!harnessStore) throw new Error('expected harness storage');
+    const sessionId = 'sess-accepted-mode-drift';
+    const queuedItemId = 'q-accepted-mode-drift';
+    const now = Date.now();
+    await harnessStore.saveSession(
+      {
+        harnessName: 'default',
+        id: sessionId,
+        resourceId: 'u',
+        threadId: 't-accepted-mode-drift',
+        origin: 'top-level',
+        ownsThread: false,
+        modeId: 'other',
+        modelId: 'default',
+        subagentModelOverrides: {},
+        permissionRules: { categories: {}, tools: {} },
+        sessionGrants: { categories: [], tools: [] },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        pendingQueue: [
+          {
+            id: queuedItemId,
+            admissionId: 'queue-accepted-mode-drift',
+            admissionHash: 'hash-accepted-mode-drift',
+            enqueuedAt: now,
+            content: 'recover on original mode',
+            attachments: [],
+          },
+        ],
+        queueAdmissionReceipts: {
+          [queuedItemId]: {
+            admissionId: 'queue-accepted-mode-drift',
+            admissionHash: 'hash-accepted-mode-drift',
+            queuedItemId,
+            modeId: 'default',
+            status: 'accepted',
+            runId: 'stale-run',
+            signalId: 'stale-signal',
+            attempts: 1,
+            enqueuedAt: now,
+            acceptedAt: now,
+            updatedAt: now,
+          },
+        },
+        state: undefined,
+        createdAt: now,
+        lastActivityAt: now,
+        version: 0,
+      },
+      { harnessName: 'default', ifVersion: 0 },
+    );
+
+    const defaultAgent = new MockAgent({ id: 'default' });
+    const otherAgent = new MockAgent({ id: 'other' });
+    defaultAgent.enqueueRun({ finishReason: 'stop', text: 'mode recovered' });
+    const replayHarness = new Harness({
+      agents: { default: defaultAgent, other: otherAgent } as any,
+      storage,
+      modes: [
+        { id: 'default', agentId: 'default' },
+        { id: 'other', agentId: 'other' },
+      ],
+      defaultModeId: 'other',
+    });
+
+    const replaySession = await replayHarness.session({ sessionId });
+    await replaySession.waitForIdle({ timeoutMs: 1000 });
+
+    expect(defaultAgent.streamCalls.map(c => extractSignalContents(c.messages))).toEqual(['recover on original mode']);
+    expect(otherAgent.streamCalls).toHaveLength(0);
+    expect(replaySession.getRecord().queueAdmissionReceipts?.[queuedItemId]).toMatchObject({
+      status: 'completed',
+      modeId: 'default',
+      result: expect.objectContaining({ text: 'mode recovered' }),
+    });
+  });
+
+  it('replays an accepted receipt when pending signal evidence has no persisted memory signal', async () => {
+    const storage = new InMemoryStore();
+    const harnessStore = await storage.getStore('harness');
+    if (!harnessStore) throw new Error('expected harness storage');
+    const sessionId = 'sess-accepted-pending-without-memory';
+    const queuedItemId = 'q-accepted-pending-without-memory';
+    const now = Date.now();
+    await harnessStore.saveSession(
+      {
+        harnessName: 'default',
+        id: sessionId,
+        resourceId: 'u',
+        threadId: 't-accepted-pending-without-memory',
+        origin: 'top-level',
+        ownsThread: false,
+        modeId: 'default',
+        modelId: 'default',
+        subagentModelOverrides: {},
+        permissionRules: { categories: {}, tools: {} },
+        sessionGrants: { categories: [], tools: [] },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        pendingQueue: [
+          {
+            id: queuedItemId,
+            admissionId: 'queue-accepted-pending-without-memory',
+            admissionHash: 'hash-accepted-pending-without-memory',
+            enqueuedAt: now,
+            content: 'recover pending without memory',
+            attachments: [],
+          },
+        ],
+        queueAdmissionReceipts: {
+          [queuedItemId]: {
+            admissionId: 'queue-accepted-pending-without-memory',
+            admissionHash: 'hash-accepted-pending-without-memory',
+            queuedItemId,
+            status: 'accepted',
+            runId: 'stale-run',
+            signalId: 'stale-signal',
+            attempts: 1,
+            enqueuedAt: now,
+            acceptedAt: now,
+            updatedAt: now,
+          },
+        },
+        state: undefined,
+        createdAt: now,
+        lastActivityAt: now,
+        version: 0,
+      },
+      { harnessName: 'default', ifVersion: 0 },
+    );
+    await harnessStore.writeMessageResultEvidence({
+      harnessName: 'default',
+      sessionId,
+      resourceId: 'u',
+      threadId: 't-accepted-pending-without-memory',
+      signalId: 'stale-signal',
+      runId: 'stale-run',
+      status: 'pending',
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const replayAgent = new MockAgent({ id: 'default' });
+    replayAgent.enqueueRun({ finishReason: 'stop', text: 'pending recovered' });
+    const replayHarness = new Harness({
+      agents: { default: replayAgent } as any,
+      storage,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+
+    const replaySession = await replayHarness.session({ sessionId });
+    await replaySession.waitForIdle({ timeoutMs: 1000 });
+
+    expect(replayAgent.streamCalls.map(c => extractSignalContents(c.messages))).toEqual([
+      'recover pending without memory',
+    ]);
+    expect(replaySession.getRecord().pendingQueue).toEqual([]);
+    const receipt = replaySession.getRecord().queueAdmissionReceipts?.[queuedItemId];
+    expect(receipt).toMatchObject({
+      status: 'completed',
+      result: expect.objectContaining({ text: 'pending recovered' }),
+    });
+    expect(receipt?.signalId).not.toBe('stale-signal');
+  });
+
+  it('completes an accepted receipt from durable signal result evidence after hydration', async () => {
+    const storage = new InMemoryStore();
+    const harnessStore = await storage.getStore('harness');
+    if (!harnessStore) throw new Error('expected harness storage');
+    const sessionId = 'sess-accepted-signal-result';
+    const queuedItemId = 'q-accepted-signal-result';
+    const now = Date.now();
+    await harnessStore.saveSession(
+      {
+        harnessName: 'default',
+        id: sessionId,
+        resourceId: 'u',
+        threadId: 't-accepted-signal-result',
+        origin: 'top-level',
+        ownsThread: false,
+        modeId: 'default',
+        modelId: 'default',
+        subagentModelOverrides: {},
+        permissionRules: { categories: {}, tools: {} },
+        sessionGrants: { categories: [], tools: [] },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        pendingQueue: [
+          {
+            id: queuedItemId,
+            admissionId: 'queue-accepted-signal-result',
+            admissionHash: 'hash-accepted-signal-result',
+            enqueuedAt: now,
+            content: 'already reconciled',
+            attachments: [],
+          },
+        ],
+        queueAdmissionReceipts: {
+          [queuedItemId]: {
+            admissionId: 'queue-accepted-signal-result',
+            admissionHash: 'hash-accepted-signal-result',
+            queuedItemId,
+            status: 'accepted',
+            runId: 'stale-run',
+            signalId: 'stale-signal',
+            attempts: 1,
+            enqueuedAt: now,
+            acceptedAt: now,
+            postRunFinalizedAt: now,
+            updatedAt: now,
+          },
+        },
+        state: undefined,
+        createdAt: now,
+        lastActivityAt: now,
+        version: 0,
+      },
+      { harnessName: 'default', ifVersion: 0 },
+    );
+    await harnessStore.writeMessageResultEvidence({
+      harnessName: 'default',
+      sessionId,
+      resourceId: 'u',
+      threadId: 't-accepted-signal-result',
+      signalId: 'stale-signal',
+      runId: 'stale-run',
+      status: 'completed',
+      result: { text: 'durable full result', finishReason: 'stop', runId: 'stale-run' },
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const replayAgent = new MockAgent({ id: 'default' });
+    replayAgent.enqueueRun({ finishReason: 'stop', text: 'must not run' });
+    const replayHarness = new Harness({
+      agents: { default: replayAgent } as any,
+      storage,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+
+    const events: HarnessEvent[] = [];
+    replayHarness.subscribe(e => events.push(e));
+    const replaySession = await replayHarness.session({ sessionId });
+    await replaySession.waitForIdle({ timeoutMs: 1000 });
+
+    expect(replayAgent.streamCalls).toHaveLength(0);
+    expect(events.some(e => e.type === 'agent_end')).toBe(false);
+    expect(replaySession.getRecord().pendingQueue).toEqual([]);
+    expect(replaySession.getRecord().queueAdmissionReceipts?.[queuedItemId]).toMatchObject({
+      status: 'completed',
+      runId: 'stale-run',
+      signalId: 'stale-signal',
+      postRunFinalizedAt: now,
+      result: expect.objectContaining({ text: 'durable full result' }),
+    });
+  });
+
+  it('parks an accepted receipt once the signal is visible without live result evidence', async () => {
+    const storage = new InMemoryStore();
+    const harnessStore = await storage.getStore('harness');
+    const memory = await storage.getStore('memory');
+    if (!harnessStore || !memory) throw new Error('expected harness and memory storage');
+    const sessionId = 'sess-accepted-incomplete';
+    const queuedItemId = 'q-accepted-incomplete';
+    const now = Date.now();
+    await harnessStore.saveSession(
+      {
+        harnessName: 'default',
+        id: sessionId,
+        resourceId: 'u',
+        threadId: 't-accepted-incomplete',
+        origin: 'top-level',
+        ownsThread: false,
+        modeId: 'default',
+        modelId: 'default',
+        subagentModelOverrides: {},
+        permissionRules: { categories: {}, tools: {} },
+        sessionGrants: { categories: [], tools: [] },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        pendingQueue: [
+          {
+            id: queuedItemId,
+            admissionId: 'queue-accepted-incomplete',
+            admissionHash: 'hash-accepted-incomplete',
+            enqueuedAt: now,
+            content: 'do not replay accepted',
+            attachments: [],
+          },
+        ],
+        queueAdmissionReceipts: {
+          [queuedItemId]: {
+            admissionId: 'queue-accepted-incomplete',
+            admissionHash: 'hash-accepted-incomplete',
+            queuedItemId,
+            status: 'accepted',
+            runId: 'stale-run',
+            signalId: 'stale-signal',
+            attempts: 1,
+            enqueuedAt: now,
+            acceptedAt: now,
+            updatedAt: now,
+          },
+        },
+        state: undefined,
+        createdAt: now,
+        lastActivityAt: now,
+        version: 0,
+      },
+      { harnessName: 'default', ifVersion: 0 },
+    );
+    await memory.saveMessages({
+      messages: [
+        {
+          id: 'stale-signal',
+          role: 'user',
+          threadId: 't-accepted-incomplete',
+          resourceId: 'u',
+          createdAt: new Date(now),
+          content: { format: 2, parts: [{ type: 'text', text: 'do not replay accepted' }] },
+        } as any,
+        {
+          id: 'assistant-result',
+          role: 'assistant',
+          threadId: 't-accepted-incomplete',
+          resourceId: 'u',
+          createdAt: new Date(now + 1),
+          content: { format: 2, parts: [{ type: 'text', text: 'durable but not full result evidence' }] },
+        } as any,
+      ],
+    });
+
+    const replayAgent = new MockAgent({ id: 'default' });
+    replayAgent.enqueueRun({ finishReason: 'stop', text: 'must not run' });
+    const replayHarness = new Harness({
+      agents: { default: replayAgent } as any,
+      storage,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+
+    const events: HarnessEvent[] = [];
+    replayHarness.subscribe(e => events.push(e));
+    const replaySession = await replayHarness.session({ sessionId });
+    await new Promise(resolve => setImmediate(resolve));
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(replayAgent.streamCalls).toHaveLength(0);
+    expect(events.some(e => e.type === 'queue_item_replayed')).toBe(true);
+    expect(replaySession.getRecord().pendingQueue).toMatchObject([{ id: queuedItemId }]);
+    expect(replaySession.isBusy()).toBe(true);
+    expect(replaySession.getRecord().queueAdmissionReceipts?.[queuedItemId]).toMatchObject({
+      status: 'accepted',
+      runId: 'stale-run',
+      signalId: 'stale-signal',
+    });
+  });
+
+  it('fails a stale accepted receipt when no live run or durable result evidence is available', async () => {
+    const storage = new InMemoryStore();
+    const harnessStore = await storage.getStore('harness');
+    const memory = await storage.getStore('memory');
+    if (!harnessStore || !memory) throw new Error('expected harness and memory storage');
+    const sessionId = 'sess-accepted-stale';
+    const queuedItemId = 'q-accepted-stale';
+    const now = Date.now();
+    const staleAt = now - 60_000;
+    await harnessStore.saveSession(
+      {
+        harnessName: 'default',
+        id: sessionId,
+        resourceId: 'u',
+        threadId: 't-accepted-stale',
+        origin: 'top-level',
+        ownsThread: false,
+        modeId: 'default',
+        modelId: 'default',
+        subagentModelOverrides: {},
+        permissionRules: { categories: {}, tools: {} },
+        sessionGrants: { categories: [], tools: [] },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        pendingQueue: [
+          {
+            id: queuedItemId,
+            admissionId: 'queue-accepted-stale',
+            admissionHash: 'hash-accepted-stale',
+            enqueuedAt: staleAt,
+            content: 'stale accepted',
+            attachments: [],
+          },
+        ],
+        queueAdmissionReceipts: {
+          [queuedItemId]: {
+            admissionId: 'queue-accepted-stale',
+            admissionHash: 'hash-accepted-stale',
+            queuedItemId,
+            status: 'accepted',
+            runId: 'stale-run',
+            signalId: 'stale-signal',
+            attempts: 1,
+            enqueuedAt: staleAt,
+            acceptedAt: staleAt,
+            updatedAt: staleAt,
+          },
+        },
+        state: undefined,
+        createdAt: staleAt,
+        lastActivityAt: staleAt,
+        version: 0,
+      },
+      { harnessName: 'default', ifVersion: 0 },
+    );
+    await memory.saveMessages({
+      messages: [
+        {
+          id: 'stale-signal',
+          role: 'signal',
+          threadId: 't-accepted-stale',
+          resourceId: 'u',
+          createdAt: new Date(staleAt),
+          content: { format: 2, parts: [{ type: 'text', text: 'stale accepted' }] },
+        } as any,
+      ],
+    });
+
+    const replayAgent = new MockAgent({ id: 'default' });
+    replayAgent.enqueueRun({ finishReason: 'stop', text: 'must not run' });
+    const replayHarness = new Harness({
+      agents: { default: replayAgent } as any,
+      storage,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+
+    const replaySession = await replayHarness.session({ sessionId });
+    await replaySession.waitForIdle({ timeoutMs: 1000 });
+
+    expect(replayAgent.streamCalls).toHaveLength(0);
+    expect(replaySession.getRecord().pendingQueue).toEqual([]);
+    expect(replaySession.getRecord().queueAdmissionReceipts?.[queuedItemId]).toMatchObject({
+      status: 'failed',
+      runId: 'stale-run',
+      signalId: 'stale-signal',
+      error: { code: 'harness.queue_recovery_stale' },
+    });
   });
 });

--- a/packages/core/src/harness/v1/session.suspend.test.ts
+++ b/packages/core/src/harness/v1/session.suspend.test.ts
@@ -256,6 +256,42 @@ describe('Session — suspend capture on message()', () => {
     expect(session.getRecord().pendingResume).toBeUndefined();
   });
 
+  it('persists a message mode override on pendingResume and resumes through that mode', async () => {
+    const agentA = new FakeAgent();
+    const agentB = new FakeAgent();
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    const harness = new Harness({
+      agents: { agentA, agentB } as any,
+      modes: [
+        { id: 'modeA', agentId: 'agentA' },
+        { id: 'modeB', agentId: 'agentB' },
+      ],
+      defaultModeId: 'modeA',
+      sessions: { storage },
+    });
+    agentB.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-mode-b',
+      suspendPayload: { toolCallId: 'tc-mode-b', toolName: 'shell', args: { cmd: 'ls' } },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await session.message({ content: 'use mode b', mode: 'modeB' });
+
+    expect(session.getRecord().pendingResume).toMatchObject({
+      modeId: 'modeB',
+    });
+    expect(agentB.streamCalls).toHaveLength(1);
+    expect(agentA.streamCalls).toHaveLength(0);
+
+    agentB.enqueueRun({ finishReason: 'stop', runId: 'run-mode-b', text: 'resumed on mode b' });
+    const result = await session.respondToToolApproval({ approved: true });
+
+    expect(result.text).toBe('resumed on mode b');
+    expect(agentB.resumeCalls).toHaveLength(1);
+    expect(agentA.resumeCalls).toHaveLength(0);
+  });
+
   it('keeps a question registered by the tool before suspend capture', async () => {
     const { harness } = setup();
     const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
@@ -281,6 +317,7 @@ describe('Session — suspend capture on message()', () => {
     const pending = session.getRecord().pendingResume!;
     expect(pending.kind).toBe('question');
     expect(pending.itemId).toBe('tc-registered');
+    expect(pending.modeId).toBe('default');
     expect(pending.payload).toEqual({
       question: 'registered prompt',
       options: [{ label: 'yes' }],
@@ -317,6 +354,7 @@ describe('Session — suspend capture on message()', () => {
     const pending = session.getRecord().pendingResume!;
     expect(pending.kind).toBe('plan-approval');
     expect(pending.itemId).toBe('tc-plan');
+    expect(pending.modeId).toBe('planner');
     expect(pending.payload).toEqual({ title: 'registered title', plan: 'registered plan' });
     expect(pending.transitionModeId).toBe('builder');
   });

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -408,6 +408,8 @@ export class Session {
   /** `queuedItem.source` of the turn currently running. Used by the goal
    *  judge loop to skip re-judging on goal-driven continuation turns. */
   private _currentQueuedItemSource?: 'user' | 'goal';
+  /** Hydrated queue items should emit `queue_item_replayed` once per session instance. */
+  private readonly _replayedQueuedItemIds = new Set<string>();
   /** True while `_maybeDrainQueue` is running so re-entrant kicks are no-ops. */
   private _draining = false;
   private _queuedResumeRecoveryTimer?: ReturnType<typeof setTimeout>;
@@ -3697,6 +3699,11 @@ export class Session {
       );
     }
 
+    const pendingQueuedItemId = this._queuedItemIdForPendingResume(pending);
+    if (pendingQueuedItemId !== undefined) {
+      this._ensureQueuedItemContext(pendingQueuedItemId);
+    }
+
     // Mark resumed under the lease BEFORE calling the agent (idempotency
     // marker per §5.4 / §5.7). On crash here, the next caller observes
     // resumedAt set and rejects rather than double-resuming.
@@ -3760,27 +3767,21 @@ export class Session {
     // queued terminal resume has already persisted its completed receipt before
     // this point, so crash recovery never sees "pending cleared, queue still
     // accepted".
-    const pendingQueuedItemId = this._queuedItemIdForPendingResume(pending);
     const completingQueuedItemId = full.finishReason !== 'suspended' ? pendingQueuedItemId : undefined;
     try {
-      let queuedResumeFinalized = false;
       if (completingQueuedItemId !== undefined) {
         if (modeFlipTarget && modeFlipTarget !== previousModeId) {
           await this._flushUpdate(prev => ({ ...prev, modeId: modeFlipTarget }));
         }
         const queuedItem = this._record.pendingQueue.find(item => item.id === completingQueuedItemId);
         if (queuedItem) {
-          await this._finalizeCompletedQueuedTurn(queuedItem, full, resumeModeId);
-        } else {
-          this._recordTurnCompletion(full);
-          this._emitTurnEvent({
-            type: 'agent_end',
-            reason: full.finishReason === 'error' ? 'error' : 'complete',
-            runId: full.runId,
-          });
-          await this._runGoalJudge(full, false);
+          try {
+            await this._markQueuedPostRunFinalized(completingQueuedItemId);
+          } catch (err) {
+            throw new QueuePostRunFinalizationPendingError(Date.now() + QUEUE_POST_RUN_FINALIZATION_RETRY_MS, err);
+          }
         }
-        queuedResumeFinalized = true;
+        this._recordTurnCompletion(full);
       } else {
         this._recordTurnCompletion(full);
       }
@@ -3827,25 +3828,22 @@ export class Session {
       // The resumed run can itself suspend again (multi-step approval chains).
       // Mirror message()'s post-run hook so the next respond* call sees the
       // new pending record.
-      if (!queuedResumeFinalized) {
-        await this._maybeCaptureSuspend(full, pendingQueuedItemId, resumeModeId);
-      }
+      await this._maybeCaptureSuspend(full, pendingQueuedItemId, resumeModeId);
 
       // If the resumed run did NOT suspend again, the turn is complete from
       // the harness's perspective. Surface that to subscribers via agent_end.
       if (full.finishReason !== 'suspended') {
-        if (!queuedResumeFinalized) {
-          this._emitTurnEvent({
-            type: 'agent_end',
-            reason: full.finishReason === 'error' ? 'error' : 'complete',
-            runId: full.runId,
-          });
-        }
+        this._emitTurnEvent({
+          type: 'agent_end',
+          reason: full.finishReason === 'error' ? 'error' : 'complete',
+          runId: full.runId,
+        });
 
         // If this was the terminal completion of a queued turn, settle the
         // resolver, remove the head item, clear current, then kick the drain
         // for the next item.
         const wasGoalDriven = (this._currentQueuedItemSource ?? 'user') === 'goal';
+        await this._runGoalJudge(full, wasGoalDriven);
         if (completingQueuedItemId !== undefined) {
           this._currentQueuedItemId = undefined;
           this._currentQueuedItemSource = undefined;
@@ -3856,9 +3854,6 @@ export class Session {
           }
           this._notifyMaybeIdle();
           void this._maybeDrainQueue();
-        }
-        if (!queuedResumeFinalized) {
-          await this._runGoalJudge(full, wasGoalDriven);
         }
       }
     } catch (err) {
@@ -3894,23 +3889,23 @@ export class Session {
     if (pending?.resumedAt === undefined) return { status: 'none' };
     const queuedItemId = this._queuedItemIdForPendingResume(pending);
     if (queuedItemId === undefined) return { status: 'none' };
+    if (!this._queueResolvers.has(queuedItemId)) {
+      this._emitQueueItemReplayedOnce(queuedItemId);
+    }
+    this._ensureQueuedItemContext(queuedItemId);
 
     const currentReceipt = this._record.queueAdmissionReceipts?.[queuedItemId];
     if (currentReceipt?.status === 'completed') {
       const queuedItem = this._record.pendingQueue.find(item => item.id === queuedItemId);
-      if (queuedItem && currentReceipt.postRunFinalizedAt === undefined) {
+      const shouldRunPostRunSideEffects = queuedItem !== undefined && currentReceipt.postRunFinalizedAt === undefined;
+      if (shouldRunPostRunSideEffects) {
         try {
-          await this._finalizeCompletedQueuedTurn(
-            queuedItem,
-            currentReceipt.result as FullOutput<unknown>,
-            pending.modeId ?? currentReceipt.modeId ?? queuedItem.mode ?? this._record.modeId,
-          );
+          await this._markQueuedPostRunFinalized(queuedItemId);
         } catch (err) {
-          if (err instanceof QueuePostRunFinalizationPendingError) {
-            this._deferQueuedTurnRetry(err);
-            return { status: 'none' };
-          }
-          throw err;
+          this._deferQueuedTurnRetry(
+            new QueuePostRunFinalizationPendingError(Date.now() + QUEUE_POST_RUN_FINALIZATION_RETRY_MS, err),
+          );
+          return { status: 'none' };
         }
       }
       await this._flushUpdate(prev => {
@@ -3930,6 +3925,13 @@ export class Session {
         delete next.pendingResume;
         return next;
       });
+      if (shouldRunPostRunSideEffects && queuedItem) {
+        await this._finalizeQueuedRunCompletion(
+          queuedItem,
+          currentReceipt.result as FullOutput<unknown>,
+          pending.modeId ?? currentReceipt.modeId ?? queuedItem.mode ?? this._record.modeId,
+        );
+      }
       this._currentQueuedItemId = undefined;
       this._currentQueuedItemSource = undefined;
       const resolver = this._queueResolvers.get(queuedItemId);
@@ -4383,11 +4385,11 @@ export class Session {
         this._currentQueuedItemId = head.id;
         this._currentQueuedItemSource = head.source ?? 'user';
         const isReplay = !this._queueResolvers.has(head.id);
-        this._emitter.emit(
-          isReplay
-            ? { type: 'queue_item_replayed', queuedItemId: head.id }
-            : { type: 'queue_item_started', queuedItemId: head.id },
-        );
+        if (isReplay) {
+          this._emitQueueItemReplayedOnce(head.id);
+        } else {
+          this._emitter.emit({ type: 'queue_item_started', queuedItemId: head.id });
+        }
 
         let suspended = false;
         try {
@@ -4981,6 +4983,19 @@ export class Session {
       const timer = setTimeout(() => void this._maybeDrainQueue(), delayMs);
       timer.unref?.();
     }
+  }
+
+  private _emitQueueItemReplayedOnce(queuedItemId: string): void {
+    if (this._replayedQueuedItemIds.has(queuedItemId)) return;
+    this._replayedQueuedItemIds.add(queuedItemId);
+    this._emitter.emit({ type: 'queue_item_replayed', queuedItemId });
+  }
+
+  private _ensureQueuedItemContext(queuedItemId: string): void {
+    if (this._currentQueuedItemId !== undefined) return;
+    const queuedItem = this._record.pendingQueue.find(item => item.id === queuedItemId);
+    this._currentQueuedItemId = queuedItemId;
+    this._currentQueuedItemSource = queuedItem?.source ?? 'user';
   }
 
   private _deferQueuedTurnRetry(err: QueuePostRunFinalizationPendingError): void {

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -8,10 +8,9 @@
  * The current local surface includes message/signal/queue turns, mode/model
  * and state mutation, display snapshots, message listing, pending inbox
  * responses, permissions, code/workspace skills, subagents, goals, event
- * forwarding, abort, and idle waiting. It is not yet the production remote or
- * recovery surface: durable admission/result rows, server routes, remote SDKs,
- * channels, wakeups, and request-context `registerQuestion` /
- * `registerPlanApproval` support remain follow-up lanes.
+ * forwarding, abort, and idle waiting. Server routes, remote SDKs, channels,
+ * wakeups, and request-context `registerQuestion` / `registerPlanApproval`
+ * support remain follow-up lanes.
  *
  * Lifecycle states tracked here:
  *   - 'live'    — session is in the harness's live map and holds the lease.
@@ -41,6 +40,7 @@ import type {
   AgentSignalResultStatus,
   HarnessStorage,
   HarnessStorageAttachmentUnavailableError,
+  QueueAdmissionReceipt,
   PendingResume,
   PermissionRules,
   PersistedAttachment,
@@ -127,6 +127,11 @@ type MessageAdmissionStart = {
   promise: Promise<string>;
 };
 
+type QueueResumeRecoveryResult =
+  | { status: 'none' }
+  | { status: 'completed'; result: AgentResult }
+  | { status: 'stale' };
+
 /**
  * Tool IDs the harness translates from `tool-call-approval` /
  * `tool-call-suspended` events into `question` / `plan-approval` `kind`s.
@@ -137,6 +142,8 @@ const ASK_USER_TOOL_NAME = ASK_USER_TOOL_ID;
 const SUBMIT_PLAN_TOOL_NAME = SUBMIT_PLAN_TOOL_ID;
 const MESSAGE_ADMISSION_DURABLE_WAIT_TIMEOUT_MS = 30_000;
 const MESSAGE_ADMISSION_DURABLE_WAIT_INTERVAL_MS = 100;
+const QUEUE_ACCEPTED_RECOVERY_STALE_MS = 30_000;
+const QUEUE_POST_RUN_FINALIZATION_RETRY_MS = 1_000;
 const SUPPORTED_SKILL_ARG_SCHEMA_KEYS = new Set([
   'required',
   'properties',
@@ -394,7 +401,7 @@ export class Session {
    */
   private readonly _queueResolvers = new Map<
     string,
-    { resolve: (result: AgentResult) => void; reject: (err: unknown) => void }
+    { promise: Promise<AgentResult>; resolve: (result: AgentResult) => void; reject: (err: unknown) => void }
   >();
   /** `queuedItem.id` of the turn currently running (live or suspended). */
   private _currentQueuedItemId?: string;
@@ -403,6 +410,7 @@ export class Session {
   private _currentQueuedItemSource?: 'user' | 'goal';
   /** True while `_maybeDrainQueue` is running so re-entrant kicks are no-ops. */
   private _draining = false;
+  private _queuedResumeRecoveryTimer?: ReturnType<typeof setTimeout>;
   /**
    * Tracks the AbortController for the currently-running turn (message or
    * queued). Set when a turn begins, cleared on terminal completion or
@@ -1913,7 +1921,7 @@ export class Session {
         });
         const full = result as FullOutput<unknown>;
         this._recordTurnCompletion(full);
-        await this._maybeCaptureSuspend(full);
+        await this._maybeCaptureSuspend(full, undefined, effectiveModeId);
         this._emitTurnEvent({
           type: 'agent_end',
           reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
@@ -2095,7 +2103,7 @@ export class Session {
           }).then(() => full);
         })
         .then(full => {
-          return this._maybeCaptureSuspend(full).then(() => {
+          return this._maybeCaptureSuspend(full, undefined, effectiveModeId).then(() => {
             this._emitTurnEvent({
               type: 'agent_end',
               reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
@@ -2146,7 +2154,7 @@ export class Session {
           admissionHash: admissionHash!,
         });
       }
-      await this._maybeCaptureSuspend(full);
+      await this._maybeCaptureSuspend(full, undefined, effectiveModeId);
       this._emitTurnEvent({
         type: 'agent_end',
         reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
@@ -2446,7 +2454,7 @@ export class Session {
       const result: Promise<AgentResult> = completion
         .then(async full => {
           this._recordTurnCompletion(full);
-          await this._maybeCaptureSuspend(full);
+          await this._maybeCaptureSuspend(full, undefined, effectiveModeId);
           this._emitTurnEvent({
             type: 'agent_end',
             reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
@@ -2567,7 +2575,7 @@ export class Session {
       const result = completion
         .then(async full => {
           this._recordTurnCompletion(full);
-          await this._maybeCaptureSuspend(full);
+          await this._maybeCaptureSuspend(full, undefined, effectiveModeId);
           this._emitTurnEvent({
             type: 'agent_end',
             reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
@@ -2628,7 +2636,11 @@ export class Session {
    *
    * No-op when the run did not suspend.
    */
-  private async _maybeCaptureSuspend(full: FullOutput<unknown>): Promise<void> {
+  private async _maybeCaptureSuspend(
+    full: FullOutput<unknown>,
+    queuedItemId = this._currentQueuedItemId,
+    modeId = this._record.modeId,
+  ): Promise<void> {
     if (full.finishReason !== 'suspended') return;
     const payload = full.suspendPayload as
       | { toolCallId: string; toolName: string; args?: unknown; suspendPayload?: unknown }
@@ -2653,11 +2665,13 @@ export class Session {
       toolName: payload.toolName,
       source: 'parent',
       requestedAt: Date.now(),
+      ...(queuedItemId !== undefined ? { queuedItemId } : {}),
+      modeId,
       payload: this._buildResumePayload(kind, payload),
     };
 
     if (kind === 'plan-approval') {
-      const mode = this._harness._getMode(this._record.modeId);
+      const mode = this._harness._getMode(modeId);
       if (mode.transitionsTo) pending.transitionModeId = mode.transitionsTo;
     }
 
@@ -3124,6 +3138,7 @@ export class Session {
       enqueuedAt: Date.now(),
       content,
       attachments: [],
+      mode: this._record.modeId,
       source: 'goal',
       goalId: goal.id,
     };
@@ -3671,6 +3686,11 @@ export class Session {
     // move is to surface the suspended state to the caller and let them
     // re-fetch via getDisplayState / listMessages.
     if (pending.resumedAt !== undefined) {
+      const recovery = await this._maybeRecoverStaleQueuedResume();
+      if (recovery.status === 'completed') return recovery.result;
+      if (recovery.status === 'stale') {
+        throw new QueueResumeRecoveryStaleError();
+      }
       throw new HarnessValidationError(
         `respond[${expectedKind}]`,
         'pending resume already responded; awaiting agent confirmation',
@@ -3686,9 +3706,10 @@ export class Session {
       pendingResume: prev.pendingResume ? { ...prev.pendingResume, resumedAt } : prev.pendingResume,
     }));
 
-    // For plan-approval, flip the active mode atomically with clearing the
-    // pending record. Done inside the same _flushUpdate below so the mode
-    // change and pending-clear land in one CAS write.
+    // For plan-approval, resolve the active-mode flip before finalizing the
+    // resumed turn. Queued terminal resumes persist this flip with the
+    // completed receipt so crash recovery cannot observe "completed plan
+    // approval, old mode".
     //
     // Resolution order on approval:
     //   1. Caller-supplied `transitionToMode` overrides everything.
@@ -3710,11 +3731,14 @@ export class Session {
       }
     }
 
+    const previousModeId = this._record.modeId;
+    const resumeModeId = this._modeIdForPendingResume(pending);
+
     // Resumed runs run under a session-owned AbortController too, so
     // `session.abort()` can cancel an in-flight resume (e.g. ESC after the
     // user approved a tool that's now grinding through a long workflow).
     const turnAbortController = this._beginTurn(undefined);
-    const agent = this._harness.getAgentForMode(this._record.modeId);
+    const agent = this._harness.getAgentForMode(resumeModeId);
     let full: FullOutput<unknown>;
     try {
       const out = await agent.resumeStream(resumeData, {
@@ -3723,64 +3747,273 @@ export class Session {
         abortSignal: turnAbortController.signal,
       });
       full = (await out.getFullOutput()) as FullOutput<unknown>;
-      this._recordTurnCompletion(full);
+      const resumedQueuedItemId = this._queuedItemIdForPendingResume(pending);
+      if (full.finishReason !== 'suspended' && resumedQueuedItemId !== undefined) {
+        await this._markQueuedTurnCompleted(resumedQueuedItemId, full, { modeId: modeFlipTarget });
+      }
     } catch (err) {
       this._endTurn(turnAbortController);
       throw err;
     }
 
-    // Clear pending + apply mode flip in a single CAS write. The mode flip
-    // and pending-clear must land together so a replay does not see
-    // "pending cleared, mode not yet flipped" or vice versa.
-    const previousModeId = this._record.modeId;
+    // Clear pending + apply any remaining mode flip in a single CAS write. A
+    // queued terminal resume has already persisted its completed receipt before
+    // this point, so crash recovery never sees "pending cleared, queue still
+    // accepted".
+    const pendingQueuedItemId = this._queuedItemIdForPendingResume(pending);
+    const completingQueuedItemId = full.finishReason !== 'suspended' ? pendingQueuedItemId : undefined;
+    try {
+      let queuedResumeFinalized = false;
+      if (completingQueuedItemId !== undefined) {
+        if (modeFlipTarget && modeFlipTarget !== previousModeId) {
+          await this._flushUpdate(prev => ({ ...prev, modeId: modeFlipTarget }));
+        }
+        const queuedItem = this._record.pendingQueue.find(item => item.id === completingQueuedItemId);
+        if (queuedItem) {
+          await this._finalizeCompletedQueuedTurn(queuedItem, full, resumeModeId);
+        } else {
+          this._recordTurnCompletion(full);
+          this._emitTurnEvent({
+            type: 'agent_end',
+            reason: full.finishReason === 'error' ? 'error' : 'complete',
+            runId: full.runId,
+          });
+          await this._runGoalJudge(full, false);
+        }
+        queuedResumeFinalized = true;
+      } else {
+        this._recordTurnCompletion(full);
+      }
+      const queueCompletedAt = Date.now();
+      await this._flushUpdate(prev => {
+        const next: SessionRecord = { ...prev };
+        delete next.pendingResume;
+        if (modeFlipTarget) next.modeId = modeFlipTarget;
+        if (completingQueuedItemId !== undefined) {
+          next.pendingQueue = (prev.pendingQueue ?? []).filter(x => x.id !== completingQueuedItemId);
+          const receipt = prev.queueAdmissionReceipts?.[completingQueuedItemId];
+          if (receipt) {
+            next.queueAdmissionReceipts = {
+              ...(prev.queueAdmissionReceipts ?? {}),
+              [completingQueuedItemId]: {
+                ...receipt,
+                status: 'completed',
+                result: full,
+                completedAt: receipt.completedAt ?? queueCompletedAt,
+                updatedAt: queueCompletedAt,
+              },
+            };
+          }
+        }
+        return next;
+      });
+
+      // Pending resolved — emit before the (optional) re-suspension capture
+      // so subscribers see ordering: resolved → (mode_changed?) → required?.
+      this._emitTurnEvent({
+        type: 'suspension_resolved',
+        kind: expectedKind,
+        toolCallId: pending.toolCallId,
+        runId: pending.runId,
+      });
+      if (modeFlipTarget && modeFlipTarget !== previousModeId) {
+        this._emitter.emit({
+          type: 'mode_changed',
+          modeId: modeFlipTarget,
+          previousModeId,
+        });
+      }
+
+      // The resumed run can itself suspend again (multi-step approval chains).
+      // Mirror message()'s post-run hook so the next respond* call sees the
+      // new pending record.
+      if (!queuedResumeFinalized) {
+        await this._maybeCaptureSuspend(full, pendingQueuedItemId, resumeModeId);
+      }
+
+      // If the resumed run did NOT suspend again, the turn is complete from
+      // the harness's perspective. Surface that to subscribers via agent_end.
+      if (full.finishReason !== 'suspended') {
+        if (!queuedResumeFinalized) {
+          this._emitTurnEvent({
+            type: 'agent_end',
+            reason: full.finishReason === 'error' ? 'error' : 'complete',
+            runId: full.runId,
+          });
+        }
+
+        // If this was the terminal completion of a queued turn, settle the
+        // resolver, remove the head item, clear current, then kick the drain
+        // for the next item.
+        const wasGoalDriven = (this._currentQueuedItemSource ?? 'user') === 'goal';
+        if (completingQueuedItemId !== undefined) {
+          this._currentQueuedItemId = undefined;
+          this._currentQueuedItemSource = undefined;
+          const resolver = this._queueResolvers.get(completingQueuedItemId);
+          if (resolver) {
+            this._queueResolvers.delete(completingQueuedItemId);
+            resolver.resolve(full as AgentResult);
+          }
+          this._notifyMaybeIdle();
+          void this._maybeDrainQueue();
+        }
+        if (!queuedResumeFinalized) {
+          await this._runGoalJudge(full, wasGoalDriven);
+        }
+      }
+    } catch (err) {
+      if (err instanceof QueuePostRunFinalizationPendingError && completingQueuedItemId !== undefined) {
+        this._deferQueuedTurnRetry(err);
+      }
+      throw err;
+    } finally {
+      this._endTurn(turnAbortController);
+    }
+    return full as AgentResult;
+  }
+
+  private _queuedItemIdForPendingResume(pending: PendingResume): string | undefined {
+    if (pending.queuedItemId !== undefined) return pending.queuedItemId;
+    if (this._currentQueuedItemId !== undefined) return this._currentQueuedItemId;
+    return (this._record.pendingQueue ?? []).find(item => {
+      const receipt = this._record.queueAdmissionReceipts?.[item.id];
+      return (receipt?.status === 'accepted' || receipt?.status === 'completed') && receipt.runId === pending.runId;
+    })?.id;
+  }
+
+  private _modeIdForPendingResume(pending: PendingResume): string {
+    const queuedItemId = this._queuedItemIdForPendingResume(pending);
+    const queuedItem = queuedItemId ? this._record.pendingQueue.find(item => item.id === queuedItemId) : undefined;
+    const receipt = queuedItemId ? this._record.queueAdmissionReceipts?.[queuedItemId] : undefined;
+    return pending.modeId ?? receipt?.modeId ?? queuedItem?.mode ?? this._record.modeId;
+  }
+
+  private async _maybeRecoverStaleQueuedResume(): Promise<QueueResumeRecoveryResult> {
+    if (this._currentTurnAbortController !== undefined) return { status: 'none' };
+    const pending = this._record.pendingResume;
+    if (pending?.resumedAt === undefined) return { status: 'none' };
+    const queuedItemId = this._queuedItemIdForPendingResume(pending);
+    if (queuedItemId === undefined) return { status: 'none' };
+
+    const currentReceipt = this._record.queueAdmissionReceipts?.[queuedItemId];
+    if (currentReceipt?.status === 'completed') {
+      const queuedItem = this._record.pendingQueue.find(item => item.id === queuedItemId);
+      if (queuedItem && currentReceipt.postRunFinalizedAt === undefined) {
+        try {
+          await this._finalizeCompletedQueuedTurn(
+            queuedItem,
+            currentReceipt.result as FullOutput<unknown>,
+            pending.modeId ?? currentReceipt.modeId ?? queuedItem.mode ?? this._record.modeId,
+          );
+        } catch (err) {
+          if (err instanceof QueuePostRunFinalizationPendingError) {
+            this._deferQueuedTurnRetry(err);
+            return { status: 'none' };
+          }
+          throw err;
+        }
+      }
+      await this._flushUpdate(prev => {
+        const current = prev.pendingResume;
+        if (
+          !current ||
+          current.runId !== pending.runId ||
+          current.toolCallId !== pending.toolCallId ||
+          current.resumedAt !== pending.resumedAt
+        ) {
+          return prev;
+        }
+        const next: SessionRecord = {
+          ...prev,
+          pendingQueue: (prev.pendingQueue ?? []).filter(item => item.id !== queuedItemId),
+        };
+        delete next.pendingResume;
+        return next;
+      });
+      this._currentQueuedItemId = undefined;
+      this._currentQueuedItemSource = undefined;
+      const resolver = this._queueResolvers.get(queuedItemId);
+      if (resolver) {
+        this._queueResolvers.delete(queuedItemId);
+        resolver.resolve(currentReceipt.result as AgentResult);
+      }
+      this._notifyMaybeIdle();
+      void this._maybeDrainQueue();
+      return { status: 'completed', result: currentReceipt.result as AgentResult };
+    }
+
+    const retryAt = pending.resumedAt + QUEUE_ACCEPTED_RECOVERY_STALE_MS;
+    if (Date.now() < retryAt) {
+      if (this._queuedResumeRecoveryTimer === undefined) {
+        const delayMs = Math.max(0, retryAt - Date.now());
+        this._queuedResumeRecoveryTimer = setTimeout(() => {
+          this._queuedResumeRecoveryTimer = undefined;
+          void this._maybeDrainQueue();
+        }, delayMs);
+        this._queuedResumeRecoveryTimer.unref?.();
+      }
+      return { status: 'none' };
+    }
+
+    if (this._queuedResumeRecoveryTimer !== undefined) {
+      clearTimeout(this._queuedResumeRecoveryTimer);
+      this._queuedResumeRecoveryTimer = undefined;
+    }
+
+    const err = new QueueResumeRecoveryStaleError();
+    const now = Date.now();
     await this._flushUpdate(prev => {
-      const next: SessionRecord = { ...prev };
+      const current = prev.pendingResume;
+      if (
+        !current ||
+        current.runId !== pending.runId ||
+        current.toolCallId !== pending.toolCallId ||
+        current.resumedAt !== pending.resumedAt
+      ) {
+        return prev;
+      }
+      const receipt = prev.queueAdmissionReceipts?.[queuedItemId];
+      const next: SessionRecord = {
+        ...prev,
+        pendingQueue: (prev.pendingQueue ?? []).filter(item => item.id !== queuedItemId),
+      };
       delete next.pendingResume;
-      if (modeFlipTarget) next.modeId = modeFlipTarget;
+      if (receipt) {
+        if (receipt.status === 'completed') {
+          return next;
+        }
+        next.queueAdmissionReceipts = {
+          ...(prev.queueAdmissionReceipts ?? {}),
+          [queuedItemId]: {
+            ...receipt,
+            status: 'failed',
+            error: projectHarnessPublicError(err),
+            failedAt: receipt.failedAt ?? now,
+            updatedAt: now,
+          },
+        };
+      }
       return next;
     });
 
-    // Pending resolved — emit before the (optional) re-suspension capture
-    // so subscribers see ordering: resolved → (mode_changed?) → required?.
-    this._emitTurnEvent({
-      type: 'suspension_resolved',
-      kind: expectedKind,
-      toolCallId: pending.toolCallId,
-      runId: pending.runId,
-    });
-    if (modeFlipTarget && modeFlipTarget !== previousModeId) {
-      this._emitter.emit({
-        type: 'mode_changed',
-        modeId: modeFlipTarget,
-        previousModeId,
-      });
+    const current = this._record.pendingResume;
+    if (
+      current?.runId === pending.runId &&
+      current.toolCallId === pending.toolCallId &&
+      current.resumedAt === pending.resumedAt
+    ) {
+      return { status: 'none' };
     }
 
-    // The resumed run can itself suspend again (multi-step approval chains).
-    // Mirror message()'s post-run hook so the next respond* call sees the
-    // new pending record.
-    await this._maybeCaptureSuspend(full);
-
-    // If the resumed run did NOT suspend again, the turn is complete from
-    // the harness's perspective. Surface that to subscribers via agent_end.
-    if (full.finishReason !== 'suspended') {
-      this._emitTurnEvent({
-        type: 'agent_end',
-        reason: full.finishReason === 'error' ? 'error' : 'complete',
-        runId: full.runId,
-      });
-
-      // If this was the terminal completion of a queued turn, settle the
-      // resolver, remove the head item, clear current, then kick the drain
-      // for the next item.
-      const wasGoalDriven = (this._currentQueuedItemSource ?? 'user') === 'goal';
-      if (this._currentQueuedItemId !== undefined) {
-        await this._completeQueuedTurn(this._currentQueuedItemId, full as AgentResult);
-      }
-      await this._runGoalJudge(full, wasGoalDriven);
+    this._currentQueuedItemId = undefined;
+    this._currentQueuedItemSource = undefined;
+    const resolver = this._queueResolvers.get(queuedItemId);
+    if (resolver) {
+      this._queueResolvers.delete(queuedItemId);
+      resolver.reject(err);
     }
-    this._endTurn(turnAbortController);
-    return full as AgentResult;
+    this._notifyMaybeIdle();
+    return { status: 'stale' };
   }
 
   // -------------------------------------------------------------------------
@@ -3795,20 +4028,21 @@ export class Session {
   // Drain semantics:
   //   1. `queue()` admits → flush record → register resolver → kick drain.
   //   2. Drain pulls head item, emits `queue_item_started`, runs the turn
-  //      via the same code path as `message()` default (so `agent_start`,
-  //      `message_*`, `tool_*`, `suspension_*`, `agent_end` all flow with
-  //      `queuedItemId` stamped automatically by `_emitTurnEvent`).
+  //      by dispatching a deterministic `agent.sendSignal()` turn (so
+  //      `agent_start`, `message_*`, `tool_*`, `suspension_*`, `agent_end`
+  //      all flow with `queuedItemId` stamped automatically by
+  //      `_emitTurnEvent`).
   //   3. If the turn suspends, the head item stays in `pendingQueue` and
   //      `_currentQueuedItemId` stays set. The next `respondTo*` call calls
   //      into `_resume`; on terminal completion the resume path settles the
   //      resolver + removes the head + kicks drain again.
-  //   4. If the turn completes without suspending, the message() default
-  //      path settles the same way (post-`agent_end` hook below).
+  //   4. If the turn completes without suspending, the queue receipt,
+  //      signal-result evidence, resolver, and head item settle together.
   //
   // Promise resolution: the eventual `AgentResult` once the turn fully ends
-  // (including any suspend → resume cycles). Rejection only for "never got
-  // to run" cases (closed session before drain reached the item, or a
-  // permanent storage failure during admission).
+  // (including any suspend → resume cycles). Rejection surfaces admission
+  // conflicts, queued-run failures, stale accepted recovery, or expired
+  // duplicate-result evidence.
   // -------------------------------------------------------------------------
 
   /**
@@ -3831,20 +4065,34 @@ export class Session {
       // Validates and throws on unknown id.
       this._harness._getMode(opts.mode);
     }
+    if (opts.admissionId !== undefined && opts.admissionId.length === 0) {
+      throw new HarnessValidationError('queue().admissionId', 'admissionId must be a non-empty string');
+    }
+
+    const attachments = await this._resolveAttachmentRefs('queue().attachments', opts.attachments ?? []);
+    const effectiveModeId = opts.mode ?? this._record.modeId;
+    const admissionId = opts.admissionId ?? `queue-${randomUUID()}`;
+    const admissionHash = this._computeQueueAdmissionHash(opts, attachments);
+    const duplicate = opts.admissionId
+      ? await this._resolveQueueAdmissionDuplicate({ admissionId, admissionHash })
+      : undefined;
+    if (duplicate) return this._returnDuplicateQueueResult(duplicate);
 
     const cap = this._harness._internalMaxQueueDepth;
     if ((this._record.pendingQueue?.length ?? 0) >= cap) {
       throw new HarnessQueueFullError(this.id, cap);
     }
 
-    const attachments = await this._resolveAttachmentRefs('queue().attachments', opts.attachments ?? []);
+    const queuedItemId = this._queueAdmissionQueuedItemId(admissionId);
     const item: QueuedItem = {
-      id: `q-${randomUUID()}`,
+      id: queuedItemId,
+      admissionId,
+      admissionHash,
       enqueuedAt: Date.now(),
       content: opts.content,
       attachments,
       ...(opts.model !== undefined ? { model: opts.model } : {}),
-      ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
+      mode: effectiveModeId,
       ...(opts.yolo !== undefined ? { yolo: opts.yolo } : {}),
     };
     const attachmentReferences = attachments
@@ -3856,16 +4104,44 @@ export class Session {
         source: 'queued_item' as const,
         sourceId: item.id,
       }));
+    let admittedReceipt: QueueAdmissionReceipt | OperationAdmissionTombstone | undefined;
+    const receipt: QueueAdmissionReceipt = {
+      admissionId,
+      admissionHash,
+      queuedItemId: item.id,
+      modeId: effectiveModeId,
+      status: 'queued',
+      attempts: 0,
+      enqueuedAt: item.enqueuedAt,
+      updatedAt: item.enqueuedAt,
+    };
 
     try {
       // Atomic check + append: re-check capacity inside the updater so a
-      // concurrent in-process `queue()` cannot push us past the cap.
+      // concurrent in-process `queue()` cannot push us past the cap. Exact
+      // admission retries are resolved here too so they do not append or
+      // consume queue capacity even when racing the original admission.
       await this._flushUpdate(
         prev => {
+          for (const existing of Object.values(prev.queueAdmissionReceipts ?? {})) {
+            if (existing.admissionId !== admissionId) continue;
+            if (existing.admissionHash !== admissionHash) {
+              throw new HarnessAdmissionConflictError(this.id, admissionId, existing.admissionHash, admissionHash);
+            }
+            admittedReceipt = existing;
+            return prev;
+          }
           if ((prev.pendingQueue?.length ?? 0) >= cap) {
             throw new HarnessQueueFullError(this.id, cap);
           }
-          return { ...prev, pendingQueue: [...(prev.pendingQueue ?? []), item] };
+          return {
+            ...prev,
+            pendingQueue: [...(prev.pendingQueue ?? []), item],
+            queueAdmissionReceipts: {
+              ...(prev.queueAdmissionReceipts ?? {}),
+              [item.id]: receipt,
+            },
+          };
         },
         { attachmentReferences },
       );
@@ -3876,11 +4152,167 @@ export class Session {
       throw err;
     }
 
-    return new Promise<AgentResult>((resolve, reject) => {
-      this._queueResolvers.set(item.id, { resolve, reject });
-      // Kick the drain — fire-and-forget. Drain handles its own errors and
-      // settles the resolver via `_completeQueuedTurn` / `_failQueuedTurn`.
-      void this._maybeDrainQueue();
+    if (admittedReceipt) return this._returnDuplicateQueueResult(admittedReceipt);
+
+    const queued = createDeferred<AgentResult>();
+    const promise = queued.promise;
+    this._queueResolvers.set(item.id, { promise, resolve: queued.resolve, reject: queued.reject });
+    // Kick the drain — fire-and-forget. Drain handles its own errors and
+    // settles the resolver via `_completeQueuedTurn` / `_failQueuedTurn`.
+    void this._maybeDrainQueue();
+    void promise.catch(() => {});
+    return promise;
+  }
+
+  private async _resolveQueueAdmissionDuplicate({
+    admissionId,
+    admissionHash,
+  }: {
+    admissionId: string;
+    admissionHash: string;
+  }): Promise<QueueAdmissionReceipt | OperationAdmissionTombstone | undefined> {
+    const resolved = await this._storage.resolveOperationAdmissionEvidence({
+      harnessName: this._record.harnessName,
+      sessionId: this.id,
+      resourceId: this.resourceId,
+      kind: 'queue',
+      admissionId,
+      attemptedAdmissionHash: admissionHash,
+    });
+    if (resolved.status === 'none') return undefined;
+    if (resolved.status === 'conflict') {
+      throw new HarnessAdmissionConflictError(this.id, admissionId, resolved.storedAdmissionHash ?? '', admissionHash);
+    }
+    return resolved.evidence as QueueAdmissionReceipt | OperationAdmissionTombstone | undefined;
+  }
+
+  private async _returnDuplicateQueueResult(
+    evidence: QueueAdmissionReceipt | OperationAdmissionTombstone,
+  ): Promise<AgentResult> {
+    if ('kind' in evidence) {
+      throw new HarnessValidationError('queue().admissionId', 'duplicate queue result evidence has expired');
+    }
+    if (evidence.status === 'completed' && evidence.postRunFinalizedAt !== undefined) {
+      return evidence.result as AgentResult;
+    }
+    if (evidence.status === 'failed' || evidence.status === 'admission_failed') {
+      throw publicErrorProjectionToError(
+        evidence.error ?? { code: 'harness.queue_failed', message: 'queued turn failed' },
+      );
+    }
+    if (evidence.status === 'dead') {
+      throw publicErrorProjectionToError(
+        evidence.error ?? { code: 'harness.queue_exhausted', message: 'queued turn exhausted retry attempts' },
+      );
+    }
+    const resolver = this._queueResolvers.get(evidence.queuedItemId);
+    if (resolver) return resolver.promise;
+    void this._maybeDrainQueue();
+    return this._awaitDurableQueueResult(evidence);
+  }
+
+  private async _awaitDurableQueueResult(receipt: QueueAdmissionReceipt): Promise<AgentResult> {
+    const deadline = Date.now() + MESSAGE_ADMISSION_DURABLE_WAIT_TIMEOUT_MS;
+    while (true) {
+      const latest = await this._storage.loadQueueResultEvidence({
+        harnessName: this._record.harnessName,
+        sessionId: this.id,
+        resourceId: this.resourceId,
+        queuedItemId: receipt.queuedItemId,
+      });
+      if (!latest) {
+        throw new HarnessValidationError('queue().admissionId', 'duplicate queue result evidence has expired');
+      }
+      if ('kind' in latest) {
+        throw new HarnessValidationError('queue().admissionId', 'duplicate queue result evidence has expired');
+      }
+      if (latest.status === 'completed' && latest.postRunFinalizedAt !== undefined) return latest.result as AgentResult;
+      if (latest.status === 'failed' || latest.status === 'admission_failed') {
+        throw publicErrorProjectionToError(
+          latest.error ?? { code: 'harness.queue_failed', message: 'queued turn failed' },
+        );
+      }
+      if (latest.status === 'dead') {
+        throw publicErrorProjectionToError(
+          latest.error ?? { code: 'harness.queue_exhausted', message: 'queued turn exhausted retry attempts' },
+        );
+      }
+      const waitMs = Math.min(MESSAGE_ADMISSION_DURABLE_WAIT_INTERVAL_MS, Math.max(0, deadline - Date.now()));
+      if (waitMs === 0) {
+        throw new HarnessValidationError('queue().admissionId', 'duplicate queue result evidence has expired');
+      }
+      await delay(waitMs);
+    }
+  }
+
+  private _queueAdmissionQueuedItemId(admissionId: string): string {
+    const digest = sha256CanonicalJson({
+      kind: 'queue-admission',
+      harnessName: this._record.harnessName,
+      sessionId: this.id,
+      resourceId: this.resourceId,
+      threadId: this.threadId,
+      admissionId,
+    });
+    return `q-${digest.slice(0, 32)}`;
+  }
+
+  private _queueSignalIdentity(item: QueuedItem): MessageAdmissionIdentity {
+    const digest = sha256CanonicalJson({
+      kind: 'queue-signal',
+      harnessName: this._record.harnessName,
+      sessionId: this.id,
+      resourceId: this.resourceId,
+      threadId: this.threadId,
+      queuedItemId: item.id,
+      admissionId: item.admissionId,
+    });
+    return {
+      signalId: `harness-queue-${digest.slice(0, 32)}`,
+      runId: `harness-queue-${digest.slice(32, 64)}`,
+    };
+  }
+
+  private _computeQueueAdmissionHash(opts: QueueOptions, attachments: PersistedAttachment[]): string {
+    return sha256CanonicalJson({
+      kind: 'queue',
+      content: opts.content,
+      ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
+      ...(opts.model !== undefined ? { model: opts.model } : {}),
+      ...(opts.yolo === true ? { yolo: true } : {}),
+      attachments: attachments.map(attachment => ({
+        kind: attachment.kind,
+        name: attachment.name,
+        mimeType: attachment.mimeType,
+        ...(attachment.kind === 'ref'
+          ? {
+              attachmentId: attachment.attachmentId,
+              resourceId: this.resourceId,
+              ownerSessionId: attachment.ownerSessionId,
+              bytes: attachment.bytes,
+              sha256: attachment.sha256,
+              source: attachment.source,
+            }
+          : { url: attachment.url }),
+      })),
+    });
+  }
+
+  private async _updateQueueAdmissionReceipt(
+    queuedItemId: string,
+    update: (receipt: QueueAdmissionReceipt, now: number) => QueueAdmissionReceipt,
+  ): Promise<void> {
+    await this._flushUpdate(prev => {
+      const current = prev.queueAdmissionReceipts?.[queuedItemId];
+      if (!current) return prev;
+      const now = Date.now();
+      return {
+        ...prev,
+        queueAdmissionReceipts: {
+          ...(prev.queueAdmissionReceipts ?? {}),
+          [queuedItemId]: update(current, now),
+        },
+      };
     });
   }
 
@@ -3931,7 +4363,10 @@ export class Session {
     if (this._state !== 'live') return;
     // A live suspension means a previous queued turn is awaiting a
     // `respondTo*` call — drain stays parked until that resolves.
-    if (this._record.pendingResume !== undefined) return;
+    if (this._record.pendingResume !== undefined) {
+      const recovery = await this._maybeRecoverStaleQueuedResume();
+      if (recovery.status === 'none') return;
+    }
     if (this._currentQueuedItemId !== undefined) return;
     // A manual `message()` turn is in flight — wait for it to settle.
     // `_recordTurnCompletion` will re-kick the drain on its way out.
@@ -3962,6 +4397,14 @@ export class Session {
             await this._completeQueuedTurn(head.id, full as AgentResult);
           }
         } catch (err) {
+          if (err instanceof QueueRecoveryPendingError) {
+            this._parkQueuedTurn(head.id, err);
+            return;
+          }
+          if (err instanceof QueuePostRunFinalizationPendingError) {
+            this._deferQueuedTurnRetry(err);
+            return;
+          }
           // Permanent failure during the turn — reject the resolver and
           // remove the item so we don't replay it forever.
           await this._failQueuedTurn(head.id, err);
@@ -3986,9 +4429,54 @@ export class Session {
    */
   private async _runQueuedTurn(item: QueuedItem): Promise<FullOutput<unknown>> {
     await this._validateQueuedAttachmentRefs(item);
-    const effectiveModeId = item.mode ?? this._record.modeId;
+    const currentReceipt = this._record.queueAdmissionReceipts?.[item.id];
+    const effectiveModeId = currentReceipt?.modeId ?? item.mode ?? this._record.modeId;
     const mode = this._harness._getMode(effectiveModeId);
     const agent = this._harness.getAgentForMode(effectiveModeId);
+    const identity = this._queueSignalIdentity(item);
+    let shouldMarkAdmitting = true;
+    if (currentReceipt) {
+      if (currentReceipt.status === 'completed') {
+        const full = currentReceipt.result as FullOutput<unknown>;
+        if (currentReceipt.postRunFinalizedAt === undefined) {
+          await this._finalizeCompletedQueuedTurn(item, full, effectiveModeId);
+        }
+        return full;
+      }
+      if (currentReceipt.status === 'failed' || currentReceipt.status === 'admission_failed') {
+        throw publicErrorProjectionToError(
+          currentReceipt.error ?? { code: 'harness.queue_failed', message: 'queued turn failed' },
+        );
+      }
+      if (currentReceipt.status === 'dead') {
+        throw publicErrorProjectionToError(
+          currentReceipt.error ?? {
+            code: 'harness.queue_exhausted',
+            message: 'queued turn exhausted retry attempts',
+          },
+        );
+      }
+      if (
+        (currentReceipt.status === 'admitting' || currentReceipt.status === 'accepted') &&
+        currentReceipt.runId &&
+        currentReceipt.signalId
+      ) {
+        const recovered = await this._recoverQueuedDispatch(item, currentReceipt, agent, effectiveModeId);
+        if (recovered) return recovered;
+      }
+    }
+    if (shouldMarkAdmitting) {
+      await this._updateQueueAdmissionReceipt(item.id, (receipt, now) => ({
+        ...receipt,
+        status: 'admitting',
+        runId: identity.runId,
+        signalId: identity.signalId,
+        modeId: receipt.modeId ?? effectiveModeId,
+        attempts: receipt.attempts + 1,
+        admittingAt: receipt.admittingAt ?? now,
+        updatedAt: now,
+      }));
+    }
 
     const toolsets = this._buildToolsets(mode);
     // Queued turns run under a session-owned AbortController so
@@ -4010,27 +4498,240 @@ export class Session {
 
     try {
       await this._ensureThreadSubscription(agent);
+      await this._writeQueueSignalResultEvidence({
+        status: 'pending',
+        signalId: identity.signalId,
+        runId: identity.runId,
+      });
       const signal = agent.sendSignal(
-        { type: 'user-message', contents: item.content as never },
+        { id: identity.signalId, type: 'user-message', contents: item.content as never },
         {
+          runId: identity.runId,
           resourceId: this.resourceId,
           threadId: this.threadId,
           ifIdle: { behavior: 'wake', streamOptions: baseExecOptions as never },
         },
       );
-      const full = await this._awaitRunCompletion(signal.runId);
-      this._recordTurnCompletion(full);
-      await this._maybeCaptureSuspend(full);
-      this._emitTurnEvent({
-        type: 'agent_end',
-        reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
-        runId: full.runId,
-      });
-      await this._runGoalJudge(full, (item.source ?? 'user') === 'goal');
-      return full;
+      const signalIdentity =
+        signal.runId === identity.runId && signal.signal.id === identity.signalId
+          ? identity
+          : { runId: signal.runId, signalId: signal.signal.id };
+      const completion = this._awaitQueuedRunCompletion(
+        item,
+        signalIdentity.runId,
+        signalIdentity.signalId,
+        effectiveModeId,
+      );
+      if (signalIdentity !== identity) {
+        await this._writeQueueSignalResultEvidence({
+          status: 'pending',
+          signalId: signalIdentity.signalId,
+          runId: signalIdentity.runId,
+        });
+      }
+      await this._updateQueueAdmissionReceipt(item.id, (receipt, now) => ({
+        ...receipt,
+        status: 'accepted',
+        runId: signalIdentity.runId,
+        signalId: signalIdentity.signalId,
+        modeId: receipt.modeId ?? effectiveModeId,
+        acceptedAt: receipt.acceptedAt ?? now,
+        updatedAt: now,
+      })).catch(() => {});
+      return await completion;
     } finally {
       this._endTurn(turnAbortController);
     }
+  }
+
+  private async _recoverQueuedDispatch(
+    item: QueuedItem,
+    receipt: QueueAdmissionReceipt,
+    agent: Agent,
+    modeId: string,
+  ): Promise<FullOutput<unknown> | undefined> {
+    if (!receipt.runId || !receipt.signalId) return undefined;
+
+    await this._ensureThreadSubscription(agent);
+    if (this._hasLiveMessageRun(agent, receipt.runId)) {
+      return this._awaitQueuedRunCompletion(item, receipt.runId, receipt.signalId, modeId);
+    }
+
+    const evidence = await this._loadQueueSignalResultEvidence(receipt);
+    if (evidence.status === 'completed') {
+      const full = evidence.result as FullOutput<unknown>;
+      await this._markQueuedTurnCompleted(item.id, full);
+      if (receipt.postRunFinalizedAt === undefined) {
+        await this._finalizeCompletedQueuedTurn(item, full, modeId);
+      }
+      return full;
+    }
+    if (evidence.status === 'failed') {
+      throw publicErrorProjectionToError(
+        evidence.error ?? { code: 'harness.queue_failed', message: 'queued turn failed' },
+      );
+    }
+
+    const recovery = await this._inspectQueueReceiptMemory(receipt);
+    if (recovery.status === 'pending') {
+      const dispatchAt = receipt.acceptedAt ?? receipt.admittingAt ?? receipt.updatedAt;
+      const retryAt = dispatchAt + QUEUE_ACCEPTED_RECOVERY_STALE_MS;
+      if (Date.now() >= retryAt) throw new QueueRecoveryStaleError();
+      throw new QueueRecoveryPendingError(retryAt);
+    }
+
+    return undefined;
+  }
+
+  private async _awaitQueuedRunCompletion(
+    item: QueuedItem,
+    runId: string,
+    signalId: string,
+    modeId: string,
+  ): Promise<FullOutput<unknown>> {
+    let full: FullOutput<unknown>;
+    try {
+      full = await this._awaitRunCompletion(runId);
+    } catch (err) {
+      await this._writeQueueSignalResultEvidence({
+        status: 'failed',
+        signalId,
+        runId,
+        error: projectHarnessPublicError(err),
+      }).catch(() => {});
+      throw err;
+    }
+
+    if (full.finishReason !== 'suspended') {
+      await this._markQueuedTurnCompleted(item.id, full);
+      await this._finalizeCompletedQueuedTurn(item, full, modeId);
+      await this._writeQueueSignalResultEvidence({
+        status: 'completed',
+        signalId,
+        runId,
+        result: full,
+      }).catch(() => {});
+    } else {
+      await this._finalizeQueuedRunCompletion(item, full, modeId);
+    }
+    return full;
+  }
+
+  private async _finalizeCompletedQueuedTurn(
+    item: QueuedItem,
+    full: FullOutput<unknown>,
+    modeId: string,
+  ): Promise<void> {
+    if (this._record.queueAdmissionReceipts?.[item.id]?.postRunFinalizedAt === undefined) {
+      // Mark before running non-idempotent post-run side effects. Recovery may
+      // retry a failed marker write, but must not replay goal continuations,
+      // token accounting, or terminal turn events after the marker persists.
+      try {
+        await this._markQueuedPostRunFinalized(item.id);
+      } catch (err) {
+        throw new QueuePostRunFinalizationPendingError(Date.now() + QUEUE_POST_RUN_FINALIZATION_RETRY_MS, err);
+      }
+    }
+    await this._finalizeQueuedRunCompletion(item, full, modeId);
+  }
+
+  private async _markQueuedTurnCompleted(
+    queuedItemId: string,
+    full: FullOutput<unknown>,
+    opts?: { modeId?: string },
+  ): Promise<void> {
+    await this._flushUpdate(prev => {
+      const receipt = prev.queueAdmissionReceipts?.[queuedItemId];
+      if (!receipt && opts?.modeId === undefined) return prev;
+      const now = Date.now();
+      const next: SessionRecord = { ...prev };
+      if (opts?.modeId !== undefined) next.modeId = opts.modeId;
+      if (receipt) {
+        next.queueAdmissionReceipts = {
+          ...(prev.queueAdmissionReceipts ?? {}),
+          [queuedItemId]:
+            receipt.status === 'completed'
+              ? receipt
+              : {
+                  ...receipt,
+                  status: 'completed',
+                  result: full,
+                  completedAt: receipt.completedAt ?? now,
+                  updatedAt: now,
+                },
+        };
+      }
+      return next;
+    });
+  }
+
+  private async _finalizeQueuedRunCompletion(
+    item: QueuedItem,
+    full: FullOutput<unknown>,
+    modeId?: string,
+  ): Promise<FullOutput<unknown>> {
+    this._recordTurnCompletion(full);
+    await this._maybeCaptureSuspend(full, item.id, modeId ?? item.mode ?? this._record.modeId);
+    this._emitTurnEvent({
+      type: 'agent_end',
+      reason: full.finishReason === 'suspended' ? 'suspended' : full.finishReason === 'error' ? 'error' : 'complete',
+      runId: full.runId,
+    });
+    await this._runGoalJudge(full, (item.source ?? 'user') === 'goal');
+    return full;
+  }
+
+  private async _markQueuedPostRunFinalized(queuedItemId: string): Promise<void> {
+    await this._updateQueueAdmissionReceipt(queuedItemId, (receipt, now) =>
+      receipt.postRunFinalizedAt !== undefined
+        ? receipt
+        : {
+            ...receipt,
+            postRunFinalizedAt: now,
+            updatedAt: now,
+          },
+    );
+  }
+
+  private async _loadQueueSignalResultEvidence(
+    receipt: QueueAdmissionReceipt,
+  ): Promise<AgentSignalResultStatus | { status: 'not_found' }> {
+    if (!receipt.signalId) return { status: 'not_found' };
+    const evidence = await this._storage.loadMessageResultEvidence({
+      harnessName: this._record.harnessName,
+      sessionId: this.id,
+      resourceId: this.resourceId,
+      threadId: this.threadId,
+      signalId: receipt.signalId,
+    });
+    if (!evidence || 'kind' in evidence) return { status: 'not_found' };
+    return evidence;
+  }
+
+  private async _writeQueueSignalResultEvidence(status: AgentSignalResultStatus): Promise<void> {
+    const now = Date.now();
+    await this._storage.writeMessageResultEvidence({
+      ...status,
+      harnessName: this._record.harnessName,
+      sessionId: this.id,
+      resourceId: this.resourceId,
+      threadId: this.threadId,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  private async _inspectQueueReceiptMemory(
+    receipt: QueueAdmissionReceipt,
+  ): Promise<{ status: 'not_found' } | { status: 'pending' }> {
+    if (!receipt.signalId) return { status: 'not_found' };
+
+    const memory = await this._harness._internalTryGetMemoryStorage();
+    if (!memory) return { status: 'not_found' };
+
+    const result = await memory.listMessages({ threadId: this.threadId, resourceId: this.resourceId, perPage: false });
+    const messages = result.messages as StoredMessageRow[];
+    return messages.some(message => message.id === receipt.signalId) ? { status: 'pending' } : { status: 'not_found' };
   }
 
   private async _validateQueuedAttachmentRefs(item: QueuedItem): Promise<void> {
@@ -4062,7 +4763,7 @@ export class Session {
   }
 
   private async _registerQuestion(
-    params: RegisterQuestionParams & { runId?: string; toolCallId?: string },
+    params: RegisterQuestionParams & { runId?: string; toolCallId?: string; modeId?: string },
   ): Promise<void> {
     this._assertLive('ctx.registerQuestion');
     if (typeof params.questionId !== 'string' || params.questionId.length === 0) {
@@ -4091,6 +4792,7 @@ export class Session {
       toolName: ASK_USER_TOOL_NAME,
       source: (this._record.subagentDepth ?? 0) > 0 ? 'subagent' : 'parent',
       requestedAt: Date.now(),
+      modeId: params.modeId ?? this._record.modeId,
       payload: {
         question: params.question,
         ...(params.options ? { options: params.options } : {}),
@@ -4147,6 +4849,7 @@ export class Session {
       toolName: SUBMIT_PLAN_TOOL_NAME,
       source: (this._record.subagentDepth ?? 0) > 0 ? 'subagent' : 'parent',
       requestedAt: Date.now(),
+      modeId: submittingModeId,
       payload: {
         ...(params.title !== undefined ? { title: params.title } : {}),
         plan: params.plan,
@@ -4178,14 +4881,33 @@ export class Session {
   /**
    * Settle a queued item's resolver with success and remove it from the
    * head of `pendingQueue`. The CAS write here is the durable record that
-   * the item ran exactly once. Crash recovery uses `pendingQueue[0]` and
-   * the absence of `pendingResume` to decide whether to replay.
+   * the item ran exactly once. Crash recovery uses `pendingQueue[0]`,
+   * `pendingResume`, queue receipts, and signal-result evidence to decide
+   * whether to replay, await, or fail a previously admitted item.
    */
   private async _completeQueuedTurn(itemId: string, result: AgentResult): Promise<void> {
-    await this._flushUpdate(prev => ({
-      ...prev,
-      pendingQueue: (prev.pendingQueue ?? []).filter(x => x.id !== itemId),
-    }));
+    const now = Date.now();
+    await this._flushUpdate(prev => {
+      const receipt = prev.queueAdmissionReceipts?.[itemId];
+      return {
+        ...prev,
+        pendingQueue: (prev.pendingQueue ?? []).filter(x => x.id !== itemId),
+        ...(receipt
+          ? {
+              queueAdmissionReceipts: {
+                ...(prev.queueAdmissionReceipts ?? {}),
+                [itemId]: {
+                  ...receipt,
+                  status: 'completed',
+                  result,
+                  completedAt: receipt.completedAt ?? now,
+                  updatedAt: now,
+                },
+              },
+            }
+          : {}),
+      };
+    });
     this._currentQueuedItemId = undefined;
     this._currentQueuedItemSource = undefined;
     const resolver = this._queueResolvers.get(itemId);
@@ -4200,10 +4922,52 @@ export class Session {
 
   /** Same as `_completeQueuedTurn` but rejects the resolver with `err`. */
   private async _failQueuedTurn(itemId: string, err: unknown): Promise<void> {
-    await this._flushUpdate(prev => ({
-      ...prev,
-      pendingQueue: (prev.pendingQueue ?? []).filter(x => x.id !== itemId),
-    }));
+    const now = Date.now();
+    let completedResult: AgentResult | undefined;
+    await this._flushUpdate(prev => {
+      const receipt = prev.queueAdmissionReceipts?.[itemId];
+      if (receipt?.status === 'completed') {
+        completedResult = receipt.result as AgentResult | undefined;
+        return {
+          ...prev,
+          pendingQueue: (prev.pendingQueue ?? []).filter(x => x.id !== itemId),
+        };
+      }
+      return {
+        ...prev,
+        pendingQueue: (prev.pendingQueue ?? []).filter(x => x.id !== itemId),
+        ...(receipt
+          ? {
+              queueAdmissionReceipts: {
+                ...(prev.queueAdmissionReceipts ?? {}),
+                [itemId]: {
+                  ...receipt,
+                  status: 'failed',
+                  error: projectHarnessPublicError(err),
+                  failedAt: receipt.failedAt ?? now,
+                  updatedAt: now,
+                },
+              },
+            }
+          : {}),
+      };
+    });
+    this._currentQueuedItemId = undefined;
+    this._currentQueuedItemSource = undefined;
+    const resolver = this._queueResolvers.get(itemId);
+    if (resolver) {
+      this._queueResolvers.delete(itemId);
+      if (completedResult !== undefined) {
+        resolver.resolve(completedResult);
+      } else {
+        resolver.reject(err);
+      }
+    }
+    this._notifyMaybeIdle();
+    void this._maybeDrainQueue();
+  }
+
+  private _parkQueuedTurn(itemId: string, err: unknown): void {
     this._currentQueuedItemId = undefined;
     this._currentQueuedItemSource = undefined;
     const resolver = this._queueResolvers.get(itemId);
@@ -4212,7 +4976,20 @@ export class Session {
       resolver.reject(err);
     }
     this._notifyMaybeIdle();
-    void this._maybeDrainQueue();
+    if (err instanceof QueueRecoveryPendingError) {
+      const delayMs = Math.max(0, err.retryAt - Date.now());
+      const timer = setTimeout(() => void this._maybeDrainQueue(), delayMs);
+      timer.unref?.();
+    }
+  }
+
+  private _deferQueuedTurnRetry(err: QueuePostRunFinalizationPendingError): void {
+    this._currentQueuedItemId = undefined;
+    this._currentQueuedItemSource = undefined;
+    this._notifyMaybeIdle();
+    const delayMs = Math.max(0, err.retryAt - Date.now());
+    const timer = setTimeout(() => void this._maybeDrainQueue(), delayMs);
+    timer.unref?.();
   }
 
   /** @internal — used by the Harness on hydration to start replay drain. */
@@ -4328,7 +5105,7 @@ export class Session {
         return session.setState(updatesOrUpdater as Partial<unknown>);
       }) as HarnessRequestContext<unknown>['setState'],
       abortSignal: turn.abortSignal,
-      registerQuestion: params => session._registerQuestion(params),
+      registerQuestion: params => session._registerQuestion({ ...params, modeId: turn.modeId }),
       registerPlanApproval: params => session._registerPlanApproval({ ...params, modeId: turn.modeId }),
       // Subagent linkage — set from the record so spawned sessions report
       // their depth + parent linkage on the harness slot.
@@ -4484,6 +5261,48 @@ function publicErrorProjectionToError(error: { code: string; message: string }):
   projected.name = error.code;
   (projected as Error & { code: string }).code = error.code;
   return projected;
+}
+
+class QueueRecoveryPendingError extends Error {
+  code = 'harness.queue_recovery_pending';
+  readonly retryAt: number;
+
+  constructor(retryAt: number) {
+    super('queued turn was accepted by the signal runtime and is awaiting durable terminal result evidence');
+    this.name = 'harness.queue_recovery_pending';
+    this.retryAt = retryAt;
+  }
+}
+
+class QueueRecoveryStaleError extends Error {
+  code = 'harness.queue_recovery_stale';
+
+  constructor() {
+    super('queued turn was accepted by the signal runtime but no live run or durable terminal result is available');
+    this.name = 'harness.queue_recovery_stale';
+  }
+}
+
+class QueueResumeRecoveryStaleError extends Error {
+  code = 'harness.queue_resume_recovery_stale';
+
+  constructor() {
+    super('queued turn resume was marked in flight but no terminal queue result is available');
+    this.name = 'harness.queue_resume_recovery_stale';
+  }
+}
+
+class QueuePostRunFinalizationPendingError extends Error {
+  code = 'harness.queue_post_run_finalization_pending';
+  readonly retryAt: number;
+  readonly cause: unknown;
+
+  constructor(retryAt: number, cause: unknown) {
+    super('queued turn completed and is waiting for post-run finalization to persist');
+    this.name = 'harness.queue_post_run_finalization_pending';
+    this.retryAt = retryAt;
+    this.cause = cause;
+  }
 }
 
 function throwIfAborted(signal: AbortSignal | undefined, path: string): void {

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -892,6 +892,9 @@ export interface QueueOptions extends QueueOverrides {
   /** Free-form user content. The only required field. */
   content: string;
 
+  /** Optional idempotency key for retry-safe queue admission. */
+  admissionId?: string;
+
   /** Optional pre-uploaded attachments to include with the user message. */
   attachments?: AttachmentRef[];
 }

--- a/packages/core/src/storage/domains/harness/inmemory.test.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.test.ts
@@ -104,6 +104,52 @@ describe('InMemoryHarness admission storage contract', () => {
       }),
     ).resolves.toEqual(tombstone);
   });
+
+  it('resolves queue admission duplicates and conflicts from retained receipts', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    await storage.saveSession(
+      sampleSession({
+        queueAdmissionReceipts: {
+          'queued-1': {
+            admissionId: 'admission-1',
+            admissionHash: 'hash-1',
+            queuedItemId: 'queued-1',
+            status: 'queued',
+            attempts: 0,
+            enqueuedAt: 1000,
+            updatedAt: 1000,
+          },
+        },
+      }),
+      { ownerId: 'h', ifVersion: 0 },
+    );
+
+    await expect(
+      storage.resolveOperationAdmissionEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        kind: 'queue',
+        admissionId: 'admission-1',
+        attemptedAdmissionHash: 'hash-1',
+      }),
+    ).resolves.toMatchObject({ status: 'duplicate', storedAdmissionHash: 'hash-1' });
+    await expect(
+      storage.resolveOperationAdmissionEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        kind: 'queue',
+        admissionId: 'admission-1',
+        attemptedAdmissionHash: 'different-hash',
+      }),
+    ).resolves.toMatchObject({ status: 'conflict', storedAdmissionHash: 'hash-1' });
+    await expect(
+      storage.loadQueueResultEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        queuedItemId: 'queued-1',
+      }),
+    ).resolves.toMatchObject({ admissionId: 'admission-1', status: 'queued' });
+  });
 });
 
 function sampleSession(overrides: Partial<SessionRecord> = {}): SessionRecord {

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -127,6 +127,10 @@ export interface PendingResume {
   source: 'parent' | 'subagent';
   subagentToolCallId?: string;
   requestedAt: number;
+  /** Present when this pending resume belongs to a queued turn. */
+  queuedItemId?: string;
+  /** Mode whose backing agent produced this pending resume. */
+  modeId?: string;
   /**
    * Idempotency marker. Set by the resume helper before calling
    * `agent.resumeStream(...)` and observed on replay so a crash between
@@ -352,6 +356,7 @@ export interface QueueAdmissionReceipt {
   admissionId: string;
   admissionHash: string;
   queuedItemId: string;
+  modeId?: string;
   status: 'queued' | 'admitting' | 'accepted' | 'completed' | 'admission_failed' | 'failed' | 'dead';
   runId?: string;
   signalId?: string;
@@ -361,6 +366,7 @@ export interface QueueAdmissionReceipt {
   enqueuedAt: number;
   admittingAt?: number;
   acceptedAt?: number;
+  postRunFinalizedAt?: number;
   completedAt?: number;
   failedAt?: number;
   deadAt?: number;

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from 'node:crypto';
 
 import { createClient } from '@libsql/client';
 import { TABLE_HARNESS_ATTACHMENTS } from '@mastra/core/storage';
+import type { SessionRecord } from '@mastra/core/storage';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { HarnessLibSQL } from './index';
@@ -240,3 +241,81 @@ describe('HarnessLibSQL message result evidence', () => {
     ).resolves.toEqual(compacted);
   });
 });
+
+describe('HarnessLibSQL queue admission evidence', () => {
+  let storage: HarnessLibSQL;
+
+  beforeEach(async () => {
+    const client = createHarnessTestClient();
+    storage = new HarnessLibSQL({ client });
+    await storage.init();
+  });
+
+  it('resolves queue admission duplicates and conflicts from retained receipts', async () => {
+    await storage.saveSession(
+      sampleSession({
+        queueAdmissionReceipts: {
+          'queued-1': {
+            admissionId: 'admission-1',
+            admissionHash: 'hash-1',
+            queuedItemId: 'queued-1',
+            status: 'queued',
+            attempts: 0,
+            enqueuedAt: 1000,
+            updatedAt: 1000,
+          },
+        },
+      }),
+      { ownerId: 'h', ifVersion: 0 },
+    );
+
+    await expect(
+      storage.resolveOperationAdmissionEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        kind: 'queue',
+        admissionId: 'admission-1',
+        attemptedAdmissionHash: 'hash-1',
+      }),
+    ).resolves.toMatchObject({ status: 'duplicate', storedAdmissionHash: 'hash-1' });
+    await expect(
+      storage.resolveOperationAdmissionEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        kind: 'queue',
+        admissionId: 'admission-1',
+        attemptedAdmissionHash: 'different-hash',
+      }),
+    ).resolves.toMatchObject({ status: 'conflict', storedAdmissionHash: 'hash-1' });
+    await expect(
+      storage.loadQueueResultEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        queuedItemId: 'queued-1',
+      }),
+    ).resolves.toMatchObject({ admissionId: 'admission-1', status: 'queued' });
+  });
+});
+
+function sampleSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    harnessName: 'default',
+    id: 'session-1',
+    resourceId: 'resource-1',
+    threadId: 'thread-1',
+    origin: 'top-level',
+    ownsThread: false,
+    modeId: 'build',
+    modelId: 'model-1',
+    subagentModelOverrides: {},
+    permissionRules: { categories: {}, tools: {} },
+    sessionGrants: { categories: [], tools: [] },
+    tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    pendingQueue: [],
+    state: {},
+    createdAt: 1000,
+    lastActivityAt: 1000,
+    version: 0,
+    ...overrides,
+  };
+}

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -985,7 +985,8 @@ export class HarnessLibSQL extends HarnessStorage {
     if (kind === 'queue') {
       const session = await this.loadSession({ harnessName: namespace, sessionId });
       if (session && session.resourceId !== resourceId) return { status: 'none' };
-      for (const receipt of Object.values(session?.queueAdmissionReceipts ?? {})) {
+      const receipts = Object.values(session?.queueAdmissionReceipts ?? {}) as QueueAdmissionReceipt[];
+      for (const receipt of receipts) {
         if (receipt.admissionId !== admissionId) continue;
         return {
           status: receipt.admissionHash === attemptedAdmissionHash ? 'duplicate' : 'conflict',


### PR DESCRIPTION
## Linear

PF-354: https://linear.app/papersflow/issue/PF-354/harness-v1pr09-queue-admission-idempotency-and-drain-recovery-core

## Summary

- Adds retry-safe `Session.queue({ admissionId })` admission receipts with deterministic queued item, signal, and run identities.
- Persists queue admission hash, mode, signal/run linkage, completion result, and post-run finalization marker for duplicate admission and crash recovery.
- Reuses Mastra `agent.sendSignal()` for queued execution; the durable queue receipt is an admission/recovery ledger, not a separate execution runner.
- Recovers accepted queued turns from live runs, durable signal result evidence, or memory-visible pending signals, and fails stale accepted/replayed resumes instead of stranding the queue.
- Persists/resolves queued and suspended mode context so queued mode overrides and message mode overrides resume through the right backing agent.
- Extends focused queue, suspend, storage, libsql, and docs coverage.

## Scope / coordination

Current open `mbenhamd/mastra` PR overlap was rechecked on 2026-05-15 before opening:

- #69 touches broad legacy agent/durable/tool-gate/flow-signal files, not `packages/core/src/harness/v1/**`, harness storage types, libsql harness domain, or harness docs touched here.
- #68 touches legacy harness/tool-gate and durable agent paths, not Harness v1 queue admission files touched here.
- #58 touches ClickHouse memory storage only.

This PR can proceed independently. It does not touch production Convex, production Docker, secrets, signing, release, or publish actions.

## Design notes

- Exact queue duplicates return retained results only after completed queue receipts are post-run-finalized; in-process duplicates during the completed-but-not-finalized gap join the live resolver.
- Duplicate queue admission polling remains bounded by the existing durable wait timeout rather than waiting forever.
- `postRunFinalizedAt` is written before non-idempotent post-run hooks so recovery can retry marker writes without replaying token accounting, `agent_end`, or goal continuation side effects after the marker persists.
- Queue admission hashes intentionally include explicit `mode` only. A retry after a session default-mode switch dedupes to the original accepted item rather than conflicting on ambient default mode drift; the receipt stores the effective mode used for recovery/resume.

## Local validation

Pre-rebase and post-fix checks run:

- `pnpm run prettier:changed`
- `git diff --check`
- `timeout 180s pnpm --filter @mastra/core exec vitest run src/harness/v1/session.queue.test.ts --reporter verbose` (30 tests)
- `timeout 180s pnpm --filter @mastra/core exec vitest run src/harness/v1/session.suspend.test.ts --reporter verbose` (38 tests)
- `timeout 180s pnpm --filter @mastra/core exec vitest run src/harness/v1/session.builtin-tools.test.ts --reporter verbose` (8 tests)
- `timeout 120s pnpm --filter @mastra/core exec vitest run src/storage/domains/harness/inmemory.test.ts --reporter verbose` (5 tests)
- `timeout 120s pnpm --filter @mastra/libsql exec vitest run src/storage/domains/harness/index.test.ts --reporter verbose` (5 tests)
- `timeout 120s pnpm --filter @mastra/core exec vitest run src/harness/v1/harness.test.ts --reporter verbose` (49 passed, 1 todo)
- `timeout 240s pnpm --filter @mastra/core run check`
- `timeout 240s pnpm --filter @mastra/core run build:lib`
- `timeout 240s pnpm --filter @mastra/libsql run build:lib`

Post-rebase sanity checks against current `origin/main`:

- `git diff --check origin/main...HEAD`
- `timeout 180s pnpm --filter @mastra/core exec vitest run src/harness/v1/session.queue.test.ts --reporter verbose` (30 tests)
- `timeout 240s pnpm --filter @mastra/core run check`
- `timeout 240s pnpm --filter @mastra/core run build:lib`
- `timeout 240s pnpm --filter @mastra/libsql run build:lib`

Notes:

- One parallel `@mastra/libsql build:lib` run failed while `@mastra/core build:lib` was still running because it could not resolve `@mastra/core/*` entrypoints. Rerunning libsql serially after the core build passed.
- Two local Codex review passes found post-run finalization replay risks; those were fixed. A final short rerun was blocked by the local Codex usage limit until 7:42 PM.
- CodeRabbit CLI is installed and authenticated, but `coderabbit doctor` reported local storage and backend/WebSocket reachability failures; `coderabbit review --plain` did not produce review output and exited nonzero. Please use the GitHub CodeRabbit app review for PR review evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes session.queue retry-safe: if you queue the same task twice with the same admissionId, the system detects it and avoids duplicate work, returning the original result or joining the live work instead.

## Summary

Implements queue admission idempotency and durable admission receipts for Harness v1 sessions, adding deterministic queued identities, richer receipts, crash/replay recovery, and tests/docs to cover admission/recovery semantics.

### Key changes

- Type & storage shape
  - QueueOptions: added optional admissionId?: string.
  - PendingResume persisted metadata: queuedItemId?: string and modeId?: string.
  - QueueAdmissionReceipt: added modeId?: string and postRunFinalizedAt?: number.

- Core session behavior (packages/core/src/harness/v1/session.ts)
  - session.queue(admissionId) supports deterministic queued-item IDs/hashes and validates admissionId.
  - Durable queue admission receipts with states (queued → admitting/accepted → completed/failed) and admission-result evidence for duplicate/race resolution.
  - Post-run finalization marker written before non-idempotent hooks to allow safe retries.
  - _runQueuedTurn and related helpers replay/recover using receipts, stored signal-result evidence, and deterministic signal identities.
  - Queue/resume flow updated to persist resume mode, select resumeModeId explicitly, finalize receipts on completion, and apply correct queued-mode agent on resume.
  - New queue-specific errors and timing constants for stale-accepted recovery and post-run finalization retries.
  - Request-context wiring: registerQuestion/registerPlanApproval include modeId so pending resumes carry mode attribution.

- Harness-level recovery (packages/core/src/harness/v1/harness.ts)
  - Queue-drain recovery broadened to kick when there are pending queue items and either no live pendingResume or pendingResume.resumedAt exists, enabling stale queued-resume recovery and emitting queue_item_replayed rather than leaving busy recovery hung.

- Storage implementations and helpers
  - In-memory and LibSQL storage tests and logic updated to materialize and inspect queue admission receipts.
  - resolveOperationAdmissionEvidence(kind: 'queue') classifies attempts as duplicate (matching admission hash) vs conflict (different payload) and preserves retained evidence for replayed results.
  - loadQueueResultEvidence exposes queued evidence and metadata.

- Tests
  - Large expansion of session.queue tests to cover admission deduplication, retained receipts when evidence writes fail, post-run finalization retry behavior, conflict detection for differing payloads with same admissionId, replaying completed admission results, mode override persistence and resume routing, hydration/crash replay scenarios, and stale accepted receipt handling.
  - session.suspend tests updated to assert pendingResume.modeId preservation and correct agent routing on resume.
  - Storage contract tests added/extended for queue admission evidence resolution in both in-memory and LibSQL stores.

- Documentation & release
  - docs: added session.queue docs with examples and idempotency semantics.
  - .changeset: entry describing retry-safe session.queue({ admissionId }) and example usage.

### Notable commit
- "Fix queued resume recovery events" — targeted corrective change addressing queued resume recovery behavior.

### Testing & validation
- Multiple vitest suites added/updated, lint/format/build checks performed locally; tests cover hydration, crash replay, admission-result evidence, and finalization retry scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/89)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->