### PR TITLE
fix(clickhouse): [PF-532] quote generated storage identifiers

### DIFF
--- a/.changeset/pf-532-clickhouse-key-quoting.md
+++ b/.changeset/pf-532-clickhouse-key-quoting.md
@@ -1,0 +1,5 @@
+---
+"@mastra/clickhouse": patch
+---
+
+ClickHouse-backed stores now support column names containing special characters, including quotes and backslashes, without initialization or record-loading query failures.

--- a/stores/clickhouse/src/storage/db/index.test.ts
+++ b/stores/clickhouse/src/storage/db/index.test.ts
@@ -1,0 +1,133 @@
+import { TABLE_MESSAGES, TABLE_SPANS, TABLE_WORKFLOW_SNAPSHOT } from '@mastra/core/storage';
+import type { StorageColumn, TABLE_NAMES } from '@mastra/core/storage';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ClickhouseDB } from '.';
+
+function createDb() {
+  const client = {
+    query: vi.fn(async () => undefined),
+  };
+
+  return {
+    client,
+    db: new ClickhouseDB({ client: client as any, ttl: {} }),
+  };
+}
+
+describe('ClickhouseDB createTable', () => {
+  it('quotes generated default key columns', async () => {
+    const { client, db } = createDb();
+
+    await db.createTable({
+      tableName: TABLE_MESSAGES,
+      schema: {
+        id: { type: 'text' },
+        createdAt: { type: 'timestamp' },
+      },
+    });
+
+    const query = client.query.mock.calls[0]?.[0]?.query;
+    expect(query).toContain('PRIMARY KEY ("createdAt", "id")');
+    expect(query).toContain('ORDER BY ("createdAt", "id")');
+  });
+
+  it('quotes harness fallback key columns', async () => {
+    const { client, db } = createDb();
+    const schema: Record<string, StorageColumn> = {
+      id: { type: 'text' },
+      created_at: { type: 'bigint' },
+    };
+
+    await db.createTable({
+      tableName: 'mastra_harness_future_table' as TABLE_NAMES,
+      schema,
+    });
+
+    const query = client.query.mock.calls[0]?.[0]?.query;
+    expect(query).toContain('PRIMARY KEY ("created_at")');
+    expect(query).toContain('ORDER BY ("created_at")');
+  });
+
+  it('escapes generated key column identifiers using ClickHouse quoted identifier rules', async () => {
+    const { client, db } = createDb();
+
+    await db.createTable({
+      tableName: 'mastra_harness_future_table' as TABLE_NAMES,
+      schema: {
+        'quote"key': { type: 'text', primaryKey: true },
+      },
+    });
+
+    const query = client.query.mock.calls[0]?.[0]?.query;
+    expect(query).toContain('PRIMARY KEY ("quote\\"key")');
+    expect(query).toContain('ORDER BY ("quote\\"key")');
+  });
+
+  it('escapes backslashes in generated key column identifiers', async () => {
+    const { client, db } = createDb();
+
+    await db.createTable({
+      tableName: 'mastra_harness_future_table' as TABLE_NAMES,
+      schema: {
+        'back\\slash': { type: 'text', primaryKey: true },
+      },
+    });
+
+    const query = client.query.mock.calls[0]?.[0]?.query;
+    expect(query).toContain('PRIMARY KEY ("back\\\\slash")');
+    expect(query).toContain('ORDER BY ("back\\\\slash")');
+  });
+
+  it('quotes workflow snapshot key columns', async () => {
+    const { client, db } = createDb();
+
+    await db.createTable({
+      tableName: TABLE_WORKFLOW_SNAPSHOT,
+      schema: {
+        createdAt: { type: 'timestamp' },
+        run_id: { type: 'text' },
+        workflow_name: { type: 'text' },
+      },
+    });
+
+    const query = client.query.mock.calls[0]?.[0]?.query;
+    expect(query).toContain('PRIMARY KEY ("createdAt", "run_id", "workflow_name")');
+    expect(query).toContain('ORDER BY ("createdAt", "run_id", "workflow_name")');
+  });
+
+  it('quotes spans key columns', async () => {
+    const { client, db } = createDb();
+
+    await db.createTable({
+      tableName: TABLE_SPANS,
+      schema: {
+        traceId: { type: 'text' },
+        spanId: { type: 'text' },
+        createdAt: { type: 'timestamp' },
+        updatedAt: { type: 'timestamp', nullable: true },
+      },
+    });
+
+    const query = client.query.mock.calls[0]?.[0]?.query;
+    expect(query).toContain('PRIMARY KEY ("traceId", "spanId")');
+    expect(query).toContain('ORDER BY ("traceId", "spanId")');
+  });
+});
+
+describe('ClickhouseDB load', () => {
+  it('quotes condition key identifiers and uses stable query parameter names', async () => {
+    const { client, db } = createDb();
+
+    await db.load({
+      tableName: 'mastra_harness_future_table' as TABLE_NAMES,
+      keys: {
+        'quote"key': 'value',
+      },
+    });
+
+    const query = client.query.mock.calls[0]?.[0]?.query;
+    expect(query).toContain('WHERE "quote\\"key" = {var_0:String}');
+    expect(client.query.mock.calls[0]?.[0]?.query_params).toEqual({ var_0: 'value' });
+  });
+});

