### PR TITLE
fix(libsql): [PF-521] reject completed evidence without run id

### DIFF
--- a/.changeset/pf-521-libsql-message-evidence-run-id.md
+++ b/.changeset/pf-521-libsql-message-evidence-run-id.md
@@ -1,0 +1,5 @@
+---
+'@mastra/libsql': patch
+---
+
+Fixed LibSQL Harness result evidence so completed message results must include their run id when written or read from storage.

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -8,6 +8,7 @@ import type { Client } from '@libsql/client';
 import {
   TABLE_HARNESS_ATTACHMENT_REFERENCES,
   TABLE_HARNESS_ATTACHMENTS,
+  TABLE_HARNESS_MESSAGE_RESULTS,
   TABLE_HARNESS_SESSIONS,
   TABLE_HARNESS_THREAD_DELETE_FENCES,
   HarnessStorageDeleteGuardConflictError,
@@ -538,9 +539,10 @@ describe('HarnessLibSQL active session admission', () => {
 
 describe('HarnessLibSQL message result evidence', () => {
   let storage: HarnessLibSQL;
+  let client: Client;
 
   beforeEach(async () => {
-    const client = createHarnessTestClient();
+    client = createHarnessTestClient();
     storage = new HarnessLibSQL({ client });
     await storage.init();
   });
@@ -622,6 +624,56 @@ describe('HarnessLibSQL message result evidence', () => {
         attemptedAdmissionHash: 'different-hash',
       }),
     ).resolves.toMatchObject({ status: 'conflict', storedAdmissionHash: 'hash-1' });
+  });
+
+  it('rejects completed message evidence without a run id', async () => {
+    await expect(
+      storage.writeMessageResultEvidence({
+        harnessName: 'default',
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        signalId: 'signal-1',
+        admissionId: 'admission-1',
+        admissionHash: 'hash-1',
+        status: 'completed',
+        result: { text: 'done' },
+        createdAt: 1000,
+        updatedAt: 2000,
+      } as unknown as Parameters<HarnessLibSQL['writeMessageResultEvidence']>[0]),
+    ).rejects.toThrow('completed status requires run_id');
+
+    await client.execute({
+      sql: `INSERT INTO ${TABLE_HARNESS_MESSAGE_RESULTS}
+            (id, harness_name, session_id, resource_id, thread_id, signal_id, run_id,
+             admission_id, admission_hash, status, result, error, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        'default\0session-1\0signal-1',
+        'default',
+        'session-1',
+        'resource-1',
+        'thread-1',
+        'signal-1',
+        null,
+        'admission-1',
+        'hash-1',
+        'completed',
+        JSON.stringify({ text: 'done' }),
+        null,
+        1000,
+        2000,
+      ],
+    });
+
+    await expect(
+      storage.loadMessageResultEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        signalId: 'signal-1',
+      }),
+    ).rejects.toThrow('completed status requires run_id');
   });
 
   it('compacts terminal message evidence into tombstones', async () => {

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -1161,6 +1161,7 @@ export class HarnessLibSQL extends HarnessStorage {
   async writeMessageResultEvidence(record: AgentSignalResultEvidence): Promise<{ created: boolean }> {
     await this.#ensureMessageResultsTable();
     const namespacedRecord = { ...record, harnessName: this.#resolveHarnessName(record.harnessName) };
+    if (namespacedRecord.status === 'completed') completedMessageEvidenceRunId(namespacedRecord);
     const id = messageEvidenceId(namespacedRecord);
     const loadCurrent = async () => {
       const current = await this.loadMessageResultEvidence({
@@ -1968,10 +1969,11 @@ function rowToMessageResultEvidence(row: Record<string, unknown>): AgentSignalRe
   };
   const status = String(row.status);
   if (status === 'completed') {
+    const runId = completedMessageEvidenceRunId(base);
     return {
       ...base,
       status: 'completed',
-      runId: base.runId ?? '',
+      runId,
       result: parseJson(row.result),
     };
   }
@@ -1992,6 +1994,14 @@ function tombstoneId(record: OperationAdmissionTombstone): string {
 
 function messageEvidenceId(record: Pick<AgentSignalResultEvidence, 'harnessName' | 'sessionId' | 'signalId'>): string {
   return `${record.harnessName}\u0000${record.sessionId}\u0000${record.signalId}`;
+}
+
+/** Completed message evidence is only useful for recovery when it preserves the runtime run id. */
+function completedMessageEvidenceRunId(record: { runId?: string; sessionId: string; signalId: string }): string {
+  if (record.runId !== undefined && record.runId.length > 0) return record.runId;
+  throw new Error(
+    `Invalid Harness message result evidence for session "${record.sessionId}" signal "${record.signalId}": completed status requires run_id`,
+  );
 }
 
 function sameTombstoneIdentity(a: OperationAdmissionTombstone, b: OperationAdmissionTombstone): boolean {


### PR DESCRIPTION
## Summary
- rejects completed Harness message result evidence writes that omit a run id
- rejects corrupt persisted completed LibSQL evidence rows that have no run_id
- adds focused LibSQL regression coverage for both write and read paths

## Linear
- PF-521

## Validation
- pnpm install --offline
- pnpm prettier --write .changeset/pf-521-libsql-message-evidence-run-id.md stores/libsql/src/storage/domains/harness/index.ts stores/libsql/src/storage/domains/harness/index.test.ts
- pnpm turbo build --filter @mastra/core...
- pnpm --filter @mastra/libsql test src/storage/domains/harness/index.test.ts
- pnpm --filter @mastra/libsql build:lib
- git diff --check
- local Codex review pass 1: no findings
- local Codex review pass 2: no findings
- pnpm --filter ./stores/libsql exec tsc -p tsconfig.json --noEmit
- pnpm --filter ./stores/libsql exec tsc -p tsconfig.build.json --noEmit
- pnpm --filter ./stores/libsql lint
- CodeRabbit CLI local review: 15 inherited/out-of-scope findings; no PF-521 diff findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Completed Harness message results must include a run ID now; attempts to save or load a completed result without a run ID will be rejected as invalid.

## Changes

### Changeset Entry
- Adds a patch changeset for `@mastra/libsql` documenting that completed Harness message-result evidence requires a run id when written or read.

### Implementation (`stores/libsql/src/storage/domains/harness/index.ts`)
- writeMessageResultEvidence validates that evidence with status: 'completed' has a non-empty runId and rejects the write otherwise.
- rowToMessageResultEvidence (the read mapping) enforces the same invariant and throws when a persisted completed row has a missing/empty run_id.
- Introduces an internal helper completedMessageEvidenceRunId to centralize the completed-status runId validation and error message formatting.

### Tests (`stores/libsql/src/storage/domains/harness/index.test.ts`)
- Promotes the test client variable for reuse and imports TABLE_HARNESS_MESSAGE_RESULTS for direct SQL seeding/verification.
- Adds a test asserting writeMessageResultEvidence rejects completed evidence without runId.
- Adds a test that seeds a completed message-result row with run_id = NULL via direct INSERT and verifies loadMessageResultEvidence throws the same 'completed status requires run_id' error.

## Validation
- Local build/test/lint/type checks and focused tests for the libsql harness domain were run as recorded in the PR objectives.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->