### PR TITLE
[PF-513] Snapshot Agent PubSub per execution path

### DIFF
--- a/.changeset/pf-513-agent-thread-signals.md
+++ b/.changeset/pf-513-agent-thread-signals.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed thread signal routing so concurrent streams, duplicate admissions, and aborted setup runs clean up correctly.

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -1176,6 +1176,112 @@ describe('Agent signals', () => {
     expect(signalResult).toEqual(expect.objectContaining({ accepted: true, runId: stream.runId }));
   });
 
+  it('reserves thread-only streams while default options are pending', async () => {
+    let markDefaultOptionsStarted!: () => void;
+    let releaseDefaultOptions!: () => void;
+    const defaultOptionsStarted = new Promise<void>(resolve => {
+      markDefaultOptionsStarted = resolve;
+    });
+    const defaultOptionsReleased = new Promise<void>(resolve => {
+      releaseDefaultOptions = resolve;
+    });
+
+    const runner = new Agent({
+      id: 'thread-only-reserved-agent',
+      name: 'Thread Only Reserved Agent',
+      instructions: 'Test',
+      defaultOptions: async () => {
+        markDefaultOptionsStarted();
+        await defaultOptionsReleased;
+        return {};
+      },
+      model: createTextStreamModel('thread only reserved response'),
+    });
+
+    const streamPromise = runner.stream('Hello', { memory: { thread: 'thread-only-reserved-thread' } });
+    await defaultOptionsStarted;
+    const signalResult = runner.sendSignal(
+      { type: 'user-message', contents: 'Hello while thread-only stream is starting' },
+      { threadId: 'thread-only-reserved-thread' },
+    );
+    releaseDefaultOptions();
+
+    const stream = await streamPromise;
+    expect(signalResult).toEqual(expect.objectContaining({ accepted: true, runId: stream.runId }));
+  });
+
+  it('routes thread-only signals after default options add a resource target', async () => {
+    let markDefaultOptionsStarted!: () => void;
+    let releaseDefaultOptions!: () => void;
+    let releaseStream!: () => void;
+    const defaultOptionsStarted = new Promise<void>(resolve => {
+      markDefaultOptionsStarted = resolve;
+    });
+    const defaultOptionsReleased = new Promise<void>(resolve => {
+      releaseDefaultOptions = resolve;
+    });
+    const streamReleased = new Promise<void>(resolve => {
+      releaseStream = resolve;
+    });
+
+    const runner = new Agent({
+      id: 'thread-only-retargeted-agent',
+      name: 'Thread Only Retargeted Agent',
+      instructions: 'Test',
+      defaultOptions: async () => {
+        markDefaultOptionsStarted();
+        await defaultOptionsReleased;
+        return { memory: { resource: 'thread-only-retargeted-user' } };
+      },
+      model: new MockLanguageModelV2({
+        doStream: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: new ReadableStream({
+            async start(controller) {
+              controller.enqueue({ type: 'stream-start', warnings: [] });
+              controller.enqueue({
+                type: 'response-metadata',
+                id: 'thread-only-retargeted-id',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              });
+              controller.enqueue({ type: 'text-start', id: 'text-1' });
+              controller.enqueue({ type: 'text-delta', id: 'text-1', delta: 'thread only retargeted response' });
+              controller.enqueue({ type: 'text-end', id: 'text-1' });
+              await streamReleased;
+              controller.enqueue({
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              });
+              controller.close();
+            },
+          }),
+        }),
+      }),
+    });
+
+    const streamPromise = runner.stream('Hello', { memory: { thread: 'thread-only-retargeted-thread' } });
+    await defaultOptionsStarted;
+    const earlySignal = runner.sendSignal(
+      { type: 'user-message', contents: 'Hello before retarget' },
+      { threadId: 'thread-only-retargeted-thread' },
+    );
+    releaseDefaultOptions();
+
+    const stream = await streamPromise;
+    const lateSignal = runner.sendSignal(
+      { type: 'user-message', contents: 'Hello after retarget' },
+      { threadId: 'thread-only-retargeted-thread' },
+    );
+
+    expect(earlySignal).toEqual(expect.objectContaining({ accepted: true, runId: stream.runId }));
+    expect(lateSignal).toEqual(expect.objectContaining({ accepted: true, runId: stream.runId }));
+    releaseStream();
+    await expect(stream.text).resolves.toBe('thread only retargeted response');
+  });
+
   it('supports cross-instance thread subscriptions through the Mastra runtime', async () => {
     const pubsub = new EventEmitterPubSub();
     const runner = new Agent({

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EventEmitterPubSub } from '../../events/event-emitter';
 import { PubSub } from '../../events/pubsub';
 import type { EventCallback, SubscribeOptions } from '../../events/types';
+import { buildFakeOutput } from '../../harness/v1/__test-utils__/fake-output';
 import { Mastra } from '../../mastra';
 import { MockMemory } from '../../memory/mock';
 import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY, RequestContext } from '../../request-context';
@@ -61,6 +62,26 @@ class AsyncFanoutPubSub extends PubSub {
 
   async flush(): Promise<void> {
     await this.#inner.flush();
+  }
+}
+
+class BlockingRunCompletedPubSub extends EventEmitterPubSub {
+  #unblockRunCompleted!: () => void;
+  readonly blockedRunCompleted = new Promise<void>(resolve => {
+    this.#unblockRunCompleted = resolve;
+  });
+  sawRunCompleted = false;
+
+  override async publish(topic: string, event: Parameters<PubSub['publish']>[1]): Promise<void> {
+    if ((event as { data?: { type?: string } }).data?.type === 'run-completed') {
+      this.sawRunCompleted = true;
+      await this.blockedRunCompleted;
+    }
+    await super.publish(topic, event);
+  }
+
+  unblockRunCompleted() {
+    this.#unblockRunCompleted();
   }
 }
 
@@ -901,6 +922,52 @@ describe('Agent signals', () => {
     subscription.unsubscribe();
   });
 
+  it('honors an injected PubSub when test agents register streams through the internal hook', async () => {
+    const initialPubSub = new EventEmitterPubSub();
+    const swappedPubSub = new EventEmitterPubSub();
+    const agent = new Agent({
+      id: 'internal-register-pubsub-agent',
+      name: 'Internal Register PubSub Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('unused'),
+    });
+    agent.__setPubSub(swappedPubSub);
+    const observer = new Agent({
+      id: 'internal-register-pubsub-agent',
+      name: 'Internal Register Observer',
+      instructions: 'Test',
+      model: createTextStreamModel('observer response'),
+    });
+    observer.__setPubSub(initialPubSub);
+    const subscription = await observer.subscribeToThread({
+      threadId: 'internal-register-thread',
+      resourceId: 'internal-register-user',
+    });
+    const nextRun = readNextRun(subscription.stream[Symbol.asyncIterator]());
+    const output = buildFakeOutput({
+      runId: 'internal-register-run',
+      fullOutput: { text: 'internal response', finishReason: 'stop', usage: {} },
+      chunks: [
+        { runId: 'internal-register-run', type: 'text-delta', payload: { text: 'internal response' } },
+        { runId: 'internal-register-run', type: 'finish', payload: {} },
+      ],
+    });
+
+    agent._internalRegisterStreamRun(output, {
+      runId: 'internal-register-run',
+      memory: { resource: 'internal-register-user', thread: 'internal-register-thread' },
+      _pubsub: initialPubSub,
+    } as any);
+    expect(agent.getRunOutput('internal-register-run')).toBe(output);
+
+    await expect(nextRun).resolves.toMatchObject({
+      value: { runId: 'internal-register-run', text: 'internal response' },
+      done: false,
+    });
+
+    subscription.unsubscribe();
+  });
+
   it('re-reserves a pre-default stream when default options change the request-context thread target', async () => {
     let markDefaultOptionsStarted!: () => void;
     let releaseDefaultOptions!: () => void;
@@ -952,6 +1019,64 @@ describe('Agent signals', () => {
     subscription.unsubscribe();
   });
 
+  it('preserves accepted setup signals when default options retarget a reserved stream', async () => {
+    let markDefaultOptionsStarted!: () => void;
+    let releaseDefaultOptions!: () => void;
+    const defaultOptionsStarted = new Promise<void>(resolve => {
+      markDefaultOptionsStarted = resolve;
+    });
+    const defaultOptionsReleased = new Promise<void>(resolve => {
+      releaseDefaultOptions = resolve;
+    });
+    const requestContext = new RequestContext();
+    requestContext.set(MASTRA_RESOURCE_ID_KEY, 'retarget-signal-context-user');
+    requestContext.set(MASTRA_THREAD_ID_KEY, 'retarget-signal-context-thread');
+    const prompts: any[][] = [];
+
+    const runner = new Agent({
+      id: 'retarget-preserve-signal-agent',
+      name: 'Retarget Preserve Signal Agent',
+      instructions: 'Test',
+      defaultOptions: async () => {
+        markDefaultOptionsStarted();
+        await defaultOptionsReleased;
+        return { requestContext };
+      },
+      model: new MockLanguageModelV2({
+        doStream: async ({ prompt }) => {
+          prompts.push(prompt);
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+              { type: 'text-start', id: 'text-1' },
+              { type: 'text-delta', id: 'text-1', delta: 'retarget response' },
+              { type: 'text-end', id: 'text-1' },
+              { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+            ]),
+          };
+        },
+      }),
+    });
+
+    const streamPromise = runner.stream('Hello', {
+      memory: { thread: 'retarget-signal-original-thread', resource: 'retarget-signal-original-user' },
+    });
+    await defaultOptionsStarted;
+    const signalResult = runner.sendSignal(
+      { type: 'user-message', contents: 'accepted before retarget' },
+      { resourceId: 'retarget-signal-original-user', threadId: 'retarget-signal-original-thread' },
+    );
+    releaseDefaultOptions();
+
+    const stream = await streamPromise;
+    expect(signalResult.runId).toBe(stream.runId);
+    await expect(stream.text).resolves.toBe('retarget response');
+    expect(JSON.stringify(prompts)).toContain('accepted before retarget');
+  });
+
   it('forgets a re-reserved PubSub mapping when stream setup fails before preparation', async () => {
     const swappedPubSub = new EventEmitterPubSub();
     let useUnsupportedModel = true;
@@ -982,6 +1107,7 @@ describe('Agent signals', () => {
 
     await expect(
       runner.stream('Hello', {
+        runId: 'failed-rereserve-explicit-run',
         memory: { thread: 'failed-rereserve-original-thread', resource: 'failed-rereserve-original-user' },
       }),
     ).rejects.toThrow('not compatible with stream()');
@@ -994,9 +1120,11 @@ describe('Agent signals', () => {
     });
     const nextRun = readNextRun(subscription.stream[Symbol.asyncIterator]());
     const stream = await runner.stream('Hello again', {
+      runId: 'failed-rereserve-explicit-run',
       memory: { thread: 'failed-rereserve-context-thread', resource: 'failed-rereserve-context-user' },
     });
 
+    expect(stream.runId).toBe('failed-rereserve-explicit-run');
     await expect(stream.text).resolves.toBe('post failure response');
     const observedRun = await Promise.race([
       nextRun,
@@ -1864,6 +1992,7 @@ describe('Agent signals', () => {
 
     rejectStream(new Error('immediate idle stream failed'));
     await expect(result.output).rejects.toThrow('immediate idle stream failed');
+    await expect(runtime.waitForRunOutput(result.runId)).rejects.toThrow('was rejected');
     await waiter;
     expect(waiterResolved).toBe(true);
   });
@@ -2070,6 +2199,66 @@ describe('Agent signals', () => {
     expect(stream).not.toHaveBeenCalled();
   });
 
+  it('rejects run-output waiters when a queued idle run is aborted before it starts', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+
+    runtime.registerRun(
+      { id: 'active-agent' } as any,
+      {
+        runId: 'active-before-waiter-abort',
+        status: 'running',
+        fullStream: (async function* () {})(),
+        _waitUntilFinished: () => new Promise<any>(() => {}),
+      } as any,
+      {
+        runId: 'active-before-waiter-abort',
+        memory: { resource: 'queued-waiter-abort-user', thread: 'queued-waiter-abort-thread' },
+      } as any,
+      pubsub,
+    );
+
+    const result = runtime.sendSignal(
+      { id: 'queued-waiter-abort-agent', stream: vi.fn() } as any,
+      { type: 'user-message', contents: 'queued waiter abort' },
+      {
+        resourceId: 'queued-waiter-abort-user',
+        threadId: 'queued-waiter-abort-thread',
+        ifIdle: {
+          streamOptions: { memory: { resource: 'queued-waiter-abort-user', thread: 'queued-waiter-abort-thread' } },
+        } as any,
+      },
+      pubsub,
+    );
+    const waiter = runtime.waitForRunOutput(result.runId, pubsub);
+
+    expect(runtime.abortRun(result.runId, pubsub)).toBe(true);
+    await expect(waiter).rejects.toThrow('has been aborted');
+  });
+
+  it('does not tombstone unknown run ids when abort returns false', () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+
+    expect(runtime.abortRun('unknown-abort-run', pubsub)).toBe(false);
+    const output = buildFakeOutput({
+      runId: 'unknown-abort-run',
+      fullOutput: { text: 'not aborted', finishReason: 'stop', usage: {} },
+      chunks: [{ runId: 'unknown-abort-run', type: 'finish', payload: {} }],
+    });
+    expect(() =>
+      runtime.registerRun(
+        { id: 'unknown-abort-agent' } as any,
+        output,
+        {
+          runId: 'unknown-abort-run',
+          memory: { resource: 'unknown-abort-user', thread: 'unknown-abort-thread' },
+        } as any,
+        pubsub,
+      ),
+    ).not.toThrow();
+  });
+
   it('aborts a reserved setup run before stream preparation', () => {
     const runtime = new AgentThreadStreamRuntime();
     const pubsub = new EventEmitterPubSub();
@@ -2090,6 +2279,283 @@ describe('Agent signals', () => {
       pubsub,
     );
     expect(prepared.abortSignal?.aborted).toBe(true);
+  });
+
+  it('rejects run-output waiters and releases a prepared setup run on abort before registration', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    runtime.reserveRun(
+      {
+        runId: 'prepared-setup-abort-run',
+        memory: { resource: 'prepared-setup-abort-user', thread: 'prepared-setup-abort-thread' },
+      } as any,
+      pubsub,
+    );
+    runtime.prepareRunOptions(
+      {
+        runId: 'prepared-setup-abort-run',
+        memory: { resource: 'prepared-setup-abort-user', thread: 'prepared-setup-abort-thread' },
+      } as any,
+      pubsub,
+    );
+    const waiter = runtime.waitForRunOutput('prepared-setup-abort-run', pubsub);
+
+    expect(runtime.abortRun('prepared-setup-abort-run', pubsub)).toBe(true);
+    await expect(waiter).rejects.toThrow('has been aborted');
+    const successorRelease = runtime.reserveRun(
+      {
+        runId: 'prepared-setup-successor-run',
+        memory: { resource: 'prepared-setup-abort-user', thread: 'prepared-setup-abort-thread' },
+      } as any,
+      pubsub,
+    );
+    expect(successorRelease).toBeDefined();
+    const lateOutput = buildFakeOutput({
+      runId: 'prepared-setup-abort-run',
+      fullOutput: { text: 'late aborted response', finishReason: 'stop', usage: {} },
+      chunks: [{ runId: 'prepared-setup-abort-run', type: 'finish', payload: {} }],
+    });
+    expect(() =>
+      runtime.registerRun(
+        { id: 'prepared-setup-abort-agent' } as any,
+        lateOutput,
+        {
+          runId: 'prepared-setup-abort-run',
+          memory: { resource: 'prepared-setup-abort-user', thread: 'prepared-setup-abort-thread' },
+        } as any,
+        pubsub,
+      ),
+    ).toThrow('has been aborted');
+  });
+
+  it('keeps run-output waiters when a reservation is released for non-terminal retargeting', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    runtime.reserveRun(
+      {
+        runId: 'retarget-waiter-run',
+        memory: { resource: 'retarget-waiter-old-user', thread: 'retarget-waiter-old-thread' },
+      } as any,
+      pubsub,
+    );
+    const waiter = runtime.waitForRunOutput('retarget-waiter-run', pubsub);
+    let waiterRejected = false;
+    void waiter.catch(() => {
+      waiterRejected = true;
+    });
+
+    expect(
+      runtime.releaseRunReservation('retarget-waiter-run', pubsub, { cleanupPrepared: true, clearAbort: true }),
+    ).toBe(true);
+    await nextTick();
+    expect(waiterRejected).toBe(false);
+
+    runtime.reserveRun(
+      {
+        runId: 'retarget-waiter-run',
+        memory: { resource: 'retarget-waiter-new-user', thread: 'retarget-waiter-new-thread' },
+      } as any,
+      pubsub,
+    );
+    const output = buildFakeOutput({
+      runId: 'retarget-waiter-run',
+      fullOutput: { text: 'retarget waiter response', finishReason: 'stop', usage: {} },
+      chunks: [{ runId: 'retarget-waiter-run', type: 'finish', payload: {} }],
+    });
+    runtime.registerRun(
+      { id: 'retarget-waiter-agent' } as any,
+      output,
+      {
+        runId: 'retarget-waiter-run',
+        memory: { resource: 'retarget-waiter-new-user', thread: 'retarget-waiter-new-thread' },
+      } as any,
+      pubsub,
+    );
+
+    await expect(waiter).resolves.toBe(output);
+  });
+
+  it('cancels run-output waiters without poisoning a later registration', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    runtime.reserveRun(
+      {
+        runId: 'abortable-waiter-run',
+        memory: { resource: 'abortable-waiter-user', thread: 'abortable-waiter-thread' },
+      } as any,
+      pubsub,
+    );
+    const waitAbortController = new AbortController();
+    const waiter = runtime.waitForRunOutput('abortable-waiter-run', pubsub, waitAbortController.signal);
+
+    waitAbortController.abort(new Error('stop waiting'));
+    await expect(waiter).rejects.toThrow('stop waiting');
+
+    const output = buildFakeOutput({
+      runId: 'abortable-waiter-run',
+      fullOutput: { text: 'abortable waiter response', finishReason: 'stop', usage: {} },
+      chunks: [{ runId: 'abortable-waiter-run', type: 'finish', payload: {} }],
+    });
+    runtime.registerRun(
+      { id: 'abortable-waiter-agent' } as any,
+      output,
+      {
+        runId: 'abortable-waiter-run',
+        memory: { resource: 'abortable-waiter-user', thread: 'abortable-waiter-thread' },
+      } as any,
+      pubsub,
+    );
+
+    await expect(runtime.waitForRunOutput('abortable-waiter-run', pubsub)).resolves.toBe(output);
+  });
+
+  it('keeps rejected run ids tombstoned when retry cannot reserve an active thread', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    const releaseRejected = runtime.reserveRun(
+      {
+        runId: 'rejected-retry-run',
+        memory: { resource: 'rejected-retry-user', thread: 'rejected-retry-thread' },
+      } as any,
+      pubsub,
+    );
+    const rejectedWaiter = runtime.waitForRunOutput('rejected-retry-run', pubsub);
+    releaseRejected!();
+    await expect(rejectedWaiter).rejects.toThrow('was rejected');
+    runtime.registerRun(
+      { id: 'active-retry-agent' } as any,
+      {
+        runId: 'active-retry-run',
+        status: 'running',
+        fullStream: (async function* () {})(),
+        _waitUntilFinished: () => new Promise<void>(() => {}),
+      } as any,
+      {
+        runId: 'active-retry-run',
+        memory: { resource: 'rejected-retry-user', thread: 'rejected-retry-thread' },
+      } as any,
+      pubsub,
+    );
+
+    expect(
+      runtime.reserveRun(
+        {
+          runId: 'rejected-retry-run',
+          memory: { resource: 'rejected-retry-user', thread: 'rejected-retry-thread' },
+        } as any,
+        pubsub,
+      ),
+    ).toBeUndefined();
+
+    const staleOutput = buildFakeOutput({
+      runId: 'rejected-retry-run',
+      fullOutput: { text: 'stale rejected response', finishReason: 'stop', usage: {} },
+      chunks: [{ runId: 'rejected-retry-run', type: 'finish', payload: {} }],
+    });
+    expect(() =>
+      runtime.registerRun(
+        { id: 'stale-retry-agent' } as any,
+        staleOutput,
+        {
+          runId: 'rejected-retry-run',
+          memory: { resource: 'rejected-retry-user', thread: 'rejected-retry-thread' },
+        } as any,
+        pubsub,
+      ),
+    ).toThrow('was rejected');
+  });
+
+  it('starts queued idle wakes left behind when a reservation is retargeted', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    runtime.reserveRun(
+      {
+        runId: 'retarget-with-idle-run',
+        memory: { resource: 'retarget-idle-old-user', thread: 'retarget-idle-old-thread' },
+      } as any,
+      pubsub,
+      'retarget-owner-agent',
+    );
+    const stream = vi.fn(async () => ({
+      runId: 'retarget-queued-idle-run',
+      status: 'running',
+      fullStream: (async function* () {})(),
+      _waitUntilFinished: async () => {},
+    }));
+
+    const result = runtime.sendSignal(
+      { id: 'retarget-queued-idle-agent', stream } as any,
+      { type: 'user-message', contents: 'wake after retarget' },
+      {
+        resourceId: 'retarget-idle-old-user',
+        threadId: 'retarget-idle-old-thread',
+        ifIdle: {
+          streamOptions: { memory: { resource: 'retarget-idle-old-user', thread: 'retarget-idle-old-thread' } },
+        } as any,
+      },
+      pubsub,
+    );
+    expect(stream).not.toHaveBeenCalled();
+
+    expect(
+      runtime.retargetReservedRun(
+        'retarget-with-idle-run',
+        { resourceId: 'retarget-idle-old-user', threadId: 'retarget-idle-old-thread' },
+        { resourceId: 'retarget-idle-new-user', threadId: 'retarget-idle-new-thread' },
+        pubsub,
+        'retarget-owner-agent',
+      ),
+    ).toBe(true);
+    await waitForCondition(() => stream.mock.calls.length > 0);
+    expect(stream).toHaveBeenCalledWith(
+      expect.objectContaining({ contents: 'wake after retarget' }),
+      expect.objectContaining({
+        runId: result.runId,
+        memory: { resource: 'retarget-idle-old-user', thread: 'retarget-idle-old-thread' },
+      }),
+    );
+  });
+
+  it('wakes waiters parked on the old thread when a reservation is retargeted', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    runtime.reserveRun(
+      {
+        runId: 'retarget-wakes-old-thread-run',
+        memory: { resource: 'retarget-wakes-old-user', thread: 'retarget-wakes-old-thread' },
+      } as any,
+      pubsub,
+      'retarget-wakes-owner',
+    );
+
+    let waiterResolved = false;
+    const waiter = runtime
+      .waitForCrossAgentThreadRun(
+        { id: 'retarget-wakes-waiter' } as any,
+        {
+          runId: 'retarget-wakes-waiter-run',
+          memory: { resource: 'retarget-wakes-old-user', thread: 'retarget-wakes-old-thread' },
+        } as any,
+        pubsub,
+      )
+      .then(() => {
+        waiterResolved = true;
+      });
+    await nextTick();
+    expect(waiterResolved).toBe(false);
+
+    expect(
+      runtime.retargetReservedRun(
+        'retarget-wakes-old-thread-run',
+        { resourceId: 'retarget-wakes-old-user', threadId: 'retarget-wakes-old-thread' },
+        { resourceId: 'retarget-wakes-new-user', threadId: 'retarget-wakes-new-thread' },
+        pubsub,
+        'retarget-wakes-owner',
+      ),
+    ).toBe(true);
+
+    await waiter;
+    expect(waiterResolved).toBe(true);
   });
 
   it('starts a queued idle wake when a reserved setup run is aborted', async () => {
@@ -2134,6 +2600,70 @@ describe('Agent signals', () => {
         memory: { resource: 'reserved-abort-idle-user', thread: 'reserved-abort-idle-thread' },
       }),
     );
+  });
+
+  it('releases waiters when draining a queued active signal fails', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    let finishActive!: () => void;
+    const activeFinished = new Promise<void>(resolve => {
+      finishActive = resolve;
+    });
+    const stream = vi.fn(async () => {
+      throw new Error('queued active setup failed');
+    });
+    const owner = { id: 'queued-active-failure-agent', stream };
+    const completion = runtime.registerRun(
+      owner as any,
+      {
+        runId: 'queued-active-failure-run',
+        status: 'running',
+        fullStream: (async function* () {})(),
+        _waitUntilFinished: () => activeFinished,
+      } as any,
+      {
+        runId: 'queued-active-failure-run',
+        memory: { resource: 'queued-active-failure-user', thread: 'queued-active-failure-thread' },
+      } as any,
+      pubsub,
+    );
+    const signalResult = runtime.sendSignal(
+      owner as any,
+      { type: 'user-message', contents: 'queued active failure' },
+      { resourceId: 'queued-active-failure-user', threadId: 'queued-active-failure-thread' },
+      pubsub,
+    );
+    expect(signalResult.accepted).toBe(true);
+
+    let waiterResolved = false;
+    const waiter = runtime
+      .waitForCrossAgentThreadRun(
+        { id: 'queued-active-failure-waiter' } as any,
+        {
+          runId: 'queued-active-failure-next-run',
+          memory: { resource: 'queued-active-failure-user', thread: 'queued-active-failure-thread' },
+        } as any,
+        pubsub,
+      )
+      .then(() => {
+        waiterResolved = true;
+      });
+    await nextTick();
+    expect(waiterResolved).toBe(false);
+
+    finishActive();
+    await expect(completion).rejects.toThrow('queued active setup failed');
+    await waiter;
+    expect(waiterResolved).toBe(true);
+    expect(
+      runtime.reserveRun(
+        {
+          runId: 'queued-active-failure-next-run',
+          memory: { resource: 'queued-active-failure-user', thread: 'queued-active-failure-thread' },
+        } as any,
+        pubsub,
+      ),
+    ).toEqual(expect.any(Function));
   });
 
   it('drops queued signals when a prepared run is aborted', async () => {
@@ -2226,6 +2756,335 @@ describe('Agent signals', () => {
         pubsub,
       ),
     ).toThrow('already registered');
+  });
+
+  it('rejects same-agent registration when another run is active on the thread', () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    const streamOptions = {
+      memory: { resource: 'same-agent-active-user', thread: 'same-agent-active-thread' },
+    } as any;
+
+    runtime.registerRun(
+      { id: 'same-active-agent' } as any,
+      {
+        runId: 'same-active-first-run',
+        status: 'running',
+        fullStream: (async function* () {})(),
+        _waitUntilFinished: () => new Promise<void>(() => {}),
+      } as any,
+      { ...streamOptions, runId: 'same-active-first-run' },
+      pubsub,
+    );
+
+    expect(() =>
+      runtime.registerRun(
+        { id: 'same-active-agent' } as any,
+        {
+          runId: 'same-active-second-run',
+          status: 'running',
+          fullStream: (async function* () {})(),
+          _waitUntilFinished: () => new Promise<void>(() => {}),
+        } as any,
+        { ...streamOptions, runId: 'same-active-second-run' },
+        pubsub,
+      ),
+    ).toThrow('already active for this thread');
+  });
+
+  it('waits for same-agent active runs before allowing another stream on the thread', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    let finishActive!: () => void;
+    const activeFinished = new Promise<void>(resolve => {
+      finishActive = resolve;
+    });
+    const completion = runtime.registerRun(
+      { id: 'same-wait-agent' } as any,
+      {
+        runId: 'same-wait-active-run',
+        status: 'running',
+        fullStream: (async function* () {})(),
+        _waitUntilFinished: () => activeFinished,
+      } as any,
+      {
+        runId: 'same-wait-active-run',
+        memory: { resource: 'same-wait-user', thread: 'same-wait-thread' },
+      } as any,
+      pubsub,
+    );
+
+    let waiterResolved = false;
+    const waiter = runtime
+      .waitForCrossAgentThreadRun(
+        { id: 'same-wait-agent' } as any,
+        {
+          runId: 'same-wait-next-run',
+          memory: { resource: 'same-wait-user', thread: 'same-wait-thread' },
+        } as any,
+        pubsub,
+      )
+      .then(() => {
+        waiterResolved = true;
+      });
+    await nextTick();
+    expect(waiterResolved).toBe(false);
+
+    finishActive();
+    await completion;
+    await waiter;
+    expect(waiterResolved).toBe(true);
+  });
+
+  it('waits for completed active records to clear before allowing another stream on the thread', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    let finishActive!: () => void;
+    const activeFinished = new Promise<void>(resolve => {
+      finishActive = resolve;
+    });
+    const completion = runtime.registerRun(
+      { id: 'completed-window-agent' } as any,
+      {
+        runId: 'completed-window-active-run',
+        status: 'success',
+        fullStream: (async function* () {})(),
+        _waitUntilFinished: () => activeFinished,
+      } as any,
+      {
+        runId: 'completed-window-active-run',
+        memory: { resource: 'completed-window-user', thread: 'completed-window-thread' },
+      } as any,
+      pubsub,
+    );
+
+    let waiterResolved = false;
+    const waiter = runtime
+      .waitForCrossAgentThreadRun(
+        { id: 'completed-window-agent' } as any,
+        {
+          runId: 'completed-window-next-run',
+          memory: { resource: 'completed-window-user', thread: 'completed-window-thread' },
+        } as any,
+        pubsub,
+      )
+      .then(() => {
+        waiterResolved = true;
+      });
+    await nextTick();
+    expect(waiterResolved).toBe(false);
+
+    finishActive();
+    await completion;
+    await waiter;
+    expect(waiterResolved).toBe(true);
+  });
+
+  it('reserves the thread after waiting so concurrent stream callers do not overlap execution', async () => {
+    let finishActive!: () => void;
+    const activeFinished = new Promise<void>(resolve => {
+      finishActive = resolve;
+    });
+    let finishFirstWaiter!: () => void;
+    const firstWaiterFinished = new Promise<void>(resolve => {
+      finishFirstWaiter = resolve;
+    });
+    let streamCalls = 0;
+    const runner = new Agent({
+      id: 'post-wait-reservation-agent',
+      name: 'Post Wait Reservation Agent',
+      instructions: 'Test',
+      model: new MockLanguageModelV2({
+        doStream: async () => {
+          streamCalls += 1;
+          const call = streamCalls;
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+            stream: new ReadableStream({
+              async start(controller) {
+                controller.enqueue({ type: 'stream-start', warnings: [] });
+                controller.enqueue({
+                  type: 'response-metadata',
+                  id: `id-${call}`,
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                });
+                controller.enqueue({ type: 'text-start', id: `text-${call}` });
+                controller.enqueue({ type: 'text-delta', id: `text-${call}`, delta: `response ${call}` });
+                if (call === 1) await firstWaiterFinished;
+                controller.enqueue({ type: 'text-end', id: `text-${call}` });
+                controller.enqueue({
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                });
+                controller.close();
+              },
+            }),
+          };
+        },
+      }),
+    });
+    const activeCompletion = agentThreadStreamRuntime.registerRun(
+      runner as any,
+      {
+        runId: 'post-wait-active-run',
+        status: 'running',
+        fullStream: (async function* () {})(),
+        _waitUntilFinished: () => activeFinished,
+      } as any,
+      {
+        runId: 'post-wait-active-run',
+        memory: { resource: 'post-wait-user', thread: 'post-wait-thread' },
+      } as any,
+    );
+
+    const first = runner.stream('first', {
+      memory: { resource: 'post-wait-user', thread: 'post-wait-thread' },
+    });
+    const second = runner.stream('second', {
+      memory: { resource: 'post-wait-user', thread: 'post-wait-thread' },
+    });
+    await nextTick();
+    expect(streamCalls).toBe(0);
+
+    finishActive();
+    await activeCompletion;
+    await waitForCondition(() => streamCalls === 1);
+    await nextTick();
+    expect(streamCalls).toBe(1);
+
+    const firstOutput = await first;
+    const firstText = firstOutput.text;
+    finishFirstWaiter();
+    await expect(firstText).resolves.toBe('response 1');
+    await waitForCondition(() => streamCalls === 2);
+
+    const secondOutput = await second;
+    await expect(secondOutput.text).resolves.toBe('response 2');
+  });
+
+  it('drains accepted queued signals before releasing waiters after async completion publish', async () => {
+    const runtime = agentThreadStreamRuntime;
+    const pubsub = new BlockingRunCompletedPubSub();
+    let finishActive!: () => void;
+    const activeFinished = new Promise<void>(resolve => {
+      finishActive = resolve;
+    });
+    let finishQueued!: () => void;
+    const queuedFinished = new Promise<void>(resolve => {
+      finishQueued = resolve;
+    });
+    const ownerCalls: string[] = [];
+    const competitorCalls: string[] = [];
+    const callOrder: string[] = [];
+    const owner = new Agent({
+      id: 'completion-drain-agent',
+      name: 'Completion Drain Owner',
+      instructions: 'Test',
+      model: new MockLanguageModelV2({
+        doStream: async ({ prompt }) => {
+          callOrder.push('queued');
+          ownerCalls.push(JSON.stringify(prompt));
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+            stream: new ReadableStream({
+              async start(controller) {
+                controller.enqueue({ type: 'stream-start', warnings: [] });
+                controller.enqueue({
+                  type: 'response-metadata',
+                  id: 'queued-id',
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                });
+                controller.enqueue({ type: 'text-start', id: 'queued-text' });
+                controller.enqueue({ type: 'text-delta', id: 'queued-text', delta: 'queued response' });
+                await queuedFinished;
+                controller.enqueue({ type: 'text-end', id: 'queued-text' });
+                controller.enqueue({
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                });
+                controller.close();
+              },
+            }),
+          };
+        },
+      }),
+    });
+    const competitor = new Agent({
+      id: 'completion-drain-agent',
+      name: 'Completion Drain Competitor',
+      instructions: 'Test',
+      model: new MockLanguageModelV2({
+        doStream: async ({ prompt }) => {
+          callOrder.push('competitor');
+          competitorCalls.push(JSON.stringify(prompt));
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'competitor-id', modelId: 'mock-model-id', timestamp: new Date(0) },
+              { type: 'text-start', id: 'competitor-text' },
+              { type: 'text-delta', id: 'competitor-text', delta: 'competitor response' },
+              { type: 'text-end', id: 'competitor-text' },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              },
+            ]),
+          };
+        },
+      }),
+    });
+
+    const completion = runtime.registerRun(
+      owner as any,
+      {
+        runId: 'completion-drain-active-run',
+        status: 'running',
+        fullStream: (async function* () {})(),
+        _waitUntilFinished: () => activeFinished,
+      } as any,
+      {
+        runId: 'completion-drain-active-run',
+        memory: { resource: 'completion-drain-user', thread: 'completion-drain-thread' },
+      } as any,
+      pubsub,
+    );
+    const queuedSignal = runtime.sendSignal(
+      owner as any,
+      { type: 'user-message', contents: 'queued signal' },
+      { resourceId: 'completion-drain-user', threadId: 'completion-drain-thread' },
+      pubsub,
+    );
+    expect(queuedSignal.accepted).toBe(true);
+
+    finishActive();
+    await waitForCondition(() => pubsub.sawRunCompleted);
+    const competitorStream = competitor.stream('competing stream', {
+      memory: { resource: 'completion-drain-user', thread: 'completion-drain-thread' },
+      _pubsub: pubsub,
+    } as any);
+    await nextTick();
+    expect(ownerCalls).toHaveLength(0);
+    expect(competitorCalls).toHaveLength(0);
+
+    pubsub.unblockRunCompleted();
+    await waitForCondition(() => ownerCalls.length === 1);
+    expect(JSON.stringify(ownerCalls)).toContain('queued signal');
+    expect(callOrder[0]).toBe('queued');
+
+    finishQueued();
+    await completion;
+    await expect(competitorStream.then(stream => stream.text)).resolves.toBe('competitor response');
+    expect(competitorCalls).toHaveLength(1);
+    expect(callOrder).toEqual(['queued', 'competitor']);
   });
 
   it('moves reservation waiters onto the registered run on setup success', async () => {
@@ -2359,6 +3218,36 @@ describe('Agent signals', () => {
     release?.();
     await waiter;
     expect(waiterResolved).toBe(true);
+  });
+
+  it('rejects registration when another agent owns the reservation', () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    runtime.reserveRun(
+      {
+        runId: 'reserved-owner-register-run',
+        memory: { resource: 'reserved-owner-register-user', thread: 'reserved-owner-register-thread' },
+      } as any,
+      pubsub,
+      'owner-agent',
+    );
+
+    expect(() =>
+      runtime.registerRun(
+        { id: 'different-agent' } as any,
+        {
+          runId: 'reserved-owner-register-run',
+          status: 'running',
+          fullStream: (async function* () {})(),
+          _waitUntilFinished: () => new Promise<void>(() => {}),
+        } as any,
+        {
+          runId: 'reserved-owner-register-run',
+          memory: { resource: 'reserved-owner-register-user', thread: 'reserved-owner-register-thread' },
+        } as any,
+        pubsub,
+      ),
+    ).toThrow('reserved by another agent');
   });
 
   it('cleans up a thread subscription and completes the iterator', async () => {

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -1,3 +1,4 @@
+import { MockLanguageModelV1 } from '@internal/ai-sdk-v4/test';
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -6,6 +7,7 @@ import { PubSub } from '../../events/pubsub';
 import type { EventCallback, SubscribeOptions } from '../../events/types';
 import { Mastra } from '../../mastra';
 import { MockMemory } from '../../memory/mock';
+import { MASTRA_RESOURCE_ID_KEY, MASTRA_THREAD_ID_KEY, RequestContext } from '../../request-context';
 import { Agent } from '../agent';
 import {
   createSignal,
@@ -651,6 +653,399 @@ describe('Agent signals', () => {
 
     expect(fork.getPubSub()).toBe(pubsub);
     expect(fork.hasOwnPubSub()).toBe(true);
+  });
+
+  it('keeps one PubSub for a stream run when the agent gets a PubSub during execution setup', async () => {
+    const swappedPubSub = new EventEmitterPubSub();
+    let markDefaultOptionsStarted!: () => void;
+    let releaseDefaultOptions!: () => void;
+    const defaultOptionsStarted = new Promise<void>(resolve => {
+      markDefaultOptionsStarted = resolve;
+    });
+    const defaultOptionsReleased = new Promise<void>(resolve => {
+      releaseDefaultOptions = resolve;
+    });
+    let releaseFirst!: () => void;
+    const firstFinished = new Promise<void>(resolve => {
+      releaseFirst = resolve;
+    });
+    let streamCount = 0;
+    const prompts: any[][] = [];
+
+    const runner = new Agent({
+      id: 'pubsub-snapshot-agent',
+      name: 'PubSub Snapshot Runner',
+      instructions: 'Test',
+      defaultOptions: async () => {
+        markDefaultOptionsStarted();
+        await defaultOptionsReleased;
+        return {};
+      },
+      model: new MockLanguageModelV2({
+        doStream: async ({ prompt }) => {
+          streamCount += 1;
+          const callIndex = streamCount;
+          prompts.push(prompt);
+          const responseText = callIndex === 1 ? 'first response' : 'signal response';
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+            stream: new ReadableStream({
+              async start(controller) {
+                controller.enqueue({ type: 'stream-start', warnings: [] });
+                controller.enqueue({
+                  type: 'response-metadata',
+                  id: `id-${callIndex}`,
+                  modelId: 'mock-model-id',
+                  timestamp: new Date(0),
+                });
+                controller.enqueue({ type: 'text-start', id: 'text-1' });
+                controller.enqueue({ type: 'text-delta', id: 'text-1', delta: responseText });
+                controller.enqueue({ type: 'text-end', id: 'text-1' });
+                if (callIndex === 1) {
+                  await firstFinished;
+                }
+                controller.enqueue({
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                });
+                controller.close();
+              },
+            }),
+          };
+        },
+      }),
+    });
+    const initialObserver = new Agent({
+      id: 'pubsub-snapshot-agent',
+      name: 'Initial PubSub Observer',
+      instructions: 'Test',
+      model: createTextStreamModel('initial observer response'),
+    });
+    const initialSubscription = await initialObserver.subscribeToThread({
+      threadId: 'pubsub-snapshot-thread',
+      resourceId: 'pubsub-snapshot-user',
+    });
+    const initialIterator = initialSubscription.stream[Symbol.asyncIterator]();
+    const initialNextRun = readNextRun(initialIterator);
+
+    const streamPromise = runner.stream('Hello', {
+      memory: { thread: 'pubsub-snapshot-thread', resource: 'pubsub-snapshot-user' },
+    });
+    await defaultOptionsStarted;
+    runner.__setPubSub(swappedPubSub);
+    const signalResult = await runner.sendSignal(
+      { type: 'user-message', contents: 'Hello while running' },
+      { resourceId: 'pubsub-snapshot-user', threadId: 'pubsub-snapshot-thread' },
+    );
+    expect(signalResult).toEqual(expect.objectContaining({ accepted: true }));
+    releaseDefaultOptions();
+
+    const stream = await streamPromise;
+    await expect(waitForActiveRun(initialSubscription)).resolves.toBe(stream.runId);
+    expect(runner.getRunOutput(stream.runId)).toBe(stream);
+    expect(signalResult).toEqual(expect.objectContaining({ accepted: true, runId: stream.runId }));
+
+    releaseFirst();
+    const initialRun = await Promise.race([
+      initialNextRun,
+      new Promise<'timeout'>(resolve => setTimeout(() => resolve('timeout'), 500)),
+    ]);
+    expect(initialRun).not.toBe('timeout');
+    expect(initialRun).toMatchObject({
+      value: { runId: stream.runId, text: 'first response' },
+      done: false,
+    });
+    await expect(stream.text).resolves.toBe('first response');
+    expect(JSON.stringify(prompts)).toContain('Hello while running');
+
+    initialSubscription.unsubscribe();
+  });
+
+  it('keeps one PubSub for a default idle wake signal when ifIdle options are omitted', async () => {
+    const swappedPubSub = new EventEmitterPubSub();
+    let markDefaultOptionsStarted!: () => void;
+    let releaseDefaultOptions!: () => void;
+    const defaultOptionsStarted = new Promise<void>(resolve => {
+      markDefaultOptionsStarted = resolve;
+    });
+    const defaultOptionsReleased = new Promise<void>(resolve => {
+      releaseDefaultOptions = resolve;
+    });
+
+    const runner = new Agent({
+      id: 'default-idle-wake-pubsub-agent',
+      name: 'Default Idle Wake PubSub Agent',
+      instructions: 'Test',
+      defaultOptions: async () => {
+        markDefaultOptionsStarted();
+        await defaultOptionsReleased;
+        return {};
+      },
+      model: createTextStreamModel('default idle wake response'),
+    });
+    const initialObserver = new Agent({
+      id: 'default-idle-wake-pubsub-agent',
+      name: 'Default Idle Wake Initial Observer',
+      instructions: 'Test',
+      model: createTextStreamModel('observer response'),
+    });
+    const initialSubscription = await initialObserver.subscribeToThread({
+      threadId: 'default-idle-wake-thread',
+      resourceId: 'default-idle-wake-user',
+    });
+    const initialNextRun = readNextRun(initialSubscription.stream[Symbol.asyncIterator]());
+
+    const signalResult = runner.sendSignal(
+      { type: 'user-message', contents: 'Wake without explicit ifIdle' },
+      { resourceId: 'default-idle-wake-user', threadId: 'default-idle-wake-thread' },
+    );
+    expect(signalResult.output).toBeDefined();
+    await defaultOptionsStarted;
+    runner.__setPubSub(swappedPubSub);
+    releaseDefaultOptions();
+
+    await expect(signalResult.output).resolves.toMatchObject({ runId: signalResult.runId });
+    const initialRun = await Promise.race([
+      initialNextRun,
+      new Promise<'timeout'>(resolve => setTimeout(() => resolve('timeout'), 500)),
+    ]);
+    expect(initialRun).not.toBe('timeout');
+    expect(initialRun).toMatchObject({
+      value: { runId: signalResult.runId, text: 'default idle wake response' },
+      done: false,
+    });
+
+    initialSubscription.unsubscribe();
+  });
+
+  it('tracks idle wake PubSub from ifIdle streamOptions memory when top-level thread target is omitted', async () => {
+    const swappedPubSub = new EventEmitterPubSub();
+    let markDefaultOptionsStarted!: () => void;
+    let releaseDefaultOptions!: () => void;
+    const defaultOptionsStarted = new Promise<void>(resolve => {
+      markDefaultOptionsStarted = resolve;
+    });
+    const defaultOptionsReleased = new Promise<void>(resolve => {
+      releaseDefaultOptions = resolve;
+    });
+
+    const runner = new Agent({
+      id: 'stream-options-idle-wake-pubsub-agent',
+      name: 'Stream Options Idle Wake PubSub Agent',
+      instructions: 'Test',
+      defaultOptions: async () => {
+        markDefaultOptionsStarted();
+        await defaultOptionsReleased;
+        return {};
+      },
+      model: createTextStreamModel('stream options idle wake response'),
+    });
+
+    const signalResult = runner.sendSignal(
+      { type: 'user-message', contents: 'Wake from streamOptions target' },
+      {
+        ifIdle: {
+          streamOptions: {
+            memory: { resource: 'stream-options-idle-wake-user', thread: 'stream-options-idle-wake-thread' },
+          },
+        },
+      } as any,
+    );
+    expect(signalResult.output).toBeDefined();
+    await defaultOptionsStarted;
+    runner.__setPubSub(swappedPubSub);
+    releaseDefaultOptions();
+
+    const output = await signalResult.output;
+    expect(output).toMatchObject({ runId: signalResult.runId });
+    expect(runner.getRunOutput(signalResult.runId!)).toBe(output);
+  });
+
+  it('honors an injected PubSub for streamUntilIdle when the agent PubSub changes', async () => {
+    const initialPubSub = new EventEmitterPubSub();
+    const swappedPubSub = new EventEmitterPubSub();
+    const runner = new Agent({
+      id: 'stream-until-idle-pubsub-agent',
+      name: 'Stream Until Idle PubSub Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('stream until idle response'),
+    });
+    runner.__setPubSub(swappedPubSub);
+
+    const observer = new Agent({
+      id: 'stream-until-idle-pubsub-agent',
+      name: 'Stream Until Idle PubSub Observer',
+      instructions: 'Test',
+      model: createTextStreamModel('observer response'),
+    });
+    observer.__setPubSub(initialPubSub);
+    const subscription = await observer.subscribeToThread({
+      threadId: 'stream-until-idle-thread',
+      resourceId: 'stream-until-idle-user',
+    });
+    const nextRun = readNextRun(subscription.stream[Symbol.asyncIterator]());
+
+    const stream = await runner.streamUntilIdle('Hello', {
+      memory: { thread: 'stream-until-idle-thread', resource: 'stream-until-idle-user' },
+      _pubsub: initialPubSub,
+    } as any);
+
+    await expect(stream.text).resolves.toBe('stream until idle response');
+    await expect(nextRun).resolves.toMatchObject({
+      value: { runId: stream.runId, text: 'stream until idle response' },
+      done: false,
+    });
+
+    subscription.unsubscribe();
+  });
+
+  it('re-reserves a pre-default stream when default options change the request-context thread target', async () => {
+    let markDefaultOptionsStarted!: () => void;
+    let releaseDefaultOptions!: () => void;
+    const defaultOptionsStarted = new Promise<void>(resolve => {
+      markDefaultOptionsStarted = resolve;
+    });
+    const defaultOptionsReleased = new Promise<void>(resolve => {
+      releaseDefaultOptions = resolve;
+    });
+    const requestContext = new RequestContext();
+    requestContext.set(MASTRA_RESOURCE_ID_KEY, 'default-context-user');
+    requestContext.set(MASTRA_THREAD_ID_KEY, 'default-context-thread');
+
+    const runner = new Agent({
+      id: 'default-context-reservation-agent',
+      name: 'Default Context Reservation Agent',
+      instructions: 'Test',
+      defaultOptions: async () => {
+        markDefaultOptionsStarted();
+        await defaultOptionsReleased;
+        return { requestContext };
+      },
+      model: createTextStreamModel('default context response'),
+    });
+    const observer = new Agent({
+      id: 'default-context-reservation-agent',
+      name: 'Default Context Reservation Observer',
+      instructions: 'Test',
+      model: createTextStreamModel('observer response'),
+    });
+    const subscription = await observer.subscribeToThread({
+      threadId: 'default-context-thread',
+      resourceId: 'default-context-user',
+    });
+    const nextRun = readNextRun(subscription.stream[Symbol.asyncIterator]());
+
+    const streamPromise = runner.stream('Hello', {
+      memory: { thread: 'explicit-before-default-thread', resource: 'explicit-before-default-user' },
+    });
+    await defaultOptionsStarted;
+    releaseDefaultOptions();
+
+    const stream = await streamPromise;
+    await expect(nextRun).resolves.toMatchObject({
+      value: { runId: stream.runId, text: 'default context response' },
+      done: false,
+    });
+
+    subscription.unsubscribe();
+  });
+
+  it('forgets a re-reserved PubSub mapping when stream setup fails before preparation', async () => {
+    const swappedPubSub = new EventEmitterPubSub();
+    let useUnsupportedModel = true;
+    const requestContext = new RequestContext();
+    requestContext.set(MASTRA_RESOURCE_ID_KEY, 'failed-rereserve-context-user');
+    requestContext.set(MASTRA_THREAD_ID_KEY, 'failed-rereserve-context-thread');
+    const unsupportedModel = new MockLanguageModelV1({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop',
+        usage: { promptTokens: 1, completionTokens: 1 },
+        text: 'unsupported',
+      }),
+      doStream: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        stream: convertArrayToReadableStream([]),
+      }),
+    });
+    const supportedModel = createTextStreamModel('post failure response');
+
+    const runner = new Agent({
+      id: 'failed-rereserve-pubsub-agent',
+      name: 'Failed Rereserve PubSub Agent',
+      instructions: 'Test',
+      defaultOptions: async () => ({ requestContext }),
+      model: () => (useUnsupportedModel ? unsupportedModel : supportedModel),
+    });
+
+    await expect(
+      runner.stream('Hello', {
+        memory: { thread: 'failed-rereserve-original-thread', resource: 'failed-rereserve-original-user' },
+      }),
+    ).rejects.toThrow('not compatible with stream()');
+
+    useUnsupportedModel = false;
+    runner.__setPubSub(swappedPubSub);
+    const subscription = await runner.subscribeToThread({
+      threadId: 'failed-rereserve-context-thread',
+      resourceId: 'failed-rereserve-context-user',
+    });
+    const nextRun = readNextRun(subscription.stream[Symbol.asyncIterator]());
+    const stream = await runner.stream('Hello again', {
+      memory: { thread: 'failed-rereserve-context-thread', resource: 'failed-rereserve-context-user' },
+    });
+
+    await expect(stream.text).resolves.toBe('post failure response');
+    const observedRun = await Promise.race([
+      nextRun,
+      new Promise<'timeout'>(resolve => setTimeout(() => resolve('timeout'), 500)),
+    ]);
+    expect(observedRun).not.toBe('timeout');
+    expect(observedRun).toMatchObject({
+      value: { runId: stream.runId, text: 'post failure response' },
+      done: false,
+    });
+
+    subscription.unsubscribe();
+  });
+
+  it('reserves request-context scoped streams while default options are pending', async () => {
+    let markDefaultOptionsStarted!: () => void;
+    let releaseDefaultOptions!: () => void;
+    const defaultOptionsStarted = new Promise<void>(resolve => {
+      markDefaultOptionsStarted = resolve;
+    });
+    const defaultOptionsReleased = new Promise<void>(resolve => {
+      releaseDefaultOptions = resolve;
+    });
+    const requestContext = new RequestContext();
+    requestContext.set(MASTRA_RESOURCE_ID_KEY, 'request-context-reserved-user');
+    requestContext.set(MASTRA_THREAD_ID_KEY, 'request-context-reserved-thread');
+
+    const runner = new Agent({
+      id: 'request-context-reserved-agent',
+      name: 'Request Context Reserved Agent',
+      instructions: 'Test',
+      defaultOptions: async () => {
+        markDefaultOptionsStarted();
+        await defaultOptionsReleased;
+        return {};
+      },
+      model: createTextStreamModel('request context reserved response'),
+    });
+
+    const streamPromise = runner.stream('Hello', { requestContext });
+    await defaultOptionsStarted;
+    const signalResult = runner.sendSignal(
+      { type: 'user-message', contents: 'Hello while request-context stream is starting' },
+      { resourceId: 'request-context-reserved-user', threadId: 'request-context-reserved-thread' },
+    );
+    releaseDefaultOptions();
+
+    const stream = await streamPromise;
+    expect(signalResult).toEqual(expect.objectContaining({ accepted: true, runId: stream.runId }));
   });
 
   it('supports cross-instance thread subscriptions through the Mastra runtime', async () => {
@@ -1310,6 +1705,660 @@ describe('Agent signals', () => {
     });
 
     subscription.unsubscribe();
+  });
+
+  it('runs idle wake rejection cleanup when a queued idle stream fails', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    let finishActive!: () => void;
+    const activeFinished = new Promise<void>(resolve => {
+      finishActive = resolve;
+    });
+
+    const completion = runtime.registerRun(
+      { id: 'active-agent' } as any,
+      {
+        runId: 'active-run',
+        status: 'running',
+        _waitUntilFinished: () => activeFinished,
+      } as any,
+      {
+        runId: 'active-run',
+        memory: { resource: 'queued-failure-user', thread: 'queued-failure-thread' },
+      } as any,
+    );
+    const cleanup = vi.fn();
+    const stream = vi.fn(async () => {
+      throw new Error('queued idle stream failed');
+    });
+
+    const result = runtime.sendSignal(
+      { id: 'queued-idle-agent', stream } as any,
+      { type: 'user-message', contents: 'queued wake' },
+      {
+        resourceId: 'queued-failure-user',
+        threadId: 'queued-failure-thread',
+        ifIdle: {
+          streamOptions: { memory: { resource: 'queued-failure-user', thread: 'queued-failure-thread' } },
+          _onThreadStreamRunRejected: cleanup,
+        } as any,
+      },
+    );
+
+    expect(result.output).toBeUndefined();
+    expect(cleanup).not.toHaveBeenCalled();
+
+    finishActive();
+    await completion;
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(stream).toHaveBeenCalledWith(
+      expect.objectContaining({ contents: 'queued wake' }),
+      expect.objectContaining({
+        runId: result.runId,
+        memory: { resource: 'queued-failure-user', thread: 'queued-failure-thread' },
+      }),
+    );
+  });
+
+  it('wakes reservation waiters when a queued idle stream fails', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    let finishActive!: () => void;
+    const activeFinished = new Promise<void>(resolve => {
+      finishActive = resolve;
+    });
+    let rejectStream!: (error: Error) => void;
+
+    const completion = runtime.registerRun(
+      { id: 'active-agent' } as any,
+      {
+        runId: 'active-run',
+        status: 'running',
+        _waitUntilFinished: () => activeFinished,
+      } as any,
+      {
+        runId: 'active-run',
+        memory: { resource: 'queued-waiter-user', thread: 'queued-waiter-thread' },
+      } as any,
+    );
+    const stream = vi.fn(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectStream = reject;
+        }),
+    );
+
+    runtime.sendSignal(
+      { id: 'queued-idle-agent', stream } as any,
+      { type: 'user-message', contents: 'queued wake' },
+      {
+        resourceId: 'queued-waiter-user',
+        threadId: 'queued-waiter-thread',
+        ifIdle: {
+          streamOptions: { memory: { resource: 'queued-waiter-user', thread: 'queued-waiter-thread' } },
+        } as any,
+      },
+    );
+
+    finishActive();
+    await nextTick();
+    expect(stream).toHaveBeenCalledTimes(1);
+
+    let waiterResolved = false;
+    const waiter = runtime
+      .waitForCrossAgentThreadRun(
+        { id: 'other-agent' } as any,
+        {
+          runId: 'other-run',
+          memory: { resource: 'queued-waiter-user', thread: 'queued-waiter-thread' },
+        } as any,
+      )
+      .then(() => {
+        waiterResolved = true;
+      });
+    await nextTick();
+    expect(waiterResolved).toBe(false);
+
+    rejectStream(new Error('queued idle stream failed'));
+    await completion;
+    await waiter;
+    expect(waiterResolved).toBe(true);
+  });
+
+  it('wakes reservation waiters when an immediate idle stream fails', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    let rejectStream!: (error: Error) => void;
+    const stream = vi.fn(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectStream = reject;
+        }),
+    );
+
+    const result = runtime.sendSignal(
+      { id: 'immediate-idle-agent', stream } as any,
+      { type: 'user-message', contents: 'immediate wake' },
+      {
+        resourceId: 'immediate-waiter-user',
+        threadId: 'immediate-waiter-thread',
+        ifIdle: {
+          streamOptions: { memory: { resource: 'immediate-waiter-user', thread: 'immediate-waiter-thread' } },
+        } as any,
+      },
+    );
+    expect(stream).toHaveBeenCalledTimes(1);
+
+    let waiterResolved = false;
+    const waiter = runtime
+      .waitForCrossAgentThreadRun(
+        { id: 'other-agent' } as any,
+        {
+          runId: 'other-run',
+          memory: { resource: 'immediate-waiter-user', thread: 'immediate-waiter-thread' },
+        } as any,
+      )
+      .then(() => {
+        waiterResolved = true;
+      });
+    await nextTick();
+    expect(waiterResolved).toBe(false);
+
+    rejectStream(new Error('immediate idle stream failed'));
+    await expect(result.output).rejects.toThrow('immediate idle stream failed');
+    await waiter;
+    expect(waiterResolved).toBe(true);
+  });
+
+  it('wakes waiters and drops queued signals when a reserved setup run is released', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    const streamOptions = {
+      runId: 'reserved-setup-run',
+      memory: { resource: 'reserved-setup-user', thread: 'reserved-setup-thread' },
+    } as any;
+    const release = runtime.reserveRun(streamOptions, pubsub);
+    expect(release).toBeDefined();
+
+    let waiterResolved = false;
+    const waiter = runtime
+      .waitForCrossAgentThreadRun(
+        { id: 'other-agent' } as any,
+        {
+          runId: 'reserved-setup-run',
+          memory: { resource: 'reserved-setup-user', thread: 'reserved-setup-thread' },
+        } as any,
+        pubsub,
+      )
+      .then(() => {
+        waiterResolved = true;
+      });
+    await nextTick();
+    expect(waiterResolved).toBe(false);
+
+    const signalResult = runtime.sendSignal(
+      { id: 'reserved-agent' } as any,
+      { type: 'user-message', contents: 'stale setup signal' },
+      {
+        resourceId: 'reserved-setup-user',
+        threadId: 'reserved-setup-thread',
+      },
+      pubsub,
+    );
+    expect(signalResult).toEqual(expect.objectContaining({ runId: 'reserved-setup-run' }));
+
+    release!();
+    await waiter;
+    expect(waiterResolved).toBe(true);
+
+    const laterRelease = runtime.reserveRun(
+      {
+        runId: 'later-run',
+        memory: { resource: 'reserved-setup-user', thread: 'reserved-setup-thread' },
+      } as any,
+      pubsub,
+    );
+    expect(laterRelease).toBeDefined();
+    expect(runtime.drainPendingSignals('later-run', pubsub)).toEqual([]);
+    const laterSignal = runtime.sendSignal(
+      { id: 'reserved-agent' } as any,
+      { type: 'user-message', contents: 'successor signal' },
+      {
+        resourceId: 'reserved-setup-user',
+        threadId: 'reserved-setup-thread',
+      },
+      pubsub,
+    );
+    expect(laterSignal).toEqual(expect.objectContaining({ runId: 'later-run' }));
+    expect(runtime.drainPendingSignals('later-run', pubsub)).toHaveLength(1);
+    laterRelease!();
+  });
+
+  it('does not overwrite an existing run reservation with a reused run id', () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    const release = runtime.reserveRun(
+      {
+        runId: 'reused-reserved-run',
+        memory: { resource: 'first-reservation-user', thread: 'first-reservation-thread' },
+      } as any,
+      pubsub,
+    );
+
+    expect(release).toBeDefined();
+    expect(() =>
+      runtime.reserveRun(
+        {
+          runId: 'reused-reserved-run',
+          memory: { resource: 'first-reservation-user', thread: 'first-reservation-thread' },
+        } as any,
+        pubsub,
+      ),
+    ).toThrow('already reserved');
+    expect(() =>
+      runtime.reserveRun(
+        {
+          runId: 'reused-reserved-run',
+          memory: { resource: 'second-reservation-user', thread: 'second-reservation-thread' },
+        } as any,
+        pubsub,
+      ),
+    ).toThrow('already reserved for another thread');
+    expect(runtime.abortThread({ resourceId: 'second-reservation-user', threadId: 'second-reservation-thread' }, pubsub))
+      .toBe(false);
+    expect(runtime.abortThread({ resourceId: 'first-reservation-user', threadId: 'first-reservation-thread' }, pubsub))
+      .toBe(true);
+  });
+
+  it('rejects duplicate queued idle run ids before either idle wake starts', () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    const stream = vi.fn(async () => ({
+      runId: 'queued-duplicate-idle-run',
+      status: 'running',
+      fullStream: (async function* () {})(),
+      _waitUntilFinished: async () => {},
+    }));
+
+    runtime.registerRun(
+      { id: 'active-agent' } as any,
+      {
+        runId: 'active-before-queued-duplicate',
+        status: 'running',
+        _waitUntilFinished: () => new Promise<any>(() => {}),
+      } as any,
+      {
+        runId: 'active-before-queued-duplicate',
+        memory: { resource: 'queued-duplicate-user', thread: 'queued-duplicate-thread' },
+      } as any,
+      pubsub,
+    );
+
+    const target = {
+      runId: 'queued-duplicate-idle-run',
+      resourceId: 'queued-duplicate-user',
+      threadId: 'queued-duplicate-thread',
+      ifIdle: {
+        streamOptions: { memory: { resource: 'queued-duplicate-user', thread: 'queued-duplicate-thread' } },
+      },
+    } as any;
+
+    expect(
+      runtime.sendSignal(
+        { id: 'queued-duplicate-agent', stream } as any,
+        { type: 'user-message', contents: 'first queued idle' },
+        target,
+        pubsub,
+      ),
+    ).toEqual(expect.objectContaining({ accepted: true, runId: 'queued-duplicate-idle-run' }));
+    expect(() =>
+      runtime.sendSignal(
+        { id: 'queued-duplicate-agent', stream } as any,
+        { type: 'user-message', contents: 'second queued idle' },
+        target,
+        pubsub,
+      ),
+    ).toThrow('already reserved');
+    expect(() =>
+      runtime.reserveRun(
+        {
+          runId: 'queued-duplicate-idle-run',
+          memory: { resource: 'queued-duplicate-user', thread: 'queued-duplicate-thread' },
+        } as any,
+        pubsub,
+      ),
+    ).toThrow('already reserved');
+    expect(stream).not.toHaveBeenCalled();
+  });
+
+  it('clears caller-signal idempotency when a queued idle run is aborted', () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    const stream = vi.fn(async () => ({
+      runId: 'unused-queued-idempotency-run',
+      status: 'running',
+      fullStream: (async function* () {})(),
+      _waitUntilFinished: async () => {},
+    }));
+
+    runtime.registerRun(
+      { id: 'active-agent' } as any,
+      {
+        runId: 'active-before-queued-idempotency',
+        status: 'running',
+        _waitUntilFinished: () => new Promise<any>(() => {}),
+      } as any,
+      {
+        runId: 'active-before-queued-idempotency',
+        memory: { resource: 'queued-idempotency-user', thread: 'queued-idempotency-thread' },
+      } as any,
+      pubsub,
+    );
+
+    const target = {
+      resourceId: 'queued-idempotency-user',
+      threadId: 'queued-idempotency-thread',
+      ifIdle: {
+        streamOptions: { memory: { resource: 'queued-idempotency-user', thread: 'queued-idempotency-thread' } },
+      },
+    } as any;
+    const signal = { id: 'caller-signal-id', type: 'user-message', contents: 'retry queued idle' } as any;
+
+    const first = runtime.sendSignal({ id: 'queued-idempotency-agent', stream } as any, signal, target, pubsub);
+    expect(runtime.abortRun(first.runId, pubsub)).toBe(true);
+    const second = runtime.sendSignal({ id: 'queued-idempotency-agent', stream } as any, signal, target, pubsub);
+
+    expect(second.runId).not.toBe(first.runId);
+    expect(stream).not.toHaveBeenCalled();
+  });
+
+  it('aborts a reserved setup run before stream preparation', () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    runtime.reserveRun(
+      {
+        runId: 'reserved-abort-run',
+        memory: { resource: 'reserved-abort-user', thread: 'reserved-abort-thread' },
+      } as any,
+      pubsub,
+    );
+
+    expect(runtime.abortRun('reserved-abort-run', pubsub)).toBe(true);
+    const prepared = runtime.prepareRunOptions(
+      {
+        runId: 'reserved-abort-run',
+        memory: { resource: 'reserved-abort-user', thread: 'reserved-abort-thread' },
+      } as any,
+      pubsub,
+    );
+    expect(prepared.abortSignal?.aborted).toBe(true);
+  });
+
+  it('starts a queued idle wake when a reserved setup run is aborted', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    runtime.reserveRun(
+      {
+        runId: 'reserved-abort-with-idle-run',
+        memory: { resource: 'reserved-abort-idle-user', thread: 'reserved-abort-idle-thread' },
+      } as any,
+      pubsub,
+      'reserved-agent',
+    );
+    const stream = vi.fn(async () => ({
+      runId: 'queued-idle-after-abort-run',
+      status: 'running',
+      fullStream: (async function* () {})(),
+      _waitUntilFinished: async () => {},
+    }));
+
+    const result = runtime.sendSignal(
+      { id: 'queued-idle-after-abort-agent', stream } as any,
+      { type: 'user-message', contents: 'wake after abort' },
+      {
+        resourceId: 'reserved-abort-idle-user',
+        threadId: 'reserved-abort-idle-thread',
+        ifIdle: {
+          streamOptions: { memory: { resource: 'reserved-abort-idle-user', thread: 'reserved-abort-idle-thread' } },
+        } as any,
+      },
+      pubsub,
+    );
+    expect(result).toEqual(expect.objectContaining({ runId: expect.any(String) }));
+    expect(stream).not.toHaveBeenCalled();
+
+    expect(runtime.abortRun('reserved-abort-with-idle-run', pubsub)).toBe(true);
+    await nextTick();
+    expect(stream).toHaveBeenCalledWith(
+      expect.objectContaining({ contents: 'wake after abort' }),
+      expect.objectContaining({
+        runId: result.runId,
+        memory: { resource: 'reserved-abort-idle-user', thread: 'reserved-abort-idle-thread' },
+      }),
+    );
+  });
+
+  it('drops queued signals when a prepared run is aborted', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    let finishActive!: () => void;
+    const activeFinished = new Promise<void>(resolve => {
+      finishActive = resolve;
+    });
+
+    const completion = runtime.registerRun(
+      { id: 'active-agent' } as any,
+      {
+        runId: 'prepared-abort-run',
+        status: 'running',
+        fullStream: (async function* () {})(),
+        _waitUntilFinished: () => activeFinished,
+      } as any,
+      {
+        runId: 'prepared-abort-run',
+        memory: { resource: 'prepared-abort-user', thread: 'prepared-abort-thread' },
+      } as any,
+      pubsub,
+    );
+
+    const signalResult = runtime.sendSignal(
+      { id: 'active-agent' } as any,
+      { type: 'user-message', contents: 'stale prepared signal' },
+      {
+        runId: 'prepared-abort-run',
+      },
+      pubsub,
+    );
+    expect(signalResult).toEqual(expect.objectContaining({ runId: 'prepared-abort-run' }));
+
+    expect(runtime.abortRun('prepared-abort-run', pubsub)).toBe(true);
+    expect(() =>
+      runtime.sendSignal(
+        { id: 'active-agent' } as any,
+        { type: 'user-message', contents: 'post-abort stale signal' },
+        {
+          runId: 'prepared-abort-run',
+        },
+        pubsub,
+      ),
+    ).toThrow('has been aborted');
+    finishActive();
+    await completion;
+
+    runtime.reserveRun(
+      {
+        runId: 'prepared-abort-successor-run',
+        memory: { resource: 'prepared-abort-user', thread: 'prepared-abort-thread' },
+      } as any,
+      pubsub,
+    );
+    expect(runtime.drainPendingSignals('prepared-abort-successor-run', pubsub)).toEqual([]);
+  });
+
+  it('rejects duplicate registered run ids on the same thread', () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    const streamOptions = {
+      runId: 'duplicate-registered-run',
+      memory: { resource: 'duplicate-registered-user', thread: 'duplicate-registered-thread' },
+    } as any;
+
+    runtime.registerRun(
+      { id: 'active-agent' } as any,
+      {
+        runId: 'duplicate-registered-run',
+        status: 'running',
+        fullStream: (async function* () {})(),
+        _waitUntilFinished: () => new Promise<void>(() => {}),
+      } as any,
+      streamOptions,
+      pubsub,
+    );
+
+    expect(() =>
+      runtime.registerRun(
+        { id: 'active-agent' } as any,
+        {
+          runId: 'duplicate-registered-run',
+          status: 'running',
+          fullStream: (async function* () {})(),
+          _waitUntilFinished: () => new Promise<void>(() => {}),
+        } as any,
+        streamOptions,
+        pubsub,
+      ),
+    ).toThrow('already registered');
+  });
+
+  it('moves reservation waiters onto the registered run on setup success', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    runtime.reserveRun(
+      {
+        runId: 'reserved-success-run',
+        memory: { resource: 'reserved-success-user', thread: 'reserved-success-thread' },
+      } as any,
+      pubsub,
+      'owner-agent',
+    );
+
+    let waiterResolved = false;
+    const waiter = runtime
+      .waitForCrossAgentThreadRun(
+        { id: 'other-agent' } as any,
+        {
+          runId: 'other-run',
+          memory: { resource: 'reserved-success-user', thread: 'reserved-success-thread' },
+        } as any,
+        pubsub,
+      )
+      .then(() => {
+        waiterResolved = true;
+      });
+    await nextTick();
+    expect(waiterResolved).toBe(false);
+
+    let finishActive!: () => void;
+    const activeFinished = new Promise<void>(resolve => {
+      finishActive = resolve;
+    });
+    const completion = runtime.registerRun(
+      { id: 'owner-agent' } as any,
+      {
+        runId: 'reserved-success-run',
+        status: 'running',
+        fullStream: (async function* () {})(),
+        _waitUntilFinished: () => activeFinished,
+      } as any,
+      {
+        runId: 'reserved-success-run',
+        memory: { resource: 'reserved-success-user', thread: 'reserved-success-thread' },
+      } as any,
+      pubsub,
+    );
+    await nextTick();
+    expect(waiterResolved).toBe(false);
+
+    finishActive();
+    await completion;
+    await waiter;
+    expect(waiterResolved).toBe(true);
+  });
+
+  it('does not treat matching run ids from another agent as its own reservation', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    let finishActive!: () => void;
+    const activeFinished = new Promise<void>(resolve => {
+      finishActive = resolve;
+    });
+
+    const completion = runtime.registerRun(
+      { id: 'owner-agent' } as any,
+      {
+        runId: 'shared-run-id',
+        status: 'running',
+        fullStream: (async function* () {})(),
+        _waitUntilFinished: () => activeFinished,
+      } as any,
+      {
+        runId: 'shared-run-id',
+        memory: { resource: 'run-id-collision-user', thread: 'run-id-collision-thread' },
+      } as any,
+      pubsub,
+    );
+
+    let waiterResolved = false;
+    const waiter = runtime
+      .waitForCrossAgentThreadRun(
+        { id: 'different-agent' } as any,
+        {
+          runId: 'shared-run-id',
+          memory: { resource: 'run-id-collision-user', thread: 'run-id-collision-thread' },
+        } as any,
+        pubsub,
+      )
+      .then(() => {
+        waiterResolved = true;
+      });
+    await nextTick();
+    expect(waiterResolved).toBe(false);
+
+    finishActive();
+    await completion;
+    await waiter;
+    expect(waiterResolved).toBe(true);
+  });
+
+  it('does not treat matching run ids from the same agent as its own reservation without ownership', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    const release = runtime.reserveRun(
+      {
+        runId: 'same-agent-shared-run-id',
+        memory: { resource: 'same-agent-collision-user', thread: 'same-agent-collision-thread' },
+      } as any,
+      pubsub,
+      'owner-agent',
+    );
+
+    let waiterResolved = false;
+    const waiter = runtime
+      .waitForCrossAgentThreadRun(
+        { id: 'owner-agent' } as any,
+        {
+          runId: 'same-agent-shared-run-id',
+          memory: { resource: 'same-agent-collision-user', thread: 'same-agent-collision-thread' },
+        } as any,
+        pubsub,
+      )
+      .then(() => {
+        waiterResolved = true;
+      });
+    await nextTick();
+    expect(waiterResolved).toBe(false);
+
+    release?.();
+    await waiter;
+    expect(waiterResolved).toBe(true);
   });
 
   it('cleans up a thread subscription and completes the iterator', async () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -105,7 +105,7 @@ import { SaveQueueManager } from './save-queue';
 import { isCreatedAgentSignal } from './signals';
 import { runStreamUntilIdle, runResumeStreamUntilIdle } from './stream-until-idle';
 import type { SubAgent } from './subagent';
-import { agentThreadStreamRuntime } from './thread-stream-runtime';
+import { agentThreadStreamRuntime, defaultAgentThreadPubSub } from './thread-stream-runtime';
 import { TripWire } from './trip-wire';
 import type {
   AgentConfig,
@@ -343,6 +343,8 @@ export class Agent<
    * close if they're still the active one.
    */
   #activeStreamUntilIdle = new Map<string, () => void>();
+  #threadStreamPubSubsByRunId = new Map<string, PubSub>();
+  #threadStreamPubSubsByThreadKey = new Map<string, { runId: string; pubsub: PubSub }>();
   readonly #options?: AgentCreateOptions;
   #legacyHandler?: AgentLegacyHandler;
   #config: AgentConfig<TAgentId, TTools, TOutput, TRequestContext>;
@@ -544,6 +546,134 @@ export class Agent<
 
   getPubSub() {
     return this.#pubsub ?? this.#mastra?.pubsub;
+  }
+
+  #getThreadTarget(options?: { memory?: AgentExecutionOptionsBase<any>['memory']; requestContext?: RequestContext }) {
+    const thread = options?.memory?.thread;
+    const threadId =
+      (options?.requestContext?.get(MASTRA_THREAD_ID_KEY) as string | undefined) ||
+      (typeof thread === 'string' ? thread : thread?.id);
+    const resourceId =
+      (options?.requestContext?.get(MASTRA_RESOURCE_ID_KEY) as string | undefined) || options?.memory?.resource;
+
+    return { threadId, resourceId };
+  }
+
+  #hasExplicitThreadMemory(options?: {
+    memory?: AgentExecutionOptionsBase<any>['memory'];
+    requestContext?: RequestContext;
+  }) {
+    const contextThreadId = options?.requestContext?.get(MASTRA_THREAD_ID_KEY);
+    const contextResourceId = options?.requestContext?.get(MASTRA_RESOURCE_ID_KEY);
+    if (typeof contextThreadId === 'string' && typeof contextResourceId === 'string') return true;
+
+    const thread = options?.memory?.thread;
+    const hasThreadId =
+      typeof thread === 'string' || (thread !== null && typeof thread === 'object' && typeof thread.id === 'string');
+    return hasThreadId && options?.memory?.resource !== undefined;
+  }
+
+  #sameThreadTarget(
+    left: { threadId?: string; resourceId?: string },
+    right: { threadId?: string; resourceId?: string },
+  ) {
+    return left.threadId === right.threadId && left.resourceId === right.resourceId;
+  }
+
+  #generateStreamRunId(target?: { threadId?: string; resourceId?: string }) {
+    return (
+      this.#mastra?.generateId({
+        idType: 'run',
+        source: 'agent',
+        entityId: this.id,
+        threadId: target?.threadId,
+        resourceId: target?.resourceId,
+      }) ?? randomUUID()
+    );
+  }
+
+  #threadStreamKey(resourceId: string | undefined, threadId: string): string {
+    return [resourceId ?? '', threadId].join('\u0000');
+  }
+
+  #rememberThreadStreamPubSub(
+    options: AgentExecutionOptionsBase<any> & { runId?: string },
+    pubsub: PubSub,
+  ) {
+    const { threadId, resourceId } = this.#getThreadTarget(options);
+    if (!options.runId) return;
+
+    this.#threadStreamPubSubsByRunId.set(options.runId, pubsub);
+    if (!threadId) return;
+
+    this.#threadStreamPubSubsByThreadKey.set(this.#threadStreamKey(resourceId, threadId), {
+      runId: options.runId,
+      pubsub,
+    });
+  }
+
+  #forgetThreadStreamPubSub(options: AgentExecutionOptionsBase<any> & { runId?: string }) {
+    const { threadId, resourceId } = this.#getThreadTarget(options);
+    if (!options.runId) return;
+
+    this.#forgetThreadStreamPubSubForTarget({
+      runId: options.runId,
+      resourceId,
+      threadId,
+    });
+  }
+
+  #rememberThreadStreamPubSubForTarget(
+    options: { runId?: string; resourceId?: string; threadId?: string },
+    pubsub: PubSub,
+  ) {
+    if (!options.runId) return;
+
+    this.#threadStreamPubSubsByRunId.set(options.runId, pubsub);
+    if (!options.threadId) return;
+
+    this.#threadStreamPubSubsByThreadKey.set(this.#threadStreamKey(options.resourceId, options.threadId), {
+      runId: options.runId,
+      pubsub,
+    });
+  }
+
+  #forgetThreadStreamPubSubForTarget(options: { runId?: string; resourceId?: string; threadId?: string }) {
+    if (!options.runId) return;
+
+    this.#threadStreamPubSubsByRunId.delete(options.runId);
+    if (!options.threadId) return;
+
+    const key = this.#threadStreamKey(options.resourceId, options.threadId);
+    if (this.#threadStreamPubSubsByThreadKey.get(key)?.runId === options.runId) {
+      this.#threadStreamPubSubsByThreadKey.delete(key);
+    }
+  }
+
+  #trackThreadStreamPubSub(
+    output: MastraModelOutput<any>,
+    options: AgentExecutionOptionsBase<any> & { runId?: string },
+    completion?: Promise<void>,
+  ) {
+    void (completion ?? output._waitUntilFinished())
+      .finally(() => this.#forgetThreadStreamPubSub(options))
+      .catch(() => {});
+  }
+
+  #resolveThreadStreamPubSub(options: {
+    runId?: string;
+    threadId?: string;
+    resourceId?: string;
+  }): PubSub | undefined {
+    if (options.runId) {
+      const runPubSub = this.#threadStreamPubSubsByRunId.get(options.runId);
+      if (runPubSub) return runPubSub;
+    }
+    if (options.threadId) {
+      return this.#threadStreamPubSubsByThreadKey.get(this.#threadStreamKey(options.resourceId, options.threadId))
+        ?.pubsub;
+    }
+    return undefined;
   }
 
   hasOwnPubSub(): boolean {
@@ -5357,7 +5487,7 @@ export class Agent<
    * Executes the agent call, handling tools, memory, and streaming.
    * @internal
    */
-  async #execute<OUTPUT>({ methodType, resumeContext, ...options }: InnerAgentExecutionOptions<OUTPUT>) {
+  async #execute<OUTPUT>({ methodType, resumeContext, _pubsub, ...options }: InnerAgentExecutionOptions<OUTPUT>) {
     const existingSnapshot = resumeContext?.snapshot;
     let snapshotMemoryInfo;
     if (existingSnapshot) {
@@ -5601,6 +5731,8 @@ export class Agent<
         this.#mastra?.getToolPayloadTransform?.() ?? (this.#mastra as any)?.getToolPayloadProjection?.(),
       );
 
+    const pubsub = _pubsub ?? this.getPubSub() ?? defaultAgentThreadPubSub;
+
     // Create the workflow with all necessary context
     const executionWorkflow = createPrepareStreamWorkflow<OUTPUT>({
       capabilities: capabilities as AgentCapabilities,
@@ -5631,7 +5763,7 @@ export class Agent<
             agentBackgroundConfig: this.#backgroundTasks,
           }),
       skipBgTaskWait: options._skipBgTaskWait,
-      drainPendingSignals: runId => agentThreadStreamRuntime.drainPendingSignals(runId, this.getPubSub()),
+      drainPendingSignals: runId => agentThreadStreamRuntime.drainPendingSignals(runId, pubsub),
       initialSignalEchoes: initialSignalEchoesForRun,
     });
 
