### PR TITLE
[PF-522] Resolve close lifecycle review races

### DIFF
--- a/.changeset/pf-522-harness-close-races.md
+++ b/.changeset/pf-522-harness-close-races.md
@@ -2,4 +2,6 @@
 "@mastra/core": patch
 ---
 
-Fixed Harness v1 shutdown reliability when deleting threads with active sessions, and improved child session retries while their parent session is closing.
+Fixed race conditions that could cause errors during shutdown when sessions were still active.
+
+Improved reliability when creating child sessions while parent sessions are closing.

--- a/.changeset/pf-522-harness-close-races.md
+++ b/.changeset/pf-522-harness-close-races.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fixed Harness v1 shutdown reliability when deleting threads with active sessions, and improved child session retries while their parent session is closing.

--- a/.changeset/pf-522-libsql-parent-admission.md
+++ b/.changeset/pf-522-libsql-parent-admission.md
@@ -2,4 +2,6 @@
 "@mastra/libsql": patch
 ---
 
-Fixed Harness v1 child session admission in LibSQL storage so parent session closing and retry behavior matches the core storage contract.
+Fixed errors when creating child sessions with LibSQL storage during parent session lifecycle changes.
+
+Improved session creation and retry reliability when using LibSQL storage.

--- a/.changeset/pf-522-libsql-parent-admission.md
+++ b/.changeset/pf-522-libsql-parent-admission.md
@@ -1,0 +1,5 @@
+---
+"@mastra/libsql": patch
+---
+
+Fixed Harness v1 child session admission in LibSQL storage so parent session closing and retry behavior matches the core storage contract.

--- a/packages/core/src/harness/v1/harness.test.ts
+++ b/packages/core/src/harness/v1/harness.test.ts
@@ -484,6 +484,72 @@ describe('Harness v1 — lifecycle', () => {
     expect(stored?.closedAt).toBeUndefined();
   });
 