--- a/stores/clickhouse/src/storage/db/index.ts
+++ b/stores/clickhouse/src/storage/db/index.ts
@@ -325,7 +325,7 @@ export class ClickhouseDB extends MastraBase {
             constraints.push("DEFAULT '{}'");
           }
           const columnTtl = this.ttl?.[tableName]?.columns?.[name];
-          return `"${name}" ${sqlType} ${constraints.join(' ')} ${columnTtl ? `TTL toDateTime(${columnTtl.ttlKey ?? 'createdAt'}) + INTERVAL ${columnTtl.interval} ${columnTtl.unit}` : ''}`;
+          return `${quoteClickHouseIdentifier(name)} ${sqlType} ${constraints.join(' ')} ${columnTtl ? `TTL toDateTime(${columnTtl.ttlKey ?? 'createdAt'}) + INTERVAL ${columnTtl.interval} ${columnTtl.unit}` : ''}`;
         })
         .join(',\n');
 
@@ -334,8 +334,8 @@ export class ClickhouseDB extends MastraBase {
           ${columns}
         )
         ENGINE = ${TABLE_ENGINES[tableName] ?? 'MergeTree()'}
-        PRIMARY KEY (traceId, spanId)
-        ORDER BY (traceId, spanId)
+        PRIMARY KEY (${quoteClickHouseIdentifier('traceId')}, ${quoteClickHouseIdentifier('spanId')})
+        ORDER BY (${quoteClickHouseIdentifier('traceId')}, ${quoteClickHouseIdentifier('spanId')})
         ${rowTtl ? `TTL toDateTime(${rowTtl.ttlKey ?? 'createdAt'}) + INTERVAL ${rowTtl.interval} ${rowTtl.unit}` : ''}
         SETTINGS index_granularity = 8192
       `;
@@ -355,12 +355,16 @@ export class ClickhouseDB extends MastraBase {
 
       // Only copy columns that exist in both tables
       const columnsToInsert = Object.keys(schema).filter(col => backupColumnNames.has(col));
-      const columnList = columnsToInsert.map(c => `"${c}"`).join(', ');
+      const columnList = columnsToInsert.map(c => quoteClickHouseIdentifier(c)).join(', ');
 
       // Build SELECT expressions, using COALESCE for updatedAt to handle NULL values
       // (updatedAt must be non-nullable for ReplacingMergeTree version column)
       const selectExpressions = columnsToInsert
-        .map(c => (c === 'updatedAt' ? `COALESCE("updatedAt", "createdAt") as "updatedAt"` : `"${c}"`))
+        .map(c =>
+          c === 'updatedAt'
+            ? `COALESCE(${quoteClickHouseIdentifier('updatedAt')}, ${quoteClickHouseIdentifier('createdAt')}) as ${quoteClickHouseIdentifier('updatedAt')}`
+            : quoteClickHouseIdentifier(c),
+        )
         .join(', ');
 
       // Use LIMIT BY for deduplication with priority-based selection:
@@ -372,11 +376,11 @@ export class ClickhouseDB extends MastraBase {
         query: `INSERT INTO ${tableName} (${columnList})
                 SELECT ${selectExpressions}
                 FROM ${backupTableName}