@@ -6198,7 +6330,10 @@ export class Agent<
    * `sendSignal()` returns a `runId` to drain events from the run's output.
    */
   getRunOutput<OUTPUT = TOutput>(runId: string): MastraModelOutput<OUTPUT> | undefined {
-    return agentThreadStreamRuntime.getRunOutput<OUTPUT>(runId, this.getPubSub());
+    return agentThreadStreamRuntime.getRunOutput<OUTPUT>(
+      runId,
+      this.#resolveThreadStreamPubSub({ runId }) ?? this.getPubSub(),
+    );
   }
 
   /**
@@ -6211,7 +6346,10 @@ export class Agent<
    * their own completion deadline (e.g. tied to the per-run completion path).
    */
   waitForRunOutput<OUTPUT = TOutput>(runId: string): Promise<MastraModelOutput<OUTPUT>> {
-    return agentThreadStreamRuntime.waitForRunOutput<OUTPUT>(runId, this.getPubSub());
+    return agentThreadStreamRuntime.waitForRunOutput<OUTPUT>(
+      runId,
+      this.#resolveThreadStreamPubSub({ runId }) ?? this.getPubSub(),
+    );
   }
 
   /**
@@ -6220,26 +6358,84 @@ export class Agent<
   async subscribeToThread<OUTPUT = TOutput>(
     options: AgentSubscribeToThreadOptions,
   ): Promise<AgentThreadSubscription<OUTPUT>> {
+    const pubsub = this.#resolveThreadStreamPubSub(options) ?? this.getPubSub();
     return agentThreadStreamRuntime.subscribeToThread<OUTPUT>(
       this as Agent<any, any, any, any>,
       options,
-      this.getPubSub(),
+      pubsub,
     );
   }
 
   abortThreadStream(options: AgentSubscribeToThreadOptions): boolean {
-    return agentThreadStreamRuntime.abortThread(options, this.getPubSub());
+    return agentThreadStreamRuntime.abortThread(
+      options,
+      this.#resolveThreadStreamPubSub(options) ?? this.getPubSub(),
+    );
   }
 
   abortRunStream(runId: string): boolean {
-    return agentThreadStreamRuntime.abortRun(runId, this.getPubSub());
+    return agentThreadStreamRuntime.abortRun(runId, this.#resolveThreadStreamPubSub({ runId }) ?? this.getPubSub());
   }
 
   /**
    * @experimental Agent signals are experimental and may change in a future release.
    */
   sendSignal<OUTPUT = TOutput>(signal: AgentSignal, target: SendAgentSignalOptions<OUTPUT>): SendAgentSignalResult {
-    return agentThreadStreamRuntime.sendSignal(this as Agent<any, any, any, any>, signal, target, this.getPubSub());
+    const pubsub = this.#resolveThreadStreamPubSub(target) ?? this.getPubSub() ?? defaultAgentThreadPubSub;
+    const idleStreamTarget = this.#getThreadTarget(target.ifIdle?.streamOptions);
+    const idleResourceId = idleStreamTarget.resourceId ?? target.resourceId;
+    const idleThreadId = idleStreamTarget.threadId ?? target.threadId;
+    const previousThreadRunId = idleThreadId
+      ? this.#threadStreamPubSubsByThreadKey.get(this.#threadStreamKey(idleResourceId, idleThreadId))?.runId
+      : undefined;
+    const shouldSnapshotIdleWake =
+      Boolean(idleThreadId) && target.ifIdle?.behavior !== 'persist' && target.ifIdle?.behavior !== 'discard';
+    const shouldTrackIdleWake = shouldSnapshotIdleWake && (Boolean(target.ifIdle) || !target.runId);
+    let acceptedIdleRunId: string | undefined;
+    const forgetAcceptedIdleRunPubSub = () => {
+      if (!acceptedIdleRunId || !idleThreadId) return;
+      this.#forgetThreadStreamPubSubForTarget({
+        runId: acceptedIdleRunId,
+        resourceId: idleResourceId,
+        threadId: idleThreadId,
+      });
+    };
+    const signalTarget = shouldSnapshotIdleWake
+      ? ({
+          ...target,
+          resourceId: target.resourceId ?? idleResourceId,
+          threadId: target.threadId ?? idleThreadId,
+          ifIdle: {
+            ...(target.ifIdle ?? {}),
+            _attachToReservedRun: !target.ifIdle,
+            _onThreadStreamRunRejected: forgetAcceptedIdleRunPubSub,
+            streamOptions: {
+              ...(target.ifIdle?.streamOptions ?? {}),
+              _pubsub: pubsub,
+            },
+          },
+        } as unknown as SendAgentSignalOptions<OUTPUT>)
+      : target;
+
+    const result = agentThreadStreamRuntime.sendSignal(
+      this as Agent<any, any, any, any>,
+      signal,
+      signalTarget,
+      pubsub,
+    );
+    acceptedIdleRunId = result.runId;
+    if (shouldTrackIdleWake && idleThreadId && (result.output || result.runId !== previousThreadRunId)) {
+      this.#rememberThreadStreamPubSubForTarget(
+        {
+          runId: result.runId,
+          resourceId: idleResourceId,
+          threadId: idleThreadId,
+        },
+        pubsub,
+      );
+      void result.output?.catch(forgetAcceptedIdleRunPubSub);
+    }
+    return result;
   }
 
   async stream<
