### PR TITLE
[PF-441] Preserve workspace skill path lookup

### DIFF
--- a/.changeset/witty-pants-swim.md
+++ b/.changeset/witty-pants-swim.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Harness skill lookup so a workspace skill whose frontmatter name matches a code skill can still be invoked through its explicit `skills/<dir>` or `skills/<dir>/SKILL.md` path. Bare-name `session.skills.use()` calls still resolve to the code skill.

--- a/packages/core/src/harness/v1/session.skills.use.test.ts
+++ b/packages/core/src/harness/v1/session.skills.use.test.ts
@@ -3,8 +3,9 @@
  *
  * Programmatic skill execution against the code-registered and
  * workspace-discovered catalogues. Code skills resolve by name first.
- * Workspace skills resolve by frontmatter name or workspace-relative path
- * unless a code skill owns the same name.
+ * Workspace skills resolve by frontmatter name or workspace-relative path.
+ * Code skills own same-name refs, while explicit workspace paths still
+ * resolve shadowed workspace skills.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -57,7 +58,8 @@ class FakeWorkspaceSkills {
     this.getCalls.push(ref);
     // Resolution mirrors Flue's behaviour: either frontmatter name or the
     // workspace-relative path. The fake matches on both.
-    const e = this.entries.find(x => x.name === ref || (x.path ?? `skills/${x.name}`) === ref);
+    const pathRef = ref.replace(/\/SKILL\.md$/, '');
+    const e = this.entries.find(x => x.name === ref || (x.path ?? `skills/${x.name}`) === pathRef);
     if (!e) return null;
     return {
       name: e.name,
@@ -180,7 +182,7 @@ describe('Session.skills.use() (§4.6)', () => {
       {
         name: 'shared',
         description: 'Workspace shared',
-        path: 'skills/shared/SKILL.md',
+        path: 'skills/shared',
         instructions: 'Workspace body.',
       },
     ]);
@@ -196,12 +198,12 @@ describe('Session.skills.use() (§4.6)', () => {
     expect(fakeSkills.getCalls).toEqual([]);
   });
 
-  it('does not allow a shadowed workspace skill to bypass code precedence by path', async () => {
+  it('allows a shadowed workspace skill to resolve by path without weakening code name precedence', async () => {
     const fakeSkills = new FakeWorkspaceSkills([
       {
         name: 'shared',
         description: 'Workspace shared',
-        path: 'skills/shared/SKILL.md',
+        path: 'skills/shared',
         instructions: 'Workspace body.',
       },
     ]);
@@ -210,12 +212,18 @@ describe('Session.skills.use() (§4.6)', () => {
     ]);
     const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
 
-    await expect(session.skills.use('skills/shared/SKILL.md')).rejects.toMatchObject({
-      searchedSources: ['code-registered', 'workspace'],
-    });
+    const listed = await session.skills.list();
+    expect(listed.map(skill => skill.name)).toEqual(['shared']);
+    expect(await session.skills.get('shared')).toMatchObject({ name: 'shared', instructions: 'Code body.' });
+    expect(await session.skills.get('skills/shared')).toBeUndefined();
 
-    expect(agent.streamCalls).toHaveLength(0);
-    expect(fakeSkills.getCalls).toEqual(['skills/shared/SKILL.md']);
+    await session.skills.use('skills/shared/SKILL.md');
+    await session.skills.use('skills/shared');
+
+    expect(agent.streamCalls).toHaveLength(2);
+    expect(extractSignalContents(agent.streamCalls[0]!.messages)).toBe('Workspace body.');
+    expect(extractSignalContents(agent.streamCalls[1]!.messages)).toBe('Workspace body.');
+    expect(fakeSkills.getCalls).toEqual(['skills/shared/SKILL.md', 'skills/shared']);
   });
 
   it('does not treat a code skill filePath as a use() alias', async () => {
@@ -223,7 +231,7 @@ describe('Session.skills.use() (§4.6)', () => {
       {
         name: 'deploy',
         description: 'Workspace deploy',
-        path: 'skills/deploy/SKILL.md',
+        path: 'skills/deploy',
         instructions: 'Workspace deploy body.',
       },
     ]);
@@ -249,7 +257,7 @@ describe('Session.skills.use() (§4.6)', () => {
       {
         name: 'format',
         description: 'Format files',
-        path: 'tools/format/SKILL.md',
+        path: 'tools/format',
         instructions: 'Format every file.',
       },
     ]);

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -1061,7 +1061,9 @@ export class Session {
    * Reference resolution checks the static code registry first, then mirrors
    * Flue's workspace `session.skill(ref, ...)` behavior — either the
    * frontmatter `name` or a relative path under the workspace skill source
-   * resolves. `WorkspaceSkills.get(ref)` already supports both.
+   * resolves. `WorkspaceSkills.get(ref)` already supports both. A code skill
+   * owns its name, but does not hide an otherwise shadowed workspace skill's
+   * explicit path reference.
    */
   private async _skillsUse(ref: string, opts?: UseSkillOptions): Promise<AgentResult> {
     this._assertLive('skills.use()');
@@ -1094,10 +1096,6 @@ export class Session {
     if (!skill) {
       throw new HarnessSkillNotFoundError(ref, ['code-registered', 'workspace']);
     }
-    if (this._harness._getCodeSkill(skill.name)) {
-      throw new HarnessSkillNotFoundError(ref, ['code-registered', 'workspace']);
-    }
-
     const args = opts?.args;
     this._validateSkillArgs(skill.name, skill.metadata, args);
 

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -158,7 +158,9 @@ export type ModelAuthStatus = 'authenticated' | 'needs_auth' | 'unknown';
 // HarnessConfig registry and the session's configured `WorkspaceSkills`.
 // Static skills resolve by name; workspace skills resolve by name or path.
 // Static skills win on name conflicts so deployment-owned prompts can
-// intentionally override workspace-discovered prompts.
+// intentionally override workspace-discovered prompts. Explicit workspace
+// path refs remain available for callers that need to invoke a shadowed
+// workspace skill intentionally.
 // ---------------------------------------------------------------------------
 
 /**


### PR DESCRIPTION
## Linear
PF-441: Preserve workspace skill path lookup when code skill names collide

## Summary
- Removes the post-workspace-lookup rejection that blocked explicit workspace path refs when the workspace skill frontmatter name matched a code-registered skill.
- Keeps bare-name `session.skills.use()` precedence for code skills, and documents the path-only escape hatch in the public HarnessSkill comment and changeset.
- Updates Harness v1 skill-use tests to cover both `skills/<dir>` and `skills/<dir>/SKILL.md` path refs for shadowed workspace skills.

## Coordination / overlap
- Rechecked open mbenhamd/mastra PRs before push: #68 and #58 do not touch these files; #69 is a broad stale reset/revert PR and should not be merged over active fork work without explicit coordination.
- No production Convex, Docker, secrets, signing, release, or publish actions touched.

## Validation
- `pnpm --filter @mastra/core exec vitest run src/harness/v1/session.skills.use.test.ts src/harness/v1/session.skills.test.ts --reporter verbose` (49 passed)
- `pnpm --filter ./packages/core check`
- `git diff --check`
- Pre-commit `lint-staged --quiet`

## Reviews
- Local Codex review pass 1 (correctness/security/scope): No findings.
- Local Codex review pass 2 (tests/maintainability/merge readiness): No findings.
- Claude council review: no blockers; review/nit cleanup handled in this commit.
- CodeRabbit CLI: installed but hung after `Tools completed` on two attempts; second run was bounded and stopped. Relying on GitHub CodeRabbit app review for PR evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you have two skills with the same name—one in your code and one in your workspace folder—this PR lets you still use the workspace skill by specifying its file path (like `skills/myskill/SKILL.md`), while keeping the default behavior where just using the name goes to the code skill.

## Overview

This PR removes a restriction that blocked explicit workspace skill path references when a workspace skill's name matched a code-registered skill. The fix preserves the existing precedence where bare-name `session.skills.use()` calls resolve to code skills, while enabling workspace skills to be invoked via their explicit `skills/<dir>` or `skills/<dir>/SKILL.md` path even when shadowed by a code skill of the same name. The change is documented in the public `HarnessSkill` comment and includes a changeset entry.

## Changes

**`.changeset/witty-pants-swim.md`**
- Adds a changeset documenting the fix in Harness skill resolution logic for patch version bump of `@mastra/core`

**`packages/core/src/harness/v1/session.ts`**
- Removes the `HarnessSkillNotFoundError` rejection in `Session._skillsUse()` when a resolved workspace skill name matches a code-registered skill
- Updates documentation comment to reflect that explicit workspace-path resolution is now supported even when a code skill shares the same name

**`packages/core/src/harness/v1/session.skills.use.test.ts`**
- Normalizes workspace skill references ending in `/SKILL.md` before matching against fake workspace entries
- Adjusts test fixtures to provide workspace-relative skill paths without the `/SKILL.md` suffix
- Adds/renames test case to verify that a shadowed workspace skill can be resolved by path (including `.md` suffixed references) while maintaining code-registered name precedence
- Updates assertions to confirm correct skill resolution via `list()`, `get()`, and `use()` methods with expected agent call counts

**`packages/core/src/harness/v1/types.ts`**
- Updates inline comment documentation to clarify that static (code-registered) skills intentionally override workspace-discovered prompts, while workspace path references remain available for invoking shadowed workspace skills

## Validation

- Vitest: 49 tests passed for harness skill-use and session.skills tests
- Code quality checks: `pnpm check`, `git diff --check`, and `lint-staged` all passed
- Local Codex review: passed with no findings
- Claude council review: approved with no blockers

## Coordination

No overlap or conflicts with other open PRs; verified that related PRs (#68, #58) do not touch affected files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/91)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->