### PR TITLE
[PF-512] Sync upstream PR 16665 and memory delete fix

### DIFF
--- a/.changeset/nice-ducks-love.md
+++ b/.changeset/nice-ducks-love.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed thread deletion so it also clears thread-scoped observational memory.

--- a/.changeset/shared-signals-runtime.md
+++ b/.changeset/shared-signals-runtime.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed agent signals so standalone agents coordinate thread streams through a shared runtime.
+Fixed agent signals so thread stream coordination is routed through PubSub, with in-memory defaults for standalone agents.

--- a/.changeset/shared-signals-runtime.md
+++ b/.changeset/shared-signals-runtime.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed agent signals so thread stream coordination is routed through PubSub, with in-memory defaults for standalone agents.
+Fixed agent signals to support reliable cross-process and cross-instance coordination without changing standalone agent ergonomics.

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 
 import { Agent } from '@mastra/core/agent';
+import type { PubSub } from '@mastra/core/events';
 import { Harness } from '@mastra/core/harness';
 import type {
   CustomAvailableModel,
@@ -132,6 +133,10 @@ export interface MastraCodeConfig {
   memory?: HarnessConfig['memory'];
   /** Browser provider for browser automation tools. When set, the agent gains access to browser tools. */
   browser?: HarnessConfig['browser'];
+  /** PubSub for signal routing. When crossProcessPubSub is true, thread locks are disabled. */
+  pubsub?: PubSub;
+  /** Marks the configured PubSub as cross-process-safe, allowing Mastra Code to skip file thread locks. */
+  crossProcessPubSub?: boolean;
 }
 
 export function createAuthStorage() {
@@ -226,6 +231,9 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     project.resourceId = resourceIdOverride;
     project.resourceIdOverride = true;
   }
+
+  const signalsPubSub = config?.pubsub;
+  const crossProcessPubSub = config?.crossProcessPubSub ?? false;
 
   // Storage
   const storageConfig = config?.storage ?? getStorageConfig(project.rootPath, globalSettings.storage);
@@ -524,6 +532,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     storage,
     observability,
     memory,
+    pubsub: signalsPubSub,
     stateSchema,
     subagents,
     resolveModel: modelId => resolveModel(modelId) as LanguageModel,
@@ -628,10 +637,12 @@ export async function createMastraCode(config?: MastraCodeConfig) {
 
       return customModels;
     },
-    threadLock: {
-      acquire: acquireThreadLock,
-      release: releaseThreadLock,
-    },
+    threadLock: crossProcessPubSub
+      ? undefined
+      : {
+          acquire: acquireThreadLock,
+          release: releaseThreadLock,
+        },
   });
 
   // Sync hookManager session ID on thread changes
@@ -661,6 +672,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     resolveModel,
     storageWarning,
     observabilityWarning,
+    signalsPubSub,
     builtinPacks,
     builtinOmPacks,
     effectiveDefaults,

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -637,6 +637,22 @@ describe('Agent signals', () => {
     await nextRunPromise;
   });
 