@@ -6270,123 +6466,201 @@ export class Agent<
       structuredOutput?: PublicStructuredOutputOptions<any>;
     } & { model?: DynamicArgument<MastraModelConfig> },
   ): Promise<MastraModelOutput<OUTPUT>> {
-    // Validate request context if schema is provided
-    await this.#validateRequestContext(streamOptions?.requestContext);
+    const pubsub =
+      ((streamOptions as any)?._pubsub as PubSub | undefined) ?? this.getPubSub() ?? defaultAgentThreadPubSub;
+    const streamOptionsBase = { ...(streamOptions ?? {}) };
+    const initialThreadTarget = this.#getThreadTarget(streamOptionsBase);
+    const canReserveBeforeDefaults = this.#hasExplicitThreadMemory(streamOptionsBase);
+    const callerProvidedRunId = Boolean(streamOptionsBase.runId);
+    const streamOptionsWithRunId = {
+      ...streamOptionsBase,
+      runId:
+        streamOptionsBase.runId ?? (canReserveBeforeDefaults ? this.#generateStreamRunId(initialThreadTarget) : undefined),
+    };
+    let releaseReservedRun = canReserveBeforeDefaults
+      ? agentThreadStreamRuntime.reserveRun(streamOptionsWithRunId as AgentExecutionOptions<OUTPUT>, pubsub, this.id)
+      : undefined;
+    let reservedThreadTarget = releaseReservedRun ? initialThreadTarget : undefined;
+    let ownsReservation =
+      Boolean(releaseReservedRun) || Boolean((streamOptionsWithRunId as any)._threadRunReservationOwner);
+    let trackedThreadStreamPubSubTarget: { runId?: string; resourceId?: string; threadId?: string } | undefined;
+    if (ownsReservation) {
+      this.#rememberThreadStreamPubSub(streamOptionsWithRunId, pubsub);
+      trackedThreadStreamPubSubTarget = {
+        runId: streamOptionsWithRunId.runId,
+        resourceId: initialThreadTarget.resourceId,
+        threadId: initialThreadTarget.threadId,
+      };
+    }
+    let preparedOptionsWithPubSub: (AgentExecutionOptionsBase<any> & { runId?: string; _pubsub: PubSub }) | undefined;
 
-    // FGA authorization check
-    const streamFgaProvider = this.#mastra?.getServer()?.fga;
-    if (streamFgaProvider) {
-      const user = streamOptions?.requestContext?.get('user');
-      if (user) {
-        const { checkFGA } = await import('../auth/ee/fga-check');
-        await checkFGA({
-          fgaProvider: streamFgaProvider,
-          user,
-          resource: { type: 'agent', id: this.id },
-          permission: MastraFGAPermissions.AGENTS_EXECUTE,
+    try {
+      // Validate request context if schema is provided
+      await this.#validateRequestContext(streamOptionsWithRunId.requestContext);
+
+      // FGA authorization check
+      const streamFgaProvider = this.#mastra?.getServer()?.fga;
+      if (streamFgaProvider) {
+        const user = streamOptionsWithRunId.requestContext?.get('user');
+        if (user) {
+          const { checkFGA } = await import('../auth/ee/fga-check');
+          await checkFGA({
+            fgaProvider: streamFgaProvider,
+            user,
+            resource: { type: 'agent', id: this.id },
+            permission: MastraFGAPermissions.AGENTS_EXECUTE,
+          });
+        }
+      }
+
+      const defaultOptions = await this.getDefaultOptions({
+        requestContext: streamOptionsWithRunId.requestContext,
+      });
+      const mergedOptions = deepMerge(
+        defaultOptions as Record<string, unknown>,
+        streamOptionsWithRunId as Record<string, unknown>,
+      ) as AgentExecutionOptions<OUTPUT> & { model?: DynamicArgument<MastraModelConfig> };
+      const mergedThreadTarget = this.#getThreadTarget(mergedOptions);
+      if (!mergedOptions.runId) {
+        mergedOptions.runId = this.#generateStreamRunId(mergedThreadTarget);
+      }
+      if (ownsReservation && reservedThreadTarget) {
+        if (!this.#sameThreadTarget(reservedThreadTarget, mergedThreadTarget)) {
+          this.#forgetThreadStreamPubSubForTarget({
+            runId: streamOptionsWithRunId.runId,
+            resourceId: reservedThreadTarget.resourceId,
+            threadId: reservedThreadTarget.threadId,
+          });
+          releaseReservedRun?.();
+          releaseReservedRun = undefined;
+          ownsReservation = false;
+          reservedThreadTarget = undefined;
+          trackedThreadStreamPubSubTarget = undefined;
+          if (!callerProvidedRunId) {
+            mergedOptions.runId = this.#generateStreamRunId(mergedThreadTarget);
+          }
+        }
+      }
+      if (!ownsReservation) {
+        releaseReservedRun = agentThreadStreamRuntime.reserveRun(mergedOptions, pubsub, this.id);
+        ownsReservation = Boolean(releaseReservedRun);
+        if (ownsReservation) {
+          reservedThreadTarget = this.#getThreadTarget(mergedOptions);
+          this.#rememberThreadStreamPubSub(mergedOptions, pubsub);
+          trackedThreadStreamPubSubTarget = {
+            runId: mergedOptions.runId,
+            resourceId: reservedThreadTarget.resourceId,
+            threadId: reservedThreadTarget.threadId,
+          };
+        }
+      }
+
+      const llm = await this.getLLM({
+        requestContext: mergedOptions.requestContext,
+        model: mergedOptions.model as DynamicArgument<MastraModelConfig, TRequestContext> | undefined,
+      });
+
+      const modelInfo = llm.getModel();
+
+      if (!isSupportedLanguageModel(modelInfo)) {
+        const modelId = modelInfo.modelId || 'unknown';
+        const provider = modelInfo.provider || 'unknown';
+        const specVersion = modelInfo.specificationVersion;
+
+        throw new MastraError({
+          id: 'AGENT_STREAM_V1_MODEL_NOT_SUPPORTED',
+          domain: ErrorDomain.AGENT,
+          category: ErrorCategory.USER,
+          text:
+            specVersion === 'v1'
+              ? `Agent "${this.name}" is using AI SDK v4 model (${provider}:${modelId}) which is not compatible with stream(). Please use AI SDK v5+ models or call the streamLegacy() method instead. See https://mastra.ai/en/docs/streaming/overview for more information.`
+              : `Agent "${this.name}" has a model (${provider}:${modelId}) with unrecognized specificationVersion "${specVersion}". Supported versions: v1 (legacy), v2 (AI SDK v5), v3 (AI SDK v6). Please ensure your AI SDK provider is compatible with this version of Mastra.`,
+          details: {
+            agentName: this.name,
+            modelId,
+            provider,
+            specificationVersion: specVersion,
+          },
         });
       }
-    }
 
-    const defaultOptions = await this.getDefaultOptions({
-      requestContext: streamOptions?.requestContext,
-    });
-    const mergedOptions = deepMerge(
-      defaultOptions as Record<string, unknown>,
-      (streamOptions ?? {}) as Record<string, unknown>,
-    ) as AgentExecutionOptions<OUTPUT> & { model?: DynamicArgument<MastraModelConfig> };
+      await agentThreadStreamRuntime.waitForCrossAgentThreadRun(
+        this as Agent<any, any, any, any>,
+        mergedOptions,
+        pubsub,
+        ownsReservation,
+      );
+      const preparedOptions = agentThreadStreamRuntime.prepareRunOptions(mergedOptions, pubsub);
+      preparedOptionsWithPubSub = { ...preparedOptions, _pubsub: pubsub };
+      this.#rememberThreadStreamPubSub(preparedOptionsWithPubSub, pubsub);
+      trackedThreadStreamPubSubTarget = {
+        runId: preparedOptionsWithPubSub.runId,
+        ...this.#getThreadTarget(preparedOptionsWithPubSub),
+      };
 
-    const llm = await this.getLLM({
-      requestContext: mergedOptions.requestContext,
-      model: mergedOptions.model as DynamicArgument<MastraModelConfig, TRequestContext> | undefined,
-    });
+      const executeOptions = {
+        ...preparedOptionsWithPubSub,
+        structuredOutput: mergedOptions.structuredOutput
+          ? {
+              ...mergedOptions.structuredOutput,
+              // Convert PublicSchema to StandardSchemaWithJSON at API boundary
+              // This follows the same pattern as Tool/Workflow constructors
+              schema: toStandardSchema(mergedOptions.structuredOutput.schema),
+            }
+          : undefined,
+        messages,
+        methodType: 'stream',
+        _pubsub: pubsub,
+        // Use agent's maxProcessorRetries as default, allow options to override
+        maxProcessorRetries: mergedOptions.maxProcessorRetries ?? this.#maxProcessorRetries,
+      } as unknown as InnerAgentExecutionOptions<OUTPUT>;
 
-    const modelInfo = llm.getModel();
+      const result = await this.#execute(executeOptions);
 
-    if (!isSupportedLanguageModel(modelInfo)) {
-      const modelId = modelInfo.modelId || 'unknown';
-      const provider = modelInfo.provider || 'unknown';
-      const specVersion = modelInfo.specificationVersion;
-
-      throw new MastraError({
-        id: 'AGENT_STREAM_V1_MODEL_NOT_SUPPORTED',
-        domain: ErrorDomain.AGENT,
-        category: ErrorCategory.USER,
-        text:
-          specVersion === 'v1'
-            ? `Agent "${this.name}" is using AI SDK v4 model (${provider}:${modelId}) which is not compatible with stream(). Please use AI SDK v5+ models or call the streamLegacy() method instead. See https://mastra.ai/en/docs/streaming/overview for more information.`
-            : `Agent "${this.name}" has a model (${provider}:${modelId}) with unrecognized specificationVersion "${specVersion}". Supported versions: v1 (legacy), v2 (AI SDK v5), v3 (AI SDK v6). Please ensure your AI SDK provider is compatible with this version of Mastra.`,
-        details: {
-          agentName: this.name,
-          modelId,
-          provider,
-          specificationVersion: specVersion,
-        },
-      });
-    }
-
-    await agentThreadStreamRuntime.waitForCrossAgentThreadRun(
-      this as Agent<any, any, any, any>,
-      mergedOptions,
-      this.getPubSub(),
-    );
-
-    mergedOptions.runId ??=
-      this.#mastra?.generateId({
-        idType: 'run',
-        source: 'agent',
-        entityId: this.id,
-      }) ?? randomUUID();
-    const preparedOptions = agentThreadStreamRuntime.prepareRunOptions(mergedOptions, this.getPubSub());
-
-    const executeOptions = {
-      ...preparedOptions,
-      structuredOutput: mergedOptions.structuredOutput
-        ? {
-            ...mergedOptions.structuredOutput,
-            // Convert PublicSchema to StandardSchemaWithJSON at API boundary
-            // This follows the same pattern as Tool/Workflow constructors
-            schema: toStandardSchema(mergedOptions.structuredOutput.schema),
-          }
-        : undefined,
-      messages,
-      methodType: 'stream',
-      // Use agent's maxProcessorRetries as default, allow options to override
-      maxProcessorRetries: mergedOptions.maxProcessorRetries ?? this.#maxProcessorRetries,
-    } as unknown as InnerAgentExecutionOptions<OUTPUT>;
-
-    const result = await this.#execute(executeOptions);
-
-    if (result.status !== 'success') {
-      if (result.status === 'failed') {
-        throw new MastraError(
-          {
-            id: 'AGENT_STREAM_FAILED',
-            domain: ErrorDomain.AGENT,
-            category: ErrorCategory.USER,
-          },
-          // pass original error to preserve stack trace
-          result.error,
-        );
+      if (result.status !== 'success') {
+        this.#forgetThreadStreamPubSub(preparedOptionsWithPubSub);
+        releaseReservedRun?.();
+        if (result.status === 'failed') {
+          throw new MastraError(
+            {
+              id: 'AGENT_STREAM_FAILED',
+              domain: ErrorDomain.AGENT,
+              category: ErrorCategory.USER,
+            },
+            // pass original error to preserve stack trace
+            result.error,
+          );
+        }
+        throw new MastraError({
+          id: 'AGENT_STREAM_UNKNOWN_ERROR',
+          domain: ErrorDomain.AGENT,
+          category: ErrorCategory.USER,
+          text: 'An unknown error occurred while streaming',
+        });
       }
-      throw new MastraError({
-        id: 'AGENT_STREAM_UNKNOWN_ERROR',
-        domain: ErrorDomain.AGENT,
-        category: ErrorCategory.USER,
-        text: 'An unknown error occurred while streaming',
-      });
+
+      const output = result.result as MastraModelOutput<OUTPUT>;
+
+      const completion = agentThreadStreamRuntime.registerRun(
+        this as Agent<any, any, any, any>,
+        output,
+        preparedOptionsWithPubSub as unknown as AgentExecutionOptions<OUTPUT>,
+        pubsub,
+      );
+      this.#trackThreadStreamPubSub(output, preparedOptionsWithPubSub, completion);
+
+      return output;
+    } catch (error) {
+      if (preparedOptionsWithPubSub) {
+        this.#forgetThreadStreamPubSub(preparedOptionsWithPubSub);
+      } else if (trackedThreadStreamPubSubTarget) {
+        this.#forgetThreadStreamPubSubForTarget(trackedThreadStreamPubSubTarget);
+      } else {
+        this.#forgetThreadStreamPubSub(streamOptionsWithRunId);
+      }
+      releaseReservedRun?.();
+      throw error;
     }
-
-    const output = result.result as MastraModelOutput<OUTPUT>;
-
-    agentThreadStreamRuntime.registerRun(
-      this as Agent<any, any, any, any>,
-      output,
-      preparedOptions as AgentExecutionOptions<OUTPUT>,
-      this.getPubSub(),
-    );
-
-    return output;
   }
 
   /**
@@ -6460,7 +6734,10 @@ export class Agent<
       maxIdleMs?: number;
     } & { model?: DynamicArgument<MastraModelConfig> },
   ): Promise<MastraModelOutput<OUTPUT>> {
-    return runStreamUntilIdle<OUTPUT>(this, messages, streamOptions, {
+    const pubsub =
+      (streamOptions as { _pubsub?: PubSub } | undefined)?._pubsub ?? this.getPubSub() ?? defaultAgentThreadPubSub;
+    const streamOptionsWithPubSub = { ...(streamOptions ?? {}), _pubsub: pubsub };
+    return runStreamUntilIdle<OUTPUT>(this, messages, streamOptionsWithPubSub, {
       activeStreams: this.#activeStreamUntilIdle,
       bgManager: this.#mastra?.backgroundTaskManager,
     });
@@ -6525,7 +6802,10 @@ export class Agent<
       maxIdleMs?: number;
     } & { model?: DynamicArgument<MastraModelConfig> },
   ): Promise<MastraModelOutput<OUTPUT>> {
-    return runResumeStreamUntilIdle<OUTPUT>(this, resumeData, streamOptions, {
+    const pubsub =
+      (streamOptions as { _pubsub?: PubSub } | undefined)?._pubsub ?? this.getPubSub() ?? defaultAgentThreadPubSub;
+    const streamOptionsWithPubSub = { ...(streamOptions ?? {}), _pubsub: pubsub };
+    return runResumeStreamUntilIdle<OUTPUT>(this, resumeData, streamOptionsWithPubSub, {
       activeStreams: this.#activeStreamUntilIdle,
       bgManager: this.#mastra?.backgroundTaskManager,
     });
@@ -6575,97 +6855,182 @@ export class Agent<
       toolCallId?: string;
     } & { model?: DynamicArgument<MastraModelConfig> },
   ): Promise<MastraModelOutput<OUTPUT>> {
-    const defaultOptions = await this.getDefaultOptions({
-      requestContext: streamOptions?.requestContext,
-    });
-
-    let mergedStreamOptions = deepMerge(
-      defaultOptions as Record<string, unknown>,
-      (streamOptions ?? {}) as Record<string, unknown>,
-    ) as typeof defaultOptions & { model?: DynamicArgument<MastraModelConfig> };
-
-    const llm = await this.getLLM({
-      requestContext: mergedStreamOptions.requestContext,
-      model: mergedStreamOptions.model as DynamicArgument<MastraModelConfig, TRequestContext> | undefined,
-    });
-
-    if (!isSupportedLanguageModel(llm.getModel())) {
-      const modelInfo = llm.getModel();
-      const specVersion = modelInfo.specificationVersion;
-      throw new MastraError({
-        id: 'AGENT_STREAM_V1_MODEL_NOT_SUPPORTED',
-        domain: ErrorDomain.AGENT,
-        category: ErrorCategory.USER,
-        text:
-          specVersion === 'v1'
-            ? 'V1 models are not supported for resumeStream. Please use streamLegacy instead.'
-            : `Model has unrecognized specificationVersion "${specVersion}". Supported versions: v1 (legacy), v2 (AI SDK v5), v3 (AI SDK v6). Please ensure your AI SDK provider is compatible with this version of Mastra.`,
-        details: {
-          modelId: modelInfo.modelId,
-          provider: modelInfo.provider,
-          specificationVersion: specVersion,
-        },
-      });
+    const pubsub =
+      ((streamOptions as any)?._pubsub as PubSub | undefined) ?? this.getPubSub() ?? defaultAgentThreadPubSub;
+    const streamOptionsWithPubSub = streamOptions ? { ...streamOptions, _pubsub: pubsub } : undefined;
+    const initialThreadTarget = this.#getThreadTarget(streamOptionsWithPubSub);
+    const canReserveBeforeDefaults = this.#hasExplicitThreadMemory(streamOptionsWithPubSub);
+    let releaseReservedRun = streamOptionsWithPubSub && canReserveBeforeDefaults
+      ? agentThreadStreamRuntime.reserveRun(
+          streamOptionsWithPubSub as unknown as AgentExecutionOptions<OUTPUT>,
+          pubsub,
+          this.id,
+        )
+      : undefined;
+    let reservedThreadTarget = releaseReservedRun ? initialThreadTarget : undefined;
+    let ownsReservation =
+      Boolean(releaseReservedRun) || Boolean((streamOptionsWithPubSub as any)?._threadRunReservationOwner);
+    let trackedThreadStreamPubSubTarget: { runId?: string; resourceId?: string; threadId?: string } | undefined;
+    if (streamOptionsWithPubSub && ownsReservation) {
+      this.#rememberThreadStreamPubSub(streamOptionsWithPubSub, pubsub);
+      trackedThreadStreamPubSubTarget = {
+        runId: streamOptionsWithPubSub.runId,
+        resourceId: initialThreadTarget.resourceId,
+        threadId: initialThreadTarget.threadId,
+      };
     }
+    let preparedOptionsWithPubSub: (AgentExecutionOptionsBase<any> & { runId?: string; _pubsub: PubSub }) | undefined;
 
-    const runId = streamOptions?.runId ?? '';
-    const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeStream' });
-    await agentThreadStreamRuntime.waitForCrossAgentThreadRun(
-      this as Agent<any, any, any, any>,
-      mergedStreamOptions as unknown as AgentExecutionOptions<OUTPUT>,
-      this.getPubSub(),
-    );
-    const preparedOptions = agentThreadStreamRuntime.prepareRunOptions(
-      mergedStreamOptions as unknown as AgentExecutionOptions<OUTPUT>,
-      this.getPubSub(),
-    );
+    try {
+      const defaultOptions = await this.getDefaultOptions({
+        requestContext: streamOptionsWithPubSub?.requestContext,
+      });
 
-    const result = await this.#execute({
-      ...preparedOptions,
-      structuredOutput: mergedStreamOptions.structuredOutput
-        ? {
-            ...mergedStreamOptions.structuredOutput,
-            schema: toStandardSchema(mergedStreamOptions.structuredOutput.schema),
-          }
-        : undefined,
-      messages: [],
-      resumeContext: {
-        resumeData,
-        snapshot: existingSnapshot,
-      },
-      methodType: 'stream',
-      // Use agent's maxProcessorRetries as default, allow options to override
-      maxProcessorRetries: mergedStreamOptions.maxProcessorRetries ?? this.#maxProcessorRetries,
-    } as unknown as InnerAgentExecutionOptions<OUTPUT>);
-
-    if (result.status !== 'success') {
-      if (result.status === 'failed') {
-        throw new MastraError(
-          {
-            id: 'AGENT_STREAM_FAILED',
-            domain: ErrorDomain.AGENT,
-            category: ErrorCategory.USER,
-          },
-          // pass original error to preserve stack trace
-          result.error,
-        );
+      let mergedStreamOptions = deepMerge(
+        defaultOptions as Record<string, unknown>,
+        (streamOptionsWithPubSub ?? {}) as Record<string, unknown>,
+      ) as typeof defaultOptions & { model?: DynamicArgument<MastraModelConfig> };
+      if (ownsReservation && reservedThreadTarget) {
+        const mergedThreadTarget = this.#getThreadTarget(mergedStreamOptions);
+        if (!this.#sameThreadTarget(reservedThreadTarget, mergedThreadTarget)) {
+          this.#forgetThreadStreamPubSubForTarget({
+            runId: streamOptionsWithPubSub?.runId,
+            resourceId: reservedThreadTarget.resourceId,
+            threadId: reservedThreadTarget.threadId,
+          });
+          releaseReservedRun?.();
+          releaseReservedRun = undefined;
+          ownsReservation = false;
+          reservedThreadTarget = undefined;
+          trackedThreadStreamPubSubTarget = undefined;
+        }
       }
-      throw new MastraError({
-        id: 'AGENT_STREAM_UNKNOWN_ERROR',
-        domain: ErrorDomain.AGENT,
-        category: ErrorCategory.USER,
-        text: 'An unknown error occurred while streaming',
+      if (!ownsReservation) {
+        releaseReservedRun = agentThreadStreamRuntime.reserveRun(
+          mergedStreamOptions as unknown as AgentExecutionOptions<OUTPUT>,
+          pubsub,
+          this.id,
+        );
+        ownsReservation = Boolean(releaseReservedRun);
+        if (ownsReservation) {
+          reservedThreadTarget = this.#getThreadTarget(mergedStreamOptions);
+          this.#rememberThreadStreamPubSub(mergedStreamOptions, pubsub);
+          trackedThreadStreamPubSubTarget = {
+            runId: (mergedStreamOptions as { runId?: string }).runId,
+            resourceId: reservedThreadTarget.resourceId,
+            threadId: reservedThreadTarget.threadId,
+          };
+        }
+      }
+
+      const llm = await this.getLLM({
+        requestContext: mergedStreamOptions.requestContext,
+        model: mergedStreamOptions.model as DynamicArgument<MastraModelConfig, TRequestContext> | undefined,
       });
+
+      if (!isSupportedLanguageModel(llm.getModel())) {
+        const modelInfo = llm.getModel();
+        const specVersion = modelInfo.specificationVersion;
+        throw new MastraError({
+          id: 'AGENT_STREAM_V1_MODEL_NOT_SUPPORTED',
+          domain: ErrorDomain.AGENT,
+          category: ErrorCategory.USER,
+          text:
+            specVersion === 'v1'
+              ? 'V1 models are not supported for resumeStream. Please use streamLegacy instead.'
+              : `Model has unrecognized specificationVersion "${specVersion}". Supported versions: v1 (legacy), v2 (AI SDK v5), v3 (AI SDK v6). Please ensure your AI SDK provider is compatible with this version of Mastra.`,
+          details: {
+            modelId: modelInfo.modelId,
+            provider: modelInfo.provider,
+            specificationVersion: specVersion,
+          },
+        });
+      }
+
+      const runId = streamOptionsWithPubSub?.runId ?? '';
+      const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeStream' });
+      await agentThreadStreamRuntime.waitForCrossAgentThreadRun(
+        this as Agent<any, any, any, any>,
+        mergedStreamOptions as unknown as AgentExecutionOptions<OUTPUT>,
+        pubsub,
+        ownsReservation,
+      );
+      const preparedOptions = agentThreadStreamRuntime.prepareRunOptions(
+        mergedStreamOptions as unknown as AgentExecutionOptions<OUTPUT>,
+        pubsub,
+      );
+      preparedOptionsWithPubSub = { ...preparedOptions, _pubsub: pubsub };
+      this.#rememberThreadStreamPubSub(preparedOptionsWithPubSub, pubsub);
+      trackedThreadStreamPubSubTarget = {
+        runId: preparedOptionsWithPubSub.runId,
+        ...this.#getThreadTarget(preparedOptionsWithPubSub),
+      };
+
+      const result = await this.#execute({
+        ...preparedOptionsWithPubSub,
+        structuredOutput: mergedStreamOptions.structuredOutput
+          ? {
+              ...mergedStreamOptions.structuredOutput,
+              schema: toStandardSchema(mergedStreamOptions.structuredOutput.schema),
+            }
+          : undefined,
+        messages: [],
+        resumeContext: {
+          resumeData,
+          snapshot: existingSnapshot,
+        },
+        methodType: 'stream',
+        _pubsub: pubsub,
+        // Use agent's maxProcessorRetries as default, allow options to override
+        maxProcessorRetries: mergedStreamOptions.maxProcessorRetries ?? this.#maxProcessorRetries,
+      } as unknown as InnerAgentExecutionOptions<OUTPUT>);
+
+      if (result.status !== 'success') {
+        this.#forgetThreadStreamPubSub(preparedOptionsWithPubSub);
+        releaseReservedRun?.();
+        if (result.status === 'failed') {
+          throw new MastraError(
+            {
+              id: 'AGENT_STREAM_FAILED',
+              domain: ErrorDomain.AGENT,
+              category: ErrorCategory.USER,
+            },
+            // pass original error to preserve stack trace
+            result.error,
+          );
+        }
+        throw new MastraError({
+          id: 'AGENT_STREAM_UNKNOWN_ERROR',
+          domain: ErrorDomain.AGENT,
+          category: ErrorCategory.USER,
+          text: 'An unknown error occurred while streaming',
+        });
+      }
+
+      const completion = agentThreadStreamRuntime.registerRun(
+        this as Agent<any, any, any, any>,
+        result.result as unknown as MastraModelOutput<OUTPUT>,
+        preparedOptionsWithPubSub as unknown as AgentExecutionOptions<OUTPUT>,
+        pubsub,
+      );
+      this.#trackThreadStreamPubSub(
+        result.result as unknown as MastraModelOutput<OUTPUT>,
+        preparedOptionsWithPubSub,
+        completion,
+      );
+
+      return result.result as unknown as MastraModelOutput<OUTPUT>;
+    } catch (error) {
+      if (preparedOptionsWithPubSub) {
+        this.#forgetThreadStreamPubSub(preparedOptionsWithPubSub);
+      } else if (trackedThreadStreamPubSubTarget) {
+        this.#forgetThreadStreamPubSubForTarget(trackedThreadStreamPubSubTarget);
+      } else {
+        this.#forgetThreadStreamPubSub(streamOptionsWithPubSub ?? {});
+      }
+      releaseReservedRun?.();
+      throw error;
     }
-
-    agentThreadStreamRuntime.registerRun(
-      this as Agent<any, any, any, any>,
-      result.result as unknown as MastraModelOutput<OUTPUT>,
-      preparedOptions as AgentExecutionOptions<OUTPUT>,
-      this.getPubSub(),
-    );
-
-    return result.result as unknown as MastraModelOutput<OUTPUT>;
   }
 
   /**

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -563,8 +563,8 @@ export class Agent<
     memory?: AgentExecutionOptionsBase<any>['memory'];
     requestContext?: RequestContext;
   }) {
-    const { threadId, resourceId } = this.#getThreadTarget(options);
-    return typeof threadId === 'string' && resourceId !== undefined;
+    const { threadId } = this.#getThreadTarget(options);
+    return typeof threadId === 'string';
   }
 
   #sameThreadTarget(
@@ -5477,22 +5477,46 @@ export class Agent<
     return existingSnapshot;
   }
 
+  #getAgenticLoopSnapshotMemoryInfo(existingSnapshot: any): { threadId?: string; resourceId?: string } | undefined {
+    for (const key in existingSnapshot?.context) {
+      const step = existingSnapshot?.context[key];
+      if (step && step.status === 'suspended' && step.suspendPayload?.__streamState) {
+        return step.suspendPayload?.__streamState?.messageList?.memoryInfo;
+      }
+    }
+    return undefined;
+  }
+
+  #withSnapshotThreadTarget<T extends { memory?: AgentExecutionOptionsBase<any>['memory'] }>(
+    options: T | undefined,
+    snapshotMemoryInfo: { threadId?: string; resourceId?: string } | undefined,
+  ): T | undefined {
+    if (!snapshotMemoryInfo?.threadId && !snapshotMemoryInfo?.resourceId) return options;
+
+    const memory = options?.memory as ({ resource?: string; thread?: unknown } & Record<string, unknown>) | undefined;
+    const memoryPatch: Record<string, unknown> = {};
+    if (!memory?.resource && snapshotMemoryInfo.resourceId) memoryPatch.resource = snapshotMemoryInfo.resourceId;
+    if (!memory?.thread && snapshotMemoryInfo.threadId) memoryPatch.thread = snapshotMemoryInfo.threadId;
+    if (Object.keys(memoryPatch).length === 0) return options;
+
+    return {
+      ...(options ?? ({} as T)),
+      memory: {
+        ...(memory && typeof memory === 'object' ? memory : {}),
+        ...memoryPatch,
+      },
+    } as T;
+  }
+
   /**
    * Executes the agent call, handling tools, memory, and streaming.
    * @internal
    */
   async #execute<OUTPUT>({ methodType, resumeContext, _pubsub, ...options }: InnerAgentExecutionOptions<OUTPUT>) {
     const existingSnapshot = resumeContext?.snapshot;
-    let snapshotMemoryInfo;
-    if (existingSnapshot) {
-      for (const key in existingSnapshot?.context) {
-        const step = existingSnapshot?.context[key];
-        if (step && step.status === 'suspended' && step.suspendPayload?.__streamState) {
-          snapshotMemoryInfo = step.suspendPayload?.__streamState?.messageList?.memoryInfo;
-          break;
-        }
-      }
-    }
+    const snapshotMemoryInfo = existingSnapshot
+      ? this.#getAgenticLoopSnapshotMemoryInfo(existingSnapshot)
+      : undefined;
     const requestContext = options.requestContext || new RequestContext();
 
     // Build version overrides by merging: Mastra defaults < requestContext < call-site
@@ -6395,7 +6419,9 @@ export class Agent<
    * @experimental Agent signals are experimental and may change in a future release.
    */
   sendSignal<OUTPUT = TOutput>(signal: AgentSignal, target: SendAgentSignalOptions<OUTPUT>): SendAgentSignalResult {
-    const pubsub = this.#resolveThreadStreamPubSub(target) ?? this.getPubSub() ?? defaultAgentThreadPubSub;
+    const requestedIdlePubSub = (target.ifIdle?.streamOptions as { _pubsub?: PubSub } | undefined)?._pubsub;
+    const pubsub =
+      this.#resolveThreadStreamPubSub(target) ?? requestedIdlePubSub ?? this.getPubSub() ?? defaultAgentThreadPubSub;
     const idleStreamTarget = this.#getThreadTarget(target.ifIdle?.streamOptions);
     const idleResourceId = idleStreamTarget.resourceId ?? target.resourceId;
     const idleThreadId = idleStreamTarget.threadId ?? target.threadId;
@@ -6436,7 +6462,7 @@ export class Agent<
             _onThreadStreamRunRejected: forgetAcceptedIdleRunPubSub,
             streamOptions: {
               ...(target.ifIdle?.streamOptions ?? {}),
-              _pubsub: pubsub,
+              _pubsub: requestedIdlePubSub ?? pubsub,
             },
           },
         } as unknown as SendAgentSignalOptions<OUTPUT>)
