### PR TITLE
fix(core): [PF-523] preflight agent resume calls

### DIFF
--- a/.changeset/pf-523-agent-resume-preflight.md
+++ b/.changeset/pf-523-agent-resume-preflight.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed agent resume APIs so `resumeStream()`, `resumeStreamUntilIdle()`, and `resumeGenerate()` enforce request-context validation and `AGENTS_EXECUTE` FGA checks before loading persisted snapshots or resuming a run. Resume calls now fail closed when FGA is configured but no authenticated user is present.
+Fixed authorization checks in agent resume methods. When fine-grained access control is enabled, `resumeStream()`, `resumeStreamUntilIdle()`, and `resumeGenerate()` now require an authenticated user in the request context and will throw an error if called without one.

--- a/.changeset/pf-523-agent-resume-preflight.md
+++ b/.changeset/pf-523-agent-resume-preflight.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed agent resume APIs so `resumeStream()`, `resumeStreamUntilIdle()`, and `resumeGenerate()` enforce request-context validation and `AGENTS_EXECUTE` FGA checks before loading persisted snapshots or resuming a run. Resume calls now fail closed when FGA is configured but no authenticated user is present.

--- a/packages/core/src/agent/__tests__/agent-fga.test.ts
+++ b/packages/core/src/agent/__tests__/agent-fga.test.ts
@@ -23,12 +23,16 @@ function createMockFGAProvider(authorized = true): IFGAProvider {
   };
 }
 
-function createMockMastra(fgaProvider?: IFGAProvider) {
+function createMockMastra(
+  fgaProvider?: IFGAProvider,
+  getStorage: () => unknown = () => undefined,
+  getMemory: () => unknown = () => undefined,
+) {
   return {
     getServer: () => (fgaProvider ? { fga: fgaProvider } : {}),
     getLogger: () => undefined,
-    getMemory: () => undefined,
-    getStorage: () => undefined,
+    getMemory,
+    getStorage,
     getWorkspace: () => undefined,
     getVersionOverrides: () => undefined,
     generateId: () => 'test-run-id',
@@ -139,6 +143,224 @@ describe('Agent FGA checks', () => {
       requestContext.set('user', { id: 'user-1' });
 
       await expect(agent.stream('test', { requestContext: requestContext as any })).rejects.toThrow(FGADeniedError);
+    });
+  });
+
+  describe('resumeStream()', () => {
+    it('should call FGA provider before loading a persisted snapshot', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1', organizationMembershipId: 'om-1' });
+
+      await expect(
+        agent.resumeStream({ approved: true }, { runId: 'missing-run-id', requestContext: requestContext as any }),
+      ).rejects.toMatchObject({ id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND' });
+
+      expect(fgaProvider.require).toHaveBeenCalledWith(
+        { id: 'user-1', organizationMembershipId: 'om-1' },
+        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+      );
+    });
+
+    it('should reject denied users before loading a persisted snapshot', async () => {
+      const fgaProvider = createMockFGAProvider(false);
+      const getStorage = vi.fn(() => ({
+        getStore: vi.fn(() => ({
+          loadWorkflowSnapshot: vi.fn(),
+        })),
+      }));
+      const mastra = createMockMastra(fgaProvider, getStorage);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+
+      await expect(
+        agent.resumeStream({ approved: true }, { runId: 'missing-run-id', requestContext: requestContext as any }),
+      ).rejects.toThrow(FGADeniedError);
+      expect(getStorage).not.toHaveBeenCalled();
+    });
+
+    it('should reject missing users before loading a persisted snapshot when FGA is configured', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const getStorage = vi.fn(() => ({
+        getStore: vi.fn(() => ({
+          loadWorkflowSnapshot: vi.fn(),
+        })),
+      }));
+      const mastra = createMockMastra(fgaProvider, getStorage);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.resumeStream({ approved: true }, { runId: 'missing-run-id' })).rejects.toThrow(FGADeniedError);
+      expect(getStorage).not.toHaveBeenCalled();
+      expect(fgaProvider.require).not.toHaveBeenCalled();
+    });
+
+    it('should ignore caller-supplied preflight skip markers', async () => {
+      const fgaProvider = createMockFGAProvider(false);
+      const getStorage = vi.fn(() => ({
+        getStore: vi.fn(() => ({
+          loadWorkflowSnapshot: vi.fn(),
+        })),
+      }));
+      const mastra = createMockMastra(fgaProvider, getStorage);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+
+      await expect(
+        agent.resumeStream({ approved: true }, {
+          runId: 'missing-run-id',
+          requestContext: requestContext as any,
+          _skipAgentExecutionPreflight: true,
+        } as any),
+      ).rejects.toThrow(FGADeniedError);
+      expect(getStorage).not.toHaveBeenCalled();
+    });
+
+    it('should reject denied users before resumeStreamUntilIdle resolves memory', async () => {
+      const fgaProvider = createMockFGAProvider(false);
+      const getMemory = vi.fn();
+      const mastra = createMockMastra(fgaProvider);
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: {} as any,
+        memory: getMemory,
+      });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+
+      await expect(
+        agent.resumeStreamUntilIdle(
+          { approved: true },
+          { runId: 'missing-run-id', requestContext: requestContext as any },
+        ),
+      ).rejects.toThrow(FGADeniedError);
+      expect(getMemory).not.toHaveBeenCalled();
+    });
+
+    it('should reject missing users before resumeStreamUntilIdle resolves memory when FGA is configured', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const getMemory = vi.fn();
+      const mastra = createMockMastra(fgaProvider);
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: {} as any,
+        memory: getMemory,
+      });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.resumeStreamUntilIdle({ approved: true }, { runId: 'missing-run-id' })).rejects.toThrow(
+        FGADeniedError,
+      );
+      expect(getMemory).not.toHaveBeenCalled();
+      expect(fgaProvider.require).not.toHaveBeenCalled();
+    });
+
+    it('should only check FGA once for authorized resumeStreamUntilIdle callers', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1', organizationMembershipId: 'om-1' });
+
+      await expect(
+        agent.resumeStreamUntilIdle(
+          { approved: true },
+          { runId: 'missing-run-id', requestContext: requestContext as any },
+        ),
+      ).rejects.toMatchObject({ id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND' });
+
+      expect(fgaProvider.require).toHaveBeenCalledTimes(1);
+      expect(fgaProvider.require).toHaveBeenCalledWith(
+        { id: 'user-1', organizationMembershipId: 'om-1' },
+        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+      );
+    });
+  });
+
+  describe('resumeGenerate()', () => {
+    it('should call FGA provider before loading a persisted snapshot', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1', organizationMembershipId: 'om-1' });
+
+      await expect(
+        agent.resumeGenerate({ approved: true }, { runId: 'missing-run-id', requestContext: requestContext as any }),
+      ).rejects.toMatchObject({ id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND' });
+
+      expect(fgaProvider.require).toHaveBeenCalledWith(
+        { id: 'user-1', organizationMembershipId: 'om-1' },
+        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+      );
+    });
+
+    it('should reject denied users before loading a persisted snapshot', async () => {
+      const fgaProvider = createMockFGAProvider(false);
+      const getStorage = vi.fn(() => ({
+        getStore: vi.fn(() => ({
+          loadWorkflowSnapshot: vi.fn(),
+        })),
+      }));
+      const mastra = createMockMastra(fgaProvider, getStorage);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+
+      await expect(
+        agent.resumeGenerate({ approved: true }, { runId: 'missing-run-id', requestContext: requestContext as any }),
+      ).rejects.toThrow(FGADeniedError);
+      expect(getStorage).not.toHaveBeenCalled();
+    });
+
+    it('should reject missing users before loading a persisted snapshot when FGA is configured', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const getStorage = vi.fn(() => ({
+        getStore: vi.fn(() => ({
+          loadWorkflowSnapshot: vi.fn(),
+        })),
+      }));
+      const mastra = createMockMastra(fgaProvider, getStorage);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.resumeGenerate({ approved: true }, { runId: 'missing-run-id' })).rejects.toThrow(
+        FGADeniedError,
+      );
+      expect(getStorage).not.toHaveBeenCalled();
+      expect(fgaProvider.require).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/agent/__tests__/agent-fga.test.ts
+++ b/packages/core/src/agent/__tests__/agent-fga.test.ts
@@ -283,6 +283,31 @@ describe('Agent FGA checks', () => {
       ).rejects.toThrow(FGADeniedError);
       expect(getStorage).not.toHaveBeenCalled();
     });
+
+    it('should authorize default requestContext before loading a persisted snapshot', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'default-user', organizationMembershipId: 'default-om' });
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: {} as any,
+        defaultOptions: { requestContext: requestContext as any },
+      });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.resumeStream({ approved: true }, { runId: 'missing-run-id' })).rejects.toMatchObject({
+        id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND',
+      });
+
+      expect(fgaProvider.require).toHaveBeenCalledWith(
+        { id: 'default-user', organizationMembershipId: 'default-om' },
+        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+      );
+    });
   });
 
   describe('resumeStreamUntilIdle()', () => {
@@ -356,6 +381,32 @@ describe('Agent FGA checks', () => {
         { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
       );
     });
+
+    it('should authorize default requestContext before resolving idle memory', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'default-user', organizationMembershipId: 'default-om' });
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: {} as any,
+        defaultOptions: { requestContext: requestContext as any },
+      });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.resumeStreamUntilIdle({ approved: true }, { runId: 'missing-run-id' })).rejects.toMatchObject({
+        id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND',
+      });
+
+      expect(fgaProvider.require).toHaveBeenCalledTimes(1);
+      expect(fgaProvider.require).toHaveBeenCalledWith(
+        { id: 'default-user', organizationMembershipId: 'default-om' },
+        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+      );
+    });
   });
 
   describe('resumeGenerate()', () => {
@@ -417,6 +468,31 @@ describe('Agent FGA checks', () => {
       );
       expect(getStorage).not.toHaveBeenCalled();
       expect(fgaProvider.require).not.toHaveBeenCalled();
+    });
+
+    it('should authorize default requestContext before loading a persisted snapshot', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'default-user', organizationMembershipId: 'default-om' });
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: {} as any,
+        defaultOptions: { requestContext: requestContext as any },
+      });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.resumeGenerate({ approved: true }, { runId: 'missing-run-id' })).rejects.toMatchObject({
+        id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND',
+      });
+
+      expect(fgaProvider.require).toHaveBeenCalledWith(
+        { id: 'default-user', organizationMembershipId: 'default-om' },
+        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+      );
     });
   });
 });