+  it('preserves an injected PubSub when forking an agent', () => {
+    const pubsub = new AsyncFanoutPubSub();
+    const agent = new Agent({
+      id: 'forked-agent-pubsub',
+      name: 'Forked Agent PubSub',
+      instructions: 'Test',
+      model: createTextStreamModel('forked response'),
+    });
+
+    agent.__setPubSub(pubsub);
+    const fork = agent.__fork();
+
+    expect(fork.getPubSub()).toBe(pubsub);
+    expect(fork.hasOwnPubSub()).toBe(true);
+  });
+
   it('supports cross-instance thread subscriptions through the Mastra runtime', async () => {
     const pubsub = new EventEmitterPubSub();
     const runner = new Agent({

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -1,6 +1,7 @@
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { EventEmitterPubSub } from '../../events/event-emitter';
 import { Mastra } from '../../mastra';
 import { MockMemory } from '../../memory/mock';
 import { Agent } from '../agent';
@@ -361,18 +362,85 @@ describe('Agent signals', () => {
     expect(JSON.stringify(prompts)).not.toContain('discard while running');
   });
 
-  it('supports cross-instance thread subscriptions through the shared runtime without Mastra', async () => {
+  it('routes active-run signals across runtime instances through PubSub', async () => {
+    const pubsub = new EventEmitterPubSub();
+    const ownerRuntime = new AgentThreadStreamRuntime();
+    const senderRuntime = new AgentThreadStreamRuntime();
+    const owner = new Agent({
+      id: 'remote-signal-agent',
+      name: 'Remote Signal Owner Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('owner response'),
+    });
+    const sender = new Agent({
+      id: 'remote-signal-agent',
+      name: 'Remote Signal Sender Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('sender response'),
+    });
+    let finishRun!: () => void;
+    const output = {
+      runId: 'remote-run-1',
+      status: 'running',
+      fullStream: (async function* () {})(),
+      _waitUntilFinished: () => new Promise<void>(resolve => (finishRun = resolve)),
+    } as any;
+
+    const ownerSubscription = await ownerRuntime.subscribeToThread(
+      owner,
+      {
+        resourceId: 'remote-resource',
+        threadId: 'remote-thread',
+      },
+      pubsub,
+    );
+    const senderSubscription = await senderRuntime.subscribeToThread(
+      sender,
+      {
+        resourceId: 'remote-resource',
+        threadId: 'remote-thread',
+      },
+      pubsub,
+    );
+
+    ownerRuntime.registerRun(
+      owner,
+      output,
+      { runId: 'remote-run-1', memory: { resource: 'remote-resource', thread: 'remote-thread' } } as any,
+      pubsub,
+    );
+    await waitForCondition(() => senderSubscription.activeRunId() === 'remote-run-1');
+
+    const result = senderRuntime.sendSignal(
+      sender,
+      { type: 'user-message', contents: [{ role: 'user', content: 'remote follow-up' }] },
+      { resourceId: 'remote-resource', threadId: 'remote-thread' },
+      pubsub,
+    );
+
+    expect(result.accepted).toBe(true);
+    await waitForCondition(() => ownerRuntime.drainPendingSignals('remote-run-1', pubsub).length === 1);
+
+    finishRun();
+    ownerSubscription.unsubscribe();
+    senderSubscription.unsubscribe();
+  });
+
+  it('supports cross-instance thread subscriptions through an injected PubSub without Mastra', async () => {
+    const pubsub = new EventEmitterPubSub();
     const runner = new Agent({
       id: 'standalone-shared-agent',
       name: 'Standalone Shared Runner Agent',
       instructions: 'Test',
       model: createTextStreamModel('standalone shared response'),
+      pubsub,
     });
     const observer = new Agent({
       id: 'standalone-shared-agent',
       name: 'Standalone Shared Observer Agent',
       instructions: 'Test',
       model: createTextStreamModel('standalone observer response'),
+      pubsub,
     });
 
     const subscription = await observer.subscribeToThread({
@@ -409,7 +477,45 @@ describe('Agent signals', () => {
     subscription.unsubscribe();
   });
 
+  it('isolates standalone agents that use different injected pubsubs', async () => {
+    const runner = new Agent({
+      id: 'standalone-isolated-agent',
+      name: 'Standalone Isolated Runner Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('isolated response'),
+      pubsub: new EventEmitterPubSub(),
+    });
+    const observer = new Agent({
+      id: 'standalone-isolated-agent',
+      name: 'Standalone Isolated Observer Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('isolated observer response'),
+      pubsub: new EventEmitterPubSub(),
+    });
+
+    const subscription = await observer.subscribeToThread({
+      threadId: 'standalone-isolated-thread',
+      resourceId: 'standalone-isolated-user',
+    });
+    const iterator = subscription.stream[Symbol.asyncIterator]();
+    const nextRunPromise = readNextRun(iterator);
+
+    await runner.stream('Hello', {
+      memory: { thread: 'standalone-isolated-thread', resource: 'standalone-isolated-user' },
+    });
+
+    const result = await Promise.race([
+      nextRunPromise.then(() => 'delivered'),
+      new Promise<'timeout'>(resolve => setTimeout(() => resolve('timeout'), 20)),
+    ]);
+    expect(result).toBe('timeout');
+
+    subscription.unsubscribe();
+    await nextRunPromise;
+  });
+
   it('supports cross-instance thread subscriptions through the Mastra runtime', async () => {
+    const pubsub = new EventEmitterPubSub();
     const runner = new Agent({
       id: 'shared-agent',
       name: 'Shared Runner Agent',
@@ -422,7 +528,9 @@ describe('Agent signals', () => {
       instructions: 'Test',
       model: createTextStreamModel('observer response'),
     });
-    new Mastra({ agents: { runner, observer }, logger: false });
+    new Mastra({ agents: { runner, observer }, logger: false, pubsub });
+    expect(runner.getPubSub()).toBe(pubsub);
+    expect(observer.getPubSub()).toBe(pubsub);
 
     const subscription = await observer.subscribeToThread({
       threadId: 'shared-thread',

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -2,6 +2,8 @@ import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { EventEmitterPubSub } from '../../events/event-emitter';
+import { PubSub } from '../../events/pubsub';
+import type { EventCallback, SubscribeOptions } from '../../events/types';
 import { Mastra } from '../../mastra';
 import { MockMemory } from '../../memory/mock';
 import { Agent } from '../agent';
@@ -37,6 +39,27 @@ function createTextStreamModel(responseText: string) {
 
 function nextTick() {
   return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+class AsyncFanoutPubSub extends PubSub {
+  #inner = new EventEmitterPubSub();
+
+  async publish(topic: string, event: Parameters<PubSub['publish']>[1]): Promise<void> {
+    await nextTick();
+    await this.#inner.publish(topic, event);
+  }
+
+  async subscribe(topic: string, cb: EventCallback, options?: SubscribeOptions): Promise<void> {
+    await this.#inner.subscribe(topic, cb, options);
+  }
+
+  async unsubscribe(topic: string, cb: EventCallback): Promise<void> {
+    await this.#inner.unsubscribe(topic, cb);
+  }
+
+  async flush(): Promise<void> {
+    await this.#inner.flush();
+  }
 }
 
 async function readNextRun(iterator: AsyncIterator<any>) {
@@ -473,6 +496,106 @@ describe('Agent signals', () => {
     expect(signalResult).toEqual(expect.objectContaining({ accepted: true, runId: signalRun.value.runId }));
     expect(signalResult.signal.id).toBeDefined();
     expect(signalRun.value.text).toBe('standalone shared response');
+
+    subscription.unsubscribe();
+  });
+
+  it('broadcasts through async PubSub without consuming the caller fullStream', async () => {
+    const pubsub = new AsyncFanoutPubSub();
+    const runner = new Agent({
+      id: 'async-shared-agent',
+      name: 'Async Shared Runner Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('async shared response'),
+      pubsub,
+    });
+    const observer = new Agent({
+      id: 'async-shared-agent',
+      name: 'Async Shared Observer Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('async observer response'),
+      pubsub,
+    });
+    const subscription = await observer.subscribeToThread({
+      resourceId: 'async-user',
+      threadId: 'async-thread',
+    });
+
+    const stream = await runner.stream('Hello', {
+      memory: { resource: 'async-user', thread: 'async-thread' },
+    });
+
+    await expect(readNextRun(stream.fullStream[Symbol.asyncIterator]())).resolves.toMatchObject({
+      value: { runId: stream.runId, text: 'async shared response' },
+      done: false,
+    });
+    await expect(readNextRun(subscription.stream[Symbol.asyncIterator]())).resolves.toMatchObject({
+      value: { runId: stream.runId, text: 'async shared response' },
+      done: false,
+    });
+
+    subscription.unsubscribe();
+  });
+
+  it('broadcasts async PubSub stream parts across runtime instances in order', async () => {
+    const pubsub = new AsyncFanoutPubSub();
+    const ownerRuntime = new AgentThreadStreamRuntime();
+    const observerRuntime = new AgentThreadStreamRuntime();
+    const runId = 'async-remote-run';
+    const chunks = [
+      { type: 'stream-start', runId, from: 'AGENT', payload: { warnings: [] } },
+      { type: 'text-start', runId, from: 'AGENT', payload: { id: 'text-1' } },
+      { type: 'text-delta', runId, from: 'AGENT', payload: { id: 'text-1', text: 'remote async response' } },
+      { type: 'text-end', runId, from: 'AGENT', payload: { id: 'text-1' } },
+      { type: 'finish', runId, from: 'AGENT', payload: {} },
+    ];
+    let finish!: () => void;
+    const finished = new Promise<void>(resolve => {
+      finish = resolve;
+    });
+
+    const subscription = await observerRuntime.subscribeToThread(
+      { id: 'async-remote-observer' } as any,
+      {
+        resourceId: 'async-remote-user',
+        threadId: 'async-remote-thread',
+      },
+      pubsub,
+    );
+    const nextRun = readNextRun(subscription.stream[Symbol.asyncIterator]());
+    const output = {
+      runId,
+      status: 'running',
+      fullStream: new ReadableStream({
+        start(controller) {
+          for (const chunk of chunks) controller.enqueue(chunk);
+          finish();
+          controller.close();
+        },
+      }),
+      _waitUntilFinished: () => finished,
+    };
+
+    ownerRuntime.registerRun(
+      { id: 'async-remote-owner' } as any,
+      output as any,
+      {
+        runId,
+        memory: { resource: 'async-remote-user', thread: 'async-remote-thread' },
+      } as any,
+      pubsub,
+    );
+    await expect(
+      readNextRun((output.fullStream as ReadableStream<unknown>)[Symbol.asyncIterator]()),
+    ).resolves.toMatchObject({
+      value: { runId, text: 'remote async response' },
+      done: false,
+    });
+
+    await expect(nextRun).resolves.toMatchObject({
+      value: { runId, text: 'remote async response' },
+      done: false,
+    });
 
     subscription.unsubscribe();
   });
@@ -1138,6 +1261,37 @@ describe('Agent signals', () => {
     expect(secondRun.value.runId).toBe(signalResult.runId);
     expect(secondRun.value.text).toBe('second response');
     expect(secondStarted).toBe(true);
+
+    subscription.unsubscribe();
+  });
+
+  it('preserves caller-provided runId for idle wake signals', async () => {
+    const agent = new Agent({
+      id: 'caller-run-id-agent',
+      name: 'Caller Run Id Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('caller run response'),
+    });
+    const subscription = await agent.subscribeToThread({
+      resourceId: 'caller-run-user',
+      threadId: 'caller-run-thread',
+    });
+
+    const signalResult = await agent.sendSignal(
+      { type: 'user-message', contents: 'wake with caller id' },
+      {
+        runId: 'caller-provided-run',
+        resourceId: 'caller-run-user',
+        threadId: 'caller-run-thread',
+        ifIdle: { streamOptions: { memory: { resource: 'caller-run-user', thread: 'caller-run-thread' } } },
+      },
+    );
+
+    expect(signalResult).toEqual(expect.objectContaining({ accepted: true, runId: 'caller-provided-run' }));
+    await expect(readNextRun(subscription.stream[Symbol.asyncIterator]())).resolves.toMatchObject({
+      value: { runId: 'caller-provided-run', text: 'caller run response' },
+      done: false,
+    });
 
     subscription.unsubscribe();
   });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -22,6 +22,7 @@ import type {
   ScoringSamplingConfig,
 } from '../evals';
 import { runScorer } from '../evals/hooks';
+import type { PubSub } from '../events/pubsub';
 import { resolveModelConfig } from '../llm';
 import type { CoreMessage } from '../llm';
 import { MastraLLMV1 } from '../llm/model';
@@ -308,6 +309,7 @@ export class Agent<
   #originalModel: DynamicArgument<MastraModelConfig | ModelWithRetries[], TRequestContext> | ModelFallbacks;
   maxRetries?: number;
   #mastra?: Mastra;
+  #pubsub?: PubSub;
   #memory?: DynamicArgument<MastraMemory, TRequestContext>;
   #skillsFormat?: SkillFormat;
   #workflows?: DynamicArgument<Record<string, AnyWorkflow>, TRequestContext>;
@@ -431,6 +433,7 @@ export class Agent<
     );
 
     this.#tools = config.tools || ({} as TTools);
+    this.#pubsub = config.pubsub;
 
     if (config.mastra) {
       this.__registerMastra(config.mastra);
@@ -537,6 +540,14 @@ export class Agent<
 
   getMastraInstance() {
     return this.#mastra;
+  }
+
+  getPubSub() {
+    return this.#pubsub ?? this.#mastra?.pubsub;
+  }
+
+  hasOwnPubSub(): boolean {
+    return Boolean(this.#pubsub);
   }
 
   /**
@@ -2615,6 +2626,10 @@ export class Agent<
 
   public __setMemory(memory: DynamicArgument<MastraMemory, TRequestContext>) {
     this.#memory = memory;
+  }
+
+  public __setPubSub(pubsub: PubSub) {
+    this.#pubsub = pubsub;
   }
 
   public __setWorkspace(workspace: DynamicArgument<AnyWorkspace | undefined, TRequestContext>) {
@@ -5613,7 +5628,7 @@ export class Agent<
             agentBackgroundConfig: this.#backgroundTasks,
           }),
       skipBgTaskWait: options._skipBgTaskWait,
-      drainPendingSignals: this.#getThreadStreamRuntime().drainPendingSignals.bind(this.#getThreadStreamRuntime()),
+      drainPendingSignals: runId => this.#getThreadStreamRuntime().drainPendingSignals(runId, this.getPubSub()),
       initialSignalEchoes: initialSignalEchoesForRun,
     });
 
@@ -6173,7 +6188,7 @@ export class Agent<
     output: MastraModelOutput<OUTPUT>,
     streamOptions: AgentExecutionOptions<OUTPUT>,
   ): void {
-    this.#getThreadStreamRuntime().registerRun(this as Agent<any, any, any, any>, output, streamOptions);
+    this.#getThreadStreamRuntime().registerRun(this as Agent<any, any, any, any>, output, streamOptions, this.getPubSub());
   }
 
   /**
@@ -6183,7 +6198,7 @@ export class Agent<
    * `sendSignal()` returns a `runId` to drain events from the run's output.
    */
   getRunOutput<OUTPUT = TOutput>(runId: string): MastraModelOutput<OUTPUT> | undefined {
-    return this.#getThreadStreamRuntime().getRunOutput<OUTPUT>(runId);
+    return this.#getThreadStreamRuntime().getRunOutput<OUTPUT>(runId, this.getPubSub());
   }
 
   /**
@@ -6196,7 +6211,7 @@ export class Agent<
    * their own completion deadline (e.g. tied to the per-run completion path).
    */
   waitForRunOutput<OUTPUT = TOutput>(runId: string): Promise<MastraModelOutput<OUTPUT>> {
-    return this.#getThreadStreamRuntime().waitForRunOutput<OUTPUT>(runId);
+    return this.#getThreadStreamRuntime().waitForRunOutput<OUTPUT>(runId, this.getPubSub());
   }
 
   /**
@@ -6205,22 +6220,31 @@ export class Agent<
   async subscribeToThread<OUTPUT = TOutput>(
     options: AgentSubscribeToThreadOptions,
   ): Promise<AgentThreadSubscription<OUTPUT>> {
-    return this.#getThreadStreamRuntime().subscribeToThread<OUTPUT>(this as Agent<any, any, any, any>, options);
+    return this.#getThreadStreamRuntime().subscribeToThread<OUTPUT>(
+      this as Agent<any, any, any, any>,
+      options,
+      this.getPubSub(),
+    );
   }
 
   abortThreadStream(options: AgentSubscribeToThreadOptions): boolean {
-    return this.#getThreadStreamRuntime().abortThread(options);
+    return this.#getThreadStreamRuntime().abortThread(options, this.getPubSub());
   }
 
   abortRunStream(runId: string): boolean {
-    return this.#getThreadStreamRuntime().abortRun(runId);
+    return this.#getThreadStreamRuntime().abortRun(runId, this.getPubSub());
   }
 
   /**
    * @experimental Agent signals are experimental and may change in a future release.
    */
   sendSignal<OUTPUT = TOutput>(signal: AgentSignal, target: SendAgentSignalOptions<OUTPUT>): SendAgentSignalResult {
-    return this.#getThreadStreamRuntime().sendSignal(this as Agent<any, any, any, any>, signal, target);
+    return this.#getThreadStreamRuntime().sendSignal(
+      this as Agent<any, any, any, any>,
+      signal,
+      target,
+      this.getPubSub(),
+    );
   }
 
   async stream<
@@ -6306,7 +6330,11 @@ export class Agent<
       });
     }
 
-    await this.#getThreadStreamRuntime().waitForCrossAgentThreadRun(this as Agent<any, any, any, any>, mergedOptions);
+    await this.#getThreadStreamRuntime().waitForCrossAgentThreadRun(
+      this as Agent<any, any, any, any>,
+      mergedOptions,
+      this.getPubSub(),
+    );
 
     mergedOptions.runId ??=
       this.#mastra?.generateId({
@@ -6314,7 +6342,7 @@ export class Agent<
         source: 'agent',
         entityId: this.id,
       }) ?? randomUUID();
-    const preparedOptions = this.#getThreadStreamRuntime().prepareRunOptions(mergedOptions);
+    const preparedOptions = this.#getThreadStreamRuntime().prepareRunOptions(mergedOptions, this.getPubSub());
 
     const executeOptions = {
       ...preparedOptions,
@@ -6358,6 +6386,7 @@ export class Agent<
       this as Agent<any, any, any, any>,
       result.result,
       preparedOptions as AgentExecutionOptions<OUTPUT>,
+      this.getPubSub(),
     );
 
     return result.result;
@@ -6587,9 +6616,11 @@ export class Agent<
     await this.#getThreadStreamRuntime().waitForCrossAgentThreadRun(
       this as Agent<any, any, any, any>,
       mergedStreamOptions as unknown as AgentExecutionOptions<OUTPUT>,
+      this.getPubSub(),
     );
     const preparedOptions = this.#getThreadStreamRuntime().prepareRunOptions(
       mergedStreamOptions as unknown as AgentExecutionOptions<OUTPUT>,
+      this.getPubSub(),
     );
 
     const result = await this.#execute({
@@ -6634,6 +6665,7 @@ export class Agent<
       this as Agent<any, any, any, any>,
       result.result as unknown as MastraModelOutput<OUTPUT>,
       preparedOptions as AgentExecutionOptions<OUTPUT>,
+      this.getPubSub(),
     );
 
     return result.result as unknown as MastraModelOutput<OUTPUT>;

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -768,7 +768,7 @@ export class Agent<
       if (validation.issues) {
         const errors = validation.issues;
         const errorMessages = errors
-          .map(e => {
+          .map((e: any) => {
             const pathStr = e.path?.map((p: any) => (typeof p === 'object' ? p.key : p)).join('.');
             return `- ${pathStr}: ${e.message}`;
           })
@@ -6162,7 +6162,8 @@ export class Agent<
       });
     }
 
-    const fullOutput = await result.result.getFullOutput();
+    const output = result.result as MastraModelOutput<OUTPUT>;
+    const fullOutput = await output.getFullOutput();
 
     const error = fullOutput.error;
 
@@ -6373,14 +6374,16 @@ export class Agent<
       });
     }
 
+    const output = result.result as MastraModelOutput<OUTPUT>;
+
     agentThreadStreamRuntime.registerRun(
       this as Agent<any, any, any, any>,
-      result.result,
+      output,
       preparedOptions as AgentExecutionOptions<OUTPUT>,
       this.getPubSub(),
     );
 
-    return result.result;
+    return output;
   }
 
   /**
@@ -6784,7 +6787,8 @@ export class Agent<
       });
     }
 
-    const fullOutput = (await result.result.getFullOutput()) as Awaited<
+    const output = result.result as MastraModelOutput<OUTPUT>;
+    const fullOutput = (await output.getFullOutput()) as Awaited<
       ReturnType<MastraModelOutput<OUTPUT>['getFullOutput']>
     >;
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -5628,7 +5628,7 @@ export class Agent<
             agentBackgroundConfig: this.#backgroundTasks,
           }),
       skipBgTaskWait: options._skipBgTaskWait,
-      drainPendingSignals: runId => this.#getThreadStreamRuntime().drainPendingSignals(runId, this.getPubSub()),
+      drainPendingSignals: runId => agentThreadStreamRuntime.drainPendingSignals(runId, this.getPubSub()),
       initialSignalEchoes: initialSignalEchoesForRun,
     });
 
@@ -6173,10 +6173,6 @@ export class Agent<
     return fullOutput;
   }
 
-  #getThreadStreamRuntime() {
-    return agentThreadStreamRuntime;
-  }
-
   /**
    * @internal Test-only hook for duck-typed agents (e.g. harness v1 MockAgent) that
    * override `stream()` without going through the real execution loop. Production
@@ -6188,7 +6184,7 @@ export class Agent<
     output: MastraModelOutput<OUTPUT>,
     streamOptions: AgentExecutionOptions<OUTPUT>,
   ): void {
-    this.#getThreadStreamRuntime().registerRun(this as Agent<any, any, any, any>, output, streamOptions, this.getPubSub());
+    agentThreadStreamRuntime.registerRun(this as Agent<any, any, any, any>, output, streamOptions, this.getPubSub());
   }
 
   /**
@@ -6198,7 +6194,7 @@ export class Agent<
    * `sendSignal()` returns a `runId` to drain events from the run's output.
    */
   getRunOutput<OUTPUT = TOutput>(runId: string): MastraModelOutput<OUTPUT> | undefined {
-    return this.#getThreadStreamRuntime().getRunOutput<OUTPUT>(runId, this.getPubSub());
+    return agentThreadStreamRuntime.getRunOutput<OUTPUT>(runId, this.getPubSub());
   }
 
   /**
@@ -6211,7 +6207,7 @@ export class Agent<
    * their own completion deadline (e.g. tied to the per-run completion path).
    */
   waitForRunOutput<OUTPUT = TOutput>(runId: string): Promise<MastraModelOutput<OUTPUT>> {
-    return this.#getThreadStreamRuntime().waitForRunOutput<OUTPUT>(runId, this.getPubSub());
+    return agentThreadStreamRuntime.waitForRunOutput<OUTPUT>(runId, this.getPubSub());
   }
 
   /**
@@ -6220,7 +6216,7 @@ export class Agent<
   async subscribeToThread<OUTPUT = TOutput>(
     options: AgentSubscribeToThreadOptions,
   ): Promise<AgentThreadSubscription<OUTPUT>> {
-    return this.#getThreadStreamRuntime().subscribeToThread<OUTPUT>(
+    return agentThreadStreamRuntime.subscribeToThread<OUTPUT>(
       this as Agent<any, any, any, any>,
       options,
       this.getPubSub(),
@@ -6228,23 +6224,18 @@ export class Agent<
   }
 
   abortThreadStream(options: AgentSubscribeToThreadOptions): boolean {
-    return this.#getThreadStreamRuntime().abortThread(options, this.getPubSub());
+    return agentThreadStreamRuntime.abortThread(options, this.getPubSub());
   }
 
   abortRunStream(runId: string): boolean {
-    return this.#getThreadStreamRuntime().abortRun(runId, this.getPubSub());
+    return agentThreadStreamRuntime.abortRun(runId, this.getPubSub());
   }
 
   /**
    * @experimental Agent signals are experimental and may change in a future release.
    */
   sendSignal<OUTPUT = TOutput>(signal: AgentSignal, target: SendAgentSignalOptions<OUTPUT>): SendAgentSignalResult {
-    return this.#getThreadStreamRuntime().sendSignal(
-      this as Agent<any, any, any, any>,
-      signal,
-      target,
-      this.getPubSub(),
-    );
+    return agentThreadStreamRuntime.sendSignal(this as Agent<any, any, any, any>, signal, target, this.getPubSub());
   }
 
   async stream<
@@ -6330,7 +6321,7 @@ export class Agent<
       });
     }
 
-    await this.#getThreadStreamRuntime().waitForCrossAgentThreadRun(
+    await agentThreadStreamRuntime.waitForCrossAgentThreadRun(
       this as Agent<any, any, any, any>,
       mergedOptions,
       this.getPubSub(),
@@ -6342,7 +6333,7 @@ export class Agent<
         source: 'agent',
         entityId: this.id,
       }) ?? randomUUID();
-    const preparedOptions = this.#getThreadStreamRuntime().prepareRunOptions(mergedOptions, this.getPubSub());
+    const preparedOptions = agentThreadStreamRuntime.prepareRunOptions(mergedOptions, this.getPubSub());
 
     const executeOptions = {
       ...preparedOptions,
@@ -6382,7 +6373,7 @@ export class Agent<
       });
     }
 