@@ -6976,11 +7002,17 @@ export class Agent<
     const pubsub =
       ((streamOptions as any)?._pubsub as PubSub | undefined) ?? this.getPubSub() ?? defaultAgentThreadPubSub;
     const streamOptionsWithPubSub = streamOptions ? { ...streamOptions, _pubsub: pubsub } : undefined;
-    const initialThreadTarget = this.#getThreadTarget(streamOptionsWithPubSub);
-    const canReserveBeforeDefaults = this.#hasExplicitThreadMemory(streamOptionsWithPubSub);
+    const runId = streamOptionsWithPubSub?.runId ?? '';
+    const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeStream' });
+    const streamOptionsWithSnapshotTarget = this.#withSnapshotThreadTarget(
+      streamOptionsWithPubSub,
+      this.#getAgenticLoopSnapshotMemoryInfo(existingSnapshot),
+    );
+    const initialThreadTarget = this.#getThreadTarget(streamOptionsWithSnapshotTarget);
+    const canReserveBeforeDefaults = this.#hasExplicitThreadMemory(streamOptionsWithSnapshotTarget);
     let releaseReservedRun = streamOptionsWithPubSub && canReserveBeforeDefaults
       ? agentThreadStreamRuntime.reserveRun(
-          streamOptionsWithPubSub as unknown as AgentExecutionOptions<OUTPUT>,
+          streamOptionsWithSnapshotTarget as unknown as AgentExecutionOptions<OUTPUT>,
           pubsub,
           this.id,
         )
