### PR TITLE
[PF-527] Reconcile partial Harness batch delete failures

### DIFF
--- a/.changeset/pf-527-harness-delete-reconcile.md
+++ b/.changeset/pf-527-harness-delete-reconcile.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Harness v1 force-delete recovery so live session handles are marked deleted when a custom batch delete adapter removes part of a closed subtree before rejecting.

--- a/packages/core/src/harness/v1/harness.test.ts
+++ b/packages/core/src/harness/v1/harness.test.ts
@@ -13,7 +13,11 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Agent } from '../../agent';
 import { Mastra } from '../../mastra';
-import { HarnessStorage, HarnessStorageVersionConflictError } from '../../storage/domains/harness';
+import {
+  HarnessStorage,
+  HarnessStorageDeleteGuardConflictError,
+  HarnessStorageVersionConflictError,
+} from '../../storage/domains/harness';
 import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
 import { InMemoryDB } from '../../storage/domains/inmemory-db';
 import { InMemoryStore } from '../../storage/mock';
@@ -1349,6 +1353,63 @@ describe('Harness v1 — delete lifecycle', () => {
 
     await expect(storage.loadSession({ sessionId: child.id, harnessName: 'default' })).resolves.toBeNull();
     await expect(storage.loadSession({ sessionId: parent.id, harnessName: 'default' })).resolves.toBeNull();
+  });
+
+  it('reconciles live sessions after a custom batch delete partially fails', async () => {
+    class PartiallyFailingBatchStorage extends InMemoryHarness {
+      override async deleteSessions(opts: Parameters<InMemoryHarness['deleteSessions']>[0]): Promise<void> {
+        await InMemoryHarness.prototype.deleteSessions.call(this, { sessions: [opts.sessions[0]!] });
+        throw new HarnessStorageDeleteGuardConflictError(opts.sessions[1]!.sessionId, 'ifVersion', 1, 2);
+      }
+    }
+    const storage = new PartiallyFailingBatchStorage({ db: new InMemoryDB() });
+    const harness = makeHarness({ sessions: { storage } });
+    const parent = await harness.session({ threadId: 'parent-thread', resourceId: 'r1' });
+    const child = await harness.session({
+      threadId: { fresh: true },
+      resourceId: 'r1',
+      parentSessionId: parent.id,
+    });
+
+    await expect(harness.deleteSession({ sessionId: parent.id, resourceId: 'r1', force: true })).rejects.toBeInstanceOf(
+      HarnessStorageDeleteGuardConflictError,
+    );
+
+    await expect(storage.loadSession({ sessionId: child.id, harnessName: 'default' })).resolves.toBeNull();
+    await expect(storage.loadSession({ sessionId: parent.id, harnessName: 'default' })).resolves.toMatchObject({
+      id: parent.id,
+    });
+    await expect(child.setState({ afterPartialDelete: true })).rejects.toBeInstanceOf(HarnessSessionDeletedError);
+  });
+
+  it('preserves the original batch delete error when reconciliation reads fail', async () => {
+    const deleteError = new HarnessStorageDeleteGuardConflictError('parent', 'ifVersion', 1, 2);
+    class ReconciliationReadFailingStorage extends InMemoryHarness {
+      private failLoads = false;
+
+      override async deleteSessions(opts: Parameters<InMemoryHarness['deleteSessions']>[0]): Promise<void> {
+        await InMemoryHarness.prototype.deleteSessions.call(this, { sessions: [opts.sessions[0]!] });
+        this.failLoads = true;
+        throw deleteError;
+      }
+
+      override async loadSession(opts: Parameters<InMemoryHarness['loadSession']>[0]) {
+        if (this.failLoads) throw new Error('load failed during reconciliation');
+        return InMemoryHarness.prototype.loadSession.call(this, opts);
+      }
+    }
+    const storage = new ReconciliationReadFailingStorage({ db: new InMemoryDB() });
+    const harness = makeHarness({ sessions: { storage } });
+    const parent = await harness.session({ threadId: 'parent-thread', resourceId: 'r1' });
+    await harness.session({
+      threadId: { fresh: true },
+      resourceId: 'r1',
+      parentSessionId: parent.id,
+    });
+
+    await expect(harness.deleteSession({ sessionId: parent.id, resourceId: 'r1', force: true })).rejects.toBe(
+      deleteError,
+    );
   });
 
   it('force deletes an active subtree after terminalizing it through close', async () => {

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -1601,7 +1601,24 @@ export class Harness {
       requireClosed: true,
     }));
     if (storage.supportsAtomicDeleteSessions) {
-      await storage.deleteSessions({ sessions });
+      try {
+        await storage.deleteSessions({ sessions });
+      } catch (err) {
+        for (const node of bottomUp) {
+          let stillExists: SessionRecord | null;
+          try {
+            stillExists = await storage.loadSession({
+              harnessName: node.record.harnessName,
+              sessionId: node.record.id,
+            });
+          } catch {
+            continue;
+          }
+          if (stillExists) continue;
+          this._markDeletedSession(node, deletedLiveSessions);
+        }
+        throw err;
+      }
       for (const node of bottomUp) {
         this._markDeletedSession(node, deletedLiveSessions);
       }


### PR DESCRIPTION
## Linear
PF-527: [Harness v1] Reconcile live sessions after partial custom batch delete failure

## Summary
- Reconciles Harness live-session handles when a custom batch delete adapter deletes part of a closed subtree before rejecting.
- Preserves the original batch delete error if reconciliation reads fail.
- Adds focused delete lifecycle regressions plus a core-only patch changeset.

## Scope / overlap
- Branch is based on origin/main at PF-524 merge commit bbd738fa3d.
- Open PRs checked before work: #68 legacy harness/tool gate paths, #69 stale broad revert, #58 ClickHouse memory batching. No PF-527 file overlap.
- CodeRabbit local review surfaced inherited/out-of-scope findings from earlier merged branch range; the only PF-527 diff finding was changeset scope, resolved by adding a separate core-only PF-527 changeset.

## Local validation
- pnpm install --offline
- pnpm prettier --write .changeset/pf-527-harness-delete-reconcile.md .changeset/lovely-pens-laugh.md packages/core/src/harness/v1/harness.ts packages/core/src/harness/v1/harness.test.ts packages/core/src/storage/domains/harness/inmemory.ts stores/libsql/src/storage/domains/harness/index.ts
- git diff --check
- pnpm --filter @mastra/core test src/harness/v1/harness.test.ts src/storage/domains/harness/inmemory.test.ts
- pnpm --filter @mastra/libsql test src/storage/domains/harness/index.test.ts
- pnpm --filter @mastra/core typecheck
- pnpm build:core
- pnpm --filter @mastra/libsql build:lib
- pnpm --filter ./packages/core exec vitest run src/harness/v1/harness.test.ts
- pnpm --filter ./packages/core check
- Local Codex review pass 1: no findings
- Local Codex review pass 2: no findings
- CodeRabbit CLI local review: 9 findings total, PF-527 changeset scope finding fixed; remaining findings are inherited/out-of-scope follow-ups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When deleting a group of related sessions in Harness, sometimes deletion might fail partway through—some sessions are deleted, but an error is thrown before all are done. This PR fixes that by making sure any sessions that were successfully deleted before the error are properly marked as deleted in the system, preventing orphaned records that could cause problems later.

## What's Changed

### Harness Delete Reconciliation Logic
The core fix is in `packages/core/src/harness/v1/harness.ts`. The `_deleteClosedTree()` method's atomic deletion path now wraps the `storage.deleteSessions()` call in a try-catch block. When the delete operation fails:
1. The code attempts best-effort cleanup by iterating through the bottom-up session nodes
2. For each session, it checks if it still exists via `storage.loadSession()`
3. Any sessions that no longer exist are marked as deleted using `_markDeletedSession()`
4. The original error is then rethrown to preserve the failure context

The non-atomic deletion path remains unchanged.

### Test Coverage
Added two new "delete lifecycle" regression tests in `packages/core/src/harness/v1/harness.test.ts`:
1. **Partial Delete Failure Test**: Validates that when a custom `deleteSessions` implementation partially fails (deletes only the first session then throws `HarnessStorageDeleteGuardConflictError`), the child session is properly marked deleted, the parent remains reconciled, and subsequent operations on the parent correctly fail with `HarnessSessionDeletedError`
2. **Reconciliation with Read Failures Test**: Validates that when reconciliation encounters read failures, the original batch delete error is preserved and returned as the rejection from `harness.deleteSession`

Updated the test file's imports to include `HarnessStorageDeleteGuardConflictError` for these new assertions.

### Changeset
Added a core-only changeset (`pf-527-harness-delete-reconcile.md`) that documents the patch-level bump for `@mastra/core` with the fix for "Harness v1 force-delete recovery."

## Validation
- All existing tests pass including core and libsql-specific tests
- Local code review and type checking completed
- Two local Codex review passes with no findings for PF-527-scoped changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->