-    this.#getThreadStreamRuntime().registerRun(
+    agentThreadStreamRuntime.registerRun(
       this as Agent<any, any, any, any>,
       result.result,
       preparedOptions as AgentExecutionOptions<OUTPUT>,
@@ -6613,12 +6604,12 @@ export class Agent<
 
     const runId = streamOptions?.runId ?? '';
     const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeStream' });
-    await this.#getThreadStreamRuntime().waitForCrossAgentThreadRun(
+    await agentThreadStreamRuntime.waitForCrossAgentThreadRun(
       this as Agent<any, any, any, any>,
       mergedStreamOptions as unknown as AgentExecutionOptions<OUTPUT>,
       this.getPubSub(),
     );
-    const preparedOptions = this.#getThreadStreamRuntime().prepareRunOptions(
+    const preparedOptions = agentThreadStreamRuntime.prepareRunOptions(
       mergedStreamOptions as unknown as AgentExecutionOptions<OUTPUT>,
       this.getPubSub(),
     );
@@ -6661,7 +6652,7 @@ export class Agent<
       });
     }
 
-    this.#getThreadStreamRuntime().registerRun(
+    agentThreadStreamRuntime.registerRun(
       this as Agent<any, any, any, any>,
       result.result as unknown as MastraModelOutput<OUTPUT>,
       preparedOptions as AgentExecutionOptions<OUTPUT>,

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -2424,6 +2424,9 @@ export class Agent<
     if (this.#primitives) {
       fork.#primitives = this.#primitives;
     }
+    if (this.#pubsub) {
+      fork.#pubsub = this.#pubsub;
+    }
 
     fork.source = this.source;
     fork._agentNetworkAppend = this._agentNetworkAppend;

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -1,5 +1,8 @@
 import { randomUUID } from 'node:crypto';
 
+import { EventEmitterPubSub } from '../events/event-emitter';
+import type { PubSub } from '../events/pubsub';
+import type { EventCallback } from '../events/types';
 import type { RequestContext } from '../request-context';
 import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY } from '../request-context';
 import type { MastraModelOutput } from '../stream/base/output';
@@ -16,6 +19,9 @@ import type {
 } from './types';
 
 const AGENT_THREAD_KEY_SEPARATOR = '\u0000';
+const AGENT_THREAD_STREAM_TOPIC_PREFIX = 'agent.thread-stream';
+
+export let defaultAgentThreadPubSub: PubSub = new EventEmitterPubSub();
 
 function callerSignalPayloadKey(signal: AgentSignal): string | undefined {
   try {
@@ -61,27 +67,82 @@ type PendingIdleSignal<OUTPUT = unknown> = {
   streamOptions?: AgentExecutionOptions<OUTPUT>;
 };
 
+type AgentThreadRuntimeState = {
+  threadRunsById: Map<string, AgentThreadRunRecord<any>>;
+  threadKeysByRunId: Map<string, string>;
+  activeThreadRunIds: Map<string, string>;
+  pendingSignalsByThread: Map<string, CreatedAgentSignal[]>;
+  pendingIdleSignalsByThread: Map<string, PendingIdleSignal<any>[]>;
+  watchedThreadRunIds: Set<string>;
+  preparedRunsById: Map<string, PreparedThreadRun>;
+  abortedRunIds: Set<string>;
+  acceptedCallerSignals: Map<string, SendAgentSignalResult>;
+  callerSignalIdsByRunId: Map<string, Set<string>>;
+  pendingOutputWaiters: Map<string, Array<(out: MastraModelOutput<any>) => void>>;
+};
+
+type SerializableAgentSignal = AgentSignal & Pick<CreatedAgentSignal, 'id' | 'createdAt'>;
+
+type AgentThreadStreamRuntimeEvent =
+  | { type: 'run-registered'; runId: string }
+  | { type: 'run-completed'; runId: string }
+  | { type: 'run-aborted'; runId: string }
+  | { type: 'signal-enqueued'; runId: string; signal: SerializableAgentSignal; sourceId: string };
+
+function createRuntimeState(): AgentThreadRuntimeState {
+  return {
+    threadRunsById: new Map(),
+    threadKeysByRunId: new Map(),
+    activeThreadRunIds: new Map(),
+    pendingSignalsByThread: new Map(),
+    pendingIdleSignalsByThread: new Map(),
+    watchedThreadRunIds: new Set(),
+    preparedRunsById: new Map(),
+    abortedRunIds: new Set(),
+    acceptedCallerSignals: new Map(),
+    callerSignalIdsByRunId: new Map(),
+    pendingOutputWaiters: new Map(),
+  };
+}
+
 export class AgentThreadStreamRuntime {
-  #threadRunsById = new Map<string, AgentThreadRunRecord<any>>();
-  #threadKeysByRunId = new Map<string, string>();
-  #activeThreadRunIds = new Map<string, string>();
-  #threadRunSubscribers = new Map<string, Set<(run: AgentThreadRunRecord<any>) => void>>();
-  #pendingSignalsByThread = new Map<string, CreatedAgentSignal[]>();
-  #pendingIdleSignalsByThread = new Map<string, PendingIdleSignal<any>[]>();
-  #watchedThreadRunIds = new Set<string>();
-  #preparedRunsById = new Map<string, PreparedThreadRun>();
-  #abortedRunIds = new Set<string>();
-  #acceptedCallerSignals = new Map<string, SendAgentSignalResult>();
-  #callerSignalIdsByRunId = new Map<string, Set<string>>();
-  /**
-   * Per-run resolvers used by `waitForRunOutput()`. Populated lazily on the
-   * first `waitForRunOutput()` call and cleared when `registerRun()` resolves
-   * the matching entry (or when the run is cancelled).
-   */
-  #pendingOutputWaiters = new Map<string, Array<(out: MastraModelOutput<any>) => void>>();
+  #id = randomUUID();
+  #statesByPubSub = new WeakMap<PubSub, AgentThreadRuntimeState>();
+
+  #getPubSub(pubsub?: PubSub): PubSub {
+    return pubsub ?? defaultAgentThreadPubSub;
+  }
+
+  #getState(pubsub?: PubSub): AgentThreadRuntimeState {
+    const resolvedPubSub = this.#getPubSub(pubsub);
+    let state = this.#statesByPubSub.get(resolvedPubSub);
+    if (!state) {
+      state = createRuntimeState();
+      this.#statesByPubSub.set(resolvedPubSub, state);
+    }
+    return state;
+  }
 
   #threadKey(resourceId: string | undefined, threadId: string): string {
     return [resourceId ?? '', threadId].join(AGENT_THREAD_KEY_SEPARATOR);
+  }
+
+  #threadTopic(key: string): string {
+    return `${AGENT_THREAD_STREAM_TOPIC_PREFIX}.${encodeURIComponent(key)}`;
+  }
+
+  #serializeSignal(signal: CreatedAgentSignal): SerializableAgentSignal {
+    return signal;
+  }
+
+  #publish(pubsub: PubSub | undefined, key: string, event: AgentThreadStreamRuntimeEvent) {
+    void this.#getPubSub(pubsub)
+      .publish(this.#threadTopic(key), {
+        type: event.type,
+        runId: event.runId,
+        data: event,
+      })
+      .catch(() => {});
   }
 
   #getThreadTarget(options?: { memory?: AgentExecutionOptions<any>['memory']; requestContext?: RequestContext }) {
@@ -95,10 +156,11 @@ export class AgentThreadStreamRuntime {
     return { threadId, resourceId };
   }
 