@@ -6989,10 +7021,10 @@ export class Agent<
     let ownsReservation =
       Boolean(releaseReservedRun) || Boolean((streamOptionsWithPubSub as any)?._threadRunReservationOwner);
     let trackedThreadStreamPubSubTarget: { runId?: string; resourceId?: string; threadId?: string } | undefined;
-    if (streamOptionsWithPubSub && ownsReservation) {
-      this.#rememberThreadStreamPubSub(streamOptionsWithPubSub, pubsub);
+    if (streamOptionsWithSnapshotTarget && ownsReservation) {
+      this.#rememberThreadStreamPubSub(streamOptionsWithSnapshotTarget, pubsub);
       trackedThreadStreamPubSubTarget = {
-        runId: streamOptionsWithPubSub.runId,
+        runId: streamOptionsWithSnapshotTarget.runId,
         resourceId: initialThreadTarget.resourceId,
         threadId: initialThreadTarget.threadId,
       };
@@ -7006,13 +7038,13 @@ export class Agent<
 
       let mergedStreamOptions = deepMerge(
         defaultOptions as Record<string, unknown>,
-        (streamOptionsWithPubSub ?? {}) as Record<string, unknown>,
+        (streamOptionsWithSnapshotTarget ?? {}) as Record<string, unknown>,
       ) as typeof defaultOptions & { model?: DynamicArgument<MastraModelConfig> };
       if (ownsReservation && reservedThreadTarget) {
         const mergedThreadTarget = this.#getThreadTarget(mergedStreamOptions);
         if (!this.#sameThreadTarget(reservedThreadTarget, mergedThreadTarget)) {
           const retargetedReservation = agentThreadStreamRuntime.retargetReservedRun(
-            streamOptionsWithPubSub?.runId,
+            streamOptionsWithSnapshotTarget?.runId,
             reservedThreadTarget,
             mergedThreadTarget,
             pubsub,
@@ -7020,7 +7052,7 @@ export class Agent<
           );
           if (retargetedReservation) {
             this.#forgetThreadStreamPubSubForTarget({
-              runId: streamOptionsWithPubSub?.runId,
+              runId: streamOptionsWithSnapshotTarget?.runId,
               resourceId: reservedThreadTarget.resourceId,
               threadId: reservedThreadTarget.threadId,
             });
@@ -7089,8 +7121,6 @@ export class Agent<
         });
       }
 
-      const runId = streamOptionsWithPubSub?.runId ?? '';
-      const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeStream' });
       await agentThreadStreamRuntime.waitForCrossAgentThreadRun(
         this as Agent<any, any, any, any>,
         mergedStreamOptions as unknown as AgentExecutionOptions<OUTPUT>,
@@ -7234,7 +7264,7 @@ export class Agent<
       } else if (trackedThreadStreamPubSubTarget) {
         this.#forgetThreadStreamPubSubForTarget(trackedThreadStreamPubSubTarget);
       } else {
-        this.#forgetThreadStreamPubSub(streamOptionsWithPubSub ?? {});
+        this.#forgetThreadStreamPubSub(streamOptionsWithSnapshotTarget ?? {});
       }
       releaseReservedRun?.();
       throw error;

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -563,14 +563,8 @@ export class Agent<
     memory?: AgentExecutionOptionsBase<any>['memory'];
     requestContext?: RequestContext;
   }) {
-    const contextThreadId = options?.requestContext?.get(MASTRA_THREAD_ID_KEY);
-    const contextResourceId = options?.requestContext?.get(MASTRA_RESOURCE_ID_KEY);
-    if (typeof contextThreadId === 'string' && typeof contextResourceId === 'string') return true;
-
-    const thread = options?.memory?.thread;
-    const hasThreadId =
-      typeof thread === 'string' || (thread !== null && typeof thread === 'object' && typeof thread.id === 'string');
-    return hasThreadId && options?.memory?.resource !== undefined;
+    const { threadId, resourceId } = this.#getThreadTarget(options);
+    return typeof threadId === 'string' && resourceId !== undefined;
   }
 
   #sameThreadTarget(
@@ -6320,7 +6314,23 @@ export class Agent<
     output: MastraModelOutput<OUTPUT>,
     streamOptions: AgentExecutionOptions<OUTPUT>,
   ): void {
-    agentThreadStreamRuntime.registerRun(this as Agent<any, any, any, any>, output, streamOptions, this.getPubSub());
+    const pubsub =
+      (streamOptions as { _pubsub?: PubSub })._pubsub ??
+      this.#resolveThreadStreamPubSub({
+        runId: output.runId,
+        ...this.#getThreadTarget(streamOptions),
+      }) ??
+      this.getPubSub() ??
+      defaultAgentThreadPubSub;
+    const streamOptionsWithRunId = { ...streamOptions, runId: output.runId };
+    const completion = agentThreadStreamRuntime.registerRun(
+      this as Agent<any, any, any, any>,
+      output,
+      streamOptionsWithRunId,
+      pubsub,
+    );
+    this.#rememberThreadStreamPubSub(streamOptionsWithRunId, pubsub);
+    this.#trackThreadStreamPubSub(output, streamOptionsWithRunId, completion);
   }
 
   /**
@@ -6342,13 +6352,17 @@ export class Agent<
    * registered). Pairs with `sendSignal()` to give callers a handle to the
    * output without polling `getRunOutput()` until it returns non-undefined.
    *
-   * The returned promise never rejects; callers are expected to enforce
-   * their own completion deadline (e.g. tied to the per-run completion path).
+   * The returned promise rejects if the run is rejected or aborted before it registers.
+   * Callers waiting on optional/admission paths should still enforce their own deadline.
    */
-  waitForRunOutput<OUTPUT = TOutput>(runId: string): Promise<MastraModelOutput<OUTPUT>> {
+  waitForRunOutput<OUTPUT = TOutput>(
+    runId: string,
+    options?: { abortSignal?: AbortSignal; signal?: AbortSignal },
+  ): Promise<MastraModelOutput<OUTPUT>> {
     return agentThreadStreamRuntime.waitForRunOutput<OUTPUT>(
       runId,
       this.#resolveThreadStreamPubSub({ runId }) ?? this.getPubSub(),
+      options?.abortSignal ?? options?.signal,
     );
   }
 
@@ -6385,20 +6399,31 @@ export class Agent<
     const idleStreamTarget = this.#getThreadTarget(target.ifIdle?.streamOptions);
     const idleResourceId = idleStreamTarget.resourceId ?? target.resourceId;
     const idleThreadId = idleStreamTarget.threadId ?? target.threadId;
-    const previousThreadRunId = idleThreadId
-      ? this.#threadStreamPubSubsByThreadKey.get(this.#threadStreamKey(idleResourceId, idleThreadId))?.runId
+    const idleThreadKey = idleThreadId ? this.#threadStreamKey(idleResourceId, idleThreadId) : undefined;
+    const previousThreadPubSubEntry = idleThreadKey
+      ? this.#threadStreamPubSubsByThreadKey.get(idleThreadKey)
       : undefined;
+    const previousThreadRunId = previousThreadPubSubEntry?.runId;
     const shouldSnapshotIdleWake =
       Boolean(idleThreadId) && target.ifIdle?.behavior !== 'persist' && target.ifIdle?.behavior !== 'discard';
     const shouldTrackIdleWake = shouldSnapshotIdleWake && (Boolean(target.ifIdle) || !target.runId);
     let acceptedIdleRunId: string | undefined;
     const forgetAcceptedIdleRunPubSub = () => {
-      if (!acceptedIdleRunId || !idleThreadId) return;
-      this.#forgetThreadStreamPubSubForTarget({
-        runId: acceptedIdleRunId,
-        resourceId: idleResourceId,
-        threadId: idleThreadId,
-      });
+      if (!acceptedIdleRunId) return;
+      const currentThreadPubSubEntry = idleThreadKey
+        ? this.#threadStreamPubSubsByThreadKey.get(idleThreadKey)
+        : undefined;
+      this.#threadStreamPubSubsByRunId.delete(acceptedIdleRunId);
+      if (!idleThreadKey || currentThreadPubSubEntry?.runId !== acceptedIdleRunId) return;
+      if (
+        previousThreadPubSubEntry &&
+        previousThreadPubSubEntry.runId !== acceptedIdleRunId &&
+        this.#threadStreamPubSubsByRunId.get(previousThreadPubSubEntry.runId) === previousThreadPubSubEntry.pubsub
+      ) {
+        this.#threadStreamPubSubsByThreadKey.set(idleThreadKey, previousThreadPubSubEntry);
+        return;
+      }
+      this.#threadStreamPubSubsByThreadKey.delete(idleThreadKey);
     };
     const signalTarget = shouldSnapshotIdleWake
       ? ({
@@ -6526,17 +6551,50 @@ export class Agent<
       }
       if (ownsReservation && reservedThreadTarget) {
         if (!this.#sameThreadTarget(reservedThreadTarget, mergedThreadTarget)) {
-          this.#forgetThreadStreamPubSubForTarget({
-            runId: streamOptionsWithRunId.runId,
-            resourceId: reservedThreadTarget.resourceId,
-            threadId: reservedThreadTarget.threadId,
-          });
-          releaseReservedRun?.();
-          releaseReservedRun = undefined;
-          ownsReservation = false;
-          reservedThreadTarget = undefined;
-          trackedThreadStreamPubSubTarget = undefined;
-          if (!callerProvidedRunId) {
+          const retargetedReservation = agentThreadStreamRuntime.retargetReservedRun(
+            streamOptionsWithRunId.runId,
+            reservedThreadTarget,
+            mergedThreadTarget,
+            pubsub,
+            this.id,
+          );
+          if (retargetedReservation) {
+            this.#forgetThreadStreamPubSubForTarget({
+              runId: streamOptionsWithRunId.runId,
+              resourceId: reservedThreadTarget.resourceId,
+              threadId: reservedThreadTarget.threadId,
+            });
+            releaseReservedRun = () =>
+              agentThreadStreamRuntime.releaseRunReservation(mergedOptions.runId, pubsub, {
+                cleanupPrepared: true,
+                clearAbort: true,
+                rejectOutputWaiters: true,
+              });
+            reservedThreadTarget = mergedThreadTarget;
+            this.#rememberThreadStreamPubSubForTarget(
+              {
+                runId: mergedOptions.runId,
+                resourceId: mergedThreadTarget.resourceId,
+                threadId: mergedThreadTarget.threadId,
+              },
+              pubsub,
+            );
+            trackedThreadStreamPubSubTarget = {
+              runId: mergedOptions.runId,
+              resourceId: mergedThreadTarget.resourceId,
+              threadId: mergedThreadTarget.threadId,
+            };
+          } else if (!callerProvidedRunId) {
+            this.#forgetThreadStreamPubSubForTarget({
+              runId: streamOptionsWithRunId.runId,
+              resourceId: reservedThreadTarget.resourceId,
+              threadId: reservedThreadTarget.threadId,
+            });
+            releaseReservedRun?.();
+            releaseReservedRun = undefined;
+            ownsReservation = false;
+            reservedThreadTarget = undefined;
+            trackedThreadStreamPubSubTarget = undefined;
             mergedOptions.runId = this.#generateStreamRunId(mergedThreadTarget);
           }
         }
@@ -6590,6 +6648,66 @@ export class Agent<
         pubsub,
         ownsReservation,
       );
+      while (!ownsReservation && this.#getThreadTarget(mergedOptions).threadId) {
+        releaseReservedRun = agentThreadStreamRuntime.reserveRun(mergedOptions, pubsub, this.id);
+        ownsReservation = Boolean(releaseReservedRun);
+        if (ownsReservation) {
+          reservedThreadTarget = this.#getThreadTarget(mergedOptions);
+          this.#rememberThreadStreamPubSub(mergedOptions, pubsub);
+          trackedThreadStreamPubSubTarget = {
+            runId: mergedOptions.runId,
+            resourceId: reservedThreadTarget.resourceId,
+            threadId: reservedThreadTarget.threadId,
+          };
+          break;
+        }
+        await agentThreadStreamRuntime.waitForCrossAgentThreadRun(
+          this as Agent<any, any, any, any>,
+          mergedOptions,
+          pubsub,
+          ownsReservation,
+        );
+      }
+      if (ownsReservation && reservedThreadTarget) {
+        const preparedThreadTarget = this.#getThreadTarget(mergedOptions);
+        if (!this.#sameThreadTarget(reservedThreadTarget, preparedThreadTarget)) {
+          const retargetedReservation = agentThreadStreamRuntime.retargetReservedRun(
+            mergedOptions.runId,
+            reservedThreadTarget,
+            preparedThreadTarget,
+            pubsub,
+            this.id,
+          );
+          if (!retargetedReservation) {
+            throw new Error(`Agent thread run id "${mergedOptions.runId}" could not be retargeted`);
+          }
+          this.#forgetThreadStreamPubSubForTarget({
+            runId: mergedOptions.runId,
+            resourceId: reservedThreadTarget.resourceId,
+            threadId: reservedThreadTarget.threadId,
+          });
+          releaseReservedRun = () =>
+            agentThreadStreamRuntime.releaseRunReservation(mergedOptions.runId, pubsub, {
+              cleanupPrepared: true,
+              clearAbort: true,
+              rejectOutputWaiters: true,
+            });
+          reservedThreadTarget = preparedThreadTarget;
+          this.#rememberThreadStreamPubSubForTarget(
+            {
+              runId: mergedOptions.runId,
+              resourceId: preparedThreadTarget.resourceId,
+              threadId: preparedThreadTarget.threadId,
+            },
+            pubsub,
+          );
+          trackedThreadStreamPubSubTarget = {
+            runId: mergedOptions.runId,
+            resourceId: preparedThreadTarget.resourceId,
+            threadId: preparedThreadTarget.threadId,
+          };
+        }
+      }
       const preparedOptions = agentThreadStreamRuntime.prepareRunOptions(mergedOptions, pubsub);
       preparedOptionsWithPubSub = { ...preparedOptions, _pubsub: pubsub };
       this.#rememberThreadStreamPubSub(preparedOptionsWithPubSub, pubsub);