+  it('does not cascade thread delete after shutdown begins', async () => {
+    const storage = makeStorage();
+    const harness = makeHarness({ sessions: { storage } });
+    const thread = await harness.threads.create({ resourceId: 'r1', threadId: 'delete-during-shutdown' });
+    const s = await harness.session({ threadId: thread.id, resourceId: 'r1' });
+    const originalRelease = storage.releaseSessionLease.bind(storage);
+    let releaseShutdown!: () => void;
+    let releaseStarted!: () => void;
+    const releaseGate = new Promise<void>(resolve => {
+      releaseShutdown = resolve;
+    });
+    const releaseSeen = new Promise<void>(resolve => {
+      releaseStarted = resolve;
+    });
+    storage.releaseSessionLease = (async (...args: Parameters<typeof storage.releaseSessionLease>) => {
+      releaseStarted();
+      await releaseGate;
+      return originalRelease(...args);
+    }) as typeof storage.releaseSessionLease;
+
+    const shutdown = harness.shutdown();
+    await releaseSeen;
+    await harness.threads.delete({ resourceId: 'r1', threadId: thread.id });
+    releaseShutdown();
+    await shutdown;
+
+    const stored = await storage.loadSession({ sessionId: s.id, harnessName: 'default' });
+    expect(stored?.closedAt).toBeUndefined();
+  });
+
+  it('does not delete thread data when shutdown starts during a delete cascade', async () => {
+    const storage = makeStorage();
+    const harness = makeHarness({ sessions: { storage } });
+    const thread = await harness.threads.create({ resourceId: 'r1', threadId: 'delete-cascade-during-shutdown' });
+    const s = await harness.session({ threadId: thread.id, resourceId: 'r1' });
+    const originalSaveSession = storage.saveSession.bind(storage);
+    let releaseTerminalSave!: () => void;
+    let terminalSaveStarted!: () => void;
+    const terminalSaveGate = new Promise<void>(resolve => {
+      releaseTerminalSave = resolve;
+    });
+    const terminalSaveSeen = new Promise<void>(resolve => {
+      terminalSaveStarted = resolve;
+    });
+    storage.saveSession = (async (...args: Parameters<typeof storage.saveSession>) => {
+      const [record] = args;
+      if (record.id === s.id && record.closingAt !== undefined && record.closedAt !== undefined) {
+        terminalSaveStarted();
+        await terminalSaveGate;
+      }
+      return originalSaveSession(...args);
+    }) as typeof storage.saveSession;
+
+    const deleting = harness.threads.delete({ resourceId: 'r1', threadId: thread.id });
+    await terminalSaveSeen;
+    const shutdown = harness.shutdown();
+    releaseTerminalSave();
+    await Promise.all([deleting, shutdown]);
+
+    await expect(harness.threads.get({ resourceId: 'r1', threadId: thread.id })).resolves.toMatchObject({
+      id: thread.id,
+    });
+    const stored = await storage.loadSession({ sessionId: s.id, harnessName: 'default' });
+    expect(stored?.closedAt).toBeDefined();
+  });
+
   it('aborts an active turn at the close deadline before terminalizing', async () => {
     const storage = makeStorage();
     const agent = new MockAgent({ id: 'default' });
@@ -983,6 +1049,75 @@ describe('Harness v1 — deterministic-id branch (§5.3)', () => {
     const second = await harness.session({ threadId: 't1', resourceId: 'r1', sessionId: 'sess-different' });
     expect(second.id).toBe(first.id);
     expect(second.threadId).toBe('t1');
+  });
+
+  it('returns an existing active child when the parent closes after thread lookup misses', async () => {
+    const storage = makeStorage();
+    const harness = makeHarness({ sessions: { storage } });
+    const parent = await harness.session({ threadId: 'parent-thread', resourceId: 'r1', sessionId: 'parent' });
+    const now = Date.now();
+    await storage.createOrLoadActiveSession(
+      {
+        ...parent.getRecord(),
+        id: 'existing-child',
+        threadId: 'child-thread',
+        parentSessionId: parent.id,
+        origin: 'subagent-tool',
+        subagentDepth: 1,
+        createdAt: now,
+        lastActivityAt: now,
+        version: 0,
+        ownerId: harness.ownerId,
+        leaseExpiresAt: now + 30_000,
+      },
+      { initialLease: { ownerId: harness.ownerId, ttlMs: 30_000 } },
+    );
+
+    const originalLoadSessionByThread = storage.loadSessionByThread.bind(storage);
+    let forcedThreadMiss = false;
+    storage.loadSessionByThread = (async (...args: Parameters<typeof storage.loadSessionByThread>) => {
+      const [opts] = args;
+      if (opts.threadId === 'child-thread' && opts.resourceId === 'r1' && !forcedThreadMiss) {
+        forcedThreadMiss = true;
+        return null;
+      }
+      return originalLoadSessionByThread(...args);
+    }) as typeof storage.loadSessionByThread;
+
+    const originalSaveSession = storage.saveSession.bind(storage);
+    let releaseClosingMarker!: () => void;
+    let closingMarkerStarted!: () => void;
+    const closingMarkerGate = new Promise<void>(resolve => {
+      releaseClosingMarker = resolve;
+    });
+    const closingMarkerSeen = new Promise<void>(resolve => {
+      closingMarkerStarted = resolve;
+    });
+    storage.saveSession = (async (...args: Parameters<typeof storage.saveSession>) => {
+      const [record] = args;
+      if (record.id === parent.id && record.closingAt !== undefined && record.closedAt === undefined) {
+        closingMarkerStarted();
+        await closingMarkerGate;
+      }
+      return originalSaveSession(...args);
+    }) as typeof storage.saveSession;
+
+    const closing = parent.close();
+    await closingMarkerSeen;
+
+    const child = await harness.session({
+      threadId: 'child-thread',
+      resourceId: 'r1',
+      parentSessionId: parent.id,
+      sessionId: 'retry-child',
+      origin: 'subagent-tool',
+    });
+
+    expect(child.id).toBe('existing-child');
+    expect(forcedThreadMiss).toBe(true);
+    await expect(storage.loadSession({ sessionId: 'retry-child', harnessName: 'default' })).resolves.toBeNull();
+    releaseClosingMarker();
+    await closing;
   });
 });
 

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -887,8 +887,6 @@ export class Harness {
     if (!mode) {
       throw new HarnessConfigError('session().modeId', `unknown mode "${modeId}"`);
     }
-    await this._assertParentAcceptsChild(storage, init.parentSessionId, init.resourceId);
-
     const record: SessionRecord = {
       id: sessionId,
       harnessName: this._harnessName,
@@ -912,6 +910,22 @@ export class Harness {
       ownerId: this.ownerId,
       leaseExpiresAt: now + this._leaseTtlMs,
     };
+
+    const liveParentError = this._getLiveParentAdmissionError(init.parentSessionId, init.resourceId);
+    if (liveParentError) {
+      const existing = await storage.loadSessionByThread({
+        harnessName: this._harnessName,
+        threadId: init.threadId,
+        resourceId: init.resourceId,
+      });
+      if (existing) {
+        if (existing.closingAt !== undefined) {
+          throw new HarnessSessionClosingError(existing.id);
+        }
+        return this._hydrate(storage, existing);
+      }
+      throw liveParentError;
+    }
 
     let admitted;
     try {
@@ -942,37 +956,14 @@ export class Harness {
     return this._publish(storage, admitted.record);
   }
 
-  private async _assertParentAcceptsChild(
-    storage: HarnessStorage,
-    parentSessionId: string | undefined,
-    resourceId: string,
-  ): Promise<void> {
-    if (!parentSessionId) return;
-
-    const live = this._liveSessions.get(parentSessionId);
-    if (live) {
-      if (live.resourceId !== resourceId) {
-        throw new HarnessSessionNotFoundError(parentSessionId);
-      }
-      if (live.isClosing) {
-        throw new HarnessSessionClosingError(parentSessionId);
-      }
-      if (live.isClosed) {
-        throw new HarnessSessionClosedError(parentSessionId);
-      }
-      return;
-    }
-
-    const stored = await storage.loadSession({ harnessName: this._harnessName, sessionId: parentSessionId });
-    if (!stored || stored.resourceId !== resourceId) {
-      throw new HarnessSessionNotFoundError(parentSessionId);
-    }
-    if (stored.closedAt !== undefined) {
-      throw new HarnessSessionClosedError(parentSessionId);
-    }
-    if (stored.closingAt !== undefined) {
-      throw new HarnessSessionClosingError(parentSessionId);
-    }
+  private _getLiveParentAdmissionError(parentSessionId: string | undefined, resourceId: string): Error | undefined {
+    if (!parentSessionId) return undefined;
+    const liveParent = this._liveSessions.get(parentSessionId);
+    if (!liveParent) return undefined;
+    if (liveParent.resourceId !== resourceId) return new HarnessSessionNotFoundError(parentSessionId);
+    if (liveParent.isClosing) return new HarnessSessionClosingError(parentSessionId);
+    if (liveParent.isClosed) return new HarnessSessionClosedError(parentSessionId);
+    return undefined;
   }
 
   private async _hydrate(storage: HarnessStorage, stored: SessionRecord): Promise<Session> {
@@ -1190,7 +1181,11 @@ export class Harness {
     }
   }
 
-  private async _prepareCloseNode(storage: HarnessStorage, record: SessionRecord, depth: number): Promise<CloseTreeNode> {
+  private async _prepareCloseNode(
+    storage: HarnessStorage,
+    record: SessionRecord,
+    depth: number,
+  ): Promise<CloseTreeNode> {
     const live = this._liveSessions.get(record.id);
     if (live) {
       return {
@@ -1274,10 +1269,7 @@ export class Harness {
     );
   }
 
-  private async _terminalizeCloseTree(
-    storage: HarnessStorage,
-    tree: CloseTreeNode[],
-  ): Promise<void> {
+  private async _terminalizeCloseTree(storage: HarnessStorage, tree: CloseTreeNode[]): Promise<void> {
     const bottomUp = [...tree].sort((a, b) => b.depth - a.depth);
     for (const node of bottomUp) {
       if (node.record.closedAt !== undefined) {
@@ -1618,8 +1610,11 @@ export class Harness {
     },
 
     delete: async (opts: ThreadDeleteOptions): Promise<void> => {
+      if (this._shutdown) return;
       const memory = await this._requireMemoryStorage('threads.delete()');
+      if (this._shutdown) return;
       const existing = await memory.getThreadById({ threadId: opts.threadId });
+      if (this._shutdown) return;
       if (!existing || existing.resourceId !== opts.resourceId) {
         // Idempotent: deleting a missing or foreign-owned thread is a no-op
         // from the caller's perspective. Cross-resource existence is never
@@ -1636,9 +1631,11 @@ export class Harness {
         threadId: opts.threadId,
         resourceId: opts.resourceId,
       });
+      if (this._shutdown) return;
       if (stored) {
         cascaded = true;
         await this._closeSessionRecord(storage, stored);
+        if (this._shutdown) return;
       }
 
       await memory.deleteThread({ threadId: opts.threadId });

--- a/stores/_test-utils/src/domains/harness/index.ts
+++ b/stores/_test-utils/src/domains/harness/index.ts
@@ -2,6 +2,7 @@ import {
   HarnessStorageAdmissionConflictError,
   HarnessStorageAttachmentUnavailableError,
   HarnessStorageLeaseConflictError,
+  HarnessStorageParentSessionUnavailableError,
   HarnessStorageSessionNotFoundError,
   HarnessStorageVersionConflictError,
 } from '@mastra/core/storage';
@@ -316,6 +317,94 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           record: expect.objectContaining({ id: 'first', ownerId: 'h-1' }),
         });
         await expect(harness.loadSession({ sessionId: 'second' })).resolves.toBeNull();
+      });
+
+      it('rejects child admission when the parent is closing', async () => {
+        if (!harness) return;
+        await harness.saveSession(createSampleSessionRecord({ id: 'parent', closingAt: 1000, closeDeadlineAt: 2000 }), {
+          ownerId: 'h-1',
+          ifVersion: 0,
+        });
+
+        await expect(
+          harness.createOrLoadActiveSession(
+            createSampleSessionRecord({
+              id: 'child',
+              threadId: 'thread-child',
+              parentSessionId: 'parent',
+            }),
+            { initialLease: { ownerId: 'h-2', ttlMs: 30_000 } },
+          ),
+        ).rejects.toMatchObject({
+          name: 'HarnessStorageParentSessionUnavailableError',
+          reason: 'closing',
+        } satisfies Partial<HarnessStorageParentSessionUnavailableError>);
+        await expect(harness.loadSession({ sessionId: 'child' })).resolves.toBeNull();
+      });
+
+      it('returns an existing active child before re-validating a now-closing parent', async () => {
+        if (!harness) return;
+        await harness.saveSession(createSampleSessionRecord({ id: 'parent' }), { ownerId: 'h-1', ifVersion: 0 });
+        await harness.saveSession(
+          createSampleSessionRecord({
+            id: 'child',
+            threadId: 'thread-child',
+            parentSessionId: 'parent',
+          }),
+          { ownerId: 'h-2', ifVersion: 0 },
+        );
+        const parent = await harness.loadSession({ sessionId: 'parent' });
+        if (!parent) throw new Error('expected parent session');
+        await harness.saveSession(
+          {
+            ...parent,
+            closingAt: 1000,
+            closeDeadlineAt: 2000,
+          },
+          { ownerId: 'h-1', ifVersion: parent.version },
+        );
+
+        await expect(
+          harness.createOrLoadActiveSession(
+            createSampleSessionRecord({
+              id: 'retry-child',
+              threadId: 'thread-child',
+              parentSessionId: 'parent',
+            }),
+            { initialLease: { ownerId: 'h-3', ttlMs: 30_000 } },
+          ),
+        ).resolves.toMatchObject({
+          created: false,
+          leaseAcquired: false,
+          record: expect.objectContaining({ id: 'child' }),
+        });
+        await expect(harness.loadSession({ sessionId: 'retry-child' })).resolves.toBeNull();
+      });
+
+      it('checks parent availability before deterministic id conflicts', async () => {
+        if (!harness) return;
+        await harness.saveSession(createSampleSessionRecord({ id: 'parent', closingAt: 1000, closeDeadlineAt: 2000 }), {
+          ownerId: 'h-1',
+          ifVersion: 0,
+        });
+        await harness.saveSession(createSampleSessionRecord({ id: 'colliding-child', threadId: 'other-thread' }), {
+          ownerId: 'h-2',
+          ifVersion: 0,
+        });
+
+        await expect(
+          harness.createOrLoadActiveSession(
+            createSampleSessionRecord({
+              id: 'colliding-child',
+              threadId: 'thread-child',
+              parentSessionId: 'parent',
+            }),
+            { initialLease: { ownerId: 'h-3', ttlMs: 30_000 } },
+          ),
+        ).rejects.toMatchObject({
+          name: 'HarnessStorageParentSessionUnavailableError',
+          reason: 'closing',
+        } satisfies Partial<HarnessStorageParentSessionUnavailableError>);
       });
 
       it('allows the same resource/thread active key in a different harness namespace', async () => {

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -10,7 +10,7 @@ import {
   TABLE_HARNESS_ATTACHMENTS,
   TABLE_HARNESS_SESSIONS,
 } from '@mastra/core/storage';
-import type { SessionRecord } from '@mastra/core/storage';
+import type { SessionRecord, HarnessStorageParentSessionUnavailableError } from '@mastra/core/storage';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { HarnessLibSQL } from './index';
@@ -222,6 +222,76 @@ describe('HarnessLibSQL legacy Harness table migrations', () => {
       'Cannot create Harness active-session uniqueness index while duplicate active rows exist',
     );
     await expect(primaryKeyColumns(client, TABLE_HARNESS_SESSIONS)).resolves.toEqual(['id']);
+  });
+});
+
+describe('HarnessLibSQL active session admission', () => {
+  let storage: HarnessLibSQL;
+
+  beforeEach(async () => {
+    const client = createHarnessTestClient();
+    storage = new HarnessLibSQL({ client });
+    await storage.init();
+  });
+
+  it('rejects child admission when the parent is closing', async () => {
+    await storage.saveSession(sampleSession({ id: 'parent', closingAt: 1000, closeDeadlineAt: 2000 }), {
+      ownerId: 'h-1',
+      ifVersion: 0,
+    });
+
+    await expect(
+      storage.createOrLoadActiveSession(
+        sampleSession({
+          id: 'child',
+          threadId: 'thread-child',
+          parentSessionId: 'parent',
+        }),
+        { initialLease: { ownerId: 'h-2', ttlMs: 30_000 } },
+      ),
+    ).rejects.toMatchObject({
+      name: 'HarnessStorageParentSessionUnavailableError',
+      reason: 'closing',
+    } satisfies Partial<HarnessStorageParentSessionUnavailableError>);
+    await expect(storage.loadSession({ sessionId: 'child' })).resolves.toBeNull();
+  });
+
+  it('returns an existing active child session before re-validating a now-closing parent', async () => {
+    await storage.saveSession(sampleSession({ id: 'parent' }), { ownerId: 'h-1', ifVersion: 0 });
+    await storage.saveSession(
+      sampleSession({
+        id: 'child',
+        threadId: 'thread-child',
+        parentSessionId: 'parent',
+      }),
+      { ownerId: 'h-2', ifVersion: 0 },
+    );
+    const parent = await storage.loadSession({ sessionId: 'parent' });
+    if (!parent) throw new Error('expected parent session');
+    await storage.saveSession(
+      {
+        ...parent,
+        closingAt: 1000,
+        closeDeadlineAt: 2000,
+      },
+      { ownerId: 'h-1', ifVersion: parent.version },
+    );
+
+    await expect(
+      storage.createOrLoadActiveSession(
+        sampleSession({
+          id: 'retry-child',
+          threadId: 'thread-child',
+          parentSessionId: 'parent',
+        }),
+        { initialLease: { ownerId: 'h-3', ttlMs: 30_000 } },
+      ),
+    ).resolves.toMatchObject({
+      created: false,
+      leaseAcquired: false,
+      record: expect.objectContaining({ id: 'child' }),
+    });
+    await expect(storage.loadSession({ sessionId: 'retry-child' })).resolves.toBeNull();
   });
 });
 

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -7,6 +7,7 @@ import {
   HarnessStorageAttachmentInUseError,
   HarnessStorageAttachmentUnavailableError,
   HarnessStorageLeaseConflictError,
+  HarnessStorageParentSessionUnavailableError,
   HarnessStorageSessionNotFoundError,
   HarnessStorageVersionConflictError,
   TABLE_CONFIGS,
@@ -422,6 +423,25 @@ export class HarnessLibSQL extends HarnessStorage {
           expiresAt: existing.leaseExpiresAt,
           storageNow,
         };
+      }
+
+      if (record.parentSessionId !== undefined) {
+        const parent = await tx.execute({
+          sql: `SELECT resource_id, closed_at, closing_at FROM ${TABLE_HARNESS_SESSIONS}
+                WHERE harness_name = ? AND id = ?
+                LIMIT 1`,
+          args: [harnessName, record.parentSessionId],
+        });
+        const parentRow = parent.rows[0] as Record<string, unknown> | undefined;
+        if (!parentRow || String(parentRow.resource_id) !== record.resourceId) {
+          throw new HarnessStorageParentSessionUnavailableError(record.parentSessionId, 'not_found');
+        }
+        if (parentRow.closed_at != null) {
+          throw new HarnessStorageParentSessionUnavailableError(record.parentSessionId, 'closed');
+        }
+        if (parentRow.closing_at != null) {
+          throw new HarnessStorageParentSessionUnavailableError(record.parentSessionId, 'closing');
+        }
       }
 
       const existingById = await tx.execute({


### PR DESCRIPTION
## Linear

PF-522: https://linear.app/papersflow/issue/PF-522/harness-v1-resolve-pr-95-post-merge-shutdownidempotency-review-threads

## Summary

- Stop `threads.delete()` from starting a close cascade after harness shutdown has begun, and stop it from deleting thread data if shutdown begins while a cascade is in flight.
- Move persisted parent session admission to the storage `createOrLoadActiveSession()` boundary while preserving idempotent retries that return an existing active child before revalidating a now-closing parent.
- Add LibSQL parent-admission parity plus shared harness storage conformance tests for closing-parent rejection, retry behavior, and deterministic-id ordering.
- Add separate patch changesets for `@mastra/core` and `@mastra/libsql`.

## Review Threads Addressed

- PR #95 shutdown cascade thread: https://github.com/mbenhamd/mastra/pull/95#discussion_r3252715814
- PR #95 parent-state/idempotency thread: https://github.com/mbenhamd/mastra/pull/95#discussion_r3252715818

## Validation

- `timeout 180s pnpm --filter @mastra/core test src/harness/v1/harness.test.ts src/storage/domains/harness/inmemory.test.ts`
- `timeout 180s pnpm --filter @mastra/libsql test src/storage/domains/harness/index.test.ts`
- `timeout 300s pnpm --filter @mastra/libsql test src/storage/index.test.ts`
- `timeout 180s pnpm --filter @mastra/core typecheck`
- `timeout 180s pnpm --filter @mastra/libsql build:lib`
- `git diff --check`
- Local Codex review pass A: no findings after shutdown-data guard.
- Local Codex review pass B: no findings.
- Local CodeRabbit CLI review: no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes timing bugs so the session manager (Harness) stops deleting threads once shutdown starts and ensures child sessions only get created if their parent is still accepting new sessions. It prevents new hires from being added while the office is closing and makes sure already-hired people aren't removed mid-cleanup.

## Overview

Resolves race conditions in Harness v1 shutdown and parent/child session admission by:
1. Preventing thread-deletion cascades from running after harness shutdown begins (and preventing in-flight cascades from removing thread data once shutdown starts).
2. Moving parent-session availability validation into the storage create/load boundary with idempotent retry behavior.
3. Adding LibSQL parity and comprehensive tests for closing-parent rejection, retry semantics, and deterministic-id ordering.

## Changes

### New Error Type
- Introduces HarnessStorageParentSessionUnavailableError for cases where a parent session is missing, closing, or closed during child admission.

### Core Harness Logic (packages/core/src/harness/v1/harness.ts)
- Replaced `_assertParentAcceptsChild(...)` precondition with `_getLiveParentAdmissionError(...)` fast-path that inspects the live parent (matching resourceId) and rejects if closing/closed; when such an error is detected, attempts to `loadSessionByThread` to hydrate an existing child instead of blindly failing.
- Added `this._shutdown` early-return guards around `threads.delete` to stop delete work after shutdown begins.
- After performing a cascaded close, re-checks shutdown immediately following `_closeSessionRecord(...)` to avoid continuing deletions mid-shutdown.

### LibSQL Storage (stores/libsql/src/storage/domains/harness/index.ts)
- `createOrLoadActiveSession` now transactionally validates a provided `parentSessionId`: it looks up the parent by harness name and parent ID, verifies resourceId matches, and rejects with HarnessStorageParentSessionUnavailableError when the parent is missing, closing, or closed.

### Test Coverage
- Core lifecycle tests (packages/core/src/harness/v1/harness.test.ts): added regression tests that ensure (a) no delete cascade runs after shutdown begins, and (b) thread data is not deleted mid-cascade when shutdown starts.
- Deterministic-ID test: ensures an existing active child is returned even if a lookup miss is injected during parent close, and that deterministic child-id records remain null as expected.
- Conformance suite (stores/_test-utils/src/domains/harness/index.ts): extended `createOrLoadActiveSession` tests to cover closing-parent rejection, returning existing active child when parent transitions during operation, and deterministic-id ordering.
- LibSQL tests (stores/libsql/src/storage/domains/harness/index.test.ts): validate rejection shape when parent is closing and correct retry/return behavior for pre-existing active children.

### Changesets
- `@mastra/core` — patch: documents shutdown/threads reliability fix.
- `@mastra/libsql` — patch: documents parent-admission parity and reliability improvements.

## Validation / CI
- Added/updated tests and lists commands used during validation (typecheck, package tests, build, and git diff --check); local reviews reported no findings after the shutdown-data guard and related fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->