### PR TITLE
[PF-348] Add Harness inbox response receipts

### DIFF
--- a/.changeset/pf-348-inbox-response-receipts.md
+++ b/.changeset/pf-348-inbox-response-receipts.md
@@ -1,0 +1,15 @@
+---
+"@mastra/core": minor
+---
+
+Added durable Harness v1 inbox response receipts for retry-safe `respondTo*` calls with `responseId`.
+
+Pass `responseId` to receive an idempotent receipt result instead of replaying a response when a caller retries the same inbox action.
+
+```ts
+const receipt = await session.respondToQuestion({
+  itemId: 'question:approve-plan',
+  responseId: 'inbox-response-123',
+  answer: 'Yes, continue',
+});
+```

--- a/.changeset/pf-348-libsql-inbox-response-receipts.md
+++ b/.changeset/pf-348-libsql-inbox-response-receipts.md
@@ -1,0 +1,5 @@
+---
+"@mastra/libsql": patch
+---
+
+Harness v1 sessions now persist inbox response receipts when using `@mastra/libsql`, so response tracking survives restarts.

--- a/packages/core/src/harness/v1/errors.ts
+++ b/packages/core/src/harness/v1/errors.ts
@@ -108,6 +108,29 @@ export class HarnessAdmissionConflictError extends Error {
   }
 }
 