@@ -6893,16 +7011,40 @@ export class Agent<
       if (ownsReservation && reservedThreadTarget) {
         const mergedThreadTarget = this.#getThreadTarget(mergedStreamOptions);
         if (!this.#sameThreadTarget(reservedThreadTarget, mergedThreadTarget)) {
-          this.#forgetThreadStreamPubSubForTarget({
-            runId: streamOptionsWithPubSub?.runId,
-            resourceId: reservedThreadTarget.resourceId,
-            threadId: reservedThreadTarget.threadId,
-          });
-          releaseReservedRun?.();
-          releaseReservedRun = undefined;
-          ownsReservation = false;
-          reservedThreadTarget = undefined;
-          trackedThreadStreamPubSubTarget = undefined;
+          const retargetedReservation = agentThreadStreamRuntime.retargetReservedRun(
+            streamOptionsWithPubSub?.runId,
+            reservedThreadTarget,
+            mergedThreadTarget,
+            pubsub,
+            this.id,
+          );
+          if (retargetedReservation) {
+            this.#forgetThreadStreamPubSubForTarget({
+              runId: streamOptionsWithPubSub?.runId,
+              resourceId: reservedThreadTarget.resourceId,
+              threadId: reservedThreadTarget.threadId,
+            });
+            releaseReservedRun = () =>
+              agentThreadStreamRuntime.releaseRunReservation((mergedStreamOptions as { runId?: string }).runId, pubsub, {
+                cleanupPrepared: true,
+                clearAbort: true,
+                rejectOutputWaiters: true,
+              });
+            reservedThreadTarget = mergedThreadTarget;
+            this.#rememberThreadStreamPubSubForTarget(
+              {
+                runId: (mergedStreamOptions as { runId?: string }).runId,
+                resourceId: mergedThreadTarget.resourceId,
+                threadId: mergedThreadTarget.threadId,
+              },
+              pubsub,
+            );
+            trackedThreadStreamPubSubTarget = {
+              runId: (mergedStreamOptions as { runId?: string }).runId,
+              resourceId: mergedThreadTarget.resourceId,
+              threadId: mergedThreadTarget.threadId,
+            };
+          }
         }
       }
       if (!ownsReservation) {
@@ -6955,6 +7097,72 @@ export class Agent<
         pubsub,
         ownsReservation,
       );
+      while (!ownsReservation && this.#getThreadTarget(mergedStreamOptions).threadId) {
+        releaseReservedRun = agentThreadStreamRuntime.reserveRun(
+          mergedStreamOptions as unknown as AgentExecutionOptions<OUTPUT>,
+          pubsub,
+          this.id,
+        );
+        ownsReservation = Boolean(releaseReservedRun);
+        if (ownsReservation) {
+          reservedThreadTarget = this.#getThreadTarget(mergedStreamOptions);
+          this.#rememberThreadStreamPubSub(mergedStreamOptions, pubsub);
+          trackedThreadStreamPubSubTarget = {
+            runId: (mergedStreamOptions as { runId?: string }).runId,
+            resourceId: reservedThreadTarget.resourceId,
+            threadId: reservedThreadTarget.threadId,
+          };
+          break;
+        }
+        await agentThreadStreamRuntime.waitForCrossAgentThreadRun(
+          this as Agent<any, any, any, any>,
+          mergedStreamOptions as unknown as AgentExecutionOptions<OUTPUT>,
+          pubsub,
+          ownsReservation,
+        );
+      }
+      if (ownsReservation && reservedThreadTarget) {
+        const preparedThreadTarget = this.#getThreadTarget(mergedStreamOptions);
+        if (!this.#sameThreadTarget(reservedThreadTarget, preparedThreadTarget)) {
+          const retargetedReservation = agentThreadStreamRuntime.retargetReservedRun(
+            (mergedStreamOptions as { runId?: string }).runId,
+            reservedThreadTarget,
+            preparedThreadTarget,
+            pubsub,
+            this.id,
+          );
+          if (!retargetedReservation) {
+            throw new Error(
+              `Agent thread run id "${(mergedStreamOptions as { runId?: string }).runId}" could not be retargeted`,
+            );
+          }
+          this.#forgetThreadStreamPubSubForTarget({
+            runId: (mergedStreamOptions as { runId?: string }).runId,
+            resourceId: reservedThreadTarget.resourceId,
+            threadId: reservedThreadTarget.threadId,
+          });
+          releaseReservedRun = () =>
+            agentThreadStreamRuntime.releaseRunReservation((mergedStreamOptions as { runId?: string }).runId, pubsub, {
+              cleanupPrepared: true,
+              clearAbort: true,
+              rejectOutputWaiters: true,
+            });
+          reservedThreadTarget = preparedThreadTarget;
+          this.#rememberThreadStreamPubSubForTarget(
+            {
+              runId: (mergedStreamOptions as { runId?: string }).runId,
+              resourceId: preparedThreadTarget.resourceId,
+              threadId: preparedThreadTarget.threadId,
+            },
+            pubsub,
+          );
+          trackedThreadStreamPubSubTarget = {
+            runId: (mergedStreamOptions as { runId?: string }).runId,
+            resourceId: preparedThreadTarget.resourceId,
+            threadId: preparedThreadTarget.threadId,
+          };
+        }
+      }
       const preparedOptions = agentThreadStreamRuntime.prepareRunOptions(
         mergedStreamOptions as unknown as AgentExecutionOptions<OUTPUT>,
         pubsub,

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -8,6 +8,7 @@ import type { LoopConfig, LoopOptions, PrepareStepFunction } from '../loop/types
 import type { VersionOverrides } from '../mastra/types';
 import type { ObservabilityContext, TracingOptions } from '../observability';
 import type { ErrorProcessorOrWorkflow, InputProcessorOrWorkflow, OutputProcessorOrWorkflow } from '../processors';
+import type { PubSub } from '../events/pubsub';
 import type { RequestContext } from '../request-context';
 import type { ToolPayloadTransformPolicy } from '../tools';
 import type { OutputWriter } from '../workflows/types';
@@ -669,5 +670,7 @@ export type InnerAgentExecutionOptions<OUTPUT = unknown> = AgentExecutionOptions
     resumeData: any;
     snapshot: any;
   };
