### PR TITLE
[PF-442] Harden LibSQL Harness legacy migrations

### DIFF
--- a/.changeset/pf-442-libsql-harness-migration.md
+++ b/.changeset/pf-442-libsql-harness-migration.md
@@ -1,0 +1,5 @@
+---
+'@mastra/libsql': patch
+---
+
+Automatically migrates existing LibSQL Harness data to the latest schema during initialization. Sessions, attachments, and attachment references continue working after upgrade with existing rows preserved and no manual intervention required.

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -1,7 +1,12 @@
 import { createHash, randomUUID } from 'node:crypto';
 
 import { createClient } from '@libsql/client';
-import { TABLE_HARNESS_ATTACHMENTS } from '@mastra/core/storage';
+import type { Client } from '@libsql/client';
+import {
+  TABLE_HARNESS_ATTACHMENT_REFERENCES,
+  TABLE_HARNESS_ATTACHMENTS,
+  TABLE_HARNESS_SESSIONS,
+} from '@mastra/core/storage';
 import type { SessionRecord } from '@mastra/core/storage';
 import { beforeEach, describe, expect, it } from 'vitest';
 
@@ -102,12 +107,117 @@ describe('HarnessLibSQL attachments', () => {
 
     const record = await legacyStorage.getAttachmentRecord({ sessionId: 'session-1', attachmentId: 'a1' });
     expect(record).toMatchObject({ source: 'preupload', sha256: expectedSha256, bytes: 3 });
+    await expect(primaryKeyColumns(client, TABLE_HARNESS_ATTACHMENTS)).resolves.toEqual([
+      'harness_name',
+      'session_id',
+      'attachment_id',
+    ]);
+    await expect(
+      client.execute({
+        sql: `INSERT INTO ${TABLE_HARNESS_ATTACHMENTS}
+              (harness_name, session_id, attachment_id, name, mime_type, size_bytes, sha256, source, created_at, data_b64)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        args: [
+          'secondary',
+          'session-1',
+          'a1',
+          'secondary.bin',
+          'application/octet-stream',
+          1,
+          createHash('sha256')
+            .update(new Uint8Array([1]))
+            .digest('hex'),
+          'preupload',
+          Date.now(),
+          Buffer.from([1]).toString('base64'),
+        ],
+      }),
+    ).resolves.toBeDefined();
 
     await legacyStorage.init();
     await expect(legacyStorage.loadAttachment({ sessionId: 'session-1', attachmentId: 'a1' })).resolves.toMatchObject({
       bytes: 3,
       sha256: expectedSha256,
     });
+  });
+});
+
+describe('HarnessLibSQL legacy Harness table migrations', () => {
+  it('rebuilds a pre-namespace sessions table with the namespace-aware primary key', async () => {
+    const client = createClient({ url: ':memory:' });
+    const legacySession = sampleSession({
+      ownsThread: true,
+      version: 7,
+      ownerId: 'owner-1',
+      leaseExpiresAt: 3000,
+    });
+    await createLegacySessionsTable(client);
+    await insertLegacySession(client, legacySession);
+
+    const legacyStorage = new HarnessLibSQL({ client });
+    await legacyStorage.init();
+
+    await expect(primaryKeyColumns(client, TABLE_HARNESS_SESSIONS)).resolves.toEqual(['harness_name', 'id']);
+    await expect(legacyStorage.loadSession({ sessionId: 'session-1' })).resolves.toEqual(legacySession);
+    await expect(
+      legacyStorage.saveSession(sampleSession({ harnessName: 'secondary' }), { ownerId: 'h', ifVersion: 0 }),
+    ).resolves.toMatchObject({ version: 1 });
+  });
+
+  it('rebuilds pre-namespace attachment references with the namespace-aware primary key', async () => {
+    const client = createClient({ url: ':memory:' });
+    await client.execute(`
+      CREATE TABLE ${TABLE_HARNESS_ATTACHMENT_REFERENCES} (
+        session_id TEXT NOT NULL,
+        attachment_id TEXT NOT NULL,
+        source TEXT NOT NULL,
+        source_id TEXT NOT NULL,
+        retained_until INTEGER,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (session_id, attachment_id, source, source_id)
+      )
+    `);
+    await client.execute({
+      sql: `INSERT INTO ${TABLE_HARNESS_ATTACHMENT_REFERENCES}
+            (session_id, attachment_id, source, source_id, retained_until, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)`,
+      args: ['session-1', 'a1', 'queued_item', 'queued-1', 2000, 1000],
+    });
+
+    const legacyStorage = new HarnessLibSQL({ client });
+    await legacyStorage.init();
+
+    await expect(primaryKeyColumns(client, TABLE_HARNESS_ATTACHMENT_REFERENCES)).resolves.toEqual([
+      'harness_name',
+      'session_id',
+      'attachment_id',
+      'source',
+      'source_id',
+    ]);
+    await expect(
+      legacyStorage.listAttachmentReferences({ sessionId: 'session-1', attachmentId: 'a1' }),
+    ).resolves.toEqual([{ source: 'queued_item', sourceId: 'queued-1', retainedUntil: 2000 }]);
+    await expect(
+      client.execute({
+        sql: `INSERT INTO ${TABLE_HARNESS_ATTACHMENT_REFERENCES}
+              (harness_name, session_id, attachment_id, source, source_id, retained_until, created_at)
+              VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        args: ['secondary', 'session-1', 'a1', 'queued_item', 'queued-1', 3000, 1000],
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it('reports duplicate active legacy sessions before creating the active-session index', async () => {
+    const client = createClient({ url: ':memory:' });
+    await createLegacySessionsTable(client);
+    await insertLegacySession(client, { id: 'session-1', resourceId: 'resource-1', threadId: 'thread-1' });
+    await insertLegacySession(client, { id: 'session-2', resourceId: 'resource-1', threadId: 'thread-1' });
+
+    const legacyStorage = new HarnessLibSQL({ client });
+    await expect(legacyStorage.init()).rejects.toThrow(
+      'Cannot create Harness active-session uniqueness index while duplicate active rows exist',
+    );
+    await expect(primaryKeyColumns(client, TABLE_HARNESS_SESSIONS)).resolves.toEqual(['id']);
   });
 });
 
@@ -318,4 +428,83 @@ function sampleSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
     version: 0,
     ...overrides,
   };
+}
+
+async function primaryKeyColumns(client: Client, tableName: string): Promise<string[]> {
+  const result = await client.execute({ sql: `PRAGMA table_info("${tableName}")`, args: [] });
+  return result.rows
+    .map(row => ({ name: String(row.name), order: Number(row.pk ?? 0) }))
+    .filter(row => row.order > 0)
+    .sort((a, b) => a.order - b.order)
+    .map(row => row.name);
+}
+
+async function createLegacySessionsTable(client: Client): Promise<void> {
+  await client.execute(`
+    CREATE TABLE ${TABLE_HARNESS_SESSIONS} (
+      id TEXT NOT NULL,
+      resource_id TEXT NOT NULL,
+      thread_id TEXT NOT NULL,
+      parent_session_id TEXT,
+      origin TEXT NOT NULL,
+      owns_thread INTEGER NOT NULL,
+      mode_id TEXT NOT NULL,
+      model_id TEXT NOT NULL,
+      subagent_model_overrides TEXT NOT NULL,
+      permission_rules TEXT NOT NULL,
+      session_grants TEXT NOT NULL,
+      token_usage TEXT NOT NULL,
+      pending_queue TEXT NOT NULL,
+      pending_resume TEXT,
+      observational_memory TEXT,
+      goal TEXT,
+      workspace TEXT,
+      state TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      last_activity_at INTEGER NOT NULL,
+      closed_at INTEGER,
+      version INTEGER NOT NULL,
+      owner_id TEXT,
+      lease_expires_at INTEGER,
+      PRIMARY KEY (id)
+    )
+  `);
+}
+
+async function insertLegacySession(client: Client, overrides: Partial<SessionRecord> = {}): Promise<void> {
+  const session = sampleSession(overrides);
+  await client.execute({
+    sql: `INSERT INTO ${TABLE_HARNESS_SESSIONS}
+          (id, resource_id, thread_id, parent_session_id, origin, owns_thread, mode_id, model_id,
+           subagent_model_overrides, permission_rules, session_grants, token_usage, pending_queue, pending_resume,
+           observational_memory, goal, workspace, state, created_at, last_activity_at, closed_at, version,
+           owner_id, lease_expires_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      session.id,
+      session.resourceId,
+      session.threadId,
+      session.parentSessionId ?? null,
+      session.origin,
+      session.ownsThread ? 1 : 0,
+      session.modeId,
+      session.modelId,
+      JSON.stringify(session.subagentModelOverrides),
+      JSON.stringify(session.permissionRules),
+      JSON.stringify(session.sessionGrants),
+      JSON.stringify(session.tokenUsage),
+      JSON.stringify(session.pendingQueue),
+      session.pendingResume ? JSON.stringify(session.pendingResume) : null,
+      session.observationalMemory ? JSON.stringify(session.observationalMemory) : null,
+      session.goal ? JSON.stringify(session.goal) : null,
+      session.workspace ? JSON.stringify(session.workspace) : null,
+      JSON.stringify(session.state),
+      session.createdAt,
+      session.lastActivityAt,
+      session.closedAt ?? null,
+      session.version,
+      session.ownerId ?? null,
+      session.leaseExpiresAt ?? null,
+    ],
+  });
 }

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -16,6 +16,7 @@ import {
   TABLE_HARNESS_OPERATION_TOMBSTONES,
   TABLE_HARNESS_SESSIONS,
   TABLE_SCHEMAS,
+  getSqlType,
 } from '@mastra/core/storage';
 import type {
   AcquireSessionLeaseInput,
@@ -40,6 +41,7 @@ import type {
   SessionLeaseResult,
   SessionRecord,
   SessionSummary,
+  StorageColumn,
 } from '@mastra/core/storage';
 import { LibSQLDB, resolveClient } from '../../db';
 import type { LibSQLDomainConfig } from '../../db';
@@ -117,8 +119,9 @@ export class HarnessLibSQL extends HarnessStorage {
       ifNotExists: ['harness_name'],
     });
     await this.#backfillHarnessNamespace();
-    await this.#backfillAttachmentMetadata();
     await this.#assertNoDuplicateActiveSessions();
+    await this.#backfillAttachmentMetadata();
+    await this.#ensureHarnessPrimaryKeys();
     await this.#client.execute({
       sql: `CREATE UNIQUE INDEX IF NOT EXISTS idx_harness_sessions_active_key
             ON "${TABLE_HARNESS_SESSIONS}" ("harness_name", "resource_id", "thread_id")
@@ -1259,6 +1262,64 @@ export class HarnessLibSQL extends HarnessStorage {
     }
   }
 
+  async #ensureHarnessPrimaryKeys(): Promise<void> {
+    await this.#rebuildTableIfPrimaryKeyMismatch(TABLE_HARNESS_SESSIONS, ['harness_name', 'id']);
+    await this.#rebuildTableIfPrimaryKeyMismatch(TABLE_HARNESS_ATTACHMENTS, [
+      'harness_name',
+      'session_id',
+      'attachment_id',
+    ]);
+    await this.#rebuildTableIfPrimaryKeyMismatch(TABLE_HARNESS_ATTACHMENT_REFERENCES, [
+      'harness_name',
+      'session_id',
+      'attachment_id',
+      'source',
+      'source_id',
+    ]);
+  }
+
+  async #rebuildTableIfPrimaryKeyMismatch(tableName: string, primaryKey: string[]): Promise<void> {
+    const currentPrimaryKey = await this.#primaryKeyColumns(tableName);
+    if (arraysEqual(currentPrimaryKey, primaryKey)) return;
+
+    // createTable() plus the alterTable() calls in init() must bring managed
+    // Harness tables to the current column set before this PK-only rebuild.
+    const schema = TABLE_SCHEMAS[tableName as keyof typeof TABLE_SCHEMAS];
+    const tempTableName = `__${tableName}_pf442_rebuild`;
+    const columns = Object.keys(schema);
+    const quotedColumns = columns.map(quoteIdentifier).join(', ');
+
+    await this.#client.batch(
+      [
+        { sql: `DROP TABLE IF EXISTS ${quoteIdentifier(tempTableName)}`, args: [] },
+        { sql: buildCreateTableSql(tempTableName, schema, primaryKey), args: [] },
+        {
+          sql: `INSERT INTO ${quoteIdentifier(tempTableName)} (${quotedColumns})
+                SELECT ${quotedColumns} FROM ${quoteIdentifier(tableName)}`,
+          args: [],
+        },
+        { sql: `DROP TABLE ${quoteIdentifier(tableName)}`, args: [] },
+        {
+          sql: `ALTER TABLE ${quoteIdentifier(tempTableName)} RENAME TO ${quoteIdentifier(tableName)}`,
+          args: [],
+        },
+      ],
+      'write',
+    );
+  }
+
+  async #primaryKeyColumns(tableName: string): Promise<string[]> {
+    const result = await this.#client.execute({
+      sql: `PRAGMA table_info(${quoteIdentifier(tableName)})`,
+      args: [],
+    });
+    return result.rows
+      .map(row => ({ name: String(row.name), order: Number(row.pk ?? 0) }))
+      .filter(row => row.order > 0)
+      .sort((a, b) => a.order - b.order)
+      .map(row => row.name);
+  }
+
   async #assertNoDuplicateActiveSessions(): Promise<void> {
     const result = await this.#client.execute({
       sql: `SELECT harness_name, resource_id, thread_id, COUNT(*) AS duplicate_count
@@ -1574,6 +1635,33 @@ function isTerminalMessageEvidence(record: AgentSignalResultEvidence): boolean {
 
 function isTerminalQueueReceipt(receipt: QueueAdmissionReceipt): boolean {
   return receipt.status === 'completed' || receipt.status === 'failed' || receipt.status === 'dead';
+}
+
+function arraysEqual(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function buildCreateTableSql(
+  tableName: string,
+  schema: Record<string, StorageColumn>,
+  compositePrimaryKey: string[],
+): string {
+  const compositePrimaryKeySet = new Set(compositePrimaryKey);
+  const columnDefinitions = Object.entries(schema).map(([columnName, column]) => {
+    const parts = [
+      quoteIdentifier(columnName),
+      getSqlType(column.type),
+      column.nullable === false ? 'NOT NULL' : '',
+      column.primaryKey && !compositePrimaryKeySet.has(columnName) ? 'PRIMARY KEY' : '',
+    ].filter(Boolean);
+    return parts.join(' ');
+  });
+  const primaryKey = `PRIMARY KEY (${compositePrimaryKey.map(quoteIdentifier).join(', ')})`;
+  return `CREATE TABLE ${quoteIdentifier(tableName)} (\n  ${[...columnDefinitions, primaryKey].join(',\n  ')}\n)`;
 }
 
 function toAttachmentReferenceSource(value: unknown): AttachmentReference['source'] {


### PR DESCRIPTION
## Summary

PF-442 hardens the LibSQL Harness init migration for existing databases that created Harness tables before namespace-aware primary keys landed.

- Rebuilds managed Harness session, attachment, and attachment-reference tables when their current SQLite primary key does not match the namespace-aware Harness schema.
- Runs duplicate active-session preflight after namespace backfill and before PK rebuild/index creation, so duplicate active legacy rows fail with the targeted migration-required error before table rebuild DDL.
- Adds migration coverage for legacy sessions, attachments, attachment references, multi-namespace rows after rebuild, idempotent attachment migration, and duplicate-active failure preserving the old session PK.
- Adds an `@mastra/libsql` patch changeset.

## Overlap check

Open mbenhamd/mastra PRs rechecked before push:

- #91 PF-441 touches core Harness skill lookup files only; no LibSQL storage overlap.
- #68 tool gate touches core agent/Harness tool policy files; no `stores/libsql/src/storage/domains/harness/**` overlap.
- #58 ClickHouse memory storage only; no overlap.
- #69 broad stale revert/reset PR; no direct LibSQL Harness path overlap, but it remains a repo-wide hazard if revived.

## Validation

- `pnpm install` in the dedicated worktree. Lockfile unchanged.
- `pnpm build:core`
- `pnpm --filter @mastra/libsql exec vitest run src/storage/domains/harness/index.test.ts --reporter verbose` -> 8 tests passed.
- `pnpm --filter @mastra/libsql exec eslint src/storage/domains/harness/index.ts src/storage/domains/harness/index.test.ts` -> passed.
- `pnpm --filter @mastra/libsql build:lib` -> passed.
- `git diff --check` and staged diff check -> passed.
- Pre-commit `lint-staged --quiet` -> passed.

## Review evidence

- Claude read-only council review: no BLOCKER. Addressed REVIEW items by broadening full-session preservation assertion, moving duplicate-active preflight ahead of rebuild, and adding attachment-reference multi-namespace insert coverage.
- Gemini read-only council review: no BLOCKER. Managed-table caveats noted for custom secondary indexes and future schema metadata; current PF-442 scope is managed Harness tables and current schema.
- Local Codex review passes: not run. `codex exec` returned the account usage-limit error, so this limitation is recorded instead of claiming the required passes ran.
- CodeRabbit CLI: bounded run timed out after partial output. The in-scope changeset wording finding was fixed. Other partial findings referenced files not changed by this PF-442 branch, so they are out of scope for this PR. Please use the GitHub CodeRabbit app review as the primary PR review surface.

Linear: PF-442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes how the database library handles data from older versions. When you upgrade to a new version, it automatically reorganizes old data to match the new format, so everything continues to work smoothly without you having to do anything manually.

## Summary of Changes

### Changeset
- Added `@mastra/libsql` patch changeset documenting automatic migration of existing LibSQL Harness data to the latest schema, ensuring sessions, attachments, and attachment references remain functional after upgrade without manual intervention.

### Core Implementation (`stores/libsql/src/storage/domains/harness/index.ts`)
- Enhanced `HarnessLibSQL.init()` with namespace-aware primary key validation and repair logic
- Introduced `#ensureHarnessPrimaryKeys()` private method that:
  - Inspects actual primary key columns of harness tables (sessions, attachments, attachment-references) via `PRAGMA table_info`
  - Compares against expected namespace-aware composite key schemas
  - Rebuilds tables with corrected primary keys when mismatches are detected
- Added duplicate active-session validation preflight before namespace backfill to ensure targeted migration-required error occurs before table rebuild DDL
- Added utility helpers: `arraysEqual`, `quoteIdentifier`, and `buildCreateTableSql` for table recreation with proper column types and composite primary keys

### Test Coverage (`stores/libsql/src/storage/domains/harness/index.test.ts`)
- Extended legacy attachment backfill test to verify namespace-aware primary key columns and newer schema shape (including `harness_name` field)
- Added new test block for legacy Harness table migrations covering:
  - Rebuilding pre-namespace sessions table with namespace-aware primary keys
  - Rebuilding pre-namespace attachment references with namespace-aware primary keys
  - Validating `listAttachmentReferences` output after rebuild
  - Rejecting initialization when duplicate legacy active sessions exist
- Introduced test helpers: `primaryKeyColumns`, `createLegacySessionsTable`, and `insertLegacySession` for legacy schema introspection and manipulation

## Technical Approach

The hardening strategy addresses migration gaps by:
1. Creating a preflight validation for duplicate active sessions before schema modifications
2. Using table reconstruction (via temp table swap pattern) to safely rebuild tables with corrected primary keys
3. Preserving all existing data during the rebuild process while enforcing new schema constraints

## Validation

- Local vitest: 8 harness storage tests passed
- ESLint: passed for changed harness files
- Build verification: pnpm build:core and @mastra/libsql build:lib successful
- Pre-commit checks: lint-staged and git diff --check passed
- Council reviews (Claude/Gemini): no blockers identified; review items addressed (expanded full-session preservation, adjusted duplicate-active preflight timing, added attachment-reference multi-namespace coverage)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/93)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->