--- a/packages/core/src/agent/__tests__/agent-fga.test.ts
+++ b/packages/core/src/agent/__tests__/agent-fga.test.ts
@@ -107,6 +107,33 @@ describe('Agent FGA checks', () => {
 
       expect(model.doGenerateCalls).toHaveLength(1);
     });
+
+    it('should authorize the effective request context from default options', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'default-user', organizationMembershipId: 'default-om' });
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: {} as any,
+        defaultOptions: { requestContext: requestContext as any },
+      });
+      (agent as any).__registerMastra(mastra);
+
+      try {
+        await agent.generate('test');
+      } catch {
+        // Expected to fail due to no real model.
+      }
+
+      expect(fgaProvider.require).toHaveBeenCalledWith(
+        { id: 'default-user', organizationMembershipId: 'default-om' },
+        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+      );
+    });
   });
 
   describe('stream()', () => {
@@ -143,6 +170,33 @@ describe('Agent FGA checks', () => {
       requestContext.set('user', { id: 'user-1' });
 
       await expect(agent.stream('test', { requestContext: requestContext as any })).rejects.toThrow(FGADeniedError);
+    });
+
+    it('should authorize the effective request context from default options', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'default-user', organizationMembershipId: 'default-om' });
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: {} as any,
+        defaultOptions: { requestContext: requestContext as any },
+      });
+      (agent as any).__registerMastra(mastra);
+
+      try {
+        await agent.stream('test');
+      } catch {
+        // Expected to fail due to no real model.
+      }
+
+      expect(fgaProvider.require).toHaveBeenCalledWith(
+        { id: 'default-user', organizationMembershipId: 'default-om' },
+        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+      );
     });
   });
 
@@ -229,7 +283,9 @@ describe('Agent FGA checks', () => {
       ).rejects.toThrow(FGADeniedError);
       expect(getStorage).not.toHaveBeenCalled();
     });
+  });
 