+  /** Internal: PubSub captured by the public execution path for this run */
+  _pubsub?: PubSub;
   toolCallId?: string;
 } & (OUTPUT extends {} ? { structuredOutput: StructuredOutputOptions<OUTPUT> } : { structuredOutput?: never });

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -65,6 +65,7 @@ type PendingIdleSignal<OUTPUT = unknown> = {
   resourceId: string;
   threadId: string;
   streamOptions?: AgentExecutionOptions<OUTPUT>;
+  onRunRejected?: () => void;
 };
 
 type AgentThreadRuntimeState = {
@@ -73,8 +74,11 @@ type AgentThreadRuntimeState = {
   activeThreadRunIds: Map<string, string>;
   pendingSignalsByThread: Map<string, CreatedAgentSignal[]>;
   pendingIdleSignalsByThread: Map<string, PendingIdleSignal<any>[]>;
+  pendingIdleThreadKeysByRunId: Map<string, string>;
   watchedThreadRunIds: Set<string>;
   preparedRunsById: Map<string, PreparedThreadRun>;
+  reservedAgentIdsByRunId: Map<string, string>;
+  reservationWaitersByRunId: Map<string, Array<() => void>>;
   abortedRunIds: Set<string>;
   acceptedCallerSignals: Map<string, SendAgentSignalResult>;
   callerSignalIdsByRunId: Map<string, Set<string>>;
@@ -91,6 +95,11 @@ type AgentThreadStreamRuntimeEvent =
   | { type: 'run-aborted'; runId: string }
   | { type: 'signal-enqueued'; runId: string; signal: SerializableAgentSignal; sourceId: string };
 
+function getIdleRunRejectedHandler(ifIdle: unknown): (() => void) | undefined {
+  const handler = (ifIdle as { _onThreadStreamRunRejected?: unknown } | undefined)?._onThreadStreamRunRejected;
+  return typeof handler === 'function' ? () => handler() : undefined;
+}
+
 function createRuntimeState(): AgentThreadRuntimeState {
   return {
     threadRunsById: new Map(),
@@ -98,8 +107,11 @@ function createRuntimeState(): AgentThreadRuntimeState {
     activeThreadRunIds: new Map(),
     pendingSignalsByThread: new Map(),
     pendingIdleSignalsByThread: new Map(),
+    pendingIdleThreadKeysByRunId: new Map(),
     watchedThreadRunIds: new Set(),
     preparedRunsById: new Map(),
+    reservedAgentIdsByRunId: new Map(),
+    reservationWaitersByRunId: new Map(),
     abortedRunIds: new Set(),
     acceptedCallerSignals: new Map(),
     callerSignalIdsByRunId: new Map(),
@@ -248,11 +260,64 @@ export class AgentThreadStreamRuntime {
     };
   }
 
+  reserveRun<OUTPUT>(
+    options: AgentExecutionOptions<OUTPUT>,
+    pubsub?: PubSub,
+    agentId?: string,
+  ): (() => void) | undefined {
+    const { threadId, resourceId } = this.#getThreadTarget(options);
+    const runId = options.runId;
+    if (!threadId || !runId) return;
+
+    const state = this.#getState(pubsub);
+    const key = this.#threadKey(resourceId, threadId);
+    const existingKey = state.threadKeysByRunId.get(runId) ?? state.pendingIdleThreadKeysByRunId.get(runId);
+    if (existingKey) {
+      const reservedAgentId = state.reservedAgentIdsByRunId.get(runId);
+      const ownsExistingReservation =
+        existingKey === key &&
+        Boolean(agentId) &&
+        reservedAgentId === agentId &&
+        Boolean((options as { _threadRunReservationOwner?: unknown })._threadRunReservationOwner);
+      if (!ownsExistingReservation) {
+        throw new Error(
+          existingKey === key
+            ? `Agent thread run id "${runId}" is already reserved`
+            : `Agent thread run id "${runId}" is already reserved for another thread`,
+        );
+      }
+      return () => {
+        this.#releaseReservedRun(state, pubsub, key, runId, { cleanupPrepared: true, clearAbort: true });
+      };
+    }
+    if (state.activeThreadRunIds.has(key)) return;
+
+    state.activeThreadRunIds.set(key, runId);
+    state.threadKeysByRunId.set(runId, key);
+    if (agentId) {
+      state.reservedAgentIdsByRunId.set(runId, agentId);
+    }
+    return () => {
+      this.#releaseReservedRun(state, pubsub, key, runId, { cleanupPrepared: true, clearAbort: true });
+    };
+  }
+
   abortRun(runId: string, pubsub?: PubSub): boolean {
     const state = this.#getState(pubsub);
     const preparedRun = state.preparedRunsById.get(runId);
     if (!preparedRun) {
       state.abortedRunIds.add(runId);
+      const key = state.threadKeysByRunId.get(runId);
+      if (key) {
+        this.#releaseReservedRun(state, pubsub, key, runId);
+        return true;
+      }
+      const pendingIdleKey = state.pendingIdleThreadKeysByRunId.get(runId);
+      if (pendingIdleKey) {
+        this.#removePendingIdleRun(state, pendingIdleKey, runId, true);
+        this.#publish(pubsub, pendingIdleKey, { type: 'run-aborted', runId });
+        return true;
+      }
       return false;
     }
 
@@ -261,6 +326,7 @@ export class AgentThreadStreamRuntime {
 
     const key = state.threadKeysByRunId.get(runId);
     if (key) {
+      state.pendingSignalsByThread.delete(key);
       this.#publish(pubsub, key, { type: 'run-aborted', runId });
     }
 
@@ -297,8 +363,11 @@ export class AgentThreadStreamRuntime {
     state.activeThreadRunIds.clear();
     state.pendingSignalsByThread.clear();
     state.pendingIdleSignalsByThread.clear();
+    state.pendingIdleThreadKeysByRunId.clear();
     state.watchedThreadRunIds.clear();
     state.preparedRunsById.clear();
+    state.reservedAgentIdsByRunId.clear();
+    state.reservationWaitersByRunId.clear();
     state.abortedRunIds.clear();
     state.acceptedCallerSignals.clear();
     state.callerSignalIdsByRunId.clear();
@@ -317,6 +386,69 @@ export class AgentThreadStreamRuntime {
     if (!callerSignalIds) return;
     state.callerSignalIdsByRunId.delete(runId);
     for (const callerSignalId of callerSignalIds) state.acceptedCallerSignals.delete(callerSignalId);
+  }
+
+  #resolveReservationWaiters(state: AgentThreadRuntimeState, runId: string) {
+    const waiters = state.reservationWaitersByRunId.get(runId);
+    if (!waiters) return;
+
+    state.reservationWaitersByRunId.delete(runId);
+    for (const resolve of waiters) resolve();
+  }
+
+  #removePendingIdleRun(state: AgentThreadRuntimeState, key: string, runId: string, reject = false) {
+    state.pendingIdleThreadKeysByRunId.delete(runId);
+    const queue = state.pendingIdleSignalsByThread.get(key);
+    if (!queue) return false;
+
+    const index = queue.findIndex(pendingIdle => pendingIdle.runId === runId);
+    if (index === -1) return false;
+
+    const [pendingIdle] = queue.splice(index, 1);
+    if (queue.length === 0) {
+      state.pendingIdleSignalsByThread.delete(key);
+    }
+    this.#forgetCallerSignalsForRun(state, runId);
+    state.pendingOutputWaiters.delete(runId);
+    if (reject) {
+      pendingIdle?.onRunRejected?.();
+    }
+    return true;
+  }
+
+  #releaseReservedRun(
+    state: AgentThreadRuntimeState,
+    pubsub: PubSub | undefined,
+    key: string,
+    runId: string,
+    options: { cleanupPrepared?: boolean; clearAbort?: boolean } = {},
+  ) {
+    const ownsThread = state.activeThreadRunIds.get(key) === runId || state.threadKeysByRunId.get(runId) === key;
+    if (state.activeThreadRunIds.get(key) === runId) {
+      state.activeThreadRunIds.delete(key);
+    }
+    if (state.threadKeysByRunId.get(runId) === key) {
+      state.threadKeysByRunId.delete(runId);
+    }
+    if (state.pendingIdleThreadKeysByRunId.get(runId) === key) {
+      this.#removePendingIdleRun(state, key, runId);
+    }
+    state.reservedAgentIdsByRunId.delete(runId);
+    if (ownsThread) {
+      state.pendingSignalsByThread.delete(key);
+    }
+    if (options.cleanupPrepared) {
+      this.#cleanupPreparedRun(state, runId);
+    } else if (options.clearAbort) {
+      state.abortedRunIds.delete(runId);
+    }
+    this.#forgetCallerSignalsForRun(state, runId);
+    this.#resolveReservationWaiters(state, runId);
+    state.pendingOutputWaiters.delete(runId);
+    if (ownsThread) {
+      this.#publish(pubsub, key, { type: 'run-aborted', runId });
+      void this.#drainPendingIdleSignals(state, pubsub, key).catch(() => {});
+    }
   }
 
   async #persistSignal(
@@ -338,12 +470,19 @@ export class AgentThreadStreamRuntime {
     output: MastraModelOutput<OUTPUT>,
     streamOptions: AgentExecutionOptions<OUTPUT>,
     pubsub?: PubSub,
-  ) {
+  ): Promise<void> | undefined {
     const { threadId, resourceId } = this.#getThreadTarget(streamOptions);
     if (!threadId) return;
 
     const state = this.#getState(pubsub);
     const key = this.#threadKey(resourceId, threadId);
+    const existingKey = state.threadKeysByRunId.get(output.runId) ?? state.pendingIdleThreadKeysByRunId.get(output.runId);
+    if (state.threadRunsById.has(output.runId)) {
+      throw new Error(`Agent thread run id "${output.runId}" is already registered`);
+    }
+    if (existingKey && existingKey !== key) {
+      throw new Error(`Agent thread run id "${output.runId}" is already reserved for another thread`);
+    }
     const broadcastSource = this.#prepareBroadcastSource(output, pubsub, key);
     const record: AgentThreadRunRecord<OUTPUT> = {
       agent,
@@ -357,6 +496,8 @@ export class AgentThreadStreamRuntime {
     state.threadRunsById.set(output.runId, record);
     state.threadKeysByRunId.set(output.runId, key);
     state.activeThreadRunIds.set(key, output.runId);
+    state.reservedAgentIdsByRunId.delete(output.runId);
+    this.#resolveReservationWaiters(state, output.runId);
     const waiters = state.pendingOutputWaiters.get(output.runId);
     if (waiters) {
       state.pendingOutputWaiters.delete(output.runId);
@@ -367,7 +508,7 @@ export class AgentThreadStreamRuntime {
     );
     state.broadcastsByRunId.set(output.runId, broadcast);
     void broadcast.catch(() => {});
-    this.#watchThreadRunCompletion(state, pubsub, key, record);
+    return this.#watchThreadRunCompletion(state, pubsub, key, record);
   }
 
   /**
@@ -401,26 +542,26 @@ export class AgentThreadStreamRuntime {
     pubsub: PubSub | undefined,
     key: string,
     record: AgentThreadRunRecord<any>,
-  ) {
+  ): Promise<void> | undefined {
     if (state.watchedThreadRunIds.has(record.runId)) return;
     state.watchedThreadRunIds.add(record.runId);
 
-    void record.output._waitUntilFinished().finally(() => {
-      void (async () => {
-        await state.broadcastsByRunId.get(record.runId)?.catch(() => {});
-        state.broadcastsByRunId.delete(record.runId);
-        state.watchedThreadRunIds.delete(record.runId);
-        state.threadRunsById.delete(record.runId);
-        state.threadKeysByRunId.delete(record.runId);
-        this.#cleanupPreparedRun(state, record.runId);
-        this.#forgetCallerSignalsForRun(state, record.runId);
-        if (state.activeThreadRunIds.get(key) === record.runId) {
-          state.activeThreadRunIds.delete(key);
-        }
-        await this.#publishAndWait(pubsub, key, { type: 'run-completed', runId: record.runId });
-        void this.#drainPendingSignals(state, pubsub, key, record);
-      })();
+    const completion = record.output._waitUntilFinished().finally(async () => {
+      await state.broadcastsByRunId.get(record.runId)?.catch(() => {});
+      state.broadcastsByRunId.delete(record.runId);
+      state.watchedThreadRunIds.delete(record.runId);
+      state.threadRunsById.delete(record.runId);
+      state.threadKeysByRunId.delete(record.runId);
+      this.#cleanupPreparedRun(state, record.runId);
+      this.#forgetCallerSignalsForRun(state, record.runId);
+      if (state.activeThreadRunIds.get(key) === record.runId) {
+        state.activeThreadRunIds.delete(key);
+      }
+      await this.#publishAndWait(pubsub, key, { type: 'run-completed', runId: record.runId });
+      await this.#drainPendingSignals(state, pubsub, key, record);
     });
+    void completion.catch(() => {});
+    return completion;
   }
 
   async #drainPendingSignals(
@@ -475,12 +616,26 @@ export class AgentThreadStreamRuntime {
     if (idleQueue.length === 0) {
       state.pendingIdleSignalsByThread.delete(key);
     }
+    state.pendingIdleThreadKeysByRunId.delete(pendingIdle.runId);
 
     state.activeThreadRunIds.set(key, pendingIdle.runId);
+    const existingRunKey = state.threadKeysByRunId.get(pendingIdle.runId);
+    if (existingRunKey && existingRunKey !== key) {
+      pendingIdle.onRunRejected?.();
+      this.#releaseReservedRun(state, pubsub, key, pendingIdle.runId, { cleanupPrepared: true, clearAbort: true });
+      return;
+    }
+    if (state.threadRunsById.has(pendingIdle.runId)) {
+      pendingIdle.onRunRejected?.();
+      this.#releaseReservedRun(state, pubsub, key, pendingIdle.runId, { cleanupPrepared: true, clearAbort: true });
+      return;
+    }
     state.threadKeysByRunId.set(pendingIdle.runId, key);
+    state.reservedAgentIdsByRunId.set(pendingIdle.runId, pendingIdle.agent.id);
     try {
       const output = await pendingIdle.agent.stream(pendingIdle.signal, {
         ...(pendingIdle.streamOptions as any),
+        _threadRunReservationOwner: true,
         runId: pendingIdle.runId,
         memory: withThreadMemory(pendingIdle.streamOptions?.memory, pendingIdle.resourceId, pendingIdle.threadId),
       });
@@ -492,12 +647,8 @@ export class AgentThreadStreamRuntime {
         }
       }
     } catch {
-      state.threadKeysByRunId.delete(pendingIdle.runId);
-      this.#cleanupPreparedRun(state, pendingIdle.runId);
-      this.#forgetCallerSignalsForRun(state, pendingIdle.runId);
-      if (state.activeThreadRunIds.get(key) === pendingIdle.runId) {
-        state.activeThreadRunIds.delete(key);
-      }
+      pendingIdle.onRunRejected?.();
+      this.#releaseReservedRun(state, pubsub, key, pendingIdle.runId, { cleanupPrepared: true, clearAbort: true });
     }
   }
 
@@ -520,6 +671,7 @@ export class AgentThreadStreamRuntime {
     agent: Agent<any, any, any, any>,
     options: { memory?: AgentExecutionOptions<any>['memory']; requestContext?: RequestContext },
     pubsub?: PubSub,
+    ownsReservation = false,
   ) {
     const { threadId, resourceId } = this.#getThreadTarget(options);
     if (!threadId) return;
@@ -529,9 +681,33 @@ export class AgentThreadStreamRuntime {
     while (true) {
       const activeRunId = state.activeThreadRunIds.get(key);
       const activeRecord = activeRunId ? state.threadRunsById.get(activeRunId) : undefined;
-      if (!activeRunId || activeRecord?.agent.id === agent.id || activeRecord?.output.status !== 'running') return;
+      const reservedAgentId = activeRunId ? state.reservedAgentIdsByRunId.get(activeRunId) : undefined;
+      if (
+        activeRunId &&
+        activeRunId === (options as { runId?: string }).runId &&
+        ownsReservation &&
+        ((activeRecord && activeRecord.agent.id === agent.id) || (!activeRecord && reservedAgentId === agent.id))
+      ) {
+        return;
+      }
+      if (
+        !activeRunId ||
+        activeRecord?.agent.id === agent.id ||
+        (activeRecord && activeRecord.output.status !== 'running')
+      ) {
+        return;
+      }
       if (activeRecord) {
         await activeRecord.output._waitUntilFinished().catch(() => {});
+        await new Promise<void>(resolve => setTimeout(resolve, 0));
+        continue;
+      }
+      if (state.threadKeysByRunId.get(activeRunId) === key) {
+        await new Promise<void>(resolve => {
+          const waiters = state.reservationWaitersByRunId.get(activeRunId) ?? [];
+          waiters.push(resolve);
+          state.reservationWaitersByRunId.set(activeRunId, waiters);
+        });
         continue;
       }
       await this.#waitForRemoteRunToFinish(pubsub, key, activeRunId);
@@ -667,6 +843,9 @@ export class AgentThreadStreamRuntime {
         if (state.activeThreadRunIds.get(key) === data.runId) {
           state.activeThreadRunIds.delete(key);
         }
+        if (data.type === 'run-aborted') {
+          state.pendingSignalsByThread.delete(key);
+        }
         const remoteRun = remoteRuns.get(data.runId);
         if (remoteRun) {
           remoteRun.done = true;
@@ -723,11 +902,11 @@ export class AgentThreadStreamRuntime {
    * Signals can land in three places:
    * - an active same-agent run, where they are queued for the execution loop to drain;
    * - a reserved thread run that has not registered its stream record yet;
-   * - a new idle-started run, when the caller opts into `ifIdle`.
+   * - a new idle-started run, when idle behavior allows a wakeup.
    *
    * Cross-agent active runs are intentionally not interrupted here. They either finish first
    * through `waitForCrossAgentThreadRun()` on the stream path, or this method falls through to
-   * the idle-start path when the caller provided a resource/thread target and `ifIdle` options.
+   * the idle-start path when the caller provided a resource/thread target and idle behavior allows a wakeup.
    */
   sendSignal<OUTPUT = unknown>(
     agent: Agent<any, any, any, any>,
@@ -748,7 +927,11 @@ export class AgentThreadStreamRuntime {
       key = this.#threadKey(target.resourceId, target.threadId);
       let activeRunId = state.activeThreadRunIds.get(key);
       activeRecord = activeRunId ? state.threadRunsById.get(activeRunId) : undefined;
-      if (activeRecord && activeRecord.output.status !== 'running') {
+      const activeRunAborted = activeRunId ? state.abortedRunIds.has(activeRunId) : false;
+      const reservedAgentId = activeRunId ? state.reservedAgentIdsByRunId.get(activeRunId) : undefined;
+      if (activeRunAborted) {
+        activeRecord = undefined;
+      } else if (activeRecord && activeRecord.output.status !== 'running') {
         state.activeThreadRunIds.delete(key);
         activeRunId = undefined;
         activeRecord = undefined;
@@ -758,13 +941,23 @@ export class AgentThreadStreamRuntime {
       // follow-up path used by clients that know the thread/resource but not the run id.
       if (activeRecord && activeRecord.agent.id === agent.id) {
         runId = activeRecord.runId;
-      } else if (activeRunId && !activeRecord) {
+      } else if (
+        activeRunId &&
+        !activeRecord &&
+        !activeRunAborted &&
+        (!target.ifIdle ||
+          reservedAgentId === agent.id ||
+          Boolean((target.ifIdle as { _attachToReservedRun?: unknown })._attachToReservedRun))
+      ) {
         // A run can be reserved before its stream record is registered. Keep the reserved
         // id so early follow-ups still attach to the run that is starting.
         runId = activeRunId;
       }
     }
 
+    if (target.runId && state.abortedRunIds.has(target.runId)) {
+      throw new Error(`Agent thread run id "${target.runId}" has been aborted`);
+    }
     if (runId && !activeRecord) {
       activeRecord = state.threadRunsById.get(runId);
     }
@@ -876,12 +1069,30 @@ export class AgentThreadStreamRuntime {
     }
 
     key ??= this.#threadKey(resourceId, threadId);
+    const onRunRejected = getIdleRunRejectedHandler(target.ifIdle);
+    const existingRunKey = state.threadKeysByRunId.get(runId) ?? state.pendingIdleThreadKeysByRunId.get(runId);
+    if (existingRunKey) {
+      throw new Error(
+        existingRunKey === key
+          ? `Agent thread run id "${runId}" is already reserved`
+          : `Agent thread run id "${runId}" is already reserved for another thread`,
+      );
+    }
     if (state.activeThreadRunIds.has(key)) {
       // Another run owns the thread. Queue this idle-start request and let the watcher
       // launch it only after the active run clears the thread reservation.
       const idleQueue = state.pendingIdleSignalsByThread.get(key) ?? [];
-      idleQueue.push({ agent, signal, runId, resourceId, threadId, streamOptions: target.ifIdle?.streamOptions });
+      idleQueue.push({
+        agent,
+        signal,
+        runId,
+        resourceId,
+        threadId,
+        streamOptions: target.ifIdle?.streamOptions,
+        onRunRejected,
+      });
       state.pendingIdleSignalsByThread.set(key, idleQueue);
+      state.pendingIdleThreadKeysByRunId.set(runId, key);
       if (activeRecord) {
         this.#watchThreadRunCompletion(state, pubsub, key, activeRecord);
       }
@@ -892,19 +1103,17 @@ export class AgentThreadStreamRuntime {
     // the idle stream so concurrent callers do not launch duplicate runs.
     state.activeThreadRunIds.set(key, runId);
     state.threadKeysByRunId.set(runId, key);
+    state.reservedAgentIdsByRunId.set(runId, agent.id);
     const output = agent
       .stream(signal, {
         ...(target.ifIdle?.streamOptions as any),
+        _threadRunReservationOwner: true,
         runId,
         memory: withThreadMemory(target.ifIdle?.streamOptions?.memory, resourceId, threadId),
       })
       .catch(err => {
-        state.threadKeysByRunId.delete(runId);
-        this.#cleanupPreparedRun(state, runId);
-        this.#forgetCallerSignalsForRun(state, runId);
-        if (state.activeThreadRunIds.get(key) === runId) {
-          state.activeThreadRunIds.delete(key);
-        }
+        onRunRejected?.();
+        this.#releaseReservedRun(state, pubsub, key, runId, { cleanupPrepared: true, clearAbort: true });
         throw err;
       }) as Promise<MastraModelOutput<unknown>>;
     void output.catch(() => {});

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -880,11 +880,10 @@ export class AgentThreadStreamRuntime {
     }
     state.pendingIdleThreadKeysByRunId.delete(pendingIdle.runId);
 
-    state.activeThreadRunIds.set(key, pendingIdle.runId);
     const existingRunKey = state.threadKeysByRunId.get(pendingIdle.runId);
     if (existingRunKey && existingRunKey !== key) {
       pendingIdle.onRunRejected?.();
-      this.#releaseReservedRun(state, pubsub, key, pendingIdle.runId, {
+      this.#releaseReservedRun(state, pubsub, existingRunKey, pendingIdle.runId, {
         cleanupPrepared: true,
         clearAbort: true,
         rejectOutputWaiters: true,
@@ -900,6 +899,7 @@ export class AgentThreadStreamRuntime {
       });
       return;
     }
+    state.activeThreadRunIds.set(key, pendingIdle.runId);
     state.threadKeysByRunId.set(pendingIdle.runId, key);
     state.reservedAgentIdsByRunId.set(pendingIdle.runId, pendingIdle.agent.id);
     try {

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -20,6 +20,10 @@ import type {
 
 const AGENT_THREAD_KEY_SEPARATOR = '\u0000';
 const AGENT_THREAD_STREAM_TOPIC_PREFIX = 'agent.thread-stream';
+const REJECTED_RUN_TOMBSTONE_TTL_MS = 5 * 60 * 1000;
+const MAX_REJECTED_RUN_TOMBSTONES = 1000;
+const ABORTED_RUN_TOMBSTONE_TTL_MS = 5 * 60 * 1000;
+const MAX_ABORTED_RUN_TOMBSTONES = 1000;
 
 export let defaultAgentThreadPubSub: PubSub = new EventEmitterPubSub();
 
@@ -58,6 +62,11 @@ type PreparedThreadRun = {
   cleanup: () => void;
 };
 
+type RejectedRunErrorRecord = {
+  error: Error;
+  cleanupTimer: ReturnType<typeof setTimeout>;
+};
+
 type PendingIdleSignal<OUTPUT = unknown> = {
   agent: Agent<any, any, any, any>;
   signal: CreatedAgentSignal;
@@ -80,9 +89,15 @@ type AgentThreadRuntimeState = {
   reservedAgentIdsByRunId: Map<string, string>;
   reservationWaitersByRunId: Map<string, Array<() => void>>;
   abortedRunIds: Set<string>;
+  abortedRunCleanupTimersByRunId: Map<string, ReturnType<typeof setTimeout>>;
+  rejectedRunErrorsByRunId: Map<string, RejectedRunErrorRecord>;
   acceptedCallerSignals: Map<string, SendAgentSignalResult>;
   callerSignalIdsByRunId: Map<string, Set<string>>;
-  pendingOutputWaiters: Map<string, Array<(out: MastraModelOutput<any>) => void>>;
+  pendingOutputWaiters: Map<
+    string,
+    Array<{ resolve: (out: MastraModelOutput<any>) => void; reject: (error: Error) => void }>
+  >;
+  registrationPublishesByRunId: Map<string, Promise<void>>;
   broadcastsByRunId: Map<string, Promise<void>>;
 };
 
@@ -113,9 +128,12 @@ function createRuntimeState(): AgentThreadRuntimeState {
     reservedAgentIdsByRunId: new Map(),
     reservationWaitersByRunId: new Map(),
     abortedRunIds: new Set(),
+    abortedRunCleanupTimersByRunId: new Map(),
+    rejectedRunErrorsByRunId: new Map(),
     acceptedCallerSignals: new Map(),
     callerSignalIdsByRunId: new Map(),
     pendingOutputWaiters: new Map(),
+    registrationPublishesByRunId: new Map(),
     broadcastsByRunId: new Map(),
   };
 }
@@ -287,33 +305,100 @@ export class AgentThreadStreamRuntime {
         );
       }
       return () => {
-        this.#releaseReservedRun(state, pubsub, key, runId, { cleanupPrepared: true, clearAbort: true });
+        this.#releaseReservedRun(state, pubsub, key, runId, {
+          cleanupPrepared: true,
+          clearAbort: true,
+          rejectOutputWaiters: true,
+        });
       };
     }
     if (state.activeThreadRunIds.has(key)) return;
 
+    this.#forgetRejectedRunError(state, runId);
     state.activeThreadRunIds.set(key, runId);
     state.threadKeysByRunId.set(runId, key);
     if (agentId) {
       state.reservedAgentIdsByRunId.set(runId, agentId);
     }
     return () => {
-      this.#releaseReservedRun(state, pubsub, key, runId, { cleanupPrepared: true, clearAbort: true });
+      this.#releaseReservedRun(state, pubsub, key, runId, {
+        cleanupPrepared: true,
+        clearAbort: true,
+        rejectOutputWaiters: true,
+      });
     };
+  }
+
+  retargetReservedRun(
+    runId: string | undefined,
+    fromTarget: { resourceId?: string; threadId?: string },
+    toTarget: { resourceId?: string; threadId?: string },
+    pubsub?: PubSub,
+    agentId?: string,
+  ): boolean {
+    if (!runId || !fromTarget.threadId || !toTarget.threadId) return false;
+
+    const state = this.#getState(pubsub);
+    const fromKey = this.#threadKey(fromTarget.resourceId, fromTarget.threadId);
+    const toKey = this.#threadKey(toTarget.resourceId, toTarget.threadId);
+    if (fromKey === toKey) return true;
+    if (state.threadRunsById.has(runId) || state.threadKeysByRunId.get(runId) !== fromKey) return false;
+
+    const reservedAgentId = state.reservedAgentIdsByRunId.get(runId);
+    if (agentId && reservedAgentId && reservedAgentId !== agentId) {
+      throw new Error(`Agent thread run id "${runId}" is reserved by another agent`);
+    }
+
+    const activeRunId = state.activeThreadRunIds.get(toKey);
+    if (activeRunId && activeRunId !== runId) return false;
+
+    state.activeThreadRunIds.delete(fromKey);
+    state.activeThreadRunIds.set(toKey, runId);
+    state.threadKeysByRunId.set(runId, toKey);
+    this.#resolveReservationWaiters(state, runId);
+
+    const pendingSignals = state.pendingSignalsByThread.get(fromKey);
+    if (pendingSignals?.length) {
+      state.pendingSignalsByThread.delete(fromKey);
+      const existingSignals = state.pendingSignalsByThread.get(toKey) ?? [];
+      existingSignals.push(...pendingSignals);
+      state.pendingSignalsByThread.set(toKey, existingSignals);
+    }
+    if (state.pendingIdleSignalsByThread.has(fromKey)) {
+      void this.#drainPendingIdleSignals(state, pubsub, fromKey).catch(() => {});
+    }
+
+    return true;
+  }
+
+  releaseRunReservation(
+    runId: string | undefined,
+    pubsub?: PubSub,
+    options: { cleanupPrepared?: boolean; clearAbort?: boolean; rejectOutputWaiters?: boolean } = {},
+  ): boolean {
+    if (!runId) return false;
+
+    const state = this.#getState(pubsub);
+    const key = state.threadKeysByRunId.get(runId) ?? state.pendingIdleThreadKeysByRunId.get(runId);
+    if (!key) return false;
+
+    this.#releaseReservedRun(state, pubsub, key, runId, options);
+    return true;
   }
 
   abortRun(runId: string, pubsub?: PubSub): boolean {
     const state = this.#getState(pubsub);
     const preparedRun = state.preparedRunsById.get(runId);
     if (!preparedRun) {
-      state.abortedRunIds.add(runId);
       const key = state.threadKeysByRunId.get(runId);
       if (key) {
-        this.#releaseReservedRun(state, pubsub, key, runId);
+        this.#rememberAbortedRun(state, runId);
+        this.#releaseReservedRun(state, pubsub, key, runId, { rejectOutputWaiters: true });
         return true;
       }
       const pendingIdleKey = state.pendingIdleThreadKeysByRunId.get(runId);
       if (pendingIdleKey) {
+        this.#rememberAbortedRun(state, runId);
         this.#removePendingIdleRun(state, pendingIdleKey, runId, true);
         this.#publish(pubsub, pendingIdleKey, { type: 'run-aborted', runId });
         return true;
@@ -321,10 +406,19 @@ export class AgentThreadStreamRuntime {
       return false;
     }
 
-    preparedRun.abortController.abort();
-    state.abortedRunIds.add(runId);
-
     const key = state.threadKeysByRunId.get(runId);
+    if (key && !state.threadRunsById.has(runId)) {
+      preparedRun.abortController.abort();
+      this.#rememberAbortedRun(state, runId);
+      preparedRun.cleanup();
+      state.preparedRunsById.delete(runId);
+      this.#releaseReservedRun(state, pubsub, key, runId, { rejectOutputWaiters: true });
+      return true;
+    }
+
+    preparedRun.abortController.abort();
+    this.#rememberAbortedRun(state, runId);
+
     if (key) {
       state.pendingSignalsByThread.delete(key);
       this.#publish(pubsub, key, { type: 'run-aborted', runId });
@@ -368,17 +462,81 @@ export class AgentThreadStreamRuntime {
     state.preparedRunsById.clear();
     state.reservedAgentIdsByRunId.clear();
     state.reservationWaitersByRunId.clear();
-    state.abortedRunIds.clear();
+    for (const runId of state.abortedRunIds) {
+      this.#forgetAbortedRun(state, runId);
+    }
+    for (const runId of state.rejectedRunErrorsByRunId.keys()) {
+      this.#forgetRejectedRunError(state, runId);
+    }
     state.acceptedCallerSignals.clear();
     state.callerSignalIdsByRunId.clear();
-    state.pendingOutputWaiters.clear();
+    for (const runId of state.pendingOutputWaiters.keys()) {
+      this.#rejectPendingOutputWaiters(state, runId, new Error(`Agent thread run id "${runId}" was reset`));
+    }
+    for (const runId of state.rejectedRunErrorsByRunId.keys()) {
+      this.#forgetRejectedRunError(state, runId);
+    }
+    state.registrationPublishesByRunId.clear();
     state.broadcastsByRunId.clear();
   }
 
-  #cleanupPreparedRun(state: AgentThreadRuntimeState, runId: string) {
+  #cleanupPreparedRun(state: AgentThreadRuntimeState, runId: string, preserveAbort = false) {
     state.preparedRunsById.get(runId)?.cleanup();
     state.preparedRunsById.delete(runId);
+    if (!preserveAbort) this.#forgetAbortedRun(state, runId);
+  }
+
+  #forgetAbortedRun(state: AgentThreadRuntimeState, runId: string) {
+    const cleanupTimer = state.abortedRunCleanupTimersByRunId.get(runId);
+    if (cleanupTimer) {
+      clearTimeout(cleanupTimer);
+      state.abortedRunCleanupTimersByRunId.delete(runId);
+    }
     state.abortedRunIds.delete(runId);
+  }
+
+  #rememberAbortedRun(state: AgentThreadRuntimeState, runId: string) {
+    this.#forgetAbortedRun(state, runId);
+
+    const cleanupTimer = setTimeout(() => {
+      state.abortedRunIds.delete(runId);
+      state.abortedRunCleanupTimersByRunId.delete(runId);
+    }, ABORTED_RUN_TOMBSTONE_TTL_MS);
+    (cleanupTimer as { unref?: () => void }).unref?.();
+    state.abortedRunIds.add(runId);
+    state.abortedRunCleanupTimersByRunId.set(runId, cleanupTimer);
+
+    if (state.abortedRunIds.size <= MAX_ABORTED_RUN_TOMBSTONES) return;
+
+    const oldestRunId = state.abortedRunIds.values().next().value;
+    if (oldestRunId) {
+      this.#forgetAbortedRun(state, oldestRunId);
+    }
+  }
+
+  #forgetRejectedRunError(state: AgentThreadRuntimeState, runId: string) {
+    const rejectedRunError = state.rejectedRunErrorsByRunId.get(runId);
+    if (!rejectedRunError) return;
+
+    clearTimeout(rejectedRunError.cleanupTimer);
+    state.rejectedRunErrorsByRunId.delete(runId);
+  }
+
+  #rememberRejectedRunError(state: AgentThreadRuntimeState, runId: string, error: Error) {
+    this.#forgetRejectedRunError(state, runId);
+
+    const cleanupTimer = setTimeout(() => {
+      state.rejectedRunErrorsByRunId.delete(runId);
+    }, REJECTED_RUN_TOMBSTONE_TTL_MS);
+    (cleanupTimer as { unref?: () => void }).unref?.();
+    state.rejectedRunErrorsByRunId.set(runId, { error, cleanupTimer });
+
+    if (state.rejectedRunErrorsByRunId.size <= MAX_REJECTED_RUN_TOMBSTONES) return;
+
+    const oldestRunId = state.rejectedRunErrorsByRunId.keys().next().value;
+    if (oldestRunId) {
+      this.#forgetRejectedRunError(state, oldestRunId);
+    }
   }
 
   #forgetCallerSignalsForRun(state: AgentThreadRuntimeState, runId: string) {
@@ -396,6 +554,15 @@ export class AgentThreadStreamRuntime {
     for (const resolve of waiters) resolve();
   }
 
+  #rejectPendingOutputWaiters(state: AgentThreadRuntimeState, runId: string, error: Error) {
+    this.#rememberRejectedRunError(state, runId, error);
+    const waiters = state.pendingOutputWaiters.get(runId);
+    if (!waiters) return;
+
+    state.pendingOutputWaiters.delete(runId);
+    for (const waiter of waiters) waiter.reject(error);
+  }
+
   #removePendingIdleRun(state: AgentThreadRuntimeState, key: string, runId: string, reject = false) {
     state.pendingIdleThreadKeysByRunId.delete(runId);
     const queue = state.pendingIdleSignalsByThread.get(key);
@@ -409,8 +576,11 @@ export class AgentThreadStreamRuntime {
       state.pendingIdleSignalsByThread.delete(key);
     }
     this.#forgetCallerSignalsForRun(state, runId);
-    state.pendingOutputWaiters.delete(runId);
     if (reject) {
+      const error = state.abortedRunIds.has(runId)
+        ? new Error(`Agent thread run id "${runId}" has been aborted`)
+        : new Error(`Agent thread run id "${runId}" was rejected`);
+      this.#rejectPendingOutputWaiters(state, runId, error);
       pendingIdle?.onRunRejected?.();
     }
     return true;
@@ -421,9 +591,10 @@ export class AgentThreadStreamRuntime {
     pubsub: PubSub | undefined,
     key: string,
     runId: string,
-    options: { cleanupPrepared?: boolean; clearAbort?: boolean } = {},
+    options: { cleanupPrepared?: boolean; clearAbort?: boolean; rejectOutputWaiters?: boolean } = {},
   ) {
     const ownsThread = state.activeThreadRunIds.get(key) === runId || state.threadKeysByRunId.get(runId) === key;
+    const wasAborted = state.abortedRunIds.has(runId);
     if (state.activeThreadRunIds.get(key) === runId) {
       state.activeThreadRunIds.delete(key);
     }
@@ -431,20 +602,25 @@ export class AgentThreadStreamRuntime {
       state.threadKeysByRunId.delete(runId);
     }
     if (state.pendingIdleThreadKeysByRunId.get(runId) === key) {
-      this.#removePendingIdleRun(state, key, runId);
+      this.#removePendingIdleRun(state, key, runId, Boolean(options.rejectOutputWaiters));
     }
     state.reservedAgentIdsByRunId.delete(runId);
     if (ownsThread) {
       state.pendingSignalsByThread.delete(key);
     }
     if (options.cleanupPrepared) {
-      this.#cleanupPreparedRun(state, runId);
+      this.#cleanupPreparedRun(state, runId, Boolean(options.rejectOutputWaiters && wasAborted));
     } else if (options.clearAbort) {
-      state.abortedRunIds.delete(runId);
+      this.#forgetAbortedRun(state, runId);
     }
     this.#forgetCallerSignalsForRun(state, runId);
     this.#resolveReservationWaiters(state, runId);
-    state.pendingOutputWaiters.delete(runId);
+    if (options.rejectOutputWaiters) {
+      const error = wasAborted
+        ? new Error(`Agent thread run id "${runId}" has been aborted`)
+        : new Error(`Agent thread run id "${runId}" was rejected`);
+      this.#rejectPendingOutputWaiters(state, runId, error);
+    }
     if (ownsThread) {
       this.#publish(pubsub, key, { type: 'run-aborted', runId });
       void this.#drainPendingIdleSignals(state, pubsub, key).catch(() => {});
@@ -477,11 +653,26 @@ export class AgentThreadStreamRuntime {
     const state = this.#getState(pubsub);
     const key = this.#threadKey(resourceId, threadId);
     const existingKey = state.threadKeysByRunId.get(output.runId) ?? state.pendingIdleThreadKeysByRunId.get(output.runId);
+    const activeRunId = state.activeThreadRunIds.get(key);
+    const reservedAgentId = state.reservedAgentIdsByRunId.get(output.runId);
+    const rejectedRunError = state.rejectedRunErrorsByRunId.get(output.runId);
+    if (state.abortedRunIds.has(output.runId)) {
+      throw new Error(`Agent thread run id "${output.runId}" has been aborted`);
+    }
+    if (rejectedRunError) {
+      throw rejectedRunError.error;
+    }
     if (state.threadRunsById.has(output.runId)) {
       throw new Error(`Agent thread run id "${output.runId}" is already registered`);
     }
+    if (activeRunId && activeRunId !== output.runId) {
+      throw new Error(`Agent thread run id "${activeRunId}" is already active for this thread`);
+    }
     if (existingKey && existingKey !== key) {
       throw new Error(`Agent thread run id "${output.runId}" is already reserved for another thread`);
+    }
+    if (reservedAgentId && reservedAgentId !== agent.id) {
+      throw new Error(`Agent thread run id "${output.runId}" is reserved by another agent`);
     }
     const broadcastSource = this.#prepareBroadcastSource(output, pubsub, key);
     const record: AgentThreadRunRecord<OUTPUT> = {
@@ -496,16 +687,17 @@ export class AgentThreadStreamRuntime {
     state.threadRunsById.set(output.runId, record);
     state.threadKeysByRunId.set(output.runId, key);
     state.activeThreadRunIds.set(key, output.runId);
+    this.#forgetRejectedRunError(state, output.runId);
     state.reservedAgentIdsByRunId.delete(output.runId);
     this.#resolveReservationWaiters(state, output.runId);
     const waiters = state.pendingOutputWaiters.get(output.runId);
     if (waiters) {
       state.pendingOutputWaiters.delete(output.runId);
-      for (const resolve of waiters) resolve(output);
+      for (const waiter of waiters) waiter.resolve(output);
     }
-    const broadcast = this.#publishAndWait(pubsub, key, { type: 'run-registered', runId: output.runId }).then(() =>
-      this.#broadcastStream(output, broadcastSource, pubsub, key),
-    );
+    const registrationPublish = this.#publishAndWait(pubsub, key, { type: 'run-registered', runId: output.runId });
+    state.registrationPublishesByRunId.set(output.runId, registrationPublish);
+    const broadcast = registrationPublish.then(() => this.#broadcastStream(output, broadcastSource, pubsub, key));
     state.broadcastsByRunId.set(output.runId, broadcast);
     void broadcast.catch(() => {});
     return this.#watchThreadRunCompletion(state, pubsub, key, record);
@@ -526,13 +718,50 @@ export class AgentThreadStreamRuntime {
    * Resolves with the `MastraModelOutput` for `runId` as soon as `registerRun`
    * registers it, or immediately if it is already registered and retained.
    */
-  waitForRunOutput<OUTPUT = unknown>(runId: string, pubsub?: PubSub): Promise<MastraModelOutput<OUTPUT>> {
+  waitForRunOutput<OUTPUT = unknown>(
+    runId: string,
+    pubsub?: PubSub,
+    abortSignal?: AbortSignal,
+  ): Promise<MastraModelOutput<OUTPUT>> {
     const state = this.#getState(pubsub);
     const existing = state.threadRunsById.get(runId);
     if (existing) return Promise.resolve(existing.output as MastraModelOutput<OUTPUT>);
-    return new Promise<MastraModelOutput<OUTPUT>>(resolve => {
+    if (abortSignal?.aborted) {
+      return Promise.reject(abortSignal.reason ?? new Error(`Agent thread run id "${runId}" wait was aborted`));
+    }
+    if (state.abortedRunIds.has(runId)) {
+      return Promise.reject(new Error(`Agent thread run id "${runId}" has been aborted`));
+    }
+    const rejectedRunError = state.rejectedRunErrorsByRunId.get(runId);
+    if (rejectedRunError) {
+      return Promise.reject(rejectedRunError.error);
+    }
+    return new Promise<MastraModelOutput<OUTPUT>>((resolve, reject) => {
       const waiters = state.pendingOutputWaiters.get(runId) ?? [];
-      waiters.push(resolve as (out: MastraModelOutput<any>) => void);
+      let waiter: { resolve: (out: MastraModelOutput<any>) => void; reject: (error: Error) => void };
+      const cleanup = () => abortSignal?.removeEventListener('abort', onAbort);
+      const onAbort = () => {
+        const currentWaiters = state.pendingOutputWaiters.get(runId);
+        const index = currentWaiters?.indexOf(waiter) ?? -1;
+        if (index !== -1) {
+          currentWaiters!.splice(index, 1);
+          if (currentWaiters!.length === 0) state.pendingOutputWaiters.delete(runId);
+        }
+        cleanup();
+        reject(abortSignal?.reason ?? new Error(`Agent thread run id "${runId}" wait was aborted`));
+      };
+      waiter = {
+        resolve: out => {
+          cleanup();
+          resolve(out);
+        },
+        reject: error => {
+          cleanup();
+          reject(error);
+        },
+      };
+      abortSignal?.addEventListener('abort', onAbort, { once: true });
+      waiters.push(waiter);
       state.pendingOutputWaiters.set(runId, waiters);
     });
   }
@@ -547,18 +776,32 @@ export class AgentThreadStreamRuntime {
     state.watchedThreadRunIds.add(record.runId);
 
     const completion = record.output._waitUntilFinished().finally(async () => {
+      await state.registrationPublishesByRunId.get(record.runId)?.catch(() => {});
+      state.registrationPublishesByRunId.delete(record.runId);
       await state.broadcastsByRunId.get(record.runId)?.catch(() => {});
       state.broadcastsByRunId.delete(record.runId);
       state.watchedThreadRunIds.delete(record.runId);
-      state.threadRunsById.delete(record.runId);
-      state.threadKeysByRunId.delete(record.runId);
       this.#cleanupPreparedRun(state, record.runId);
       this.#forgetCallerSignalsForRun(state, record.runId);
+      let publishError: unknown;
+      try {
+        await this.#publishAndWait(pubsub, key, { type: 'run-completed', runId: record.runId });
+      } catch (err) {
+        publishError = err;
+      }
       if (state.activeThreadRunIds.get(key) === record.runId) {
         state.activeThreadRunIds.delete(key);
       }
-      await this.#publishAndWait(pubsub, key, { type: 'run-completed', runId: record.runId });
-      await this.#drainPendingSignals(state, pubsub, key, record);
+      if (state.threadKeysByRunId.get(record.runId) === key) {
+        state.threadKeysByRunId.delete(record.runId);
+      }
+      try {
+        await this.#drainPendingSignals(state, pubsub, key, record);
+      } finally {
+        state.threadRunsById.delete(record.runId);
+        this.#resolveReservationWaiters(state, record.runId);
+      }
+      if (publishError) throw publishError;
     });
     void completion.catch(() => {});
     return completion;
@@ -622,12 +865,20 @@ export class AgentThreadStreamRuntime {
     const existingRunKey = state.threadKeysByRunId.get(pendingIdle.runId);
     if (existingRunKey && existingRunKey !== key) {
       pendingIdle.onRunRejected?.();
-      this.#releaseReservedRun(state, pubsub, key, pendingIdle.runId, { cleanupPrepared: true, clearAbort: true });
+      this.#releaseReservedRun(state, pubsub, key, pendingIdle.runId, {
+        cleanupPrepared: true,
+        clearAbort: true,
+        rejectOutputWaiters: true,
+      });
       return;
     }
     if (state.threadRunsById.has(pendingIdle.runId)) {
       pendingIdle.onRunRejected?.();
-      this.#releaseReservedRun(state, pubsub, key, pendingIdle.runId, { cleanupPrepared: true, clearAbort: true });
+      this.#releaseReservedRun(state, pubsub, key, pendingIdle.runId, {
+        cleanupPrepared: true,
+        clearAbort: true,
+        rejectOutputWaiters: true,
+      });
       return;
     }
     state.threadKeysByRunId.set(pendingIdle.runId, key);
@@ -648,7 +899,11 @@ export class AgentThreadStreamRuntime {
       }
     } catch {
       pendingIdle.onRunRejected?.();
-      this.#releaseReservedRun(state, pubsub, key, pendingIdle.runId, { cleanupPrepared: true, clearAbort: true });
+      this.#releaseReservedRun(state, pubsub, key, pendingIdle.runId, {
+        cleanupPrepared: true,
+        clearAbort: true,
+        rejectOutputWaiters: true,
+      });
     }
   }
 
@@ -690,16 +945,18 @@ export class AgentThreadStreamRuntime {
       ) {
         return;
       }
-      if (
-        !activeRunId ||
-        activeRecord?.agent.id === agent.id ||
-        (activeRecord && activeRecord.output.status !== 'running')
-      ) {
-        return;
-      }
+      if (!activeRunId) return;
       if (activeRecord) {
         await activeRecord.output._waitUntilFinished().catch(() => {});
-        await new Promise<void>(resolve => setTimeout(resolve, 0));
+        if (state.activeThreadRunIds.get(key) === activeRunId && state.threadRunsById.get(activeRunId) === activeRecord) {
+          await new Promise<void>(resolve => {
+            const waiters = state.reservationWaitersByRunId.get(activeRunId) ?? [];
+            waiters.push(resolve);
+            state.reservationWaitersByRunId.set(activeRunId, waiters);
+          });
+        } else {
+          await new Promise<void>(resolve => setTimeout(resolve, 0));
+        }
         continue;
       }
       if (state.threadKeysByRunId.get(activeRunId) === key) {
@@ -1113,7 +1370,11 @@ export class AgentThreadStreamRuntime {
       })
       .catch(err => {
         onRunRejected?.();
-        this.#releaseReservedRun(state, pubsub, key, runId, { cleanupPrepared: true, clearAbort: true });
+        this.#releaseReservedRun(state, pubsub, key, runId, {
+          cleanupPrepared: true,
+          clearAbort: true,
+          rejectOutputWaiters: true,
+        });
         throw err;
       }) as Promise<MastraModelOutput<unknown>>;
     void output.catch(() => {});

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -160,6 +160,25 @@ export class AgentThreadStreamRuntime {
     return [resourceId ?? '', threadId].join(AGENT_THREAD_KEY_SEPARATOR);
   }
 
+  #threadIdFromKey(key: string): string {
+    return key.slice(key.indexOf(AGENT_THREAD_KEY_SEPARATOR) + AGENT_THREAD_KEY_SEPARATOR.length);
+  }
+
+  #findUniqueActiveThreadRunByThreadId(
+    state: AgentThreadRuntimeState,
+    threadId: string,
+  ): { key: string; runId: string } | undefined {
+    let match: { key: string; runId: string } | undefined;
+    for (const [candidateKey, candidateRunId] of state.activeThreadRunIds.entries()) {
+      if (this.#threadIdFromKey(candidateKey) !== threadId || state.abortedRunIds.has(candidateRunId)) continue;
+      if (match && match.runId !== candidateRunId) {
+        throw new Error('resourceId is required when multiple active agent runs match signal target');
+      }
+      match = { key: candidateKey, runId: candidateRunId };
+    }
+    return match;
+  }
+
   #threadTopic(key: string): string {
     return `${AGENT_THREAD_STREAM_TOPIC_PREFIX}.${encodeURIComponent(key)}`;
   }
@@ -1180,9 +1199,16 @@ export class AgentThreadStreamRuntime {
     const idleBehavior = target.ifIdle?.behavior ?? 'wake';
 
     let activeRecord: AgentThreadRunRecord<any> | undefined;
-    if (target.resourceId && target.threadId) {
+    if (target.threadId) {
       key = this.#threadKey(target.resourceId, target.threadId);
       let activeRunId = state.activeThreadRunIds.get(key);
+      if (!activeRunId && !target.resourceId) {
+        const activeThreadMatch = this.#findUniqueActiveThreadRunByThreadId(state, target.threadId);
+        if (activeThreadMatch) {
+          key = activeThreadMatch.key;
+          activeRunId = activeThreadMatch.runId;
+        }
+      }
       activeRecord = activeRunId ? state.threadRunsById.get(activeRunId) : undefined;
       const activeRunAborted = activeRunId ? state.abortedRunIds.has(activeRunId) : false;
       const reservedAgentId = activeRunId ? state.reservedAgentIdsByRunId.get(activeRunId) : undefined;

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -109,6 +109,13 @@ export type SendAgentSignalOptions<OUTPUT = unknown> =
       ifIdle?: never;
     }
   | {
+      runId?: never;
+      resourceId?: undefined;
+      threadId: string;
+      ifActive?: { behavior?: AgentSignalActiveBehavior };
+      ifIdle?: never;
+    }
+  | {
       runId?: string;
       resourceId: string;
       threadId: string;

--- a/packages/core/src/harness/v1/session.message.test.ts
+++ b/packages/core/src/harness/v1/session.message.test.ts
@@ -7,7 +7,7 @@
  * the session forwarded without standing up a real model.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
 import { Agent } from '../../agent';
@@ -27,6 +27,10 @@ interface FakeCall {
   type: 'stream' | 'generate';
   messages: unknown;
   options: any;
+}
+
+function nextTick() {
+  return new Promise(resolve => setTimeout(resolve, 0));
 }
 
 class FakeAgent extends Agent<any, any, any> {
@@ -228,6 +232,109 @@ describe('Session.message() — default path', () => {
       HarnessValidationError,
     );
     expect(agent.calls).toHaveLength(1);
+  });
+
+  it('normalizes duplicate stream retries when the pending run output was rejected', async () => {
+    const { harness, agent } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    vi.spyOn(agent, 'getRunOutput').mockReturnValue(undefined);
+    vi.spyOn(agent, 'waitForRunOutput').mockRejectedValue(new Error('raw runtime tombstone'));
+    (session as any)._completedRuns.set('rejected-run', { ok: false, err: new Error('cached failed run') });
+
+    await expect(
+      (session as any)._returnDuplicateMessageResult(
+        { status: 'pending', signalId: 'signal-1', runId: 'rejected-run' },
+        { stream: true },
+      ),
+    ).rejects.toMatchObject({
+      name: 'HarnessValidationError',
+      message: expect.stringContaining('duplicate stream is no longer live'),
+    });
+  });
+
+  it('returns a duplicate stream retry when the pending run output registers after recovery starts', async () => {
+    const { harness, agent } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const output = buildFakeOutput({
+      runId: 'pending-retry-run',
+      fullOutput: agent.fullOutput,
+    });
+    vi.spyOn(agent, 'getRunOutput').mockReturnValue(undefined);
+    vi.spyOn(agent, 'waitForRunOutput').mockResolvedValue(output);
+
+    await expect(
+      (session as any)._returnDuplicateMessageResult(
+        { status: 'pending', signalId: 'signal-1', runId: 'pending-retry-run' },
+        { stream: true },
+      ),
+    ).resolves.toBe(output);
+  });
+
+  it('does not wait for duplicate stream retries when the pending run already completed', async () => {
+    const { harness, agent } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const waitForRunOutput = vi.spyOn(agent, 'waitForRunOutput');
+    (session as any)._completedRuns.set('completed-pending-run', { ok: true, full: agent.fullOutput });
+
+    await expect(
+      (session as any)._returnDuplicateMessageResult(
+        { status: 'pending', signalId: 'signal-1', runId: 'completed-pending-run' },
+        { stream: true },
+      ),
+    ).rejects.toMatchObject({
+      name: 'HarnessValidationError',
+      message: expect.stringContaining('duplicate stream is no longer live'),
+    });
+    expect(waitForRunOutput).not.toHaveBeenCalled();
+  });
+
+  it('does not return retained completed output for duplicate stream retries', async () => {
+    const { harness, agent } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const output = buildFakeOutput({
+      runId: 'retained-completed-run',
+      fullOutput: agent.fullOutput,
+    }) as any;
+    output.status = 'success';
+    vi.spyOn(agent, 'getRunOutput').mockReturnValue(output);
+
+    await expect(
+      (session as any)._returnDuplicateMessageResult(
+        { status: 'pending', signalId: 'signal-1', runId: 'retained-completed-run' },
+        { stream: true },
+      ),
+    ).rejects.toMatchObject({
+      name: 'HarnessValidationError',
+      message: expect.stringContaining('duplicate stream is no longer live'),
+    });
+  });
+
+  it('short-circuits duplicate stream retries when pending run completion settles first', async () => {
+    const { harness, agent } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    let resolveCompletion!: (full: unknown) => void;
+    const completion = new Promise<unknown>(resolve => {
+      resolveCompletion = resolve;
+    });
+    vi.spyOn(agent, 'getRunOutput').mockReturnValue(undefined);
+    vi.spyOn(agent, 'waitForRunOutput').mockReturnValue(new Promise(() => {}));
+    (session as any)._runCompletionPromises.set('settling-pending-run', {
+      promise: completion,
+      resolve: resolveCompletion,
+      reject: vi.fn(),
+    });
+
+    const retry = (session as any)._returnDuplicateMessageResult(
+      { status: 'pending', signalId: 'signal-1', runId: 'settling-pending-run' },
+      { stream: true },
+    );
+    await nextTick();
+    resolveCompletion(agent.fullOutput);
+
+    await expect(retry).rejects.toMatchObject({
+      name: 'HarnessValidationError',
+      message: expect.stringContaining('duplicate stream is no longer live'),
+    });
   });
 });
 

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -1558,9 +1558,18 @@ export class Session {
   private async _watchRunCompletion(runId: string): Promise<void> {
     const agent = this._threadSubscriptionAgent;
     if (!agent) return;
-    const out = (await agent.waitForRunOutput(runId)) as MastraModelOutput<unknown> & {
-      _waitUntilFinished?: () => Promise<void>;
-    };
+    let out: MastraModelOutput<unknown> & { _waitUntilFinished?: () => Promise<void> };
+    try {
+      out = (await agent.waitForRunOutput(runId)) as MastraModelOutput<unknown> & {
+        _waitUntilFinished?: () => Promise<void>;
+      };
+    } catch (err) {
+      const waiter = this._runCompletionPromises.get(runId);
+      this._runCompletionPromises.delete(runId);
+      this._rememberCompletedRun(runId, { ok: false, err });
+      waiter?.reject(err);
+      return;
+    }
     try {
       if (typeof out._waitUntilFinished === 'function') {
         await out._waitUntilFinished();
@@ -2231,19 +2240,40 @@ export class Session {
           const agent = this._harness.getAgentForMode(opts.mode ?? this._record.modeId);
           await this._ensureThreadSubscription(agent);
           const runId = await this._pendingMessageRunId(evidence);
-          if (runId && !this._hasLiveMessageRun(agent, runId)) {
-            throw new HarnessValidationError('message().admissionId', 'pending message admission is not live');
+          if (runId && this._completedRuns.has(runId)) {
+            throw new HarnessValidationError('message().admissionId', 'duplicate stream is no longer live');
           }
-          const output = runId
-            ? ((agent.getRunOutput(runId) as AgentStream | undefined) ??
-              (await Promise.race([
-                agent.waitForRunOutput(runId) as Promise<AgentStream>,
-                this._awaitRunCompletion(runId).then(
+          let output = runId ? (agent.getRunOutput(runId) as AgentStream | undefined) : undefined;
+          let retainedCompletedOutput = false;
+          if (
+            output &&
+            (output as { status?: string }).status !== undefined &&
+            (output as { status?: string }).status !== 'running'
+          ) {
+            retainedCompletedOutput = true;
+            output = undefined;
+          }
+          if (runId && !output && !retainedCompletedOutput) {
+            const waitAbortController = new AbortController();
+            const completion = this._runCompletionPromises.get(runId)?.promise.then(
+              () => undefined,
+              () => undefined,
+            );
+            try {
+              output = (await Promise.race([
+                (agent.waitForRunOutput(runId, { abortSignal: waitAbortController.signal }) as Promise<AgentStream>).catch(
+                  () => undefined,
+                ),
+                ...(completion ? [completion] : []),
+                delay(MESSAGE_ADMISSION_DURABLE_WAIT_TIMEOUT_MS, waitAbortController.signal).then(
                   () => undefined,
                   () => undefined,
                 ),
-              ])))
-            : undefined;
+              ])) as AgentStream | undefined;
+            } finally {
+              waitAbortController.abort(new HarnessValidationError('message().admissionId', 'duplicate stream wait ended'));
+            }
+          }
           if (output) return output;
         }
         throw new HarnessValidationError('message().admissionId', 'duplicate stream is no longer live');

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -1067,17 +1067,44 @@ export class Session {
    * result through `message()` as a single turn. Returns the underlying
    * `AgentResult`.
    *
-   * Reference resolution checks the static code registry first, then mirrors
-   * Flue's workspace `session.skill(ref, ...)` behavior — either the
-   * frontmatter `name` or a relative path under the workspace skill source
-   * resolves. `WorkspaceSkills.get(ref)` already supports both. A code skill
+   * Reference resolution mirrors Flue's workspace `session.skill(ref, ...)`
+   * behavior for explicit workspace paths, then checks the static code
+   * registry by name, then falls back to workspace skill names. A code skill
    * owns its name, but does not hide an otherwise shadowed workspace skill's
    * explicit path reference.
    */
+  private _isExplicitWorkspaceSkillRef(ref: string): boolean {
+    return (
+      ref.includes('/') ||
+      ref.startsWith('./') ||
+      ref.startsWith('../') ||
+      /\.(?:md|mdx|txt|yaml|yml)$/i.test(ref)
+    );
+  }
+
   private async _skillsUse(ref: string, opts?: UseSkillOptions): Promise<AgentResult> {
     this._assertLive('skills.use()');
     if (typeof ref !== 'string' || ref.length === 0) {
       throw new HarnessValidationError('skills.use()', 'ref must be a non-empty string');
+    }
+
+    const tryWorkspaceSkill = async () => {
+      const workspace = await this.getWorkspace();
+      const skills = workspace?.skills;
+      return skills ? skills.get(ref) : undefined;
+    };
+
+    if (this._isExplicitWorkspaceSkillRef(ref)) {
+      const skill = await tryWorkspaceSkill();
+      if (skill) {
+        const args = opts?.args;
+        this._validateSkillArgs(skill.name, skill.metadata, args);
+        const expandedContent = this._buildSkillPrompt(skill.instructions, args);
+        return this.message({
+          content: expandedContent,
+          ...(opts?.modelOverride ? { model: opts.modelOverride } : {}),
+        });
+      }
     }
 
     const codeSkill = this._harness._getCodeSkill(ref);
@@ -1094,14 +1121,14 @@ export class Session {
     // produce a definitive answer (start a turn or refuse with a typed
     // not-found error).
     const workspace = await this.getWorkspace();
-    const workspaceSkills = workspace?.skills;
-    if (!workspaceSkills) {
+    const skills = workspace?.skills;
+    if (!skills) {
       throw new HarnessSkillNotFoundError(ref, ['code-registered']);
     }
 
     // `WorkspaceSkills.get` accepts either the frontmatter `name` or a
     // relative path under the configured skill source.
-    const skill = await workspaceSkills.get(ref);
+    const skill = await skills.get(ref);
     if (!skill) {
       throw new HarnessSkillNotFoundError(ref, ['code-registered', 'workspace']);
     }
@@ -5454,16 +5481,17 @@ export class Session {
   private _parkQueuedTurn(itemId: string, err: unknown): void {
     this._currentQueuedItemId = undefined;
     this._currentQueuedItemSource = undefined;
-    const resolver = this._queueResolvers.get(itemId);
-    if (resolver) {
-      this._queueResolvers.delete(itemId);
-      resolver.reject(err);
-    }
     this._notifyMaybeIdle();
     if (err instanceof QueueRecoveryPendingError) {
       const delayMs = Math.max(0, err.retryAt - Date.now());
       const timer = setTimeout(() => void this._maybeDrainQueue(), delayMs);
       timer.unref?.();
+      return;
+    }
+    const resolver = this._queueResolvers.get(itemId);
+    if (resolver) {
+      this._queueResolvers.delete(itemId);
+      resolver.reject(err);
     }
   }
 

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -1,4 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import { createClient } from '@libsql/client';
 import type { Client } from '@libsql/client';
@@ -16,8 +19,9 @@ let harnessDbCounter = 0;
 
 function createHarnessTestClient() {
   harnessDbCounter += 1;
+  const dbPath = join(tmpdir(), `mastra-harness-libsql-${process.pid}-${harnessDbCounter}-${randomUUID()}.db`);
   return createClient({
-    url: `file:/tmp/mastra-harness-libsql-${process.pid}-${harnessDbCounter}-${randomUUID()}.db`,
+    url: pathToFileURL(dbPath).href,
   });
 }
 

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -139,6 +139,7 @@ export class HarnessLibSQL extends HarnessStorage {
 
   async dangerouslyClearAll(): Promise<void> {
     await this.#ensureMessageResultsTable();
+    await this.#ensureOperationTombstonesTable();
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_ATTACHMENT_REFERENCES}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_ATTACHMENTS}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_MESSAGE_RESULTS}`);
@@ -1231,6 +1232,15 @@ export class HarnessLibSQL extends HarnessStorage {
       tableName: TABLE_HARNESS_MESSAGE_RESULTS,
       schema: TABLE_SCHEMAS[TABLE_HARNESS_MESSAGE_RESULTS],
       compositePrimaryKey: messageResultsConfig?.compositePrimaryKey,
+    });
+  }
+
+  async #ensureOperationTombstonesTable(): Promise<void> {
+    const tombstonesConfig = TABLE_CONFIGS[TABLE_HARNESS_OPERATION_TOMBSTONES];
+    await this.#db.createTable({
+      tableName: TABLE_HARNESS_OPERATION_TOMBSTONES,
+      schema: TABLE_SCHEMAS[TABLE_HARNESS_OPERATION_TOMBSTONES],
+      compositePrimaryKey: tombstonesConfig?.compositePrimaryKey,
     });
   }
 


### PR DESCRIPTION
## Summary

PF-513 snapshots the Agent thread-stream PubSub per execution path so a stream/resume/idle wake keeps using the bus selected at entry even if the Agent or Mastra PubSub changes while async setup is still running.

Changes:
- Snapshot and remember PubSub by run id/thread target for `stream`, `resumeStream`, `streamUntilIdle`, `resumeStreamUntilIdle`, `sendSignal`, subscriptions, run lookup, and abort helpers.
- Reserve thread runs before async default-option setup when explicit memory or request-context thread keys are available.
- Handle default-option retargeting, setup failure cleanup, queued idle wake cleanup, reservation waiters, duplicate run-id rejection, abort cleanup, and remote `run-aborted` pending-signal cleanup.
- Add focused regression coverage in `packages/core/src/agent/__tests__/agent-signals.test.ts`.

## Validation

Run from `/tmp/mastra-fork-pf-513-agent-pubsub-snapshot` after the final patch:

- `timeout 120s pnpm --filter @mastra/core test src/agent/__tests__/agent-signals.test.ts` - passed, 51 tests
- `timeout 120s pnpm --filter @mastra/core test src/agent/__tests__/stream-until-idle.test.ts` - passed, 10 tests
- `timeout 180s pnpm --filter @mastra/core typecheck` - passed
- `timeout 180s pnpm build:core` - passed
- `git diff --check` - passed

Known caveat: one review pass attempted `pnpm --filter ./packages/core check`; it failed on existing unrelated implicit-any errors in `src/agent/__tests__/mock-model.ts` and `src/test-utils/llm-mock.ts`. The focused build tsconfig typecheck above passed.

## Review Evidence

- Local Codex review pass 1 and pass 2 were run earlier on this diff family; verified findings were fixed before push.
- After CodeRabbit/Claude fixes changed the diff, re-running local Codex reviews was blocked by the Codex CLI usage limit until 5:09 AM, so no fresh final Codex result is claimed.
- `timeout 600s coderabbit review --plain` completed with 4 findings:
  - Fixed in-scope: idle wake snapshot uses resolved idle target.
  - Fixed in-scope: `streamUntilIdle`/`resumeStreamUntilIdle` honor injected `_pubsub`.
  - Skipped out-of-scope/non-diff: `packages/memory/package.json` version policy.
  - Skipped out-of-scope/non-diff: `mastracode/src/index.ts` crossProcessPubSub guard.
- Claude read-only council review completed:
  - Fixed verified re-reservation setup-failure PubSub mapping leak.
  - Fixed JSDoc indentation nit.
  - Deferred non-blocking runtime nits as follow-up candidates: bounded `abortedRunIds` retention policy and deterministic waiter handoff instead of one-tick handoff.

Linear: PF-513


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5
When a task (run) starts, the agent now pins the exact communication channel (PubSub) used to start it and keeps using that same channel for the entire run—so concurrent runs don’t get mixed up if the agent’s default channel changes while a run is setting up.

Overview
Implements per-execution-path PubSub snapshotting and explicit thread-run reservation semantics so each runId (and thread target) is associated with a specific PubSub at reservation/setup time and continues to use that PubSub for streaming, signals, aborts, lookups, and idle continuations even if agent defaults or options change during async setup. Adds robust reservation, retargeting, waiter resolution, and cleanup for failed/aborted setups to prevent cross-run/agent interference.

Key changes
- Agent (agent.ts / agent.types.ts)
  - Track per-run and per-thread-target PubSub mappings and thread-target -> runId mapping.
  - `#execute` and stream/resume flows accept/propagate an internal _pubsub option (fallback to agent.getPubSub()/defaultAgentThreadPubSub) so each execution uses a consistent PubSub.
  - Thread-signal APIs (getRunOutput, waitForRunOutput, subscribeToThread, sendSignal, abortThreadStream, abortRunStream, register/run lookup) resolve and forward the per-run PubSub.
  - Idle-loop flows (streamUntilIdle / resumeStreamUntilIdle) propagate the resolved _pubsub so continuations reuse the same routing.
  - Resume snapshot logic patches memory/thread target into resumed options for consistent retargeting.

- Runtime reservation & cleanup (thread-stream-runtime.ts)
  - Adds explicit reservation state: reservedAgentIdsByRunId, reservation waiters, pending-idle queues keyed by runId, rejected/aborted tombstones, and accepted-caller-signal bookkeeping.
  - New public APIs: reserveRun, retargetReservedRun, releaseRunReservation (reservation lifecycle management).
  - registerRun validates reservations/ownership, resolves waiters and pending-output waiters, and starts completion tracking.
  - waitForRunOutput supports an optional abortSignal and removes waiters on abort.
  - `#watchThreadRunCompletion` now drains queued signals/idle signals, performs prepared cleanup, deletes run mappings, and resolves reservation waiters on completion.
  - Idle-signal draining is reservation-aware: rejects conflicting starts via onRunRejected, preserves reservation metadata when starting reserved runs, and cleans up on failures.
  - sendSignal updated to only attach to appropriate reserved/active runs, treat aborted runs correctly, and handle idempotency/queued idle-run semantics.

- Types
  - AgentExecutionOptionsBase gained an optional internal field _pubsub?: PubSub to pass per-run PubSub through execution options.
  - SendAgentSignalOptions discriminated union adjusted to refine threadId/runId/resourceId branches.

- Tests & validation
  - Large focused regression tests added in packages/core/src/agent/__tests__/agent-signals.test.ts covering PubSub snapshotting, reservation/retargeting, setup failure cleanup, queued idle wake behavior, waiter resolution, duplicate run-id handling, abort and tombstone cleanup, and cross-agent ownership scenarios.
  - Additional harness/session tests updated to strengthen duplicate-stream retry and completion bookkeeping behavior.
  - Local validation: core agent tests (agent-signals.test.ts: 51 tests; stream-until-idle.test.ts: 10 tests) passed; core typecheck and build passed; changeset updated to release a patch for `@mastra/core`. Broader package check flagged unrelated implicit-any test-mock issues (not part of this change).

Public API impacts
- New public methods on AgentThreadStreamRuntime: reserveRun, retargetReservedRun, releaseRunReservation.
- waitForRunOutput signature extended to accept an optional abortSignal.
- registerRun return-handling and behavior updated (registration publish/async completion semantics).
- Internal: AgentExecutionOptionsBase has new optional internal _pubsub?: PubSub.
- No breaking changes to external public method signatures beyond the noted runtime additions and the optional internal field.

Size & review effort
- Significant edits concentrated in packages/core/src/agent/agent.ts and packages/core/src/agent/thread-stream-runtime.ts (hundreds–thousands of lines); tests added (~+1938 lines in agent-signals.test.ts). Estimated review effort: medium–high.

Why this matters
- Ensures deterministic routing of signals, streams, aborts, and idle continuations to the same PubSub instance that started a run, preventing cross-talk and ownership/order bugs when multiple streams and agents operate concurrently or when defaults change during async setup. Improves robustness around reservation ownership, cleanup, and waiter resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->