+export class HarnessInboxItemNotFoundError extends Error {
+  readonly name = 'HarnessInboxItemNotFoundError';
+  constructor(
+    public readonly sessionId: string,
+    public readonly itemId: string,
+  ) {
+    super(`Inbox item "${itemId}" for session "${sessionId}" was not found`);
+  }
+}
+
+export class HarnessInboxResponseConflictError extends Error {
+  readonly name = 'HarnessInboxResponseConflictError';
+  constructor(
+    public readonly sessionId: string,
+    public readonly itemId: string,
+    public readonly responseId: string,
+  ) {
+    super(
+      `Inbox response "${responseId}" for item "${itemId}" on session "${sessionId}" conflicts with stored evidence`,
+    );
+  }
+}
+
 export class HarnessAttachmentInUseError extends Error {
   readonly name = 'HarnessAttachmentInUseError';
   constructor(

--- a/packages/core/src/harness/v1/index.ts
+++ b/packages/core/src/harness/v1/index.ts
@@ -51,6 +51,8 @@ export type {
 export {
   HarnessConfigError,
   HarnessAdmissionConflictError,
+  HarnessInboxItemNotFoundError,
+  HarnessInboxResponseConflictError,
   HarnessQueueFullError,
   HarnessSessionClosedError,
   HarnessSessionLockedError,
@@ -93,6 +95,8 @@ export type {
   HarnessConfig,
   HarnessMode,
   HarnessSkill,
+  InboxResponseOptions,
+  InboxResponseResult,
   UseSkillOptions,
   HarnessWorkspaceConfig,
   ListMessagesOptions,
@@ -119,4 +123,4 @@ export type {
   ToolCategory,
 } from './types';
 
-export type { PermissionRules, SessionGrants } from '../../storage/domains/harness';
+export type { InboxResponseReceipt, PermissionRules, SessionGrants } from '../../storage/domains/harness';

--- a/packages/core/src/harness/v1/session.queue.test.ts
+++ b/packages/core/src/harness/v1/session.queue.test.ts
@@ -792,6 +792,122 @@ describe('Session.queue() — suspension', () => {
     await session.close();
   });
 
+  it('rejects a fresh responseId when queued resume recovery has no matching inbox receipt', async () => {
+    const { harness, agent } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const queuedItemId = 'q-completed-resume-fresh-response';
+    const now = Date.now();
+    await (session as any)._flushUpdate((prev: any) => ({
+      ...prev,
+      pendingQueue: [
+        {
+          id: queuedItemId,
+          admissionId: 'queue-completed-resume-fresh-response',
+          admissionHash: 'hash-completed-resume-fresh-response',
+          enqueuedAt: now,
+          content: 'already resumed',
+          attachments: [],
+          mode: 'default',
+        },
+      ],
+      pendingResume: {
+        kind: 'tool-approval',
+        itemId: 'tc-completed-fresh',
+        runId: 'completed-fresh-run',
+        toolCallId: 'tc-completed-fresh',
+        toolName: 'shell',
+        source: 'parent',
+        requestedAt: now,
+        queuedItemId,
+        modeId: 'default',
+        resumedAt: now,
+        payload: { input: { cmd: 'ls' } },
+      },
+      queueAdmissionReceipts: {
+        [queuedItemId]: {
+          admissionId: 'queue-completed-resume-fresh-response',
+          admissionHash: 'hash-completed-resume-fresh-response',
+          queuedItemId,
+          modeId: 'default',
+          status: 'completed',
+          runId: 'completed-fresh-run',
+          signalId: 'completed-fresh-signal',
+          attempts: 1,
+          enqueuedAt: now,
+          acceptedAt: now,
+          completedAt: now,
+          updatedAt: now,
+          result: { text: 'already done', finishReason: 'stop', runId: 'completed-fresh-run' },
+        },
+      },
+    }));
+
+    await expect(session.respondToToolApproval({ approved: true, responseId: 'fresh-response' })).rejects.toThrow(
+      'pending resume already responded; no matching inbox response receipt exists',
+    );
+
+    expect(agent.resumeCalls).toHaveLength(0);
+    expect(session.getRecord().inboxResponseReceipts?.['fresh-response']).toBeUndefined();
+    await session.close();
+  });
+
+  it('does not apply accepted inbox receipts from a different completed queued item with the same runId', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const now = Date.now();
+    const response = { approved: true };
+    const responseHash = (session as any)._computeInboxResponseHash({
+      kind: 'tool-approval',
+      itemId: 'tc-target',
+      runId: 'shared-run',
+      pendingRequestedAt: now,
+      response,
+    });
+    await (session as any)._flushUpdate((prev: any) => ({
+      ...prev,
+      inboxResponseReceipts: {
+        target: {
+          responseId: 'target',
+          responseHash,
+          resumeAttemptId: 'target',
+          itemId: 'tc-target',
+          queuedItemId: 'q-target',
+          kind: 'tool-approval',
+          runId: 'shared-run',
+          toolCallId: 'tc-target',
+          pendingRequestedAt: now,
+          response,
+          status: 'accepted',
+          acceptedAt: now,
+          updatedAt: now,
+        },
+      },
+      queueAdmissionReceipts: {
+        'q-other': {
+          admissionId: 'queue-other',
+          admissionHash: 'hash-other',
+          queuedItemId: 'q-other',
+          modeId: 'default',
+          status: 'completed',
+          runId: 'shared-run',
+          signalId: 'other-signal',
+          attempts: 1,
+          enqueuedAt: now,
+          acceptedAt: now,
+          completedAt: now,
+          updatedAt: now,
+          result: { text: 'wrong queue item', finishReason: 'stop', runId: 'shared-run' },
+        },
+      },
+    }));
+
+    const duplicate = await session.respondToToolApproval({ approved: true, responseId: 'target' });
+
+    expect(duplicate).toMatchObject({ status: 'accepted', duplicate: true, responseId: 'target' });
+    expect(session.getRecord().inboxResponseReceipts?.target).toMatchObject({ status: 'accepted' });
+    await session.close();
+  });
+
   it('completes a rehydrated suspended queued item when respondTo* resumes it', async () => {
     const storage = new InMemoryStore();
     const harnessStore = await storage.getStore('harness');

--- a/packages/core/src/harness/v1/session.suspend.test.ts
+++ b/packages/core/src/harness/v1/session.suspend.test.ts
@@ -17,7 +17,7 @@ import { InMemoryDB } from '../../storage/domains/inmemory-db';
 import type { MastraModelOutput } from '../../stream/base/output';
 import { buildFakeOutput } from './__test-utils__/fake-output';
 
-import { HarnessValidationError } from './errors';
+import { HarnessInboxResponseConflictError, HarnessValidationError } from './errors';
 import { Harness } from './harness';
 
 // ---------------------------------------------------------------------------
@@ -38,6 +38,7 @@ interface RunSpec {
     | undefined;
   text?: string;
   runId?: string;
+  holdUntil?: Promise<void>;
 }
 
 interface ResumeCall {
@@ -101,6 +102,7 @@ class FakeAgent extends Agent<any, any, any> {
     this.streamCalls.push({ messages: _messages, options });
     const spec = this.runs.shift();
     if (!spec) throw new Error('FakeAgent: no run enqueued for stream()');
+    await spec.holdUntil;
     const out = this.buildOutput(spec, options?.runId);
     this._internalRegisterStreamRun(out, (options ?? {}) as any);
     return out;
@@ -109,6 +111,7 @@ class FakeAgent extends Agent<any, any, any> {
   async generate(_messages: any, _options?: any): Promise<any> {
     const spec = this.runs.shift();
     if (!spec) throw new Error('FakeAgent: no run enqueued for generate()');
+    await spec.holdUntil;
     const out = this.buildOutput(spec);
     return await out.getFullOutput();
   }
@@ -117,6 +120,7 @@ class FakeAgent extends Agent<any, any, any> {
     this.resumeCalls.push({ resumeData, options });
     const spec = this.runs.shift();
     if (!spec) throw new Error('FakeAgent: no run enqueued for resumeStream()');
+    await spec.holdUntil;
     const out = this.buildOutput(spec, options?.runId);
     this._internalRegisterStreamRun(out, (options ?? {}) as any);
     return out;
@@ -389,6 +393,41 @@ describe('Session — respondToToolApproval / Suspension / Question / PlanApprov
     expect(session.getDisplayState().pending).toBeNull();
   });
 
+  it('respondToToolApproval records denial receipts and forwards reason', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-deny',
+      suspendPayload: { toolCallId: 'tc-deny', toolName: 'shell', args: { cmd: 'rm' } },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'go' });
+
+    agent.enqueueRun({ finishReason: 'stop', runId: 'run-deny', text: 'denied' });
+    const receipt = await session.respondToToolApproval({
+      approved: false,
+      reason: 'needs review',
+      responseId: 'deny-response-1',
+    });
+
+    expect(receipt).toEqual({
+      itemId: 'tool-approval:tc-deny',
+      kind: 'tool-approval',
+      status: 'applied',
+      responseId: 'deny-response-1',
+      duplicate: false,
+    });
+    expect(agent.resumeCalls[0]!.resumeData).toEqual({ approved: false, reason: 'needs review' });
+    expect(session.getRecord().inboxResponseReceipts?.['deny-response-1']).toMatchObject({
+      itemId: 'tool-approval:tc-deny',
+      kind: 'tool-approval',
+      resumeAttemptId: 'deny-response-1',
+      status: 'applied',
+      response: { approved: false, reason: 'needs review' },
+      result: expect.objectContaining({ text: 'denied' }),
+    });
+  });
+
   it('respondToToolSuspension forwards opaque resumeData', async () => {
     const { harness, agent } = setup();
     agent.enqueueRun({
@@ -411,6 +450,30 @@ describe('Session — respondToToolApproval / Suspension / Question / PlanApprov
     expect(session.getRecord().pendingResume).toBeUndefined();
   });
 
+  it('respondToToolSuspension without responseId preserves legacy opaque resumeData behavior', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-S',
+      suspendPayload: {
+        toolCallId: 'tc-S',
+        toolName: 'long',
+        args: {},
+        suspendPayload: { step: 'A' },
+      },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'go' });
+
+    const resumeData = { completedAt: new Date('2026-05-15T00:00:00.000Z') };
+    agent.enqueueRun({ finishReason: 'stop', runId: 'run-S', text: 'done' });
+    const result = await session.respondToToolSuspension({ resumeData });
+
+    expect(result.text).toBe('done');
+    expect(agent.resumeCalls[0]!.resumeData).toBe(resumeData);
+    expect(session.getRecord().inboxResponseReceipts).toBeUndefined();
+  });
+
   it('respondToQuestion forwards { answer }', async () => {
     const { harness, agent } = setup();
     agent.enqueueRun({
@@ -429,6 +492,313 @@ describe('Session — respondToToolApproval / Suspension / Question / PlanApprov
     await session.respondToQuestion({ answer: 'red' });
 
     expect(agent.resumeCalls[0]!.resumeData).toEqual({ answer: 'red' });
+  });
+
+  it('respondToQuestion returns duplicate receipt without resuming twice', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-Q',
+      suspendPayload: {
+        toolCallId: 'tc-Q',
+        toolName: 'ask_user',
+        args: { question: 'pick' },
+      },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'go' });
+
+    agent.enqueueRun({ finishReason: 'stop', runId: 'run-Q' });
+    const first = await session.respondToQuestion({ itemId: 'question:tc-Q', responseId: 'answer-1', answer: 'red' });
+    const duplicate = await session.respondToQuestion({
+      itemId: 'question:tc-Q',
+      responseId: 'answer-1',
+      answer: 'red',
+    });
+
+    expect(first).toMatchObject({ status: 'applied', duplicate: false, responseId: 'answer-1' });
+    expect(duplicate).toMatchObject({ status: 'applied', duplicate: true, responseId: 'answer-1' });
+    expect(agent.resumeCalls).toHaveLength(1);
+  });
+
+  it('respondToQuestion serializes concurrent duplicate responseIds before resuming', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-Q',
+      suspendPayload: {
+        toolCallId: 'tc-Q',
+        toolName: 'ask_user',
+        args: { question: 'pick' },
+      },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'go' });
+
+    let release!: () => void;
+    const holdUntil = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    agent.enqueueRun({ finishReason: 'stop', runId: 'run-Q', holdUntil });
+
+    const first = session.respondToQuestion({ itemId: 'question:tc-Q', responseId: 'answer-1', answer: 'red' });
+    const second = session.respondToQuestion({ itemId: 'question:tc-Q', responseId: 'answer-1', answer: 'red' });
+
+    await new Promise(resolve => setImmediate(resolve));
+    expect(agent.resumeCalls).toHaveLength(1);
+
+    release();
+    await expect(first).resolves.toMatchObject({ status: 'applied', duplicate: false, responseId: 'answer-1' });
+    await expect(second).resolves.toMatchObject({ status: 'accepted', duplicate: true, responseId: 'answer-1' });
+    expect(agent.resumeCalls).toHaveLength(1);
+  });
+
+  it('respondToQuestion rejects concurrent distinct responseIds after one response wins admission', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-Q',
+      suspendPayload: {
+        toolCallId: 'tc-Q',
+        toolName: 'ask_user',
+        args: { question: 'pick' },
+      },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'go' });
+
+    let release!: () => void;
+    const holdUntil = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    agent.enqueueRun({ finishReason: 'stop', runId: 'run-Q', holdUntil });
+
+    const first = session.respondToQuestion({ itemId: 'question:tc-Q', responseId: 'answer-1', answer: 'red' });
+    const second = session
+      .respondToQuestion({ itemId: 'question:tc-Q', responseId: 'answer-2', answer: 'red' })
+      .catch(err => err);
+
+    await new Promise(resolve => setImmediate(resolve));
+    await expect(second).resolves.toMatchObject({
+      message: expect.stringContaining('pending resume already responded; awaiting agent confirmation'),
+    });
+    expect(agent.resumeCalls).toHaveLength(1);
+
+    release();
+    await expect(first).resolves.toMatchObject({ status: 'applied', duplicate: false, responseId: 'answer-1' });
+    expect(session.getRecord().inboxResponseReceipts?.['answer-2']).toBeUndefined();
+  });
+
+  it('respondToQuestion returns accepted duplicate receipt while resume is in flight', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-Q',
+      suspendPayload: {
+        toolCallId: 'tc-Q',
+        toolName: 'ask_user',
+        args: { question: 'pick' },
+      },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'go' });
+
+    let release!: () => void;
+    const holdUntil = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    agent.enqueueRun({ finishReason: 'stop', runId: 'run-Q', holdUntil });
+
+    const first = session.respondToQuestion({ itemId: 'question:tc-Q', responseId: 'answer-1', answer: 'red' });
+    await new Promise(resolve => setImmediate(resolve));
+
+    const duplicate = await session.respondToQuestion({
+      itemId: 'question:tc-Q',
+      responseId: 'answer-1',
+      answer: 'red',
+    });
+
+    expect(duplicate).toMatchObject({ status: 'accepted', duplicate: true, responseId: 'answer-1' });
+    expect(agent.resumeCalls).toHaveLength(1);
+
+    release();
+    await expect(first).resolves.toMatchObject({ status: 'applied', duplicate: false, responseId: 'answer-1' });
+  });
+
+  it('respondToQuestion rejects same responseId with different answer', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-Q',
+      suspendPayload: {
+        toolCallId: 'tc-Q',
+        toolName: 'ask_user',
+        args: { question: 'pick' },
+      },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'go' });
+
+    agent.enqueueRun({ finishReason: 'stop', runId: 'run-Q' });
+    await session.respondToQuestion({ itemId: 'question:tc-Q', responseId: 'answer-1', answer: 'red' });
+
+    await expect(
+      session.respondToQuestion({ itemId: 'question:tc-Q', responseId: 'answer-1', answer: 'blue' }),
+    ).rejects.toBeInstanceOf(HarnessInboxResponseConflictError);
+    expect(agent.resumeCalls).toHaveLength(1);
+  });
+
+  it('respondToQuestion returns applied duplicate after the resumed run suspends again', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-Q',
+      suspendPayload: {
+        toolCallId: 'tc-Q',
+        toolName: 'ask_user',
+        args: { question: 'pick' },
+      },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'go' });
+
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-Q',
+      suspendPayload: {
+        toolCallId: 'tc-Q2',
+        toolName: 'ask_user',
+        args: { question: 'pick again' },
+      },
+    });
+    const first = await session.respondToQuestion({ itemId: 'question:tc-Q', responseId: 'answer-1', answer: 'red' });
+    const duplicate = await session.respondToQuestion({
+      itemId: 'question:tc-Q',
+      responseId: 'answer-1',
+      answer: 'red',
+    });
+
+    expect(first).toMatchObject({ status: 'applied', duplicate: false, responseId: 'answer-1' });
+    expect(duplicate).toMatchObject({ status: 'applied', duplicate: true, responseId: 'answer-1' });
+    expect(session.getRecord().pendingResume).toMatchObject({ itemId: 'question:tc-Q2' });
+    expect(agent.resumeCalls).toHaveLength(1);
+  });
+
+  it('respondToQuestion marks accepted receipts failed when resumeStream throws', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-Q',
+      suspendPayload: {
+        toolCallId: 'tc-Q',
+        toolName: 'ask_user',
+        args: { question: 'pick' },
+      },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'go' });
+
+    await expect(
+      session.respondToQuestion({ itemId: 'question:tc-Q', responseId: 'answer-1', answer: 'red' }),
+    ).rejects.toThrow('FakeAgent: no run enqueued for resumeStream()');
+
+    expect(session.getRecord().inboxResponseReceipts?.['answer-1']).toMatchObject({
+      itemId: 'question:tc-Q',
+      status: 'failed',
+      retryable: false,
+      error: expect.objectContaining({ message: 'FakeAgent: no run enqueued for resumeStream()' }),
+    });
+    await expect(
+      session.respondToQuestion({ itemId: 'question:tc-Q', responseId: 'answer-1', answer: 'red' }),
+    ).rejects.toThrow('FakeAgent: no run enqueued for resumeStream()');
+    expect(agent.resumeCalls).toHaveLength(1);
+  });
+
+  it('clears a stale non-queued pending response without replaying resumeStream', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-Q',
+      suspendPayload: {
+        toolCallId: 'tc-Q',
+        toolName: 'ask_user',
+        args: { question: 'pick' },
+      },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'go' });
+    const pending = session.getRecord().pendingResume!;
+    const staleAt = Date.now() - 60_000;
+    const response = { answer: 'red' };
+    const responseHash = (session as any)._computeInboxResponseHash({
+      kind: 'question',
+      itemId: pending.itemId,
+      runId: pending.runId,
+      pendingRequestedAt: pending.requestedAt,
+      response,
+    });
+    await (session as any)._flushUpdate((prev: any) => ({
+      ...prev,
+      pendingResume: { ...prev.pendingResume, resumedAt: staleAt },
+      inboxResponseReceipts: {
+        stale: {
+          responseId: 'stale',
+          responseHash,
+          resumeAttemptId: 'stale',
+          itemId: pending.itemId,
+          kind: 'question',
+          runId: pending.runId,
+          toolCallId: pending.toolCallId,
+          pendingRequestedAt: pending.requestedAt,
+          response,
+          status: 'accepted',
+          acceptedAt: staleAt,
+          updatedAt: staleAt,
+        },
+      },
+    }));
+
+    await expect(
+      session.respondToQuestion({ itemId: pending.itemId, responseId: 'stale', answer: 'red' }),
+    ).rejects.toThrow('queued turn resume was marked in flight');
+
+    expect(session.getRecord().pendingResume).toBeUndefined();
+    expect(session.getRecord().inboxResponseReceipts?.stale).toMatchObject({ status: 'failed' });
+
+    agent.enqueueRun({ finishReason: 'stop', text: 'fresh answer' });
+    await expect(
+      session.respondToQuestion({ itemId: pending.itemId, responseId: 'fresh', answer: 'red' }),
+    ).rejects.toThrow('no pending resume on this session');
+
+    expect(agent.resumeCalls).toHaveLength(0);
+  });
+
+  it('clears a stale non-queued pending response on a fresh responseId retry', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-Q',
+      suspendPayload: {
+        toolCallId: 'tc-Q',
+        toolName: 'ask_user',
+        args: { question: 'pick' },
+      },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'go' });
+    const pending = session.getRecord().pendingResume!;
+    await (session as any)._flushUpdate((prev: any) => ({
+      ...prev,
+      pendingResume: { ...prev.pendingResume, resumedAt: Date.now() - 60_000 },
+    }));
+
+    await expect(
+      session.respondToQuestion({ itemId: pending.itemId, responseId: 'fresh', answer: 'red' }),
+    ).rejects.toThrow('queued turn resume was marked in flight');
+
+    expect(session.getRecord().pendingResume).toBeUndefined();
+    expect(session.getRecord().inboxResponseReceipts?.fresh).toBeUndefined();
+    expect(agent.resumeCalls).toHaveLength(0);
   });
 
   it('respondToPlanApproval flips active mode atomically when approved + transitionsTo set', async () => {

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -40,6 +40,7 @@ import type {
   AgentSignalResultStatus,
   HarnessStorage,
   HarnessStorageAttachmentUnavailableError,
+  InboxResponseReceipt,
   QueueAdmissionReceipt,
   PendingResume,
   PermissionRules,
@@ -62,6 +63,8 @@ import {
   HarnessAdmissionConflictError,
   HarnessAttachmentUnavailableError,
   HarnessConfigError,
+  HarnessInboxItemNotFoundError,
+  HarnessInboxResponseConflictError,
   HarnessOverrideConflictError,
   HarnessQueueFullError,
   HarnessSessionClosedError,
@@ -91,6 +94,8 @@ import type {
   AttachmentRef,
   GoalOptions,
   HarnessMode,
+  InboxResponseOptions,
+  InboxResponseResult,
   HarnessRequestContext,
   HarnessSkill,
   UseSkillOptions,
@@ -131,6 +136,10 @@ type QueueResumeRecoveryResult =
   | { status: 'none' }
   | { status: 'completed'; result: AgentResult }
   | { status: 'stale' };
+
+type ResumeResponseMode = 'agent-result' | 'inbox-receipt';
+type InboxReceiptResponseOptions = InboxResponseOptions & { responseId: string };
+type LegacyInboxResponseOptions = Omit<InboxResponseOptions, 'responseId'> & { responseId?: undefined };
 
 /**
  * Tool IDs the harness translates from `tool-call-approval` /
@@ -3446,18 +3455,50 @@ export class Session {
   // -------------------------------------------------------------------------
 
   /** Resume a pending tool-approval. `approved: false` rejects the call. */
-  async respondToToolApproval(opts: { approved: boolean }): Promise<AgentResult> {
-    return this._resume('tool-approval', { approved: opts.approved });
+  async respondToToolApproval(
+    opts: { approved: boolean; reason?: string } & InboxReceiptResponseOptions,
+  ): Promise<InboxResponseResult>;
+  async respondToToolApproval(
+    opts: { approved: boolean; reason?: string } & LegacyInboxResponseOptions,
+  ): Promise<AgentResult>;
+  async respondToToolApproval(
+    opts: { approved: boolean; reason?: string } & InboxResponseOptions,
+  ): Promise<AgentResult | InboxResponseResult>;
+  async respondToToolApproval(
+    opts: { approved: boolean; reason?: string } & InboxResponseOptions,
+  ): Promise<AgentResult | InboxResponseResult> {
+    return this._resume(
+      'tool-approval',
+      compactJsonObject({
+        approved: opts.approved,
+        reason: opts.reason,
+      }),
+      opts,
+    );
   }
 
   /** Resume a pending tool-suspension. `resumeData` is forwarded to the tool. */
-  async respondToToolSuspension(opts: { resumeData: unknown }): Promise<AgentResult> {
-    return this._resume('tool-suspension', opts.resumeData);
+  async respondToToolSuspension(
+    opts: { resumeData: unknown } & InboxReceiptResponseOptions,
+  ): Promise<InboxResponseResult>;
+  async respondToToolSuspension(opts: { resumeData: unknown } & LegacyInboxResponseOptions): Promise<AgentResult>;
+  async respondToToolSuspension(
+    opts: { resumeData: unknown } & InboxResponseOptions,
+  ): Promise<AgentResult | InboxResponseResult>;
+  async respondToToolSuspension(
+    opts: { resumeData: unknown } & InboxResponseOptions,
+  ): Promise<AgentResult | InboxResponseResult> {
+    return this._resume('tool-suspension', opts.resumeData, opts);
   }
 
   /** Resume a pending `ask_user` question. */
-  async respondToQuestion(opts: { answer: unknown }): Promise<AgentResult> {
-    return this._resume('question', { answer: opts.answer });
+  async respondToQuestion(opts: { answer: unknown } & InboxReceiptResponseOptions): Promise<InboxResponseResult>;
+  async respondToQuestion(opts: { answer: unknown } & LegacyInboxResponseOptions): Promise<AgentResult>;
+  async respondToQuestion(opts: { answer: unknown } & InboxResponseOptions): Promise<AgentResult | InboxResponseResult>;
+  async respondToQuestion(
+    opts: { answer: unknown } & InboxResponseOptions,
+  ): Promise<AgentResult | InboxResponseResult> {
+    return this._resume('question', { answer: opts.answer }, opts);
   }
 
   /**
@@ -3473,21 +3514,48 @@ export class Session {
    * of approval — the reviewer can approve with a revision note or reject
    * with revision guidance.
    */
-  async respondToPlanApproval(opts: {
-    approved: boolean;
-    revision?: string;
-    transitionToMode?: string;
-  }): Promise<AgentResult> {
+  async respondToPlanApproval(
+    opts: {
+      approved: boolean;
+      revision?: string;
+      transitionToMode?: string;
+    } & InboxReceiptResponseOptions,
+  ): Promise<InboxResponseResult>;
+  async respondToPlanApproval(
+    opts: {
+      approved: boolean;
+      revision?: string;
+      transitionToMode?: string;
+    } & LegacyInboxResponseOptions,
+  ): Promise<AgentResult>;
+  async respondToPlanApproval(
+    opts: {
+      approved: boolean;
+      revision?: string;
+      transitionToMode?: string;
+    } & InboxResponseOptions,
+  ): Promise<AgentResult | InboxResponseResult>;
+  async respondToPlanApproval(
+    opts: {
+      approved: boolean;
+      revision?: string;
+      transitionToMode?: string;
+    } & InboxResponseOptions,
+  ): Promise<AgentResult | InboxResponseResult> {
     if (opts.transitionToMode !== undefined) {
       // Validate eagerly so callers see a clean error rather than a CAS-time
       // throw from inside the resume flow.
       this._harness._getMode(opts.transitionToMode);
     }
-    return this._resume('plan-approval', {
-      approved: opts.approved,
-      revision: opts.revision,
-      transitionToMode: opts.transitionToMode,
-    });
+    return this._resume(
+      'plan-approval',
+      compactJsonObject({
+        approved: opts.approved,
+        revision: opts.revision,
+        transitionToMode: opts.transitionToMode,
+      }),
+      opts,
+    );
   }
 
   // -------------------------------------------------------------------------
@@ -3665,8 +3733,38 @@ export class Session {
     });
   }
 
-  private async _resume(expectedKind: PendingResume['kind'], resumeData: unknown): Promise<AgentResult> {
+  private async _resume(
+    expectedKind: PendingResume['kind'],
+    resumeData: unknown,
+    responseOptions: InboxResponseOptions = {},
+  ): Promise<AgentResult | InboxResponseResult> {
     this._assertLive(`respond[${expectedKind}]`);
+    const responseId = getOwnRecordValue(responseOptions as Record<string, unknown>, 'responseId');
+    if (responseId !== undefined && typeof responseId !== 'string') {
+      throw new HarnessValidationError(`respond[${expectedKind}].responseId`, 'responseId must be a string');
+    }
+    const responseMode: ResumeResponseMode = responseId !== undefined ? 'inbox-receipt' : 'agent-result';
+    if (responseId !== undefined && responseId.length === 0) {
+      throw new HarnessValidationError(`respond[${expectedKind}].responseId`, 'responseId must be a non-empty string');
+    }
+    const requestedItemId = getOwnRecordValue(responseOptions as Record<string, unknown>, 'itemId');
+    if (requestedItemId !== undefined && typeof requestedItemId !== 'string') {
+      throw new HarnessValidationError(`respond[${expectedKind}].itemId`, 'itemId must be a string');
+    }
+
+    const storedReceipt =
+      responseId !== undefined ? getOwnRecordValue(this._record.inboxResponseReceipts, responseId) : undefined;
+    if (storedReceipt !== undefined) {
+      const duplicate = this._resolveStoredInboxResponse(expectedKind, resumeData, responseOptions);
+      if (storedReceipt.status === 'applied') {
+        return duplicate!;
+      }
+      if (this._record.pendingResume === undefined) {
+        const recoveredReceipt = await this._applyInboxReceiptFromCompletedQueue(storedReceipt);
+        if (recoveredReceipt) return this._inboxReceiptResult(recoveredReceipt, true);
+        return duplicate!;
+      }
+    }
 
     const pending = this._record.pendingResume;
     if (!pending) {
@@ -3679,6 +3777,43 @@ export class Session {
       );
     }
 
+    const itemId = pending.itemId ?? pending.toolCallId;
+    if (requestedItemId !== undefined && requestedItemId !== itemId) {
+      throw new HarnessInboxItemNotFoundError(this.id, requestedItemId);
+    }
+    const responseHash =
+      responseId !== undefined
+        ? this._computeInboxResponseHash({
+            kind: expectedKind,
+            itemId,
+            runId: pending.runId,
+            pendingRequestedAt: pending.requestedAt,
+            response: resumeData,
+          })
+        : undefined;
+    const persistedResponse =
+      responseId !== undefined ? assertJsonValue(resumeData, `respond[${expectedKind}].response`) : undefined;
+    const existingReceipt =
+      responseId !== undefined ? getOwnRecordValue(this._record.inboxResponseReceipts, responseId) : undefined;
+    if (existingReceipt !== undefined) {
+      this._assertMatchingInboxReceipt(existingReceipt, {
+        kind: expectedKind,
+        itemId,
+        responseId: responseId!,
+        responseHash: responseHash!,
+      });
+      this._throwStoredInboxResponseFailure(existingReceipt);
+      if (
+        responseMode === 'inbox-receipt' &&
+        (pending.resumedAt === undefined || existingReceipt.status === 'applied')
+      ) {
+        return this._inboxReceiptResult(existingReceipt, true);
+      }
+      if (existingReceipt.status === 'applied' && existingReceipt.result !== undefined) {
+        return existingReceipt.result as AgentResult;
+      }
+    }
+
     // Idempotency: a crash between "marked resumed" and "cleared pending"
     // surfaces here on the next call. We do not replay the agent — the prior
     // resumeStream() either landed (and cleared pending in a later flush we
@@ -3686,10 +3821,55 @@ export class Session {
     // move is to surface the suspended state to the caller and let them
     // re-fetch via getDisplayState / listMessages.
     if (pending.resumedAt !== undefined) {
+      if (existingReceipt !== undefined && responseMode === 'inbox-receipt') {
+        const recovery = await this._maybeRecoverStaleQueuedResume();
+        if (recovery.status === 'completed') {
+          await this._markInboxResponseApplied(existingReceipt.responseId, recovery.result);
+          const receipt =
+            getOwnRecordValue(this._record.inboxResponseReceipts, existingReceipt.responseId) ?? existingReceipt;
+          return this._inboxReceiptResult(receipt, true);
+        }
+        if (recovery.status === 'stale') {
+          const stale = new QueueResumeRecoveryStaleError();
+          await this._markInboxResponseFailed(existingReceipt.responseId, stale);
+          throw stale;
+        }
+        if (
+          this._currentTurnAbortController === undefined &&
+          this._queuedItemIdForPendingResume(pending) === undefined &&
+          Date.now() >= pending.resumedAt + QUEUE_ACCEPTED_RECOVERY_STALE_MS
+        ) {
+          const stale = new QueueResumeRecoveryStaleError();
+          await this._markInboxResponseFailedAndClearPending(existingReceipt.responseId, pending, stale);
+          throw stale;
+        }
+        return this._inboxReceiptResult(existingReceipt, true);
+      }
       const recovery = await this._maybeRecoverStaleQueuedResume();
-      if (recovery.status === 'completed') return recovery.result;
+      if (recovery.status === 'completed') {
+        if (responseMode === 'inbox-receipt') {
+          throw new HarnessValidationError(
+            `respond[${expectedKind}]`,
+            'pending resume already responded; no matching inbox response receipt exists',
+          );
+        }
+        return recovery.result;
+      }
       if (recovery.status === 'stale') {
-        throw new QueueResumeRecoveryStaleError();
+        const stale = new QueueResumeRecoveryStaleError();
+        if (responseId !== undefined) {
+          await this._markInboxResponseFailed(responseId, stale);
+        }
+        throw stale;
+      }
+      if (
+        this._currentTurnAbortController === undefined &&
+        this._queuedItemIdForPendingResume(pending) === undefined &&
+        Date.now() >= pending.resumedAt + QUEUE_ACCEPTED_RECOVERY_STALE_MS
+      ) {
+        const stale = new QueueResumeRecoveryStaleError();
+        await this._markInboxResponseFailedAndClearPending(responseId, pending, stale);
+        throw stale;
       }
       throw new HarnessValidationError(
         `respond[${expectedKind}]`,
@@ -3706,10 +3886,88 @@ export class Session {
     // marker per §5.4 / §5.7). On crash here, the next caller observes
     // resumedAt set and rejects rather than double-resuming.
     const resumedAt = Date.now();
-    await this._flushUpdate(prev => ({
-      ...prev,
-      pendingResume: prev.pendingResume ? { ...prev.pendingResume, resumedAt } : prev.pendingResume,
-    }));
+    let duplicateReceiptAfterAdmission: InboxResponseReceipt | undefined;
+    let pendingAlreadyResumedAfterAdmission = false;
+    await this._flushUpdate(prev => {
+      const currentReceipt =
+        responseId !== undefined ? getOwnRecordValue(prev.inboxResponseReceipts, responseId) : undefined;
+      if (currentReceipt !== undefined) {
+        this._assertMatchingInboxReceipt(currentReceipt, {
+          kind: expectedKind,
+          itemId,
+          responseId: currentReceipt.responseId,
+          responseHash: responseHash!,
+        });
+        duplicateReceiptAfterAdmission = currentReceipt;
+        return prev;
+      }
+
+      const currentPending = prev.pendingResume;
+      if (
+        currentPending === undefined ||
+        currentPending.resumedAt !== undefined ||
+        currentPending.kind !== expectedKind ||
+        currentPending.runId !== pending.runId ||
+        currentPending.toolCallId !== pending.toolCallId ||
+        (currentPending.itemId ?? currentPending.toolCallId) !== itemId
+      ) {
+        pendingAlreadyResumedAfterAdmission = true;
+        return prev;
+      }
+
+      const next: SessionRecord = {
+        ...prev,
+        pendingResume: { ...currentPending, resumedAt },
+      };
+      if (responseId === undefined) return next;
+
+      next.inboxResponseReceipts = {
+        ...(prev.inboxResponseReceipts ?? {}),
+        [responseId]: {
+          responseId,
+          responseHash: responseHash!,
+          resumeAttemptId: responseId,
+          itemId,
+          ...(pendingQueuedItemId !== undefined ? { queuedItemId: pendingQueuedItemId } : {}),
+          kind: expectedKind,
+          runId: pending.runId,
+          toolCallId: pending.toolCallId,
+          pendingRequestedAt: pending.requestedAt,
+          response: persistedResponse,
+          status: 'accepted',
+          acceptedAt: resumedAt,
+          updatedAt: resumedAt,
+        } satisfies InboxResponseReceipt,
+      };
+      return next;
+    });
+    if (duplicateReceiptAfterAdmission !== undefined) {
+      this._throwStoredInboxResponseFailure(duplicateReceiptAfterAdmission);
+      return this._inboxReceiptResult(duplicateReceiptAfterAdmission, true);
+    }
+    if (pendingAlreadyResumedAfterAdmission) {
+      const recovery = await this._maybeRecoverStaleQueuedResume();
+      if (recovery.status === 'completed') {
+        if (responseMode === 'inbox-receipt') {
+          throw new HarnessValidationError(
+            `respond[${expectedKind}]`,
+            'pending resume already responded; no matching inbox response receipt exists',
+          );
+        }
+        return recovery.result;
+      }
+      if (recovery.status === 'stale') {
+        const stale = new QueueResumeRecoveryStaleError();
+        if (responseId !== undefined) {
+          await this._markInboxResponseFailed(responseId, stale);
+        }
+        throw stale;
+      }
+      throw new HarnessValidationError(
+        `respond[${expectedKind}]`,
+        'pending resume already responded; awaiting agent confirmation',
+      );
+    }
 
     // For plan-approval, resolve the active-mode flip before finalizing the
     // resumed turn. Queued terminal resumes persist this flip with the
@@ -3758,6 +4016,9 @@ export class Session {
       }
     } catch (err) {
       this._endTurn(turnAbortController);
+      if (responseId !== undefined) {
+        await this._markInboxResponseFailed(responseId, err);
+      }
       throw err;
     }
 
@@ -3784,9 +4045,24 @@ export class Session {
         this._recordTurnCompletion(full);
       }
       const queueCompletedAt = Date.now();
+      const responseAppliedAt = queueCompletedAt;
       await this._flushUpdate(prev => {
         const next: SessionRecord = { ...prev };
         delete next.pendingResume;
+        const receipt =
+          responseId !== undefined ? getOwnRecordValue(prev.inboxResponseReceipts, responseId) : undefined;
+        if (receipt) {
+          next.inboxResponseReceipts = {
+            ...(prev.inboxResponseReceipts ?? {}),
+            [receipt.responseId]: {
+              ...receipt,
+              status: 'applied',
+              result: full,
+              appliedAt: receipt.appliedAt ?? responseAppliedAt,
+              updatedAt: responseAppliedAt,
+            },
+          };
+        }
         if (modeFlipTarget) next.modeId = modeFlipTarget;
         if (completingQueuedItemId !== undefined) {
           next.pendingQueue = (prev.pendingQueue ?? []).filter(x => x.id !== completingQueuedItemId);
@@ -3862,7 +4138,185 @@ export class Session {
     } finally {
       this._endTurn(turnAbortController);
     }
+    if (responseMode === 'inbox-receipt') {
+      const receipt =
+        responseId !== undefined ? getOwnRecordValue(this._record.inboxResponseReceipts, responseId) : undefined;
+      if (receipt) return this._inboxReceiptResult(receipt, false);
+    }
     return full as AgentResult;
+  }
+
+  private _resolveStoredInboxResponse(
+    expectedKind: PendingResume['kind'],
+    resumeData: unknown,
+    responseOptions: InboxResponseOptions,
+  ): InboxResponseResult | undefined {
+    const responseId = getOwnRecordValue(responseOptions as Record<string, unknown>, 'responseId');
+    if (typeof responseId !== 'string') return undefined;
+    const receipt = getOwnRecordValue(this._record.inboxResponseReceipts, responseId);
+    if (receipt === undefined) return undefined;
+    if (receipt.kind !== expectedKind) {
+      throw new HarnessInboxResponseConflictError(this.id, receipt.itemId, responseId);
+    }
+    const requestedItemId = getOwnRecordValue(responseOptions as Record<string, unknown>, 'itemId');
+    if (requestedItemId !== undefined && typeof requestedItemId !== 'string') {
+      throw new HarnessValidationError(`respond[${expectedKind}].itemId`, 'itemId must be a string');
+    }
+    if (requestedItemId !== undefined && receipt.itemId !== requestedItemId) {
+      throw new HarnessInboxItemNotFoundError(this.id, requestedItemId);
+    }
+    const attemptedHash = this._computeInboxResponseHash({
+      kind: expectedKind,
+      itemId: receipt.itemId,
+      runId: receipt.runId,
+      pendingRequestedAt: receipt.pendingRequestedAt,
+      response: resumeData,
+    });
+    if (attemptedHash !== receipt.responseHash) {
+      throw new HarnessInboxResponseConflictError(this.id, receipt.itemId, responseId);
+    }
+    this._throwStoredInboxResponseFailure(receipt);
+    return this._inboxReceiptResult(receipt, true);
+  }
+
+  private _assertMatchingInboxReceipt(
+    receipt: InboxResponseReceipt,
+    input: { kind: PendingResume['kind']; itemId: string; responseId: string; responseHash: string },
+  ): void {
+    if (receipt.kind !== input.kind || receipt.itemId !== input.itemId || receipt.responseHash !== input.responseHash) {
+      throw new HarnessInboxResponseConflictError(this.id, input.itemId, input.responseId);
+    }
+  }
+
+  private _inboxReceiptResult(receipt: InboxResponseReceipt, duplicate: boolean): InboxResponseResult {
+    return {
+      itemId: receipt.itemId,
+      kind: receipt.kind,
+      status: receipt.status === 'applied' ? 'applied' : 'accepted',
+      responseId: receipt.responseId,
+      duplicate,
+    };
+  }
+
+  private _throwStoredInboxResponseFailure(receipt: InboxResponseReceipt): void {
+    if (receipt.status !== 'failed' && receipt.status !== 'dead') return;
+    throw publicErrorProjectionToError(
+      receipt.error ?? { code: 'harness.inbox_response_failed', message: 'inbox response failed' },
+    );
+  }
+
+  private async _applyInboxReceiptFromCompletedQueue(
+    receipt: InboxResponseReceipt,
+  ): Promise<InboxResponseReceipt | undefined> {
+    if (receipt.queuedItemId === undefined) return undefined;
+    const completed = this._record.queueAdmissionReceipts?.[receipt.queuedItemId];
+    if (completed?.status !== 'completed' || completed.runId !== receipt.runId || completed.result === undefined) {
+      return undefined;
+    }
+    await this._markInboxResponseApplied(receipt.responseId, completed.result as AgentResult);
+    return getOwnRecordValue(this._record.inboxResponseReceipts, receipt.responseId) ?? receipt;
+  }
+
+  private async _markInboxResponseApplied(responseId: string, result: AgentResult): Promise<void> {
+    const appliedAt = Date.now();
+    await this._flushUpdate(prev => {
+      const receipt = getOwnRecordValue(prev.inboxResponseReceipts, responseId);
+      if (!receipt || receipt.status === 'applied') return prev;
+      return {
+        ...prev,
+        inboxResponseReceipts: {
+          ...(prev.inboxResponseReceipts ?? {}),
+          [responseId]: {
+            ...receipt,
+            status: 'applied',
+            result,
+            appliedAt: receipt.appliedAt ?? appliedAt,
+            updatedAt: appliedAt,
+          },
+        },
+      };
+    });
+  }
+
+  private async _markInboxResponseFailed(responseId: string, err: unknown): Promise<void> {
+    const failedAt = Date.now();
+    await this._flushUpdate(prev => {
+      const receipt = getOwnRecordValue(prev.inboxResponseReceipts, responseId);
+      if (!receipt || receipt.status === 'applied' || receipt.status === 'failed' || receipt.status === 'dead') {
+        return prev;
+      }
+      return {
+        ...prev,
+        inboxResponseReceipts: {
+          ...(prev.inboxResponseReceipts ?? {}),
+          [responseId]: {
+            ...receipt,
+            status: 'failed',
+            error: projectHarnessPublicError(err),
+            retryable: false,
+            failedAt: receipt.failedAt ?? failedAt,
+            updatedAt: failedAt,
+          },
+        },
+      };
+    });
+  }
+
+  private async _markInboxResponseFailedAndClearPending(
+    responseId: string | undefined,
+    pending: PendingResume,
+    err: unknown,
+  ): Promise<void> {
+    const failedAt = Date.now();
+    await this._flushUpdate(prev => {
+      const receipt = responseId !== undefined ? getOwnRecordValue(prev.inboxResponseReceipts, responseId) : undefined;
+      const current = prev.pendingResume;
+      const currentItemId = current ? (current.itemId ?? current.toolCallId) : undefined;
+      const pendingItemId = pending.itemId ?? pending.toolCallId;
+      const canClearPending =
+        current !== undefined &&
+        current.runId === pending.runId &&
+        current.toolCallId === pending.toolCallId &&
+        currentItemId === pendingItemId &&
+        current.resumedAt === pending.resumedAt &&
+        current.queuedItemId === undefined;
+
+      if (
+        (!receipt || receipt.status === 'applied' || receipt.status === 'failed' || receipt.status === 'dead') &&
+        !canClearPending
+      ) {
+        return prev;
+      }
+
+      const next: SessionRecord = { ...prev };
+      if (receipt && receipt.status !== 'applied' && receipt.status !== 'failed' && receipt.status !== 'dead') {
+        next.inboxResponseReceipts = {
+          ...(prev.inboxResponseReceipts ?? {}),
+          [receipt.responseId]: {
+            ...receipt,
+            status: 'failed',
+            error: projectHarnessPublicError(err),
+            retryable: false,
+            failedAt: receipt.failedAt ?? failedAt,
+            updatedAt: failedAt,
+          },
+        };
+      }
+      if (canClearPending) {
+        delete next.pendingResume;
+      }
+      return next;
+    });
+  }
+
+  private _computeInboxResponseHash(input: {
+    kind: PendingResume['kind'];
+    itemId: string;
+    runId: string;
+    pendingRequestedAt: number;
+    response: unknown;
+  }): string {
+    return sha256CanonicalJson(input);
   }
 
   private _queuedItemIdForPendingResume(pending: PendingResume): string | undefined {
@@ -5246,6 +5700,15 @@ function assertJsonValue(value: unknown, path = 'value'): JsonValue {
     return out;
   }
   throw new HarnessValidationError(path, 'must be JSON-serializable for admission hashing');
+}
+
+function compactJsonObject<T extends Record<string, unknown>>(value: T): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+function getOwnRecordValue<T>(record: Record<string, T> | undefined, key: string): T | undefined {
+  if (!record || !Object.prototype.hasOwnProperty.call(record, key)) return undefined;
+  return record[key];
 }
 
 function isPlainJsonObject(value: object): value is Record<string, unknown> {

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -858,6 +858,19 @@ export type AgentResult<OUTPUT = undefined> = FullOutput<OUTPUT>;
 /** Shorthand for the streaming return type. */
 export type AgentStream<OUTPUT = undefined> = MastraModelOutput<OUTPUT>;
 
+export interface InboxResponseOptions {
+  itemId?: string;
+  responseId?: string;
+}
+
+export interface InboxResponseResult {
+  itemId: string;
+  kind: 'tool-approval' | 'tool-suspension' | 'question' | 'plan-approval';
+  status: 'accepted' | 'applied';
+  responseId: string;
+  duplicate: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // queue() — wait-for-idle FIFO turn queue (spec §4.2 / §6).
 //

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -655,6 +655,7 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
     pending_queue: { type: 'jsonb', nullable: false },
     pending_resume: { type: 'jsonb', nullable: true },
     queue_admission_receipts: { type: 'jsonb', nullable: true },
+    inbox_response_receipts: { type: 'jsonb', nullable: true },
     observational_memory: { type: 'jsonb', nullable: true },
     goal: { type: 'jsonb', nullable: true },
     workspace: { type: 'jsonb', nullable: true },

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -271,6 +271,7 @@ export interface SessionRecord {
   pendingQueue: QueuedItem[];
   pendingResume?: PendingResume;
   queueAdmissionReceipts?: Record<string, QueueAdmissionReceipt>;
+  inboxResponseReceipts?: Record<string, InboxResponseReceipt>;
 
   // Observational memory config (per-session override)
   observationalMemory?: {
@@ -371,6 +372,28 @@ export interface QueueAdmissionReceipt {
   failedAt?: number;
   deadAt?: number;
   nextAttemptAt?: number;
+  updatedAt: number;
+}
+
+export interface InboxResponseReceipt {
+  responseId: string;
+  responseHash: string;
+  resumeAttemptId: string;
+  itemId: string;
+  queuedItemId?: string;
+  kind: PendingResume['kind'];
+  runId: string;
+  toolCallId: string;
+  pendingRequestedAt: number;
+  response: unknown;
+  status: 'accepted' | 'applied' | 'failed' | 'dead';
+  result?: unknown;
+  error?: HarnessStoredPublicError;
+  retryable?: boolean;
+  acceptedAt: number;
+  appliedAt?: number;
+  failedAt?: number;
+  deadAt?: number;
   updatedAt: number;
 }
 

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -407,6 +407,55 @@ describe('HarnessLibSQL queue admission evidence', () => {
   });
 });
 
+describe('HarnessLibSQL inbox response receipts', () => {
+  let storage: HarnessLibSQL;
+
+  beforeEach(async () => {
+    const client = createHarnessTestClient();
+    storage = new HarnessLibSQL({ client });
+    await storage.init();
+  });
+
+  it('round-trips inbox response receipts on session records', async () => {
+    await storage.saveSession(
+      sampleSession({
+        inboxResponseReceipts: {
+          'response-1': {
+            responseId: 'response-1',
+            responseHash: 'hash-1',
+            resumeAttemptId: 'response-1',
+            itemId: 'question:tool-1',
+            kind: 'question',
+            runId: 'run-1',
+            toolCallId: 'tool-1',
+            pendingRequestedAt: 1000,
+            response: { answer: 'red' },
+            status: 'applied',
+            result: { text: 'done', finishReason: 'stop', runId: 'run-1' },
+            acceptedAt: 1100,
+            appliedAt: 1200,
+            updatedAt: 1200,
+          },
+        },
+      }),
+      { ownerId: 'h', ifVersion: 0 },
+    );
+
+    await expect(storage.loadSession({ sessionId: 'session-1' })).resolves.toMatchObject({
+      inboxResponseReceipts: {
+        'response-1': {
+          responseId: 'response-1',
+          resumeAttemptId: 'response-1',
+          itemId: 'question:tool-1',
+          status: 'applied',
+          response: { answer: 'red' },
+          result: { text: 'done', finishReason: 'stop', runId: 'run-1' },
+        },
+      },
+    });
+  });
+});
+
 function sampleSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
   return {
     harnessName: 'default',

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -106,7 +106,14 @@ export class HarnessLibSQL extends HarnessStorage {
     await this.#db.alterTable({
       tableName: TABLE_HARNESS_SESSIONS,
       schema: TABLE_SCHEMAS[TABLE_HARNESS_SESSIONS],
-      ifNotExists: ['harness_name', 'subagent_depth', 'queue_admission_receipts', 'closing_at', 'close_deadline_at'],
+      ifNotExists: [
+        'harness_name',
+        'subagent_depth',
+        'queue_admission_receipts',
+        'inbox_response_receipts',
+        'closing_at',
+        'close_deadline_at',
+      ],
     });
     await this.#db.alterTable({
       tableName: TABLE_HARNESS_ATTACHMENTS,
@@ -1387,6 +1394,7 @@ const SESSION_COLUMN_NAMES = [
   'pending_queue',
   'pending_resume',
   'queue_admission_receipts',
+  'inbox_response_receipts',
   'observational_memory',
   'goal',
   'workspace',
@@ -1420,6 +1428,7 @@ function sessionColumnValues(record: SessionRecord, version: number): { names: s
     JSON.stringify(record.pendingQueue),
     record.pendingResume ? JSON.stringify(record.pendingResume) : null,
     record.queueAdmissionReceipts ? JSON.stringify(record.queueAdmissionReceipts) : null,
+    record.inboxResponseReceipts ? JSON.stringify(record.inboxResponseReceipts) : null,
     record.observationalMemory ? JSON.stringify(record.observationalMemory) : null,
     record.goal ? JSON.stringify(record.goal) : null,
     record.workspace ? JSON.stringify(record.workspace) : null,
@@ -1455,6 +1464,7 @@ function rowToSession(row: Record<string, unknown>): SessionRecord {
     pendingQueue: parseJson(row.pending_queue) ?? [],
     pendingResume: parseJson(row.pending_resume) ?? undefined,
     queueAdmissionReceipts: parseJson(row.queue_admission_receipts) ?? undefined,
+    inboxResponseReceipts: parseJson(row.inbox_response_receipts) ?? undefined,
     observationalMemory: parseJson(row.observational_memory) ?? undefined,
     goal: parseJson(row.goal) ?? undefined,
     workspace: parseJson(row.workspace) ?? undefined,


### PR DESCRIPTION
## Summary

- Adds durable Harness v1 inbox response receipts for `respondToToolApproval`, `respondToToolSuspension`, `respondToQuestion`, and `respondToPlanApproval` when callers pass `responseId`.
- Preserves legacy no-`responseId` behavior, including opaque `respondToToolSuspension({ resumeData })` payloads.
- Persists receipts on session records and wires LibSQL schema/migration mapping for `inbox_response_receipts`.
- Handles duplicate, conflicting, concurrent, failed, queued-completed, and stale non-queued response cases without replaying unsafe resumes.
- Adds public types/errors and minor/patch changesets for `@mastra/core` and `@mastra/libsql`.

## Scope / Deferrals

- This PR stores `resumeAttemptId` as the response id, but does not pass a separate `resumeAttemptId` into `agent.resumeStream`; that runtime boundary remains a follow-up for the recovery/server lanes.
- Server routes, channel ingress/outbox, remote SDK requestContext, and full background recovery remain out of scope for PF-348 and are covered by later Harness v1 roadmap issues.
- Tool denial is represented by `respondToToolApproval({ approved: false, reason?, responseId })`; the compact approval payload is forwarded to the resumed tool path.

## Review Evidence

- Claude council: blocked by API rate limit.
- Gemini council: no BLOCKER; raised resumeAttemptId runtime boundary as a deferral, recorded above.
- opencode council: blocked by local SQLite/WAL error.
- Local Codex review pass 1: found race/recovery issues; fixed concurrent duplicate/distinct response races, failed-receipt replay, stale non-queued cleanup, queued receipt matching, and overload return typing.
- Local Codex review pass 2: found changeset issue; split/fixed core minor and LibSQL patch changesets.
- CodeRabbit CLI: authenticated and ran locally. Fixed the in-scope LibSQL changeset wording. Other reported changeset/session findings were verified as unrelated pre-existing/out-of-scope lines and should be handled separately.

## Validation

- `pnpm --filter @mastra/core test src/harness/v1/session.suspend.test.ts src/harness/v1/session.queue.test.ts`
- `pnpm --filter @mastra/core typecheck`
- `pnpm --filter @mastra/core build:lib`
- `pnpm --filter @mastra/libsql exec vitest run src/storage/domains/harness/index.test.ts`
- `pnpm --filter @mastra/libsql exec tsc --noEmit`
- `pnpm prettier --check packages/core/src/harness/v1/errors.ts packages/core/src/harness/v1/index.ts packages/core/src/harness/v1/types.ts packages/core/src/harness/v1/session.ts packages/core/src/harness/v1/session.suspend.test.ts packages/core/src/harness/v1/session.queue.test.ts packages/core/src/storage/constants.ts packages/core/src/storage/domains/harness/types.ts stores/libsql/src/storage/domains/harness/index.ts stores/libsql/src/storage/domains/harness/index.test.ts .changeset/pf-348-inbox-response-receipts.md .changeset/pf-348-libsql-inbox-response-receipts.md`
- `git diff --check`

Note: an earlier LibSQL test attempt was run concurrently with `@mastra/core build:lib` and failed on a transient missing dist chunk while the build rewrote dist. It passed when rerun serially after the build completed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes it safe to retry responses in a chat/tool-calling system. When you tell a system "here's my answer to your question," and the message gets lost or you need to resend it, the system now remembers it already got your answer and won't process it twice. It does this by having you provide a unique ID (`responseId`) with your response, kind of like a receipt that prevents duplicate actions.

---

## Changes Overview

### New Types and Errors

Added two new public types for inbox response handling:
- `InboxResponseOptions`: Configuration for responses with optional `itemId` and `responseId`
- `InboxResponseResult`: Result shape containing response identifiers, categorization (`kind`), decision status (`status`), and a `duplicate` flag

Added two new error types:
- `HarnessInboxItemNotFoundError`: Thrown when an inbox item lookup fails
- `HarnessInboxResponseConflictError`: Thrown when a response conflicts with stored evidence

### API Enhancements

Extended the `Session` class with new overloads for four resume/approval methods:
- `respondToToolApproval()`
- `respondToToolSuspension()`
- `respondToQuestion()`
- `respondToPlanApproval()`

Each method now supports an optional `responseId` parameter that enables idempotent receipt behavior. The methods have dual return types: returning `InboxResponseResult` when `responseId` is provided (receipt-only mode), or `AgentResult` for legacy behavior without receipts.

The underlying `_resume` implementation now:
- Computes deterministic response hashes for idempotency validation
- Stores response outcomes in `SessionRecord.inboxResponseReceipts`
- Handles duplicate, conflicting, concurrent, and stale response cases
- Applies stored receipts when resumed turns complete
- Validates incoming responses against stored evidence to prevent replay

### Database Schema & Persistence

- Added `inbox_response_receipts` JSONB column to `mastra_harness_sessions` table
- Updated LibSQL storage layer to persist and load `inboxResponseReceipts` as a first-class field
- Introduced `InboxResponseReceipt` interface to define persisted receipt shape with fields for identifiers, hashes, timing, status, payloads, and error information

### Test Coverage

- Added comprehensive test suite for receipt handling including: duplicate detection, conflicting responses, concurrent admission ordering, failed resume handling, stale receipt cleanup, and retry scenarios
- Added end-to-end LibSQL persistence tests validating receipt round-trip storage
- Introduced `holdUntil` timing control in test harness for deterministic concurrency testing

### Changesets

- `@mastra/core`: Minor version bump documenting durable Harness v1 inbox response receipts
- `@mastra/libsql`: Patch version bump for receipt persistence support

### Scope Notes

- Response ID is stored but not passed separately into recovery/server lanes (runtime boundary deferred)
- Server routes, channel ingress/outbox, remote SDK integration, and full background recovery are out of scope
- Tool denial represented by compact approval payload forwarded to resumed tool path

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->