-  prepareRunOptions<OUTPUT>(options: AgentExecutionOptions<OUTPUT>): AgentExecutionOptions<OUTPUT> {
+  prepareRunOptions<OUTPUT>(options: AgentExecutionOptions<OUTPUT>, pubsub?: PubSub): AgentExecutionOptions<OUTPUT> {
     const { threadId } = this.#getThreadTarget(options);
     if (!threadId || !options.runId) return options;
 
+    const state = this.#getState(pubsub);
     const abortController = new AbortController();
     const upstreamAbortSignal = options.abortSignal;
     const abort = () => abortController.abort();
@@ -108,12 +170,12 @@ export class AgentThreadStreamRuntime {
       upstreamAbortSignal?.addEventListener('abort', abort, { once: true });
     }
 
-    this.#preparedRunsById.set(options.runId, {
+    state.preparedRunsById.set(options.runId, {
       abortController,
       cleanup: () => upstreamAbortSignal?.removeEventListener('abort', abort),
     });
 
-    if (this.#abortedRunIds.has(options.runId)) {
+    if (state.abortedRunIds.has(options.runId)) {
       abort();
     }
 
@@ -123,95 +185,74 @@ export class AgentThreadStreamRuntime {
     };
   }
 
-  abortRun(runId: string): boolean {
-    const preparedRun = this.#preparedRunsById.get(runId);
+  abortRun(runId: string, pubsub?: PubSub): boolean {
+    const state = this.#getState(pubsub);
+    const preparedRun = state.preparedRunsById.get(runId);
     if (!preparedRun) {
-      this.#abortedRunIds.add(runId);
+      state.abortedRunIds.add(runId);
       return false;
     }
 
     preparedRun.abortController.abort();
-    this.#abortedRunIds.add(runId);
+    state.abortedRunIds.add(runId);
+
+    const key = state.threadKeysByRunId.get(runId);
+    if (key) {
+      this.#publish(pubsub, key, { type: 'run-aborted', runId });
+    }
+
     return true;
   }
 
-  /**
-   * Returns the `MastraModelOutput` for a registered run, or `undefined` if the
-   * run has finished and been cleared. Used by signal-routed callers (e.g.
-   * harness v1 `Session.message()`) that send a signal — getting back a
-   * `runId` — and then need the matching output to drain events or await
-   * completion. Real subscribers should prefer `subscribeToThread` instead.
-   */
-  getRunOutput<OUTPUT = unknown>(runId: string): MastraModelOutput<OUTPUT> | undefined {
-    const record = this.#threadRunsById.get(runId);
-    return record?.output as MastraModelOutput<OUTPUT> | undefined;
-  }
-
-  /**
-   * Resolves with the `MastraModelOutput` for `runId` as soon as `registerRun`
-   * fires for it (or immediately if it has already been registered and the
-   * record has not yet been cleaned up). Used by signal-routed callers (e.g.
-   * harness v1 `Session.message()`) that receive a `runId` from `sendSignal`
-   * synchronously and need a handle to the output without polling.
-   *
-   * Note: if the run's output has already been registered AND finished AND
-   * cleaned up by the time this is called, the waiter never resolves. Callers
-   * should still pair this with a timeout or completion path of their own
-   * (the harness drives this off the per-run completion promise).
-   */
-  waitForRunOutput<OUTPUT = unknown>(runId: string): Promise<MastraModelOutput<OUTPUT>> {
-    const existing = this.#threadRunsById.get(runId);
-    if (existing) return Promise.resolve(existing.output as MastraModelOutput<OUTPUT>);
-    return new Promise<MastraModelOutput<OUTPUT>>(resolve => {
-      const waiters = this.#pendingOutputWaiters.get(runId) ?? [];
-      waiters.push(resolve as (out: MastraModelOutput<any>) => void);
-      this.#pendingOutputWaiters.set(runId, waiters);
-    });
-  }
-
-  abortThread(options: AgentSubscribeToThreadOptions): boolean {
+  abortThread(options: AgentSubscribeToThreadOptions, pubsub?: PubSub): boolean {
+    const state = this.#getState(pubsub);
     const key = this.#threadKey(options.resourceId, options.threadId);
-    const activeRunId = this.#activeThreadRunIds.get(key);
+    const activeRunId = state.activeThreadRunIds.get(key);
     if (!activeRunId) return false;
-    return this.abortRun(activeRunId);
+    return this.abortRun(activeRunId, pubsub);
   }
 
   /** @internal */
   resetForTests() {
-    this.#preparedRunsById.forEach(preparedRun => {
+    for (const pubsub of [defaultAgentThreadPubSub]) {
+      this.#resetState(pubsub);
+      void (pubsub as { close?: () => Promise<void> }).close?.();
+    }
+    defaultAgentThreadPubSub = new EventEmitterPubSub();
+  }
+
+  #resetState(pubsub: PubSub) {
+    const state = this.#statesByPubSub.get(pubsub);
+    if (!state) return;
+
+    state.preparedRunsById.forEach(preparedRun => {
       preparedRun.abortController.abort();
       preparedRun.cleanup();
     });
-    this.#threadRunsById.clear();
-    this.#threadKeysByRunId.clear();
-    this.#activeThreadRunIds.clear();
-    this.#threadRunSubscribers.clear();
-    this.#pendingSignalsByThread.clear();
-    this.#pendingIdleSignalsByThread.clear();
-    this.#pendingOutputWaiters.clear();
-    this.#watchedThreadRunIds.clear();
-    this.#preparedRunsById.clear();
-    this.#abortedRunIds.clear();
-    this.#acceptedCallerSignals.clear();
-    this.#callerSignalIdsByRunId.clear();
+    state.threadRunsById.clear();
+    state.threadKeysByRunId.clear();
+    state.activeThreadRunIds.clear();
+    state.pendingSignalsByThread.clear();
+    state.pendingIdleSignalsByThread.clear();
+    state.watchedThreadRunIds.clear();
+    state.preparedRunsById.clear();
+    state.abortedRunIds.clear();
+    state.acceptedCallerSignals.clear();
+    state.callerSignalIdsByRunId.clear();
+    state.pendingOutputWaiters.clear();
   }
 
-  #cleanupPreparedRun(runId: string) {
-    this.#preparedRunsById.get(runId)?.cleanup();
-    this.#preparedRunsById.delete(runId);
-    this.#abortedRunIds.delete(runId);
+  #cleanupPreparedRun(state: AgentThreadRuntimeState, runId: string) {
+    state.preparedRunsById.get(runId)?.cleanup();
+    state.preparedRunsById.delete(runId);
+    state.abortedRunIds.delete(runId);
   }
 
-  #forgetCallerSignalsForRun(runId: string) {
-    const callerSignalIds = this.#callerSignalIdsByRunId.get(runId);
+  #forgetCallerSignalsForRun(state: AgentThreadRuntimeState, runId: string) {
+    const callerSignalIds = state.callerSignalIdsByRunId.get(runId);
     if (!callerSignalIds) return;
-    this.#callerSignalIdsByRunId.delete(runId);
-    for (const callerSignalId of callerSignalIds) this.#acceptedCallerSignals.delete(callerSignalId);
-  }
-
-  #notifyThreadRun(record: AgentThreadRunRecord<any>) {
-    const key = this.#threadKey(record.resourceId, record.threadId);
-    this.#threadRunSubscribers.get(key)?.forEach(listener => listener(record));
+    state.callerSignalIdsByRunId.delete(runId);
+    for (const callerSignalId of callerSignalIds) state.acceptedCallerSignals.delete(callerSignalId);
   }
 
   async #persistSignal(