-                ORDER BY traceId, spanId,
+                ORDER BY ${quoteClickHouseIdentifier('traceId')}, ${quoteClickHouseIdentifier('spanId')},
                          (endedAt IS NOT NULL AND endedAt != '') DESC,
-                         COALESCE(updatedAt, createdAt) DESC,
-                         createdAt DESC
-                LIMIT 1 BY traceId, spanId`,
+                         COALESCE(${quoteClickHouseIdentifier('updatedAt')}, ${quoteClickHouseIdentifier('createdAt')}) DESC,
+                         ${quoteClickHouseIdentifier('createdAt')} DESC
+                LIMIT 1 BY ${quoteClickHouseIdentifier('traceId')}, ${quoteClickHouseIdentifier('spanId')}`,
       });
 
       // Step 4: Drop backup table
@@ -476,7 +480,7 @@ export class ClickhouseDB extends MastraBase {
             constraints.push("DEFAULT '{}'");
           }
           const columnTtl = this.ttl?.[tableName]?.columns?.[name];
-          return `"${name}" ${sqlType} ${constraints.join(' ')} ${columnTtl ? `TTL toDateTime(${columnTtl.ttlKey ?? 'createdAt'}) + INTERVAL ${columnTtl.interval} ${columnTtl.unit}` : ''}`;
+          return `${quoteClickHouseIdentifier(name)} ${sqlType} ${constraints.join(' ')} ${columnTtl ? `TTL toDateTime(${columnTtl.ttlKey ?? 'createdAt'}) + INTERVAL ${columnTtl.interval} ${columnTtl.unit}` : ''}`;
         })
         .join(',\n');
 