+  describe('resumeStreamUntilIdle()', () => {
     it('should reject denied users before resumeStreamUntilIdle resolves memory', async () => {
       const fgaProvider = createMockFGAProvider(false);
       const getMemory = vi.fn();

--- a/packages/core/src/agent/__tests__/request-context-schema.test.ts
+++ b/packages/core/src/agent/__tests__/request-context-schema.test.ts
@@ -174,6 +174,62 @@ describe('Agent requestContextSchema', () => {
     });
   });
 
+  describe('resume validation', () => {
+    it('should validate requestContext before resumeStream loads a snapshot', async () => {
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'You are a helpful assistant',
+        model: mockModel,
+        requestContextSchema,
+      });
+
+      const requestContext = new RequestContext<{ userId: string }>();
+      requestContext.set('userId', 'user-123');
+      // Missing apiKey
+
+      await expect(agent.resumeStream({ approved: true }, { runId: 'missing-run-id', requestContext })).rejects.toThrow(
+        /Request context validation failed for agent/,
+      );
+    });
+
+    it('should validate requestContext before resumeGenerate loads a snapshot', async () => {
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'You are a helpful assistant',
+        model: mockModel,
+        requestContextSchema,
+      });
+
+      const requestContext = new RequestContext();
+      requestContext.set('userId', 123 as any); // Wrong type
+      requestContext.set('apiKey', 'key-456');
+
+      await expect(
+        agent.resumeGenerate({ approved: true }, { runId: 'missing-run-id', requestContext }),
+      ).rejects.toThrow(/Request context validation failed for agent/);
+    });
+
+    it('should validate requestContext before resumeStreamUntilIdle resolves memory', async () => {
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'You are a helpful assistant',
+        model: mockModel,
+        requestContextSchema,
+      });
+
+      const requestContext = new RequestContext<{ userId: string }>();
+      requestContext.set('userId', 'user-123');
+      // Missing apiKey
+
+      await expect(
+        agent.resumeStreamUntilIdle({ approved: true }, { runId: 'missing-run-id', requestContext }),
+      ).rejects.toThrow(/Request context validation failed for agent/);
+    });
+  });
+
   describe('backwards compatibility', () => {
     it('should work without requestContextSchema on agent', async () => {
       const agent = new Agent({

--- a/packages/core/src/agent/__tests__/request-context-schema.test.ts
+++ b/packages/core/src/agent/__tests__/request-context-schema.test.ts
@@ -232,6 +232,25 @@ describe('Agent requestContextSchema', () => {
       );
     });
 
+    it('should validate default requestContext before resumeStream loads a snapshot', async () => {
+      const requestContext = new RequestContext<{ userId: string; apiKey: string }>();
+      requestContext.set('userId', 'default-user');
+      requestContext.set('apiKey', 'default-key');
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'You are a helpful assistant',
+        model: mockModel,
+        requestContextSchema,
+        defaultOptions: { requestContext },
+      });
+
+      await expect(agent.resumeStream({ approved: true }, { runId: 'missing-run-id' })).rejects.toMatchObject({
+        id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND',
+      });
+    });
+
     it('should validate requestContext before resumeGenerate loads a snapshot', async () => {
       const agent = new Agent({
         id: 'test-agent',
@@ -250,6 +269,25 @@ describe('Agent requestContextSchema', () => {
       ).rejects.toThrow(/Request context validation failed for agent/);
     });
 
+    it('should validate default requestContext before resumeGenerate loads a snapshot', async () => {
+      const requestContext = new RequestContext<{ userId: string; apiKey: string }>();
+      requestContext.set('userId', 'default-user');
+      requestContext.set('apiKey', 'default-key');
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'You are a helpful assistant',
+        model: mockModel,
+        requestContextSchema,
+        defaultOptions: { requestContext },
+      });
+
+      await expect(agent.resumeGenerate({ approved: true }, { runId: 'missing-run-id' })).rejects.toMatchObject({
+        id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND',
+      });
+    });
+
     it('should validate requestContext before resumeStreamUntilIdle resolves memory', async () => {
       const agent = new Agent({
         id: 'test-agent',
@@ -266,6 +304,25 @@ describe('Agent requestContextSchema', () => {
       await expect(
         agent.resumeStreamUntilIdle({ approved: true }, { runId: 'missing-run-id', requestContext }),
       ).rejects.toThrow(/Request context validation failed for agent/);
+    });
+
+    it('should validate default requestContext before resumeStreamUntilIdle resolves memory', async () => {
+      const requestContext = new RequestContext<{ userId: string; apiKey: string }>();
+      requestContext.set('userId', 'default-user');
+      requestContext.set('apiKey', 'default-key');
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'You are a helpful assistant',
+        model: mockModel,
+        requestContextSchema,
+        defaultOptions: { requestContext },
+      });
+
+      await expect(agent.resumeStreamUntilIdle({ approved: true }, { runId: 'missing-run-id' })).rejects.toMatchObject({
+        id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND',
+      });
     });
   });
 

--- a/packages/core/src/agent/__tests__/request-context-schema.test.ts
+++ b/packages/core/src/agent/__tests__/request-context-schema.test.ts
@@ -114,6 +114,25 @@ describe('Agent requestContextSchema', () => {
 
       await expect(agent.generate('Hello', { requestContext })).rejects.toThrow(/my-special-agent/);
     });
+
+    it('should validate the effective requestContext from default options', async () => {
+      const requestContext = new RequestContext<{ userId: string; apiKey: string }>();
+      requestContext.set('userId', 'default-user');
+      requestContext.set('apiKey', 'default-key');
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'You are a helpful assistant',
+        model: mockModel,
+        requestContextSchema,
+        defaultOptions: { requestContext },
+      });
+
+      const result = await agent.generate('Hello');
+
+      expect(result.text).toContain('Hello');
+    });
   });
 
   describe('stream validation', () => {
@@ -171,6 +190,26 @@ describe('Agent requestContextSchema', () => {
       await expect(agent.stream('Hello', { requestContext })).rejects.toThrow(
         /Request context validation failed for agent/,
       );
+    });
+
+    it('should validate the effective requestContext from default options', async () => {
+      const requestContext = new RequestContext<{ userId: string; apiKey: string }>();
+      requestContext.set('userId', 'default-user');
+      requestContext.set('apiKey', 'default-key');
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'Test Agent',
+        instructions: 'You are a helpful assistant',
+        model: mockModel,
+        requestContextSchema,
+        defaultOptions: { requestContext },
+      });
+
+      const result = await agent.stream('Hello');
+
+      expect(result).toBeDefined();
+      await result.getFullOutput();
     });
   });
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -135,6 +135,16 @@ import type { AgentCapabilities } from './workflows/prepare-stream/schema';
 
 export type MastraLLM = MastraLLMV1 | MastraLLMVNext;
 
+const SKIP_AGENT_EXECUTION_PREFLIGHT = Symbol('skipAgentExecutionPreflight');
+
+type ResumeStreamInternalOptions = AgentExecutionOptionsBase<any> & {
+  structuredOutput?: PublicStructuredOutputOptions<any>;
+  toolCallId?: string;
+  model?: DynamicArgument<MastraModelConfig>;
+  _pubsub: PubSub;
+  [SKIP_AGENT_EXECUTION_PREFLIGHT]?: true;
+};
+
 type ModelFallbacks = {
   id: string;
   model: DynamicArgument<MastraModelConfig>;
@@ -590,10 +600,7 @@ export class Agent<
     return [resourceId ?? '', threadId].join('\u0000');
   }
 