@@ -232,10 +273,12 @@ export class AgentThreadStreamRuntime {
     agent: Agent<any, any, any, any>,
     output: MastraModelOutput<OUTPUT>,
     streamOptions: AgentExecutionOptions<OUTPUT>,
+    pubsub?: PubSub,
   ) {
     const { threadId, resourceId } = this.#getThreadTarget(streamOptions);
     if (!threadId) return;
 
+    const state = this.#getState(pubsub);
     const key = this.#threadKey(resourceId, threadId);
     const record: AgentThreadRunRecord<OUTPUT> = {
       agent,
@@ -246,45 +289,82 @@ export class AgentThreadStreamRuntime {
       streamOptions: streamOptions as AgentThreadRunRecord<OUTPUT>['streamOptions'],
     };
 
-    this.#threadRunsById.set(output.runId, record);
-    this.#threadKeysByRunId.set(output.runId, key);
-    this.#activeThreadRunIds.set(key, output.runId);
-    const waiters = this.#pendingOutputWaiters.get(output.runId);
+    state.threadRunsById.set(output.runId, record);
+    state.threadKeysByRunId.set(output.runId, key);
+    state.activeThreadRunIds.set(key, output.runId);
+    const waiters = state.pendingOutputWaiters.get(output.runId);
     if (waiters) {
-      this.#pendingOutputWaiters.delete(output.runId);
+      state.pendingOutputWaiters.delete(output.runId);
       for (const resolve of waiters) resolve(output);
     }
-    this.#notifyThreadRun(record);
-    this.#watchThreadRunCompletion(key, record);
+    this.#publish(pubsub, key, { type: 'run-registered', runId: output.runId });
+    this.#watchThreadRunCompletion(state, pubsub, key, record);
   }
 
-  #watchThreadRunCompletion(key: string, record: AgentThreadRunRecord<any>) {
-    if (this.#watchedThreadRunIds.has(record.runId)) return;
-    this.#watchedThreadRunIds.add(record.runId);
+  /**
+   * Returns the `MastraModelOutput` for a registered run, or `undefined` if the
+   * run has finished and been cleared. Used by signal-routed callers that send
+   * a signal, receive a `runId`, and then need the matching output handle.
+   */
+  getRunOutput<OUTPUT = unknown>(runId: string, pubsub?: PubSub): MastraModelOutput<OUTPUT> | undefined {
+    const state = this.#getState(pubsub);
+    const record = state.threadRunsById.get(runId);
+    return record?.output as MastraModelOutput<OUTPUT> | undefined;
+  }
 
-    void record.output._waitUntilFinished().finally(() => {
-      this.#watchedThreadRunIds.delete(record.runId);
-      this.#threadRunsById.delete(record.runId);
-      this.#threadKeysByRunId.delete(record.runId);
-      this.#cleanupPreparedRun(record.runId);
-      this.#forgetCallerSignalsForRun(record.runId);
-      if (this.#activeThreadRunIds.get(key) === record.runId) {
-        this.#activeThreadRunIds.delete(key);
-      }
-      void this.#drainPendingSignals(key, record);
+  /**
+   * Resolves with the `MastraModelOutput` for `runId` as soon as `registerRun`
+   * registers it, or immediately if it is already registered and retained.
+   */
+  waitForRunOutput<OUTPUT = unknown>(runId: string, pubsub?: PubSub): Promise<MastraModelOutput<OUTPUT>> {
+    const state = this.#getState(pubsub);
+    const existing = state.threadRunsById.get(runId);
+    if (existing) return Promise.resolve(existing.output as MastraModelOutput<OUTPUT>);
+    return new Promise<MastraModelOutput<OUTPUT>>(resolve => {
+      const waiters = state.pendingOutputWaiters.get(runId) ?? [];
+      waiters.push(resolve as (out: MastraModelOutput<any>) => void);
+      state.pendingOutputWaiters.set(runId, waiters);
     });
   }
 
-  async #drainPendingSignals(key: string, previousRun: AgentThreadRunRecord<any>) {
-    if (this.#activeThreadRunIds.has(key)) {
+  #watchThreadRunCompletion(
+    state: AgentThreadRuntimeState,
+    pubsub: PubSub | undefined,
+    key: string,
+    record: AgentThreadRunRecord<any>,
+  ) {
+    if (state.watchedThreadRunIds.has(record.runId)) return;
+    state.watchedThreadRunIds.add(record.runId);
+
+    void record.output._waitUntilFinished().finally(() => {
+      state.watchedThreadRunIds.delete(record.runId);
+      state.threadRunsById.delete(record.runId);
+      state.threadKeysByRunId.delete(record.runId);
+      this.#cleanupPreparedRun(state, record.runId);
+      this.#forgetCallerSignalsForRun(state, record.runId);
+      if (state.activeThreadRunIds.get(key) === record.runId) {
+        state.activeThreadRunIds.delete(key);
+      }
+      this.#publish(pubsub, key, { type: 'run-completed', runId: record.runId });
+      void this.#drainPendingSignals(state, pubsub, key, record);
+    });
+  }
+
+  async #drainPendingSignals(
+    state: AgentThreadRuntimeState,
+    pubsub: PubSub | undefined,
+    key: string,
+    previousRun: AgentThreadRunRecord<any>,
+  ) {
+    if (state.activeThreadRunIds.has(key)) {
       return;
     }
 
-    const queue = this.#pendingSignalsByThread.get(key);
+    const queue = state.pendingSignalsByThread.get(key);
     const signal = queue?.shift();
     if (signal && queue) {
       if (queue.length === 0) {
-        this.#pendingSignalsByThread.delete(key);
+        state.pendingSignalsByThread.delete(key);
       }
 
       const output = await previousRun.agent.stream(signal, {
@@ -298,25 +378,33 @@ export class AgentThreadStreamRuntime {
       });
 
       if (queue.length > 0) {
-        const nextRecord = this.#threadRunsById.get(output.runId);
+        const nextRecord = state.threadRunsById.get(output.runId);
         if (nextRecord) {
-          this.#watchThreadRunCompletion(key, nextRecord);
+          this.#watchThreadRunCompletion(state, pubsub, key, nextRecord);
         }
       }
       return;
     }
 
-    const idleQueue = this.#pendingIdleSignalsByThread.get(key);
+    await this.#drainPendingIdleSignals(state, pubsub, key);
+  }
+
+  async #drainPendingIdleSignals(state: AgentThreadRuntimeState, pubsub: PubSub | undefined, key: string) {
+    if (state.activeThreadRunIds.has(key)) {
+      return;
+    }
+
+    const idleQueue = state.pendingIdleSignalsByThread.get(key);
     const pendingIdle = idleQueue?.shift();
     if (!pendingIdle || !idleQueue) {
       return;
     }
     if (idleQueue.length === 0) {
-      this.#pendingIdleSignalsByThread.delete(key);
+      state.pendingIdleSignalsByThread.delete(key);
     }
 
-    this.#activeThreadRunIds.set(key, pendingIdle.runId);
-    this.#threadKeysByRunId.set(pendingIdle.runId, key);
+    state.activeThreadRunIds.set(key, pendingIdle.runId);
+    state.threadKeysByRunId.set(pendingIdle.runId, key);
     try {
       const output = await pendingIdle.agent.stream(pendingIdle.signal, {
         ...(pendingIdle.streamOptions as any),
@@ -325,57 +413,83 @@ export class AgentThreadStreamRuntime {
       });
 
       if ((idleQueue?.length ?? 0) > 0) {
-        const nextRecord = this.#threadRunsById.get(output.runId);
+        const nextRecord = state.threadRunsById.get(output.runId);
         if (nextRecord) {
-          this.#watchThreadRunCompletion(key, nextRecord);
+          this.#watchThreadRunCompletion(state, pubsub, key, nextRecord);
         }
       }
     } catch {
-      this.#threadKeysByRunId.delete(pendingIdle.runId);
-      this.#cleanupPreparedRun(pendingIdle.runId);
-      this.#forgetCallerSignalsForRun(pendingIdle.runId);
-      if (this.#activeThreadRunIds.get(key) === pendingIdle.runId) {
-        this.#activeThreadRunIds.delete(key);
+      state.threadKeysByRunId.delete(pendingIdle.runId);
+      this.#cleanupPreparedRun(state, pendingIdle.runId);
+      this.#forgetCallerSignalsForRun(state, pendingIdle.runId);
+      if (state.activeThreadRunIds.get(key) === pendingIdle.runId) {
+        state.activeThreadRunIds.delete(key);
       }
     }
   }
 
-  drainPendingSignals(runId: string) {
-    const record = this.#threadRunsById.get(runId);
-    const key = record ? this.#threadKey(record.resourceId, record.threadId) : this.#threadKeysByRunId.get(runId);
+  drainPendingSignals(runId: string, pubsub?: PubSub) {
+    const state = this.#getState(pubsub);
+    const record = state.threadRunsById.get(runId);
+    const key = record ? this.#threadKey(record.resourceId, record.threadId) : state.threadKeysByRunId.get(runId);
     if (!key) return [];
 
-    const queue = this.#pendingSignalsByThread.get(key);
+    const queue = state.pendingSignalsByThread.get(key);
     if (!queue || queue.length === 0) {
       return [];
     }
 
-    this.#pendingSignalsByThread.delete(key);
+    state.pendingSignalsByThread.delete(key);
     return queue;
   }
 
   async waitForCrossAgentThreadRun(
     agent: Agent<any, any, any, any>,
     options: { memory?: AgentExecutionOptions<any>['memory']; requestContext?: RequestContext },
+    pubsub?: PubSub,
   ) {
     const { threadId, resourceId } = this.#getThreadTarget(options);
     if (!threadId) return;
 
+    const state = this.#getState(pubsub);
     const key = this.#threadKey(resourceId, threadId);
     while (true) {
-      const activeRunId = this.#activeThreadRunIds.get(key);
-      const activeRecord = activeRunId ? this.#threadRunsById.get(activeRunId) : undefined;
-      if (!activeRecord || activeRecord.agent.id === agent.id || activeRecord.output.status !== 'running') return;
-      await activeRecord.output._waitUntilFinished().catch(() => {});
+      const activeRunId = state.activeThreadRunIds.get(key);
+      const activeRecord = activeRunId ? state.threadRunsById.get(activeRunId) : undefined;
+      if (!activeRunId || activeRecord?.agent.id === agent.id || activeRecord?.output.status !== 'running') return;
+      if (activeRecord) {
+        await activeRecord.output._waitUntilFinished().catch(() => {});
+        continue;
+      }
+      await this.#waitForRemoteRunToFinish(pubsub, key, activeRunId);
     }
+  }
+
+  async #waitForRemoteRunToFinish(pubsub: PubSub | undefined, key: string, runId: string) {
+    const resolvedPubSub = this.#getPubSub(pubsub);
+    const topic = this.#threadTopic(key);
+    await new Promise<void>(resolve => {
+      const onEvent: EventCallback = event => {
+        const data = event.data as AgentThreadStreamRuntimeEvent | undefined;
+        if ((data?.type === 'run-completed' || data?.type === 'run-aborted') && data.runId === runId) {
+          void resolvedPubSub.unsubscribe(topic, onEvent).catch(() => {});
+          resolve();
+        }
+      };
+      void resolvedPubSub.subscribe(topic, onEvent).catch(() => resolve());
+    });
   }
 
   async subscribeToThread<OUTPUT = unknown>(
     agent: Agent<any, any, any, any>,
     options: AgentSubscribeToThreadOptions,
+    pubsub?: PubSub,
   ): Promise<AgentThreadSubscription<OUTPUT>> {
     void agent;
+    const resolvedPubSub = this.#getPubSub(pubsub);
+    const state = this.#getState(resolvedPubSub);
     const key = this.#threadKey(options.resourceId, options.threadId);
+    const topic = this.#threadTopic(key);
     const seenRunIds = new Set<string>();
     const pendingRuns: AgentThreadRunRecord<any>[] = [];
     const waiters: Array<() => void> = [];
@@ -386,10 +500,10 @@ export class AgentThreadStreamRuntime {
     };
 
     const activeRunId = () => {
-      const runId = this.#activeThreadRunIds.get(key);
+      const runId = state.activeThreadRunIds.get(key);
       if (!runId) return null;
-      const record = this.#threadRunsById.get(runId);
-      if (!record) return null;
+      const record = state.threadRunsById.get(runId);
+      if (!record) return state.threadKeysByRunId.get(runId) === key ? null : runId;
       return record.output.status === 'running' ? runId : null;
     };
 
@@ -400,12 +514,36 @@ export class AgentThreadStreamRuntime {
       wake();
     };
 
-    const listeners = this.#threadRunSubscribers.get(key) ?? new Set<(run: AgentThreadRunRecord<any>) => void>();
-    listeners.add(enqueueRun);
-    this.#threadRunSubscribers.set(key, listeners);
+    const onEvent: EventCallback = event => {
+      const data = event.data as AgentThreadStreamRuntimeEvent | undefined;
+      if (!data) return;
+      if (data.type === 'run-registered') {
+        state.activeThreadRunIds.set(key, data.runId);
+        const record = state.threadRunsById.get(data.runId);
+        if (record) enqueueRun(record);
+        wake();
+        return;
+      }
+      if (data.type === 'signal-enqueued') {
+        if (data.sourceId === this.#id) return;
+        const queue = state.pendingSignalsByThread.get(key) ?? [];
+        queue.push(createSignal(data.signal));
+        state.pendingSignalsByThread.set(key, queue);
+        return;
+      }
+      if (data.type === 'run-completed' || data.type === 'run-aborted') {
+        if (state.activeThreadRunIds.get(key) === data.runId) {
+          state.activeThreadRunIds.delete(key);
+        }
+        void this.#drainPendingIdleSignals(state, resolvedPubSub, key);
+        wake();
+      }
+    };
+
+    await resolvedPubSub.subscribe(topic, onEvent);
 
     const currentRunId = activeRunId();
-    const currentRecord = currentRunId ? this.#threadRunsById.get(currentRunId) : undefined;
+    const currentRecord = currentRunId ? state.threadRunsById.get(currentRunId) : undefined;
     if (currentRecord) {
       enqueueRun(currentRecord);
     }
@@ -413,16 +551,13 @@ export class AgentThreadStreamRuntime {
     const unsubscribe = () => {
       if (done) return;
       done = true;
-      listeners.delete(enqueueRun);
-      if (listeners.size === 0) {
-        this.#threadRunSubscribers.delete(key);
-      }
+      void resolvedPubSub.unsubscribe(topic, onEvent).catch(() => {});
       wake();
     };
 
     return {
       activeRunId,
-      abort: () => this.abortThread(options),
+      abort: () => this.abortThread(options, resolvedPubSub),
       unsubscribe,
       stream: (async function* () {
         try {
@@ -460,7 +595,9 @@ export class AgentThreadStreamRuntime {
     agent: Agent<any, any, any, any>,
     signalInput: AgentSignal,
     target: SendAgentSignalOptions<OUTPUT>,
+    pubsub?: PubSub,
   ): SendAgentSignalResult {
+    const state = this.#getState(pubsub);
     const signal = createSignal(signalInput);
     const callerSignalId = signalInput.id;
     let key: string | undefined;
@@ -471,10 +608,10 @@ export class AgentThreadStreamRuntime {
     let activeRecord: AgentThreadRunRecord<any> | undefined;
     if (target.resourceId && target.threadId) {
       key = this.#threadKey(target.resourceId, target.threadId);
-      const activeRunId = this.#activeThreadRunIds.get(key);
-      activeRecord = activeRunId ? this.#threadRunsById.get(activeRunId) : undefined;
+      const activeRunId = state.activeThreadRunIds.get(key);
+      activeRecord = activeRunId ? state.threadRunsById.get(activeRunId) : undefined;
       if (activeRecord && activeRecord.output.status !== 'running') {
-        this.#activeThreadRunIds.delete(key);
+        state.activeThreadRunIds.delete(key);
         activeRecord = undefined;
       }
 
@@ -490,13 +627,13 @@ export class AgentThreadStreamRuntime {
     }
 
     if (runId && !activeRecord) {
-      activeRecord = this.#threadRunsById.get(runId);
+      activeRecord = state.threadRunsById.get(runId);
     }
     if (!key && activeRecord) {
       key = this.#threadKey(activeRecord.resourceId, activeRecord.threadId);
     }
     const isActiveTarget = Boolean(
-      runId && (activeRecord?.output.status === 'running' || (key && this.#activeThreadRunIds.get(key) === runId)),
+      runId && (activeRecord?.output.status === 'running' || (key && state.activeThreadRunIds.get(key) === runId)),
     );
     const resourceId = target.resourceId ?? activeRecord?.resourceId;
     const threadId = target.threadId ?? activeRecord?.threadId;
@@ -509,15 +646,15 @@ export class AgentThreadStreamRuntime {
           )
         : undefined;
     if (callerSignalKey) {
-      const accepted = this.#acceptedCallerSignals.get(callerSignalKey);
+      const accepted = state.acceptedCallerSignals.get(callerSignalKey);
       if (accepted) return accepted;
     }
-    const acceptSignal = (result: SendAgentSignalResult): SendAgentSignalResult => {
-      if (callerSignalKey) {
-        this.#acceptedCallerSignals.set(callerSignalKey, result);
-        const signalIds = this.#callerSignalIdsByRunId.get(result.runId) ?? new Set<string>();
+    const acceptSignal = (result: SendAgentSignalResult, cache = true): SendAgentSignalResult => {
+      if (callerSignalKey && cache) {
+        state.acceptedCallerSignals.set(callerSignalKey, result);
+        const signalIds = state.callerSignalIdsByRunId.get(result.runId) ?? new Set<string>();
         signalIds.add(callerSignalKey);
-        this.#callerSignalIdsByRunId.set(result.runId, signalIds);
+        state.callerSignalIdsByRunId.set(result.runId, signalIds);
       }
       return result;
     };
@@ -541,26 +678,40 @@ export class AgentThreadStreamRuntime {
     }
 
     if (runId) {
-      activeRecord ??= this.#threadRunsById.get(runId);
+      activeRecord ??= state.threadRunsById.get(runId);
       if (activeRecord?.output.status === 'running') {
         key ??= this.#threadKey(activeRecord.resourceId, activeRecord.threadId);
         if (activeRecord.agent.id === agent.id) {
           // Same-agent active run: queue the signal for in-loop draining so it becomes
           // the next model input instead of waiting for the run to finish.
-          const queue = this.#pendingSignalsByThread.get(key) ?? [];
+          const queue = state.pendingSignalsByThread.get(key) ?? [];
           queue.push(signal);
-          this.#pendingSignalsByThread.set(key, queue);
-          this.#watchThreadRunCompletion(key, activeRecord);
+          state.pendingSignalsByThread.set(key, queue);
+          this.#publish(pubsub, key, {
+            type: 'signal-enqueued',
+            runId,
+            signal: this.#serializeSignal(signal),
+            sourceId: this.#id,
+          });
+          this.#watchThreadRunCompletion(state, pubsub, key, activeRecord);
           return acceptSignal({ accepted: true, runId, signal });
         }
       }
 
-      if (key && this.#activeThreadRunIds.get(key) === runId) {
-        // Reserved run without a record yet: queue by thread key until registerRun()
-        // attaches the stream record and the execution loop can drain it.
-        const queue = this.#pendingSignalsByThread.get(key) ?? [];
-        queue.push(signal);
-        this.#pendingSignalsByThread.set(key, queue);
+      if (key && state.activeThreadRunIds.get(key) === runId) {
+        // Reserved local runs need a local queue until registerRun() attaches the stream record.
+        // Remote active runs only need the PubSub event; the owning process queues it locally.
+        if (state.threadKeysByRunId.get(runId) === key) {
+          const queue = state.pendingSignalsByThread.get(key) ?? [];
+          queue.push(signal);
+          state.pendingSignalsByThread.set(key, queue);
+        }
+        this.#publish(pubsub, key, {
+          type: 'signal-enqueued',
+          runId,
+          signal: this.#serializeSignal(signal),
+          sourceId: this.#id,
+        });
         return acceptSignal({ accepted: true, runId, signal });
       }
     }
@@ -569,7 +720,7 @@ export class AgentThreadStreamRuntime {
       throw new Error('No active agent run found for signal target');
     }
 
-    runId ??= randomUUID();
+    runId = randomUUID();
     if (idleBehavior !== 'wake') {
       if (idleBehavior === 'persist') {
         const persisted = this.#persistSignal(
@@ -580,28 +731,28 @@ export class AgentThreadStreamRuntime {
           target.ifIdle?.streamOptions?.requestContext,
         );
         void persisted.catch(() => {});
-        return acceptSignal({ accepted: true, runId, signal, persisted });
+        return acceptSignal({ accepted: true, runId, signal, persisted }, false);
       }
-      return acceptSignal({ accepted: true, runId, signal });
+      return acceptSignal({ accepted: true, runId, signal }, false);
     }
 
     key ??= this.#threadKey(resourceId, threadId);
-    if (this.#activeThreadRunIds.has(key)) {
+    if (state.activeThreadRunIds.has(key)) {
       // Another run owns the thread. Queue this idle-start request and let the watcher
       // launch it only after the active run clears the thread reservation.
-      const idleQueue = this.#pendingIdleSignalsByThread.get(key) ?? [];
+      const idleQueue = state.pendingIdleSignalsByThread.get(key) ?? [];
       idleQueue.push({ agent, signal, runId, resourceId, threadId, streamOptions: target.ifIdle?.streamOptions });
-      this.#pendingIdleSignalsByThread.set(key, idleQueue);
+      state.pendingIdleSignalsByThread.set(key, idleQueue);
       if (activeRecord) {
-        this.#watchThreadRunCompletion(key, activeRecord);
+        this.#watchThreadRunCompletion(state, pubsub, key, activeRecord);
       }
       return acceptSignal({ accepted: true, runId, signal });
     }
 
     // No active same-agent run accepted the signal. Reserve the thread before starting
     // the idle stream so concurrent callers do not launch duplicate runs.
-    this.#activeThreadRunIds.set(key, runId);
-    this.#threadKeysByRunId.set(runId, key);
+    state.activeThreadRunIds.set(key, runId);
+    state.threadKeysByRunId.set(runId, key);
     const output = agent
       .stream(signal, {
         ...(target.ifIdle?.streamOptions as any),
@@ -609,11 +760,11 @@ export class AgentThreadStreamRuntime {
         memory: withThreadMemory(target.ifIdle?.streamOptions?.memory, resourceId, threadId),
       })
       .catch(err => {
-        this.#threadKeysByRunId.delete(runId);
-        this.#cleanupPreparedRun(runId);
-        this.#forgetCallerSignalsForRun(runId);
-        if (this.#activeThreadRunIds.get(key) === runId) {
-          this.#activeThreadRunIds.delete(key);
+        state.threadKeysByRunId.delete(runId);
+        this.#cleanupPreparedRun(state, runId);
+        this.#forgetCallerSignalsForRun(state, runId);
+        if (state.activeThreadRunIds.get(key) === runId) {
+          state.activeThreadRunIds.delete(key);
         }
         throw err;
       }) as Promise<MastraModelOutput<unknown>>;

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -79,6 +79,7 @@ type AgentThreadRuntimeState = {
   acceptedCallerSignals: Map<string, SendAgentSignalResult>;
   callerSignalIdsByRunId: Map<string, Set<string>>;
   pendingOutputWaiters: Map<string, Array<(out: MastraModelOutput<any>) => void>>;
+  broadcastsByRunId: Map<string, Promise<void>>;
 };
 
 type SerializableAgentSignal = AgentSignal & Pick<CreatedAgentSignal, 'id' | 'createdAt'>;
@@ -103,6 +104,7 @@ function createRuntimeState(): AgentThreadRuntimeState {
     acceptedCallerSignals: new Map(),
     callerSignalIdsByRunId: new Map(),
     pendingOutputWaiters: new Map(),
+    broadcastsByRunId: new Map(),
   };
 }
 
@@ -148,43 +150,62 @@ export class AgentThreadStreamRuntime {
     });
   }
 
-  #withBroadcastStream<OUTPUT>(output: MastraModelOutput<OUTPUT>, pubsub: PubSub | undefined, key: string) {
-    if (this.#getPubSub(pubsub) instanceof EventEmitterPubSub) return output;
-    const runtime = this;
-    const source = output.fullStream as any;
-    if (!source) return output;
-    const fullStream =
-      typeof source.pipeThrough === 'function'
-        ? source.pipeThrough(
-            new TransformStream({
-              transform(part, controller) {
-                runtime.#publish(pubsub, key, {
-                  type: 'stream-part',
-                  runId: output.runId,
-                  part,
-                  sourceId: runtime.#id,
-                });
-                controller.enqueue(part);
-              },
-            }) as any,
-          )
-        : (async function* () {
-            for await (const part of source) {
-              runtime.#publish(pubsub, key, {
-                type: 'stream-part',
-                runId: output.runId,
-                part,
-                sourceId: runtime.#id,
-              });
-              yield part;
-            }
-          })();
-    Object.defineProperty(output, 'fullStream', {
-      configurable: true,
-      enumerable: true,
-      value: fullStream,
-    });
-    return output;
+  #prepareBroadcastSource<OUTPUT>(output: MastraModelOutput<OUTPUT>, pubsub: PubSub | undefined, key: string) {
+    if (this.#getPubSub(pubsub) instanceof EventEmitterPubSub) return;
+
+    let source = output.fullStream as any;
+    if (!source) return;
+
+    if (Object.prototype.hasOwnProperty.call(output, 'fullStream')) {
+      if (typeof source.tee === 'function') {
+        const [broadcastSource, callerSource] = source.tee();
+        source = broadcastSource;
+        Object.defineProperty(output, 'fullStream', {
+          configurable: true,
+          enumerable: true,
+          value: callerSource,
+        });
+      } else {
+        const runtime = this;
+        const fullStream = (async function* () {
+          for await (const part of source) {
+            await runtime.#publishAndWait(pubsub, key, {
+              type: 'stream-part',
+              runId: output.runId,
+              part,
+              sourceId: runtime.#id,
+            });
+            yield part;
+          }
+        })();
+        Object.defineProperty(output, 'fullStream', {
+          configurable: true,
+          enumerable: true,
+          value: fullStream,
+        });
+        return;
+      }
+    }
+
+    return source;
+  }
+
+  async #broadcastStream<OUTPUT>(
+    output: MastraModelOutput<OUTPUT>,
+    source: AsyncIterable<unknown> | ReadableStream<unknown> | undefined,
+    pubsub: PubSub | undefined,
+    key: string,
+  ) {
+    if (!source) return;
+
+    for await (const part of source) {
+      await this.#publishAndWait(pubsub, key, {
+        type: 'stream-part',
+        runId: output.runId,
+        part,
+        sourceId: this.#id,
+      });
+    }
   }
 
   #getThreadTarget(options?: { memory?: AgentExecutionOptions<any>['memory']; requestContext?: RequestContext }) {
@@ -282,6 +303,7 @@ export class AgentThreadStreamRuntime {
     state.acceptedCallerSignals.clear();
     state.callerSignalIdsByRunId.clear();
     state.pendingOutputWaiters.clear();
+    state.broadcastsByRunId.clear();
   }
 
   #cleanupPreparedRun(state: AgentThreadRuntimeState, runId: string) {
@@ -322,10 +344,10 @@ export class AgentThreadStreamRuntime {
 
     const state = this.#getState(pubsub);
     const key = this.#threadKey(resourceId, threadId);
-    const outputForSubscribers = this.#withBroadcastStream(output, pubsub, key);
+    const broadcastSource = this.#prepareBroadcastSource(output, pubsub, key);
     const record: AgentThreadRunRecord<OUTPUT> = {
       agent,
-      output: outputForSubscribers,
+      output,
       runId: output.runId,
       threadId,
       resourceId,
@@ -340,7 +362,11 @@ export class AgentThreadStreamRuntime {
       state.pendingOutputWaiters.delete(output.runId);
       for (const resolve of waiters) resolve(output);
     }
-    this.#publish(pubsub, key, { type: 'run-registered', runId: output.runId });
+    const broadcast = this.#publishAndWait(pubsub, key, { type: 'run-registered', runId: output.runId }).then(() =>
+      this.#broadcastStream(output, broadcastSource, pubsub, key),
+    );
+    state.broadcastsByRunId.set(output.runId, broadcast);
+    void broadcast.catch(() => {});
     this.#watchThreadRunCompletion(state, pubsub, key, record);
   }
 
@@ -380,16 +406,20 @@ export class AgentThreadStreamRuntime {
     state.watchedThreadRunIds.add(record.runId);
 
     void record.output._waitUntilFinished().finally(() => {
-      state.watchedThreadRunIds.delete(record.runId);
-      state.threadRunsById.delete(record.runId);
-      state.threadKeysByRunId.delete(record.runId);
-      this.#cleanupPreparedRun(state, record.runId);
-      this.#forgetCallerSignalsForRun(state, record.runId);
-      if (state.activeThreadRunIds.get(key) === record.runId) {
-        state.activeThreadRunIds.delete(key);
-      }
-      this.#publish(pubsub, key, { type: 'run-completed', runId: record.runId });
-      void this.#drainPendingSignals(state, pubsub, key, record);
+      void (async () => {
+        await state.broadcastsByRunId.get(record.runId)?.catch(() => {});
+        state.broadcastsByRunId.delete(record.runId);
+        state.watchedThreadRunIds.delete(record.runId);
+        state.threadRunsById.delete(record.runId);
+        state.threadKeysByRunId.delete(record.runId);
+        this.#cleanupPreparedRun(state, record.runId);
+        this.#forgetCallerSignalsForRun(state, record.runId);
+        if (state.activeThreadRunIds.get(key) === record.runId) {
+          state.activeThreadRunIds.delete(key);
+        }
+        await this.#publishAndWait(pubsub, key, { type: 'run-completed', runId: record.runId });
+        void this.#drainPendingSignals(state, pubsub, key, record);
+      })();
     });
   }
 
@@ -716,10 +746,11 @@ export class AgentThreadStreamRuntime {
     let activeRecord: AgentThreadRunRecord<any> | undefined;
     if (target.resourceId && target.threadId) {
       key = this.#threadKey(target.resourceId, target.threadId);
-      const activeRunId = state.activeThreadRunIds.get(key);
+      let activeRunId = state.activeThreadRunIds.get(key);
       activeRecord = activeRunId ? state.threadRunsById.get(activeRunId) : undefined;
       if (activeRecord && activeRecord.output.status !== 'running') {
         state.activeThreadRunIds.delete(key);
+        activeRunId = undefined;
         activeRecord = undefined;
       }
 
@@ -828,7 +859,7 @@ export class AgentThreadStreamRuntime {
       throw new Error('No active agent run found for signal target');
     }
 
-    runId = randomUUID();
+    runId ??= randomUUID();
     if (idleBehavior !== 'wake') {
       if (idleBehavior === 'persist') {
         const persisted = this.#persistSignal(

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -85,6 +85,7 @@ type SerializableAgentSignal = AgentSignal & Pick<CreatedAgentSignal, 'id' | 'cr
 
 type AgentThreadStreamRuntimeEvent =
   | { type: 'run-registered'; runId: string }
+  | { type: 'stream-part'; runId: string; part: unknown; sourceId: string }
   | { type: 'run-completed'; runId: string }
   | { type: 'run-aborted'; runId: string }
   | { type: 'signal-enqueued'; runId: string; signal: SerializableAgentSignal; sourceId: string };
@@ -136,13 +137,54 @@ export class AgentThreadStreamRuntime {
   }
 
   #publish(pubsub: PubSub | undefined, key: string, event: AgentThreadStreamRuntimeEvent) {
-    void this.#getPubSub(pubsub)
-      .publish(this.#threadTopic(key), {
-        type: event.type,
-        runId: event.runId,
-        data: event,
-      })
-      .catch(() => {});
+    void this.#publishAndWait(pubsub, key, event).catch(() => {});
+  }
+
+  async #publishAndWait(pubsub: PubSub | undefined, key: string, event: AgentThreadStreamRuntimeEvent) {
+    await this.#getPubSub(pubsub).publish(this.#threadTopic(key), {
+      type: event.type,
+      runId: event.runId,
+      data: event,
+    });
+  }
+
+  #withBroadcastStream<OUTPUT>(output: MastraModelOutput<OUTPUT>, pubsub: PubSub | undefined, key: string) {
+    if (this.#getPubSub(pubsub) instanceof EventEmitterPubSub) return output;
+    const runtime = this;
+    const source = output.fullStream as any;
+    if (!source) return output;
+    const fullStream =
+      typeof source.pipeThrough === 'function'
+        ? source.pipeThrough(
+            new TransformStream({
+              transform(part, controller) {
+                runtime.#publish(pubsub, key, {
+                  type: 'stream-part',
+                  runId: output.runId,
+                  part,
+                  sourceId: runtime.#id,
+                });
+                controller.enqueue(part);
+              },
+            }) as any,
+          )
+        : (async function* () {
+            for await (const part of source) {
+              runtime.#publish(pubsub, key, {
+                type: 'stream-part',
+                runId: output.runId,
+                part,
+                sourceId: runtime.#id,
+              });
+              yield part;
+            }
+          })();
+    Object.defineProperty(output, 'fullStream', {
+      configurable: true,
+      enumerable: true,
+      value: fullStream,
+    });
+    return output;
   }
 
   #getThreadTarget(options?: { memory?: AgentExecutionOptions<any>['memory']; requestContext?: RequestContext }) {
@@ -280,9 +322,10 @@ export class AgentThreadStreamRuntime {
 
     const state = this.#getState(pubsub);
     const key = this.#threadKey(resourceId, threadId);
+    const outputForSubscribers = this.#withBroadcastStream(output, pubsub, key);
     const record: AgentThreadRunRecord<OUTPUT> = {
       agent,
-      output,
+      output: outputForSubscribers,
       runId: output.runId,
       threadId,
       resourceId,
@@ -493,6 +536,10 @@ export class AgentThreadStreamRuntime {
     const seenRunIds = new Set<string>();
     const pendingRuns: AgentThreadRunRecord<any>[] = [];
     const waiters: Array<() => void> = [];
+    const remoteRuns = new Map<
+      string,
+      { parts: unknown[]; waiters: Array<() => void>; done: boolean; stream: ReadableStream<unknown> }
+    >();
     let done = false;
 
     const wake = () => {
@@ -514,14 +561,69 @@ export class AgentThreadStreamRuntime {
       wake();
     };
 
+    const createRemoteRun = (runId: string): AgentThreadRunRecord<any> => {
+      const remoteRun = {
+        parts: [] as unknown[],
+        waiters: [] as Array<() => void>,
+        done: false,
+        stream: undefined as unknown as ReadableStream<unknown>,
+        closed: false,
+      };
+      remoteRun.stream = new ReadableStream({
+        pull(controller) {
+          const drain = () => {
+            if (remoteRun.closed) return;
+            while (remoteRun.parts.length > 0) {
+              controller.enqueue(remoteRun.parts.shift());
+            }
+            if (remoteRun.done) {
+              remoteRun.closed = true;
+              controller.close();
+            }
+          };
+          drain();
+          if (!remoteRun.done && !remoteRun.closed) {
+            remoteRun.waiters.push(drain);
+          }
+        },
+        cancel() {
+          remoteRun.done = true;
+          remoteRun.closed = true;
+          remoteRun.waiters.length = 0;
+        },
+      });
+      remoteRuns.set(runId, remoteRun);
+      return {
+        agent,
+        output: {
+          runId,
+          status: 'running',
+          fullStream: remoteRun.stream,
+          _waitUntilFinished: async () => {},
+        } as MastraModelOutput<any>,
+        runId,
+        threadId: options.threadId,
+        resourceId: options.resourceId,
+        streamOptions: {},
+      };
+    };
+
     const onEvent: EventCallback = event => {
       const data = event.data as AgentThreadStreamRuntimeEvent | undefined;
       if (!data) return;
       if (data.type === 'run-registered') {
         state.activeThreadRunIds.set(key, data.runId);
-        const record = state.threadRunsById.get(data.runId);
-        if (record) enqueueRun(record);
+        const record = state.threadRunsById.get(data.runId) ?? createRemoteRun(data.runId);
+        enqueueRun(record);
         wake();
+        return;
+      }
+      if (data.type === 'stream-part') {
+        if (data.sourceId === this.#id) return;
+        const remoteRun = remoteRuns.get(data.runId);
+        if (!remoteRun) return;
+        remoteRun.parts.push(data.part);
+        while (remoteRun.waiters.length) remoteRun.waiters.shift()?.();
         return;
       }
       if (data.type === 'signal-enqueued') {
@@ -534,6 +636,12 @@ export class AgentThreadStreamRuntime {
       if (data.type === 'run-completed' || data.type === 'run-aborted') {
         if (state.activeThreadRunIds.get(key) === data.runId) {
           state.activeThreadRunIds.delete(key);
+        }
+        const remoteRun = remoteRuns.get(data.runId);
+        if (remoteRun) {
+          remoteRun.done = true;
+          while (remoteRun.waiters.length) remoteRun.waiters.shift()?.();
+          remoteRuns.delete(data.runId);
         }
         void this.#drainPendingIdleSignals(state, resolvedPubSub, key);
         wake();

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -402,6 +402,11 @@ export interface AgentConfig<
    */
   mastra?: Mastra;
   /**
+   * Pub/sub system for coordinating runtime services such as thread signals.
+   * When omitted, the agent uses its Mastra instance pubsub or the default in-memory pubsub.
+   */
+  pubsub?: PubSub;
+  /**
    * Sub-Agents that the agent can access. Can be provided statically or resolved dynamically.
    */
   agents?: DynamicArgument<Record<string, SubAgent<string, TRequestContext>>, TRequestContext>;

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -968,6 +968,9 @@ export class Harness<TState = {}> {
     const isDeletingCurrentThread = this.currentThreadId === threadId;
 
     await memoryStorage.deleteThread({ threadId });
+    if (memoryStorage.supportsObservationalMemory) {
+      await memoryStorage.clearObservationalMemory(threadId, thread.resourceId);
+    }
 
     if (isDeletingCurrentThread) {
       try {

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -439,7 +439,7 @@ export class Harness<TState = {}> {
     if (this.stateSchema) {
       const result = await this.stateSchema['~standard'].validate(newState);
       if (result.issues) {
-        const messages = result.issues.map(i => i.message).join('; ');
+        const messages = result.issues.map((i: { message: string }) => i.message).join('; ');
         throw new Error(`Invalid state update: ${messages}`);
       }
       this.state = result.value as TState;

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -347,6 +347,7 @@ export class Harness<TState = {}> {
       this.#internalMastra = new Mastra({
         logger: false,
         storage: this.config.storage,
+        ...(this.config.pubsub ? { pubsub: this.config.pubsub } : {}),
         ...(this.config.observability ? { observability: this.config.observability } : {}),
       });
       await this.#internalMastra.getStorage()!.init();
@@ -379,28 +380,11 @@ export class Harness<TState = {}> {
       }
     }
 
-    // Propagate harness-level Mastra, memory, workspace, and browser to mode agents (after workspace init)
-    const workspaceForAgents = this.workspaceFn ?? this.workspace;
-    const browserForAgents = this.browserFn ?? this.browser;
+    // Propagate harness-level Mastra, memory, workspace, browser, and pubsub to mode agents (after workspace init)
     for (const mode of this.config.modes) {
       const agent = typeof mode.agent === 'function' ? null : mode.agent;
       if (!agent) continue;
-
-      const alreadyHasMastra = !!agent.getMastraInstance();
-
-      if (this.config.memory && !agent.hasOwnMemory()) {
-        agent.__setMemory(this.config.memory);
-      }
-      if (workspaceForAgents && !agent.hasOwnWorkspace()) {
-        agent.__setWorkspace(workspaceForAgents);
-      }
-      if (browserForAgents && !agent.hasOwnBrowser()) {
-        agent.setBrowser(browserForAgents as MastraBrowser);
-      }
-
-      if (this.#internalMastra && !alreadyHasMastra) {
-        this.#internalMastra.addAgent(agent);
-      }
+      this.propagateRuntimeServicesToAgent(agent);
     }
 
     this.startHeartbeats();
@@ -421,6 +405,7 @@ export class Harness<TState = {}> {
     await this.config.threadLock?.acquire(mostRecent.id);
     this.currentThreadId = mostRecent.id;
     await this.loadThreadMetadata();
+    await this.ensureCurrentAgentThreadSubscription();
 
     return mostRecent;
   }
@@ -603,15 +588,38 @@ export class Harness<TState = {}> {
     return null;
   }
 
+  private propagateRuntimeServicesToAgent(agent: Agent): Agent {
+    const alreadyHasMastra = !!agent.getMastraInstance();
+    const workspaceForAgents = this.workspaceFn ?? this.workspace;
+    const browserForAgents = this.browserFn ?? this.browser;
+
+    if (this.config.memory && !agent.hasOwnMemory()) {
+      agent.__setMemory(this.config.memory);
+    }
+    if (workspaceForAgents && !agent.hasOwnWorkspace()) {
+      agent.__setWorkspace(workspaceForAgents);
+    }
+    if (browserForAgents && !agent.hasOwnBrowser()) {
+      agent.setBrowser(browserForAgents as MastraBrowser);
+    }
+    if (this.config.pubsub && !agent.hasOwnPubSub()) {
+      agent.__setPubSub(this.config.pubsub);
+    }
+
+    if (this.#internalMastra && !alreadyHasMastra) {
+      this.#internalMastra.addAgent(agent);
+    }
+
+    return agent;
+  }
+
   /**
    * Get the agent for the current mode.
    */
   private getCurrentAgent(): Agent {
     const mode = this.getCurrentMode();
-    if (typeof mode.agent === 'function') {
-      return mode.agent(this.state);
-    }
-    return mode.agent;
+    const agent = typeof mode.agent === 'function' ? mode.agent(this.state) : mode.agent;
+    return this.propagateRuntimeServicesToAgent(agent);
   }
 
   /**
@@ -929,6 +937,7 @@ export class Harness<TState = {}> {
     }
 
     this.tokenUsage = createEmptyTokenUsage();
+    await this.ensureCurrentAgentThreadSubscription();
     this.emit({ type: 'thread_created', thread });
 
     return thread;
@@ -1044,6 +1053,7 @@ export class Harness<TState = {}> {
     this.currentThreadId = clonedThread.id;
     await this.loadThreadMetadata();
     this.tokenUsage = createEmptyTokenUsage();
+    await this.ensureCurrentAgentThreadSubscription();
     this.emit({ type: 'thread_created', thread: clonedThread });
 
     return clonedThread;
@@ -1073,6 +1083,7 @@ export class Harness<TState = {}> {
     this.currentThreadId = threadId;
 
     await this.loadThreadMetadata();
+    await this.ensureCurrentAgentThreadSubscription();
 
     this.emit({ type: 'thread_changed', threadId, previousThreadId });
   }
@@ -1573,6 +1584,11 @@ export class Harness<TState = {}> {
     this.agentThreadSubscription = subscription;
     this.agentThreadSubscriptionKey = key;
     void this.processSubscribedThreadStream(subscription);
+  }
+
+  private async ensureCurrentAgentThreadSubscription(): Promise<void> {
+    if (!this.currentThreadId) return;
+    await this.ensureAgentThreadSubscription(this.getCurrentAgent(), this.currentThreadId);
   }
 
   private async drainFollowUpQueue(options?: { tracingContext?: TracingContext; tracingOptions?: TracingOptions }) {

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -599,8 +599,8 @@ export class Harness<TState = {}> {
     if (workspaceForAgents && !agent.hasOwnWorkspace()) {
       agent.__setWorkspace(workspaceForAgents);
     }
-    if (browserForAgents && !agent.hasOwnBrowser()) {
-      agent.setBrowser(browserForAgents as MastraBrowser);
+    if (browserForAgents && typeof browserForAgents !== 'function' && !agent.hasOwnBrowser()) {
+      agent.setBrowser(browserForAgents);
     }
     if (this.config.pubsub && !agent.hasOwnPubSub()) {
       agent.__setPubSub(this.config.pubsub);
@@ -969,7 +969,11 @@ export class Harness<TState = {}> {
 
     await memoryStorage.deleteThread({ threadId });
     if (memoryStorage.supportsObservationalMemory) {
-      await memoryStorage.clearObservationalMemory(threadId, thread.resourceId);
+      try {
+        await memoryStorage.clearObservationalMemory(threadId, thread.resourceId);
+      } catch (error) {
+        this.emit({ type: 'error', error: error instanceof Error ? error : new Error(String(error)) });
+      }
     }
 
     if (isDeletingCurrentThread) {

--- a/packages/core/src/harness/thread-locking.test.ts
+++ b/packages/core/src/harness/thread-locking.test.ts
@@ -3,7 +3,10 @@ import { Agent } from '../agent';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
 
-function createHarness(threadLock?: { acquire: (id: string) => void; release: (id: string) => void }) {
+function createHarness(
+  threadLock?: { acquire: (id: string) => void; release: (id: string) => void },
+  storage = new InMemoryStore(),
+) {
   const agent = new Agent({
     name: 'test-agent',
     instructions: 'You are a test agent.',
@@ -12,7 +15,7 @@ function createHarness(threadLock?: { acquire: (id: string) => void; release: (i
 
   return new Harness({
     id: 'test-harness',
-    storage: new InMemoryStore(),
+    storage,
     modes: [{ id: 'default', name: 'Default', default: true, agent }],
     threadLock,
   });
@@ -243,6 +246,25 @@ describe('Harness thread locking', () => {
 
       const threads = await harness.listThreads();
       expect(threads.find(t => t.id === thread.id)).toBeUndefined();
+    });
+
+    it('clears thread-scoped observational memory when deleting a thread', async () => {
+      const storage = new InMemoryStore();
+      const harnessWithStorage = createHarness({ acquire, release }, storage);
+      await harnessWithStorage.init();
+      const thread = await harnessWithStorage.createThread({ title: 'with observations' });
+      const memoryStorage = (await storage.getStore('memory'))!;
+      await memoryStorage.initializeObservationalMemory({
+        threadId: thread.id,
+        resourceId: thread.resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      await expect(memoryStorage.getObservationalMemory(thread.id, thread.resourceId)).resolves.not.toBeNull();
+      await harnessWithStorage.memory.deleteThread({ threadId: thread.id });
+
+      await expect(memoryStorage.getObservationalMemory(thread.id, thread.resourceId)).resolves.toBeNull();
     });
 
     it('releases lock when deleting the current thread', async () => {

--- a/packages/core/src/harness/thread-locking.test.ts
+++ b/packages/core/src/harness/thread-locking.test.ts
@@ -176,6 +176,29 @@ describe('Harness thread locking', () => {
     });
   });
 
+  describe('runtime service propagation', () => {
+    it('does not install a browser factory as a concrete agent browser', async () => {
+      const agent = new Agent({
+        name: 'browser-factory-agent',
+        instructions: 'You are a test agent.',
+        model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+      });
+      const browserFactory = vi.fn(() => ({}) as any);
+      const harnessWithBrowserFactory = new Harness({
+        id: 'browser-factory-harness',
+        storage: new InMemoryStore(),
+        browser: browserFactory,
+        modes: [{ id: 'default', name: 'Default', default: true, agent }],
+      });
+
+      await harnessWithBrowserFactory.init();
+
+      expect(browserFactory).not.toHaveBeenCalled();
+      expect(agent.browser).toBeUndefined();
+      expect(agent.hasOwnBrowser()).toBe(false);
+    });
+  });
+
   describe('selectOrCreateThread', () => {
     it('acquires lock when selecting an existing thread', async () => {
       // Pre-create a thread so selectOrCreateThread finds it
@@ -265,6 +288,26 @@ describe('Harness thread locking', () => {
       await harnessWithStorage.memory.deleteThread({ threadId: thread.id });
 
       await expect(memoryStorage.getObservationalMemory(thread.id, thread.resourceId)).resolves.toBeNull();
+    });
+
+    it('continues current-thread teardown when observational memory cleanup fails', async () => {
+      const storage = new InMemoryStore();
+      const harnessWithStorage = createHarness({ acquire, release }, storage);
+      await harnessWithStorage.init();
+      const thread = await harnessWithStorage.createThread({ title: 'cleanup failure' });
+      const memoryStorage = (await storage.getStore('memory'))!;
+      const errors: Error[] = [];
+      harnessWithStorage.subscribe(event => {
+        if (event.type === 'error') errors.push(event.error);
+      });
+      vi.spyOn(memoryStorage, 'clearObservationalMemory').mockRejectedValueOnce(new Error('om cleanup failed'));
+
+      await expect(harnessWithStorage.memory.deleteThread({ threadId: thread.id })).resolves.toBeUndefined();
+
+      expect(release).toHaveBeenCalledWith(thread.id);
+      expect(harnessWithStorage.getCurrentThreadId()).toBeNull();
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.message).toBe('om cleanup failed');
     });
 
     it('releases lock when deleting the current thread', async () => {

--- a/packages/core/src/harness/tools.ts
+++ b/packages/core/src/harness/tools.ts
@@ -7,7 +7,7 @@ import { RequestContext } from '../request-context';
 import { createTool } from '../tools/tool';
 import { createWorkspaceTools } from '../workspace/tools/tools';
 
-import type { HarnessQuestionAnswer, HarnessRequestContext, HarnessSubagent } from './types';
+import type { HarnessQuestionAnswer, HarnessQuestionOption, HarnessRequestContext, HarnessSubagent } from './types';
 
 let questionCounter = 0;
 let planCounter = 0;
@@ -83,7 +83,7 @@ export const askUserTool = createTool({
       if (!harnessCtx?.emitEvent || !harnessCtx?.registerQuestion) {
         return {
           content: `[Question for user]: ${question}${
-            options?.length ? '\nOptions: ' + options.map(o => o.label).join(', ') : ''
+            options?.length ? '\nOptions: ' + options.map((o: HarnessQuestionOption) => o.label).join(', ') : ''
           }${resolvedSelectionMode ? '\nSelection mode: ' + resolvedSelectionMode : ''}`,
           isError: false,
         };

--- a/packages/core/src/harness/types.ts
+++ b/packages/core/src/harness/types.ts
@@ -1,6 +1,7 @@
 import type { Agent } from '../agent';
 import type { AgentInstructions, ToolsInput } from '../agent/types';
 import type { MastraBrowser } from '../browser/browser';
+import type { PubSub } from '../events/pubsub';
 import type { MastraLanguageModel } from '../llm/model/shared.types';
 import type { LoopOptions } from '../loop/types';
 import type { MastraMemory } from '../memory/memory';
@@ -272,6 +273,11 @@ export interface HarnessConfig<TState = {}> {
    * If not provided, all tools default to the "other" category.
    */
   toolCategoryResolver?: (toolName: string) => ToolCategory | null;
+
+  /**
+   * PubSub instance used by the internal Mastra instance and mode agents.
+   */
+  pubsub?: PubSub;
 
   /**
    * Optional thread locking callbacks.

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -1333,6 +1333,9 @@ export class Harness {
       }
 
       await memory.deleteThread({ threadId: opts.threadId });
+      if (memory.supportsObservationalMemory) {
+        await memory.clearObservationalMemory(opts.threadId, opts.resourceId);
+      }
       this._emitter.emit({
         type: 'thread_deleted',
         threadId: opts.threadId,

--- a/packages/core/src/harness/v1/threads.test.ts
+++ b/packages/core/src/harness/v1/threads.test.ts
@@ -157,6 +157,23 @@ describe('harness.threads — CRUD', () => {
     const fetched = await harness.threads.get({ resourceId: 'r1', threadId: created.id });
     expect(fetched).toBeNull();
   });
+
+  it('clears thread-scoped observational memory when deleting a thread', async () => {
+    const { harness } = setupHarness();
+    const created = await harness.threads.create({ resourceId: 'r1', title: 'with observations' });
+    const memory = (await harness._internalTryGetMemoryStorage())!;
+    await memory.initializeObservationalMemory({
+      threadId: created.id,
+      resourceId: 'r1',
+      scope: 'thread',
+      config: {},
+    });
+
+    await expect(memory.getObservationalMemory(created.id, 'r1')).resolves.not.toBeNull();
+    await harness.threads.delete({ resourceId: 'r1', threadId: created.id });
+
+    await expect(memory.getObservationalMemory(created.id, 'r1')).resolves.toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/memory/src/index.test.ts
+++ b/packages/memory/src/index.test.ts
@@ -2271,6 +2271,45 @@ describe('Memory', () => {
       await expect(memory.deleteMessages(['msg-789'])).resolves.not.toThrow();
     });
 
+    it('should clear thread-scoped observational memory when deleting a thread', async () => {
+      const storage = new InMemoryStore();
+      const memory = new Memory({
+        storage,
+        options: {
+          observationalMemory: {
+            scope: 'thread',
+          },
+        },
+      });
+      const memoryStore = await storage.getStore('memory');
+      const threadId = 'thread-with-observations';
+      const resourceId = 'resource-with-observations';
+
+      await memory.saveThread({
+        thread: {
+          id: threadId,
+          resourceId,
+          title: 'Thread with observations',
+          metadata: {},
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+      await memoryStore?.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      await expect(memoryStore?.getObservationalMemory(threadId, resourceId)).resolves.not.toBeNull();
+
+      await memory.deleteThread(threadId);
+
+      await expect(memory.getThreadById({ threadId })).resolves.toBeNull();
+      await expect(memoryStore?.getObservationalMemory(threadId, resourceId)).resolves.toBeNull();
+    });
+
     it('should batch message vector deletions when messageIds exceed batch size', async () => {
       const memory = createMemoryWithMockVector('_');
       const messageIds = Array.from({ length: 250 }, (_, i) => `msg-${i}`);

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -657,7 +657,11 @@ export class Memory extends MastraMemory {
 
   async deleteThread(threadId: string): Promise<void> {
     const memoryStore = await this.getMemoryStore();
+    const thread = await memoryStore.getThreadById({ threadId });
     await memoryStore.deleteThread({ threadId });
+    if (thread?.resourceId && memoryStore.supportsObservationalMemory) {
+      await memoryStore.clearObservationalMemory(threadId, thread.resourceId);
+    }
     if (this.vector) {
       void this.deleteThreadVectors(threadId);
     }


### PR DESCRIPTION
## Summary
- Cherry-pick upstream memory cleanup commit 1be079325f05cdec100cc6967572576dfc9e2e44.
- Cherry-pick upstream PR 16665 implementation commits for agent signal/thread-stream PubSub routing.
- Preserve fork PF-352 signal/idempotency/output-waiter behavior and add conflict-regression fixes for idle wake run ids, stale active run ids, one-shot stream broadcasting, and raw harness OM cleanup guards.

## Upstream Scope
- mastra-ai/mastra#16665 implementation commits: route agent signals through pubsub, route thread streams through pubsub.
- mastra-ai/mastra@1be079325f05cdec100cc6967572576dfc9e2e44: clear observational memory on thread deletion.
- Merge commit from upstream PR 16665 was intentionally not cherry-picked; the two implementation commits were applied directly.

## Local Review Evidence
- Required local Codex review pass 1 found caller runId/stream ordering risks; fixed.
- Required local Codex review pass 2 found raw harness observational-memory cleanup gap and missing non-EventEmitter coverage; fixed.
- Follow-up Codex reviews after fixes found the unsupported-OM guard gap and caller-owned one-shot stream risk; fixed.
- Final follow-up Codex review reported no actionable findings.
- CodeRabbit CLI doctor passed, but local coderabbit review --plain hung after reaching reviewing state; use GitHub CodeRabbit app review for PR evidence.

## Validation
- pnpm --filter @internal/ai-sdk-v4 build
- pnpm --filter @internal/ai-sdk-v5 build
- pnpm --filter @internal/ai-v6 build
- pnpm --filter @internal/core build:lib
- pnpm --filter @internal/llm-recorder build
- pnpm --filter @internal/test-utils build
- pnpm --filter @mastra/schema-compat build
- pnpm --filter @internal/external-types build:lib
- timeout 120s pnpm --dir packages/core exec vitest run --exclude '**/tool-builder/**' src/agent/__tests__/agent-signals.test.ts src/harness/thread-locking.test.ts src/harness/v1/threads.test.ts
- timeout 120s pnpm --dir packages/core exec vitest run --exclude '**/tool-builder/**' src/harness/v1/session.signal.test.ts src/harness/v1/session.subscription-lifecycle.test.ts src/harness/v1/session.events.test.ts
- timeout 180s pnpm --filter @mastra/core build:lib
- timeout 120s pnpm --dir packages/memory exec vitest run src/index.test.ts
- timeout 180s pnpm --filter @mastra/memory build:lib
- git diff --check
- commit hook: lint-staged --quiet

Linear: PF-512

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes agent-to-agent communication more reliable by routing signals and streams through a shared mailbox system (PubSub) and fixes a bug so that when a conversation thread is deleted, any notes the system kept about that thread are also cleaned up.

## Summary

This branch syncs key upstream changes (mastra-ai/mastra#16665) and applies fork-specific fixes to ensure robust cross-instance signal/stream routing and correct observational-memory cleanup:

What was cherry-picked
- Upstream memory cleanup commit to ensure observational memory is cleared on thread deletion.
- Two upstream commits implementing PubSub-based routing for agent signals and thread streams (the upstream merge commit was not cherry-picked).

Fork-preserved behavior and local fixes
- Preserves fork-specific PF-352 behavior (signal idempotency, output-waiter semantics).
- Adds conflict-regression fixes addressing:
  - idle wake run ID preservation,
  - stale active run ID handling,
  - one-shot stream broadcasting risks,
  - raw-harness observational-memory cleanup guards.

Key code changes
- Memory
  - Memory.deleteThread now clears thread-scoped observational memory when storage supports it; tests added in packages/memory and harness to verify cleanup.
- PubSub & agent wiring
  - Introduces optional PubSub injection across MastraCode, Harness, and Agent.
  - MastraCodeConfig: pubsub?: PubSub, crossProcessPubSub?: boolean (disables file-based thread locking when true).
  - HarnessConfig/Harness: accepts and propagates pubsub to agents; ensures current-agent thread subscription wiring.
  - Agent API: accepts/returns a PubSub via getPubSub(), hasOwnPubSub(), __setPubSub(); pubsub propagated on fork.
- AgentThreadStreamRuntime
  - Refactored to maintain per-PubSub runtime state (WeakMap) and publish/subscribe on computed topics (agent.thread-stream.<key>).
  - Signal routing and run/stream lifecycle updated to support queued/reserved/idle signals and cross-instance ReadableStream delivery.
  - New exported defaults and signatures to accept optional pubsub parameters for register/drain/abort/subscribe/getRunOutput operations.
- Types
  - AgentConfig and HarnessConfig include optional pubsub?: PubSub.

Tests and validation
- Extensive unit tests added/extended for cross-instance signal/stream behavior, idle-wake runId preservation, one-shot stream safety, and thread deletion memory cleanup.
- Local review evidence: multiple Codex/CodeRabbit passes, targeted builds/tests across many packages, git diff/lint hooks, and CodeRabbit CLI/PR review runs reported; associated Linear ticket PF-512.

Notes
- Upstream merge commit was intentionally not applied; only the two implementation commits and the memory-cleanup commit were cherry-picked.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->