### PR TITLE
fix(core): [PF-529] remove duplicate Harness session column PK

### DIFF
--- a/.changeset/pf-529-harness-session-primary-key.md
+++ b/.changeset/pf-529-harness-session-primary-key.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Harness session schema metadata so the namespace-aware session primary key is defined only as the table-level `harness_name,id` key.

--- a/packages/core/src/storage/constants.test.ts
+++ b/packages/core/src/storage/constants.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+import { TABLE_CONFIGS, TABLE_HARNESS_SESSIONS, TABLE_SCHEMAS } from './constants';
+
+describe('storage table constants', () => {
+  it('keeps Harness sessions primary key metadata at table level', () => {
+    expect(TABLE_SCHEMAS[TABLE_HARNESS_SESSIONS].id.primaryKey).toBeUndefined();
+    expect(TABLE_CONFIGS[TABLE_HARNESS_SESSIONS]?.compositePrimaryKey).toEqual(['harness_name', 'id']);
+  });
+});

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -641,7 +641,7 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
   // their internals.
   [TABLE_HARNESS_SESSIONS]: {
     harness_name: { type: 'text', nullable: false },
-    id: { type: 'text', nullable: false, primaryKey: true },
+    id: { type: 'text', nullable: false },
     resource_id: { type: 'text', nullable: false },
     thread_id: { type: 'text', nullable: false },
     parent_session_id: { type: 'text', nullable: true },


### PR DESCRIPTION
## Summary
- removes the legacy column-level primaryKey marker from Harness session id metadata
- keeps the namespace-aware table-level composite key on (harness_name, id)
- adds a focused constants test so the schema/config invariant stays explicit

## Linear
- PF-529

## Validation
- pnpm install --offline
- pnpm prettier --write .changeset/pf-529-harness-session-primary-key.md packages/core/src/storage/constants.ts packages/core/src/storage/constants.test.ts
- git diff --check
- pnpm --filter @mastra/core test src/storage/constants.test.ts
- pnpm --filter @mastra/libsql test src/storage/domains/harness/index.test.ts
- pnpm --filter @mastra/core typecheck
- local Codex review pass 1: no findings
- local Codex review pass 2: no findings
- CodeRabbit CLI local review: 18 findings; PF-529-scoped Harness session primary key finding is addressed by this diff, remaining findings are inherited/out of scope under PF-528/follow-ups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR fixes how the database identifies Harness sessions. Instead of saying "the ID alone is unique," it now properly says "the combination of Harness name AND ID is unique." This is like using both a room number AND a building name to uniquely identify a place, rather than trying to use just the room number alone. The change also includes a test to make sure this setup stays correct in the future.

## Changes

**`packages/core/src/storage/constants.ts`**
- Removed the `primaryKey: true` property from the `id` column definition in the `mastra_harness_sessions` table schema
- The namespace-aware composite primary key remains defined at the table level as `(harness_name, id)`

**`packages/core/src/storage/constants.test.ts`**
- New test file added to verify the corrected schema
- Test asserts that the `id` column no longer has primary key metadata at the column level
- Test confirms the table configuration specifies the composite primary key `['harness_name', 'id']`

**`.changeset/pf-529-harness-session-primary-key.md`**
- Release metadata updated to document this fix with a patch version bump for `@mastra/core`

## Impact

This removes a conflicting/duplicate primary key definition, ensuring Harness sessions are uniquely identified only by the intended composite key of harness name and session ID, preventing potential schema inconsistencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->