-  #rememberThreadStreamPubSub(
-    options: AgentExecutionOptionsBase<any> & { runId?: string },
-    pubsub: PubSub,
-  ) {
+  #rememberThreadStreamPubSub(options: AgentExecutionOptionsBase<any> & { runId?: string }, pubsub: PubSub) {
     const { threadId, resourceId } = this.#getThreadTarget(options);
     if (!options.runId) return;
 
@@ -654,11 +661,7 @@ export class Agent<
       .catch(() => {});
   }
 
-  #resolveThreadStreamPubSub(options: {
-    runId?: string;
-    threadId?: string;
-    resourceId?: string;
-  }): PubSub | undefined {
+  #resolveThreadStreamPubSub(options: { runId?: string; threadId?: string; resourceId?: string }): PubSub | undefined {
     if (options.runId) {
       const runPubSub = this.#threadStreamPubSubsByRunId.get(options.runId);
       if (runPubSub) return runPubSub;
@@ -909,6 +912,33 @@ export class Agent<
         });
       }
     }
+  }
+
+  /**
+   * Enforces the request-context and FGA boundary shared by fresh and resumed agent execution.
+   */
+  async #assertAgentExecutionPreflight(
+    requestContext?: RequestContext,
+    { requireFgaUser = false }: { requireFgaUser?: boolean } = {},
+  ) {
+    await this.#validateRequestContext(requestContext);
+
+    const fgaProvider = this.#mastra?.getServer()?.fga;
+    if (!fgaProvider) return;
+
+    const user = requestContext?.get('user');
+    if (!user && !requireFgaUser) return;
+
+    const { checkFGA, FGADeniedError } = await import(/* @vite-ignore */ '../auth/ee/fga-check');
+    if (!user) {
+      throw new FGADeniedError({ id: 'unknown' }, { type: 'agent', id: this.id }, MastraFGAPermissions.AGENTS_EXECUTE);
+    }
+    await checkFGA({
+      fgaProvider,
+      user,
+      resource: { type: 'agent', id: this.id },
+      permission: MastraFGAPermissions.AGENTS_EXECUTE,
+    });
   }
 
   /**
@@ -5514,9 +5544,7 @@ export class Agent<
    */
   async #execute<OUTPUT>({ methodType, resumeContext, _pubsub, ...options }: InnerAgentExecutionOptions<OUTPUT>) {
     const existingSnapshot = resumeContext?.snapshot;
-    const snapshotMemoryInfo = existingSnapshot
-      ? this.#getAgenticLoopSnapshotMemoryInfo(existingSnapshot)
-      : undefined;
+    const snapshotMemoryInfo = existingSnapshot ? this.#getAgenticLoopSnapshotMemoryInfo(existingSnapshot) : undefined;
     const requestContext = options.requestContext || new RequestContext();
 
     // Build version overrides by merging: Mastra defaults < requestContext < call-site