@@ -486,11 +490,11 @@ export class ClickhouseDB extends MastraBase {
       if (tableName === TABLE_WORKFLOW_SNAPSHOT) {
         sql = `
             CREATE TABLE IF NOT EXISTS ${tableName} (
-              ${['id String'].concat(columns)}
+              ${[`${quoteClickHouseIdentifier('id')} String`].concat(columns)}
             )
             ENGINE = ${TABLE_ENGINES[tableName] ?? 'MergeTree()'}
-            PRIMARY KEY (createdAt, run_id, workflow_name)
-            ORDER BY (createdAt, run_id, workflow_name)
+            PRIMARY KEY (${quoteClickHouseIdentifier('createdAt')}, ${quoteClickHouseIdentifier('run_id')}, ${quoteClickHouseIdentifier('workflow_name')})
+            ORDER BY (${quoteClickHouseIdentifier('createdAt')}, ${quoteClickHouseIdentifier('run_id')}, ${quoteClickHouseIdentifier('workflow_name')})
             ${rowTtl ? `TTL toDateTime(${rowTtl.ttlKey ?? 'createdAt'}) + INTERVAL ${rowTtl.interval} ${rowTtl.unit}` : ''}
             SETTINGS index_granularity = 8192
               `;
@@ -504,13 +508,15 @@ export class ClickhouseDB extends MastraBase {
               ${columns}
             )
             ENGINE = ${TABLE_ENGINES[tableName] ?? 'MergeTree()'}
-            PRIMARY KEY (traceId, spanId)
-            ORDER BY (traceId, spanId)
+            PRIMARY KEY (${quoteClickHouseIdentifier('traceId')}, ${quoteClickHouseIdentifier('spanId')})
+            ORDER BY (${quoteClickHouseIdentifier('traceId')}, ${quoteClickHouseIdentifier('spanId')})
             ${rowTtl ? `TTL toDateTime(${rowTtl.ttlKey ?? 'createdAt'}) + INTERVAL ${rowTtl.interval} ${rowTtl.unit}` : ''}
             SETTINGS index_granularity = 8192
           `;
       } else {
-        const keyColumns = isHarnessTable(tableName) ? getClickHouseKeyColumns(tableName, schema) : ['createdAt', 'id'];
+        const keyColumns = isHarnessTable(tableName)
+          ? getClickHouseKeyColumns(tableName, schema)
+          : [quoteClickHouseIdentifier('createdAt'), quoteClickHouseIdentifier('id')];
         const keyClause = keyColumns.join(', ');
         sql = `
             CREATE TABLE IF NOT EXISTS ${tableName} (
@@ -576,9 +582,9 @@ export class ClickhouseDB extends MastraBase {
             sqlType = `Nullable(${sqlType})`;
           }
           const defaultValue = columnDef.nullable === false ? getDefaultValue(columnDef.type) : '';
-          // Use backticks or double quotes as needed for identifiers
+          // Quote generated identifiers consistently with createTable().
           const alterSql =
-            `ALTER TABLE ${tableName} ADD COLUMN IF NOT EXISTS "${columnName}" ${sqlType} ${defaultValue}`.trim();
+            `ALTER TABLE ${tableName} ADD COLUMN IF NOT EXISTS ${quoteClickHouseIdentifier(columnName)} ${sqlType} ${defaultValue}`.trim();
 
           await this.client.query({
             query: alterSql,
@@ -738,12 +744,12 @@ export class ClickhouseDB extends MastraBase {
       const keyEntries = Object.entries(keys);
       const conditions = keyEntries
         .map(
-          ([key]) =>
-            `"${key}" = {var_${key}:${this.getSqlType(TABLE_SCHEMAS[tableName as TABLE_NAMES]?.[key]?.type ?? 'text')}}`,
+          ([key], index) =>
+            `${quoteClickHouseIdentifier(key)} = {var_${index}:${this.getSqlType(TABLE_SCHEMAS[tableName as TABLE_NAMES]?.[key]?.type ?? 'text')}}`,
         )
         .join(' AND ');
-      const values = keyEntries.reduce((acc, [key, value]) => {
-        return { ...acc, [`var_${key}`]: value };
+      const values = keyEntries.reduce<Record<string, string>>((acc, [, value], index) => {
+        return { ...acc, [`var_${index}`]: value };
       }, {});
 
       const hasUpdatedAt = TABLE_SCHEMAS[tableName as TABLE_NAMES]?.updatedAt;
@@ -798,23 +804,27 @@ export class ClickhouseDB extends MastraBase {
 function getClickHouseKeyColumns(tableName: TABLE_NAMES, schema: Record<string, StorageColumn>): string[] {
   const compositePrimaryKey = TABLE_CONFIGS[tableName]?.compositePrimaryKey;
   if (compositePrimaryKey && compositePrimaryKey.length > 0) {
-    return compositePrimaryKey.map(column => `"${column}"`);
+    return compositePrimaryKey.map(column => quoteClickHouseIdentifier(column));
   }
 
-  if (schema.createdAt && schema.id) return ['createdAt', 'id'];
+  if (schema.createdAt && schema.id) return [quoteClickHouseIdentifier('createdAt'), quoteClickHouseIdentifier('id')];
 
   const primaryColumns = Object.entries(schema)
     .filter(([, column]) => column.primaryKey === true)
-    .map(([name]) => `"${name}"`);
+    .map(([name]) => quoteClickHouseIdentifier(name));
   if (primaryColumns.length > 0) return primaryColumns;
 
-  if (schema.createdAt) return ['createdAt'];
-  if (schema.created_at) return ['created_at'];
-  if (schema.id) return ['id'];
+  if (schema.createdAt) return [quoteClickHouseIdentifier('createdAt')];
+  if (schema.created_at) return [quoteClickHouseIdentifier('created_at')];
+  if (schema.id) return [quoteClickHouseIdentifier('id')];
 
   const firstColumn = Object.keys(schema)[0];
-  if (firstColumn) return [`"${firstColumn}"`];
+  if (firstColumn) return [quoteClickHouseIdentifier(firstColumn)];
   throw new Error(`Cannot derive ClickHouse key columns for empty table schema: ${tableName}`);
+}
+
+function quoteClickHouseIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
 }
 
 function isHarnessTable(tableName: TABLE_NAMES): boolean {


### PR DESCRIPTION
## Summary
- Quote generated ClickHouse identifiers consistently in storage table creation, span migration copy SQL, and ALTER ADD COLUMN paths.
- Cover default, Harness fallback, escaped identifier, workflow snapshot, and spans key clauses with a mocked-client unit test.
- Add a ClickHouse changeset focused on initialization behavior for special-character column names.

## Linear
- PF-532
- Follow-ups created from out-of-scope local review findings: PF-533, PF-534, PF-535, PF-536, PF-537, PF-538

## Validation
- pnpm install --offline (fresh worktree relink; no downloads; warnings recorded in Linear)
- pnpm build:core
- pnpm --filter @mastra/clickhouse exec vitest run src/storage/db/index.test.ts
- pnpm --filter @mastra/clickhouse lint
- pnpm --filter @mastra/clickhouse build:lib
- git diff --check
- Local Codex review pass 1: no findings on final diff
- Local Codex review pass 2: no findings on final diff
- coderabbit doctor: passed, with one auth-environment warning
- coderabbit review --plain: PF-532 changeset finding fixed; final rerun had no PF-532 in-scope findings, out-of-scope findings recorded in PF-538

## Notes
- No production Convex, Docker, Cloudflare/R2 buckets, secrets, signing, deploy, or publish actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes the ClickHouse storage code consistently wrap generated column names in quotes so column names with spaces, quotes, backslashes, or other special characters don't break table creation, migrations, or queries.

## Summary of changes

**Changeset entry**
- Adds a patch changeset for `@mastra/clickhouse` documenting the fix so column names containing special characters (including double quotes and backslashes) are properly quoted and no longer fail during initialization or record loading.

**Unit tests**
- Adds/extends Vitest tests in stores/clickhouse/src/storage/db/index.test.ts to verify generated SQL correctly quotes and escapes key column identifiers across scenarios:
  - createTable: asserts PRIMARY KEY and ORDER BY quoting for default schema-derived keys, Harness fallback keys, keys containing a double quote, keys containing backslashes, workflow snapshot keys, and spans keys.
  - load: verifies WHERE-clause identifier quoting/escaping and deterministic named query parameter generation (e.g., var_0) for a key containing a double quote.
- Includes a focused test covering a key that contains a double quote.

**Core implementation**
- Introduces and centralizes quoting via quoteClickHouseIdentifier(), escaping backslashes and double quotes before wrapping identifiers in double quotes.
- Applies quoting consistently across dynamic SQL generation:
  - migrateSpansTableSortingKey: quotes identifiers in the new spans-table schema, the INSERT ... SELECT copy/deduplication statement (including COALESCE(... ) aliasing), and the deduplication ORDER BY ... LIMIT 1 BY logic.
  - createTable(): quotes column definitions and PRIMARY KEY / ORDER BY clauses for TABLE_WORKFLOW_SNAPSHOT, TABLE_SPANS, and other tables.
  - alterTable(): quotes identifiers for ADD COLUMN IF NOT EXISTS.
  - load(): quotes key columns in parameterized WHERE clauses and uses quoted identifiers when deriving named query parameters.
- getClickHouseKeyColumns() now returns quoted identifier strings.

## Validation performed

- pnpm install --offline
- pnpm build:core
- Unit tests: pnpm --filter `@mastra/clickhouse` exec vitest run src/storage/db/index.test.ts (tests for the file passed)
- Lint and build: pnpm --filter `@mastra/clickhouse` lint && pnpm --filter `@mastra/clickhouse` build:lib (passed)
- git diff --check (passed)
- Two local CodeRabbit review passes; coderabbit doctor passed (one auth-environment warning); coderabbit review rerun clean for in-scope items after changeset wording cleanup
- Local validation notes: PF-532 changeset finding fixed; final rerun clean for in-scope items; out-of-scope findings recorded

## Follow-ups / notes

- Recorded follow-up Linear issues for out-of-scope local review findings: PF-533, PF-534, PF-535, PF-536, PF-537, PF-538.
- No production Convex, Docker, Cloudflare/R2 buckets, secrets, signing, deploy, or publish actions were modified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->