### PR TITLE
[PF-354] Mark fork-only secret checks skipped

### DIFF
--- a/.github/workflows/contributor_actions.yml
+++ b/.github/workflows/contributor_actions.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Setup custom action
         uses: ./.github/workflows/shared-actions/set-pr-status
         with:
-          status: 'pending'
+          status: ${{ github.repository == 'mastra-ai/mastra' && 'pending' || 'success' }}
           context: ${{ matrix.description }}
+          description: ${{ github.repository == 'mastra-ai/mastra' && 'Waiting for secret-backed workflow' || 'Skipped in fork; upstream-only secret workflow' }}
           sha: ${{ github.event.pull_request.head.sha }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          target_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Summary
- keep upstream mastra-ai/mastra contributor secret-check statuses pending for the secret-backed workflow chain
- mark those same statuses successful in forks, where the follow-up secret workflows are gated off and cannot complete them
- add a target URL and explicit skip description to make the fork behavior auditable

## Validation
- git diff --check
- local Codex review pass 1: no findings
- local Codex review pass 2: one operational REVIEW note: existing PRs need a new opened/synchronize/reopened event after this lands; recorded for PR #89 handling
- actionlint unavailable locally; npx actionlint attempt failed because npm could not determine an executable
- CodeRabbit CLI attempted but stalled after Tools completed, so no completed local CodeRabbit review is claimed

## PR #89 follow-up
After this lands on fork main, PR #89 still needs a new PR event, such as close/reopen or an empty synchronize push, so the fork main workflow rewrites its currently pending statuses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When contributors submit PRs to this project, GitHub needs to know whether certain security-related tests are running. This PR makes the system smarter: in the official repository, it tells GitHub "I'm waiting to run secret-backed tests" (pending status), but in personal forks where those secret tests can't run, it tells GitHub "We skipped this on purpose because it's fork-only" (success status). This keeps things clear and transparent about what's happening and why.

---

## Changes

Modified `.github/workflows/contributor_actions.yml` to conditionally set PR status checks based on whether the workflow is running in the upstream repository or a fork.

### Key Modifications

The workflow's `set-pr-status` action now includes:

- **Conditional `status`**: Reports `pending` for the upstream repository (`mastra-ai/mastra`), `success` for forks
- **Conditional `description`**: Reports "Waiting for secret-backed workflow" upstream, "Skipped in fork; upstream-only secret workflow" in forks  
- **Explicit `target_url`**: Added link to the GitHub Actions run URL for auditability

### Rationale

Secret-backed workflows cannot complete in forks (they lack repository secrets), causing upstream contributor PRs to show blocked statuses. This change:
- Keeps upstream status pending (accurate, since secret workflows will run)
- Marks fork status as success with clear skip explanation (prevents false failure indicators)
- Provides direct link to the workflow run for transparency

### Testing Notes

- Existing PRs will require a new `open`, `synchronize`, or `reopen` event to update their previously pending statuses after this lands on the main branch

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/90)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->