@@ -6222,23 +6250,7 @@ export class Agent<
       structuredOutput?: PublicStructuredOutputOptions<any>;
     } & { model?: DynamicArgument<MastraModelConfig> },
   ): Promise<FullOutput<OUTPUT>> {
-    // Validate request context if schema is provided
-    await this.#validateRequestContext(options?.requestContext);
-
-    // FGA authorization check
-    const fgaProvider = this.#mastra?.getServer()?.fga;
-    if (fgaProvider) {
-      const user = options?.requestContext?.get('user');
-      if (user) {
-        const { checkFGA } = await import(/* @vite-ignore */ '../auth/ee/fga-check');
-        await checkFGA({
-          fgaProvider,
-          user,
-          resource: { type: 'agent', id: this.id },
-          permission: MastraFGAPermissions.AGENTS_EXECUTE,
-        });
-      }
-    }
+    await this.#assertAgentExecutionPreflight(options?.requestContext);
 
     const defaultOptions = await this.getDefaultOptions({
       requestContext: options?.requestContext,
@@ -6397,18 +6409,11 @@ export class Agent<
     options: AgentSubscribeToThreadOptions,
   ): Promise<AgentThreadSubscription<OUTPUT>> {
     const pubsub = this.#resolveThreadStreamPubSub(options) ?? this.getPubSub();
-    return agentThreadStreamRuntime.subscribeToThread<OUTPUT>(
-      this as Agent<any, any, any, any>,
-      options,
-      pubsub,
-    );
+    return agentThreadStreamRuntime.subscribeToThread<OUTPUT>(this as Agent<any, any, any, any>, options, pubsub);
   }
 
   abortThreadStream(options: AgentSubscribeToThreadOptions): boolean {
-    return agentThreadStreamRuntime.abortThread(
-      options,
-      this.#resolveThreadStreamPubSub(options) ?? this.getPubSub(),
-    );
+    return agentThreadStreamRuntime.abortThread(options, this.#resolveThreadStreamPubSub(options) ?? this.getPubSub());
   }
 
   abortRunStream(runId: string): boolean {
@@ -6468,12 +6473,7 @@ export class Agent<
         } as unknown as SendAgentSignalOptions<OUTPUT>)
       : target;
 
-    const result = agentThreadStreamRuntime.sendSignal(
-      this as Agent<any, any, any, any>,
-      signal,
-      signalTarget,
-      pubsub,
-    );
+    const result = agentThreadStreamRuntime.sendSignal(this as Agent<any, any, any, any>, signal, signalTarget, pubsub);
     acceptedIdleRunId = result.runId;
     if (shouldTrackIdleWake && idleThreadId && (result.output || result.runId !== previousThreadRunId)) {
       this.#rememberThreadStreamPubSubForTarget(
@@ -6526,7 +6526,8 @@ export class Agent<
     const streamOptionsWithRunId = {
       ...streamOptionsBase,
       runId:
-        streamOptionsBase.runId ?? (canReserveBeforeDefaults ? this.#generateStreamRunId(initialThreadTarget) : undefined),
+        streamOptionsBase.runId ??
+        (canReserveBeforeDefaults ? this.#generateStreamRunId(initialThreadTarget) : undefined),
     };
     let releaseReservedRun = canReserveBeforeDefaults
       ? agentThreadStreamRuntime.reserveRun(streamOptionsWithRunId as AgentExecutionOptions<OUTPUT>, pubsub, this.id)
@@ -6546,23 +6547,7 @@ export class Agent<
     let preparedOptionsWithPubSub: (AgentExecutionOptionsBase<any> & { runId?: string; _pubsub: PubSub }) | undefined;
 
     try {
-      // Validate request context if schema is provided
-      await this.#validateRequestContext(streamOptionsWithRunId.requestContext);
-
-      // FGA authorization check
-      const streamFgaProvider = this.#mastra?.getServer()?.fga;
-      if (streamFgaProvider) {
-        const user = streamOptionsWithRunId.requestContext?.get('user');
-        if (user) {
-          const { checkFGA } = await import('../auth/ee/fga-check');
-          await checkFGA({
-            fgaProvider: streamFgaProvider,
-            user,
-            resource: { type: 'agent', id: this.id },
-            permission: MastraFGAPermissions.AGENTS_EXECUTE,
-          });
-        }
-      }
+      await this.#assertAgentExecutionPreflight(streamOptionsWithRunId.requestContext);
 
       const defaultOptions = await this.getDefaultOptions({
         requestContext: streamOptionsWithRunId.requestContext,
@@ -6948,7 +6933,13 @@ export class Agent<
   ): Promise<MastraModelOutput<OUTPUT>> {
     const pubsub =
       (streamOptions as { _pubsub?: PubSub } | undefined)?._pubsub ?? this.getPubSub() ?? defaultAgentThreadPubSub;
-    const streamOptionsWithPubSub = { ...(streamOptions ?? {}), _pubsub: pubsub };
+    const streamOptionsWithPubSub = {
+      ...(streamOptions ?? {}),
+      _pubsub: pubsub,
+      [SKIP_AGENT_EXECUTION_PREFLIGHT]: true,
+    };
+    // Preflight before idle-wrapper setup, which can resolve defaults and memory before delegating to resumeStream().
+    await this.#assertAgentExecutionPreflight(streamOptionsWithPubSub.requestContext, { requireFgaUser: true });
     return runResumeStreamUntilIdle<OUTPUT>(this, resumeData, streamOptionsWithPubSub, {
       activeStreams: this.#activeStreamUntilIdle,
       bgManager: this.#mastra?.backgroundTaskManager,
@@ -7001,8 +6992,17 @@ export class Agent<
   ): Promise<MastraModelOutput<OUTPUT>> {
     const pubsub =
       ((streamOptions as any)?._pubsub as PubSub | undefined) ?? this.getPubSub() ?? defaultAgentThreadPubSub;
-    const streamOptionsWithPubSub = streamOptions ? { ...streamOptions, _pubsub: pubsub } : undefined;
+    const streamOptionsWithPubSub: ResumeStreamInternalOptions | undefined = streamOptions
+      ? {
+          ...streamOptions,
+          _pubsub: pubsub,
+        }
+      : undefined;
     const runId = streamOptionsWithPubSub?.runId ?? '';
+    if (!streamOptionsWithPubSub?.[SKIP_AGENT_EXECUTION_PREFLIGHT]) {
+      // Keep resume preflight before snapshot loading/reservation so denied callers cannot touch persisted runs.
+      await this.#assertAgentExecutionPreflight(streamOptionsWithPubSub?.requestContext, { requireFgaUser: true });
+    }
     const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeStream' });
     const streamOptionsWithSnapshotTarget = this.#withSnapshotThreadTarget(
       streamOptionsWithPubSub,
@@ -7010,13 +7010,14 @@ export class Agent<
     );
     const initialThreadTarget = this.#getThreadTarget(streamOptionsWithSnapshotTarget);
     const canReserveBeforeDefaults = this.#hasExplicitThreadMemory(streamOptionsWithSnapshotTarget);
-    let releaseReservedRun = streamOptionsWithPubSub && canReserveBeforeDefaults
-      ? agentThreadStreamRuntime.reserveRun(
-          streamOptionsWithSnapshotTarget as unknown as AgentExecutionOptions<OUTPUT>,
-          pubsub,
-          this.id,
-        )
-      : undefined;
+    let releaseReservedRun =
+      streamOptionsWithPubSub && canReserveBeforeDefaults
+        ? agentThreadStreamRuntime.reserveRun(
+            streamOptionsWithSnapshotTarget as unknown as AgentExecutionOptions<OUTPUT>,
+            pubsub,
+            this.id,
+          )
+        : undefined;
     let reservedThreadTarget = releaseReservedRun ? initialThreadTarget : undefined;
     let ownsReservation =
       Boolean(releaseReservedRun) || Boolean((streamOptionsWithPubSub as any)?._threadRunReservationOwner);
@@ -7057,11 +7058,15 @@ export class Agent<
               threadId: reservedThreadTarget.threadId,
             });
             releaseReservedRun = () =>
-              agentThreadStreamRuntime.releaseRunReservation((mergedStreamOptions as { runId?: string }).runId, pubsub, {
-                cleanupPrepared: true,
-                clearAbort: true,
-                rejectOutputWaiters: true,
-              });
+              agentThreadStreamRuntime.releaseRunReservation(
+                (mergedStreamOptions as { runId?: string }).runId,
+                pubsub,
+                {
+                  cleanupPrepared: true,
+                  clearAbort: true,
+                  rejectOutputWaiters: true,
+                },
+              );
             reservedThreadTarget = mergedThreadTarget;
             this.#rememberThreadStreamPubSubForTarget(
               {
@@ -7315,6 +7320,12 @@ export class Agent<
       toolCallId?: string;
     } & { model?: DynamicArgument<MastraModelConfig> },
   ): Promise<FullOutput<OUTPUT>> {
+    // Keep resume preflight before snapshot loading/model resolution so denied callers cannot touch persisted runs.
+    await this.#assertAgentExecutionPreflight(options?.requestContext, { requireFgaUser: true });
+
+    const runId = options?.runId ?? '';
+    const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeGenerate' });
+
     const defaultOptions = await this.getDefaultOptions({
       requestContext: options?.requestContext,
     });
@@ -7351,9 +7362,6 @@ export class Agent<
         },
       });
     }
-
-    const runId = options?.runId ?? '';
-    const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeGenerate' });
 
     const result = await this.#execute({
       ...mergedOptions,

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -6250,15 +6250,23 @@ export class Agent<
       structuredOutput?: PublicStructuredOutputOptions<any>;
     } & { model?: DynamicArgument<MastraModelConfig> },
   ): Promise<FullOutput<OUTPUT>> {
-    await this.#assertAgentExecutionPreflight(options?.requestContext);
+    const requestContextToUse = options?.requestContext;
+    if (requestContextToUse) {
+      await this.#assertAgentExecutionPreflight(requestContextToUse);
+    }
 
     const defaultOptions = await this.getDefaultOptions({
-      requestContext: options?.requestContext,
+      requestContext: requestContextToUse,
     });
     const mergedOptions = deepMerge(
       defaultOptions as Record<string, unknown>,
       (options ?? {}) as Record<string, unknown>,
     ) as AgentExecutionOptions<any> & { model?: DynamicArgument<MastraModelConfig> };
+    if (requestContextToUse) {
+      mergedOptions.requestContext = requestContextToUse;
+    } else {
+      await this.#assertAgentExecutionPreflight(mergedOptions.requestContext);
+    }
 
     const llm = await this.getLLM({
       requestContext: mergedOptions.requestContext,
@@ -6547,15 +6555,24 @@ export class Agent<
     let preparedOptionsWithPubSub: (AgentExecutionOptionsBase<any> & { runId?: string; _pubsub: PubSub }) | undefined;
 
     try {
-      await this.#assertAgentExecutionPreflight(streamOptionsWithRunId.requestContext);
+      const requestContextToUse = streamOptionsWithRunId.requestContext;
+      if (requestContextToUse) {
+        await this.#assertAgentExecutionPreflight(requestContextToUse);
+      }
 
       const defaultOptions = await this.getDefaultOptions({
-        requestContext: streamOptionsWithRunId.requestContext,
+        requestContext: requestContextToUse,
       });
       const mergedOptions = deepMerge(
         defaultOptions as Record<string, unknown>,
         streamOptionsWithRunId as Record<string, unknown>,
       ) as AgentExecutionOptions<OUTPUT> & { model?: DynamicArgument<MastraModelConfig> };
+      if (requestContextToUse) {
+        mergedOptions.requestContext = requestContextToUse;
+      } else {
+        await this.#assertAgentExecutionPreflight(mergedOptions.requestContext);
+      }
+
       const mergedThreadTarget = this.#getThreadTarget(mergedOptions);
       if (!mergedOptions.runId) {
         mergedOptions.runId = this.#generateStreamRunId(mergedThreadTarget);
@@ -6999,9 +7016,10 @@ export class Agent<
         }
       : undefined;
     const runId = streamOptionsWithPubSub?.runId ?? '';
+    const requestContextToUse = streamOptionsWithPubSub?.requestContext;
     if (!streamOptionsWithPubSub?.[SKIP_AGENT_EXECUTION_PREFLIGHT]) {
       // Keep resume preflight before snapshot loading/reservation so denied callers cannot touch persisted runs.
-      await this.#assertAgentExecutionPreflight(streamOptionsWithPubSub?.requestContext, { requireFgaUser: true });
+      await this.#assertAgentExecutionPreflight(requestContextToUse, { requireFgaUser: true });
     }
     const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeStream' });
     const streamOptionsWithSnapshotTarget = this.#withSnapshotThreadTarget(
@@ -7034,13 +7052,17 @@ export class Agent<
 
     try {
       const defaultOptions = await this.getDefaultOptions({
-        requestContext: streamOptionsWithPubSub?.requestContext,
+        requestContext: requestContextToUse,
       });
 
       let mergedStreamOptions = deepMerge(
         defaultOptions as Record<string, unknown>,
         (streamOptionsWithSnapshotTarget ?? {}) as Record<string, unknown>,
       ) as typeof defaultOptions & { model?: DynamicArgument<MastraModelConfig> };
+      if (requestContextToUse) {
+        mergedStreamOptions.requestContext = requestContextToUse;
+      }
+
       if (ownsReservation && reservedThreadTarget) {
         const mergedThreadTarget = this.#getThreadTarget(mergedStreamOptions);
         if (!this.#sameThreadTarget(reservedThreadTarget, mergedThreadTarget)) {
@@ -7320,20 +7342,24 @@ export class Agent<
       toolCallId?: string;
     } & { model?: DynamicArgument<MastraModelConfig> },
   ): Promise<FullOutput<OUTPUT>> {
+    const requestContextToUse = options?.requestContext;
     // Keep resume preflight before snapshot loading/model resolution so denied callers cannot touch persisted runs.
-    await this.#assertAgentExecutionPreflight(options?.requestContext, { requireFgaUser: true });
+    await this.#assertAgentExecutionPreflight(requestContextToUse, { requireFgaUser: true });
 
     const runId = options?.runId ?? '';
     const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeGenerate' });
 
     const defaultOptions = await this.getDefaultOptions({
-      requestContext: options?.requestContext,
+      requestContext: requestContextToUse,
     });
 
     const mergedOptions = deepMerge(
       defaultOptions as Record<string, unknown>,
       (options ?? {}) as Record<string, unknown>,
     ) as typeof defaultOptions & { model?: DynamicArgument<MastraModelConfig> };
+    if (requestContextToUse) {
+      mergedOptions.requestContext = requestContextToUse;
+    }
 
     const llm = await this.getLLM({
       requestContext: mergedOptions.requestContext,

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -103,7 +103,7 @@ import { MessageList } from './message-list';
 import type { MessageInput, MessageListInput, UIMessageWithMetadata, MastraDBMessage } from './message-list';
 import { SaveQueueManager } from './save-queue';
 import { isCreatedAgentSignal } from './signals';
-import { runStreamUntilIdle, runResumeStreamUntilIdle } from './stream-until-idle';
+import { runStreamUntilIdle, runResumeStreamUntilIdle, STREAM_UNTIL_IDLE_DEFAULT_OPTIONS } from './stream-until-idle';
 import type { SubAgent } from './subagent';
 import { agentThreadStreamRuntime, defaultAgentThreadPubSub } from './thread-stream-runtime';
 import { TripWire } from './trip-wire';
@@ -143,6 +143,7 @@ type ResumeStreamInternalOptions = AgentExecutionOptionsBase<any> & {
   model?: DynamicArgument<MastraModelConfig>;
   _pubsub: PubSub;
   [SKIP_AGENT_EXECUTION_PREFLIGHT]?: true;
+  [STREAM_UNTIL_IDLE_DEFAULT_OPTIONS]?: AgentExecutionOptions<any>;
 };
 
 type ModelFallbacks = {
@@ -6950,13 +6951,33 @@ export class Agent<
   ): Promise<MastraModelOutput<OUTPUT>> {
     const pubsub =
       (streamOptions as { _pubsub?: PubSub } | undefined)?._pubsub ?? this.getPubSub() ?? defaultAgentThreadPubSub;
-    const streamOptionsWithPubSub = {
+    let streamOptionsWithPubSub: AgentExecutionOptionsBase<any> & {
+      toolCallId?: string;
+      maxIdleMs?: number;
+      model?: DynamicArgument<MastraModelConfig>;
+      _pubsub: PubSub;
+      [SKIP_AGENT_EXECUTION_PREFLIGHT]: true;
+      [STREAM_UNTIL_IDLE_DEFAULT_OPTIONS]?: AgentExecutionOptions<TOutput>;
+    } = {
       ...(streamOptions ?? {}),
       _pubsub: pubsub,
       [SKIP_AGENT_EXECUTION_PREFLIGHT]: true,
     };
-    // Preflight before idle-wrapper setup, which can resolve defaults and memory before delegating to resumeStream().
-    await this.#assertAgentExecutionPreflight(streamOptionsWithPubSub.requestContext, { requireFgaUser: true });
+    if (streamOptionsWithPubSub.requestContext) {
+      // Preflight before idle-wrapper setup, which can resolve defaults and memory before delegating to resumeStream().
+      await this.#assertAgentExecutionPreflight(streamOptionsWithPubSub.requestContext, { requireFgaUser: true });
+    } else {
+      const defaultOptions = await this.getDefaultOptions({
+        requestContext: streamOptionsWithPubSub.requestContext,
+      });
+      await this.#assertAgentExecutionPreflight(defaultOptions.requestContext, { requireFgaUser: true });
+      streamOptionsWithPubSub = {
+        ...streamOptionsWithPubSub,
+        _pubsub: pubsub,
+        [STREAM_UNTIL_IDLE_DEFAULT_OPTIONS]: defaultOptions,
+        [SKIP_AGENT_EXECUTION_PREFLIGHT]: true,
+      };
+    }
     return runResumeStreamUntilIdle<OUTPUT>(this, resumeData, streamOptionsWithPubSub, {
       activeStreams: this.#activeStreamUntilIdle,
       bgManager: this.#mastra?.backgroundTaskManager,
@@ -7017,9 +7038,20 @@ export class Agent<
       : undefined;
     const runId = streamOptionsWithPubSub?.runId ?? '';
     const requestContextToUse = streamOptionsWithPubSub?.requestContext;
+    const preflightedDefaultOptions = streamOptionsWithPubSub?.[STREAM_UNTIL_IDLE_DEFAULT_OPTIONS] as
+      | AgentExecutionOptions<TOutput>
+      | undefined;
+    let defaultOptions: AgentExecutionOptions<TOutput> | undefined = preflightedDefaultOptions;
     if (!streamOptionsWithPubSub?.[SKIP_AGENT_EXECUTION_PREFLIGHT]) {
-      // Keep resume preflight before snapshot loading/reservation so denied callers cannot touch persisted runs.
-      await this.#assertAgentExecutionPreflight(requestContextToUse, { requireFgaUser: true });
+      if (requestContextToUse) {
+        // Keep explicit-context resume preflight before snapshot loading/reservation so denied callers cannot touch persisted runs.
+        await this.#assertAgentExecutionPreflight(requestContextToUse, { requireFgaUser: true });
+      } else if (this.#requestContextSchema || this.#mastra?.getServer()?.fga) {
+        defaultOptions = (await this.getDefaultOptions({
+          requestContext: requestContextToUse,
+        })) as AgentExecutionOptions<TOutput>;
+        await this.#assertAgentExecutionPreflight(defaultOptions.requestContext, { requireFgaUser: true });
+      }
     }
     const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeStream' });
     const streamOptionsWithSnapshotTarget = this.#withSnapshotThreadTarget(
@@ -7051,10 +7083,17 @@ export class Agent<
     let preparedOptionsWithPubSub: (AgentExecutionOptionsBase<any> & { runId?: string; _pubsub: PubSub }) | undefined;
 
     try {
-      const defaultOptions = await this.getDefaultOptions({
+      defaultOptions ??= (await this.getDefaultOptions({
         requestContext: requestContextToUse,
-      });
-
+      })) as AgentExecutionOptions<TOutput>;
+      if (
+        streamOptionsWithPubSub?.[SKIP_AGENT_EXECUTION_PREFLIGHT] &&
+        !requestContextToUse &&
+        !preflightedDefaultOptions &&
+        (this.#requestContextSchema || this.#mastra?.getServer()?.fga)
+      ) {
+        await this.#assertAgentExecutionPreflight(defaultOptions.requestContext, { requireFgaUser: true });
+      }
       let mergedStreamOptions = deepMerge(
         defaultOptions as Record<string, unknown>,
         (streamOptionsWithSnapshotTarget ?? {}) as Record<string, unknown>,
@@ -7343,15 +7382,23 @@ export class Agent<
     } & { model?: DynamicArgument<MastraModelConfig> },
   ): Promise<FullOutput<OUTPUT>> {
     const requestContextToUse = options?.requestContext;
-    // Keep resume preflight before snapshot loading/model resolution so denied callers cannot touch persisted runs.
-    await this.#assertAgentExecutionPreflight(requestContextToUse, { requireFgaUser: true });
+    let defaultOptions: AgentExecutionOptions<TOutput> | undefined;
+    if (requestContextToUse) {
+      // Keep explicit-context resume preflight before snapshot loading/model resolution so denied callers cannot touch persisted runs.
+      await this.#assertAgentExecutionPreflight(requestContextToUse, { requireFgaUser: true });
+    } else if (this.#requestContextSchema || this.#mastra?.getServer()?.fga) {
+      defaultOptions = (await this.getDefaultOptions({
+        requestContext: requestContextToUse,
+      })) as AgentExecutionOptions<TOutput>;
+      await this.#assertAgentExecutionPreflight(defaultOptions.requestContext, { requireFgaUser: true });
+    }
 
     const runId = options?.runId ?? '';
     const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeGenerate' });
 
-    const defaultOptions = await this.getDefaultOptions({
+    defaultOptions ??= (await this.getDefaultOptions({
       requestContext: requestContextToUse,
-    });
+    })) as AgentExecutionOptions<TOutput>;
 
     const mergedOptions = deepMerge(
       defaultOptions as Record<string, unknown>,

--- a/packages/core/src/agent/stream-until-idle.ts
+++ b/packages/core/src/agent/stream-until-idle.ts
@@ -25,6 +25,8 @@ import { deepMerge } from '../utils';
 import type { Agent } from './agent';
 import type { MessageListInput } from './message-list';
 
+export const STREAM_UNTIL_IDLE_DEFAULT_OPTIONS = Symbol('streamUntilIdleDefaultOptions');
+
 /**
  * Dependencies the extracted function needs access to that it can't reach
  * through the public `Agent` surface (e.g. private fields).
@@ -193,15 +195,19 @@ type FirstTurnRunner<OUTPUT> = (opts: Record<string, any>) => Promise<MastraMode
  */
 async function runWithIdleWrapper<OUTPUT>(
   agent: Agent<any, any, any, any>,
-  streamOptions: (Record<string, any> & { maxIdleMs?: number }) | undefined,
+  streamOptions:
+    | (Record<string, any> & { maxIdleMs?: number; [STREAM_UNTIL_IDLE_DEFAULT_OPTIONS]?: Record<string, any> })
+    | undefined,
   deps: StreamUntilIdleDeps,
   firstTurn: FirstTurnRunner<OUTPUT>,
 ): Promise<MastraModelOutput<OUTPUT>> {
   const { maxIdleMs: _maxIdleMs, ...restStreamOptions } = streamOptions ?? {};
 
-  const defaultOptions = await agent.getDefaultOptions({
-    requestContext: streamOptions?.requestContext,
-  });
+  const defaultOptions =
+    streamOptions?.[STREAM_UNTIL_IDLE_DEFAULT_OPTIONS] ??
+    (await agent.getDefaultOptions({
+      requestContext: streamOptions?.requestContext,
+    }));
   const mergedOptions = deepMerge(
     defaultOptions as Record<string, unknown>,
     (restStreamOptions ?? {}) as Record<string, unknown>,


### PR DESCRIPTION
## Linear
PF-523: Agent resume preflight parity for resumeStream/resumeGenerate

## Summary
- Centralizes agent request-context validation and AGENTS_EXECUTE FGA checks in a shared preflight helper.
- Applies preflight before resumeStream/resumeGenerate touch persisted agentic-loop snapshots or resolve model/default options.
- Applies resumeStreamUntilIdle preflight before idle-wrapper setup, with an unforgeable internal symbol to avoid double FGA while preventing caller-supplied skip spoofing.
- Resume APIs fail closed when FGA is configured but requestContext.user is missing; fresh generate/stream preserve existing missing-user behavior, tracked separately in PF-531.

## Coordination / overlap
- Inspected open PRs before implementation: #58 no overlap, #68 no direct agent.ts overlap, #69 stale broad revert/background risk only.
- Related follow-ups: PF-530 run-owner/principal binding; PF-531 missing-user fail-closed decision for fresh agent execution.

## Validation
- pnpm --filter @mastra/core test src/agent/__tests__/agent-fga.test.ts
- pnpm --filter @mastra/core test src/agent/__tests__/request-context-schema.test.ts
- pnpm --filter @mastra/core test src/agent/__tests__/resume-stream-no-snapshot.test.ts
- pnpm --filter @mastra/core typecheck
- pnpm --filter @mastra/core exec eslint src/agent/agent.ts src/agent/__tests__/agent-fga.test.ts src/agent/__tests__/request-context-schema.test.ts
- git diff --check

## Review evidence
- Claude council review: no BLOCKER; requested storage-skip denial coverage, added.
- Local Codex security/correctness review: final REVIEW only for fresh generate/stream missing-user semantics, recorded on PF-531.
- Local Codex merge-readiness review: changeset nit handled.
- CodeRabbit CLI started but stalled after setup/tools; killed and recorded as unavailable locally. Please use the GitHub CodeRabbit app review on this PR.

## Known unrelated local gaps
- Full @mastra/core lint is not clean on current base due unrelated existing files: packages/core/src/agent/agent.types.ts import/order, packages/core/src/agent/thread-stream-runtime.ts no-floating-promises, packages/core/src/harness/v1/__test-utils__/setup.ts type import.
- A stale local reviewer-initiated broad Vitest invocation ran unrelated core suites and failed in existing unrelated areas; focused PF-523 suites listed above passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes resuming a saved agent run safer: before loading or continuing a stored conversation, the system now validates the request context and enforces that the caller is authorized, preventing unauthorized or anonymous callers from resuming someone else's saved agent work.

## Overview

Centralizes request-context validation and AGENTS_EXECUTE FGA checks into a shared preflight helper and applies it early in resume flows so authorization runs before any persisted snapshots, memory resolution, run reservation, or model/default option resolution. Resume APIs now fail closed when fine-grained authorization is configured but the request context lacks an authenticated user; fresh generate/stream behavior for missing users is unchanged (tracked as PF-531).

## Key Changes

- packages/core/src/agent/agent.ts
  - Adds private Agent.#assertAgentExecutionPreflight() to validate requestContext against the agent's schema and enforce MastraFGAPermissions.AGENTS_EXECUTE via FGA when configured (throws MastraError on schema failures, FGADeniedError on denied access).
  - Introduces internal SKIP_AGENT_EXECUTION_PREFLIGHT symbol and extends resume internal options (ResumeStreamInternalOptions) with this marker to avoid double FGA evaluation while preventing caller-supplied spoofing.
  - Routes generate(), stream(), resumeStream(), resumeGenerate(), and resumeStreamUntilIdle() through the centralized preflight helper with appropriate timing:
    - Early preflight when caller supplies requestContext.
    - Post-merge preflight when relying on defaultOptions.requestContext so default-derived contexts are validated/authorized.
    - Resume flows use requireFgaUser: true to fail closed when FGA is enabled and no user is present.
  - Ensures preflight runs before snapshot loading, memory loading, run reservation, and model/default option resolution—so denied or missing-user cases are rejected prior to persisted I/O.

- packages/core/src/agent/stream-until-idle.ts
  - Exports STREAM_UNTIL_IDLE_DEFAULT_OPTIONS symbol and updates runWithIdleWrapper to accept symbol-backed default options so resumeStreamUntilIdle can pass preflighted defaults without re-fetching agent defaults.

- Tests and test helpers
  - packages/core/src/agent/__tests__/agent-fga.test.ts: Expanded FGA coverage for generate/stream and resume variants; verifies preflight ordering (FGA require runs before storage/memory access), denies happen before persisted I/O, missing-user fail-closed behavior when FGA is configured, and caller-supplied skip markers are ignored.
  - packages/core/src/agent/__tests__/request-context-schema.test.ts: Adds schema validation tests ensuring requestContext (explicit or from defaultOptions) is validated before agent execution and before resume flows.
  - Updated createMockMastra test helper to accept getStorage/getMemory factories so tests can assert snapshot/memory access ordering.
  - changeset documenting behavioral/patch note for resume preflight enforcement.

## Validation

- Ran focused test suites and assertions for agent FGA behavior, request-context schema validation, and resume/no-snapshot flows.
- Typecheck and eslint run on modified agent files; git diff --check executed.
- Review coordination: Claude council review (no BLOCKER); CodeRabbit GitHub app review requested. Related follow-ups tracked: PF-530 (run-owner/principal binding) and PF-531 (fresh execution missing-user behavior).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->