### PR TITLE
[PF-533] Use explicit message admission hashes

### DIFF
--- a/.changeset/early-sheep-enter.md
+++ b/.changeset/early-sheep-enter.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed message admission idempotency so omitted mode and model inputs stay stable across default changes while explicit overrides remain distinct.

--- a/.changeset/early-sheep-enter.md
+++ b/.changeset/early-sheep-enter.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed message admission idempotency so omitted mode and model inputs stay stable across default changes while explicit overrides remain distinct.
+Fixed Session.message() duplicate detection so default changes do not affect messages that omitted mode or model, while explicit overrides still apply.

--- a/packages/core/src/harness/v1/session.message.test.ts
+++ b/packages/core/src/harness/v1/session.message.test.ts
@@ -7,10 +7,13 @@
  * the session forwarded without standing up a real model.
  */
 
+import { createHash } from 'node:crypto';
+
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
 import { Agent } from '../../agent';
+import { HarnessStorageAdmissionConflictError } from '../../storage/domains/harness';
 import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
 import { InMemoryDB } from '../../storage/domains/inmemory-db';
 
@@ -87,6 +90,43 @@ class FakeAgent extends Agent<any, any, any> {
   }
 }
 
+class LiveStreamFakeAgent extends FakeAgent {
+  releaseStream?: () => void;
+
+  override async stream(messages: any, options?: any): Promise<any> {
+    this.calls.push({ type: 'stream', messages, options });
+    const runId = options?.runId ?? this.fullOutput.runId;
+    const fullOutput = { ...this.fullOutput, runId };
+    let releaseStream!: () => void;
+    let finishStream!: () => void;
+    const release = new Promise<void>(resolve => {
+      releaseStream = resolve;
+    });
+    const finished = new Promise<void>(resolve => {
+      finishStream = resolve;
+    });
+    const fullStream = (async function* () {
+      try {
+        await release;
+      } finally {
+        finishStream();
+      }
+    })();
+    const out = {
+      runId,
+      getFullOutput: async () => fullOutput,
+      fullStream,
+      text: Promise.resolve(fullOutput.text),
+      finishReason: Promise.resolve(fullOutput.finishReason),
+      usage: Promise.resolve(fullOutput.usage),
+      _waitUntilFinished: () => finished,
+    };
+    this.releaseStream = releaseStream;
+    this._internalRegisterStreamRun(out as any, (options ?? {}) as any);
+    return out;
+  }
+}
+
 function setup(modes?: any) {
   const agent = new FakeAgent('default');
   const storage = new InMemoryHarness({ db: new InMemoryDB() });
@@ -97,6 +137,47 @@ function setup(modes?: any) {
     sessions: { storage },
   });
   return { harness, agent, storage };
+}
+
+function setupTwoModes() {
+  const defaultAgent = new FakeAgent('default');
+  const otherAgent = new FakeAgent('other');
+  const storage = new InMemoryHarness({ db: new InMemoryDB() });
+  const harness = new Harness({
+    agents: { default: defaultAgent, other: otherAgent } as any,
+    modes: [
+      { id: 'default', agentId: 'default' },
+      { id: 'other', agentId: 'other' },
+    ],
+    defaultModeId: 'default',
+    sessions: { storage },
+  });
+  return { harness, defaultAgent, otherAgent, storage };
+}
+
+function legacyMessageAdmissionHash(opts: { content: unknown; modeId: string; modelId: string }) {
+  return createHash('sha256')
+    .update(
+      canonicalJsonForTest({
+        kind: 'message',
+        content: opts.content,
+        mode: opts.modeId,
+        model: opts.modelId,
+        attachments: [],
+      }),
+      'utf8',
+    )
+    .digest('hex');
+}
+
+function canonicalJsonForTest(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJsonForTest).join(',')}]`;
+  return `{${Object.entries(value)
+    .filter(([, entry]) => entry !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJsonForTest(entry)}`)
+    .join(',')}}`;
 }
 
 describe('Session.message() — default path', () => {
@@ -164,6 +245,185 @@ describe('Session.message() — default path', () => {
     expect(first.text).toBe('hello back');
     expect(second.text).toBe('hello back');
     expect(agent.calls).toHaveLength(1);
+  });
+
+  it('does not treat a later default mode switch as a conflicting duplicate admission', async () => {
+    const { harness, defaultAgent, otherAgent } = setupTwoModes();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    const first = await session.message({ content: 'hi', admissionId: 'admission-mode-default' });
+    await session.switchMode({ mode: 'other' });
+    const second = await session.message({ content: 'hi', admissionId: 'admission-mode-default' });
+
+    expect(first.text).toBe('hello back');
+    expect(second.text).toBe('hello back');
+    expect(defaultAgent.calls).toHaveLength(1);
+    expect(otherAgent.calls).toHaveLength(0);
+  });
+
+  it('returns a live stream duplicate from the original mode after a default mode switch', async () => {
+    const defaultAgent = new LiveStreamFakeAgent('default');
+    const otherAgent = new FakeAgent('other');
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    const harness = new Harness({
+      agents: { default: defaultAgent, other: otherAgent } as any,
+      modes: [
+        { id: 'default', agentId: 'default' },
+        { id: 'other', agentId: 'other' },
+      ],
+      defaultModeId: 'default',
+      sessions: { storage },
+    });
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    const first = await session.message({ content: 'hi', admissionId: 'admission-live-stream', stream: true });
+    await session.switchMode({ mode: 'other' });
+    const duplicate = await session.message({ content: 'hi', admissionId: 'admission-live-stream', stream: true });
+
+    expect(duplicate).toBe(first);
+    expect(defaultAgent.calls).toHaveLength(1);
+    expect(otherAgent.calls).toHaveLength(0);
+
+    defaultAgent.releaseStream?.();
+    await session.waitForIdle({ timeoutMs: 1_000 });
+  });
+
+  it('treats an explicit default mode as distinct from an omitted default mode for admission hashing', async () => {
+    const { harness, defaultAgent } = setupTwoModes();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await session.message({ content: 'hi', admissionId: 'admission-explicit-mode' });
+    await expect(
+      session.message({ content: 'hi', mode: 'default', admissionId: 'admission-explicit-mode' }),
+    ).rejects.toBeInstanceOf(HarnessAdmissionConflictError);
+    expect(defaultAgent.calls).toHaveLength(1);
+  });
+
+  it('does not treat a later default model switch as a conflicting duplicate admission', async () => {
+    const { harness, agent } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    const first = await session.message({ content: 'hi', admissionId: 'admission-model-default' });
+    await session.models.switch({ model: 'gpt-5' });
+    const second = await session.message({ content: 'hi', admissionId: 'admission-model-default' });
+
+    expect(first.text).toBe('hello back');
+    expect(second.text).toBe('hello back');
+    expect(agent.calls).toHaveLength(1);
+  });
+
+  it('treats an explicit selected model as distinct from an omitted selected model for admission hashing', async () => {
+    const { harness, agent } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await session.models.switch({ model: 'gpt-5' });
+    await session.message({ content: 'hi', admissionId: 'admission-explicit-model' });
+    await expect(
+      session.message({ content: 'hi', model: 'gpt-5', admissionId: 'admission-explicit-model' }),
+    ).rejects.toBeInstanceOf(HarnessAdmissionConflictError);
+    expect(agent.calls).toHaveLength(1);
+  });
+
+  it('rejects legacy effective mode/model evidence after mode drift unless the original mode is explicit', async () => {
+    const { harness, defaultAgent, otherAgent, storage } = setupTwoModes();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const legacyAdmissionHash = legacyMessageAdmissionHash({
+      content: 'hi',
+      modeId: 'default',
+      modelId: (session as any)._record.modelId,
+    });
+
+    await storage.writeMessageResultEvidence({
+      harnessName: (session as any)._record.harnessName,
+      sessionId: session.id,
+      resourceId: session.resourceId,
+      threadId: session.threadId,
+      status: 'completed',
+      signalId: 'legacy-signal',
+      runId: 'legacy-run',
+      result: defaultAgent.fullOutput,
+      admissionId: 'legacy-admission',
+      admissionHash: legacyAdmissionHash,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    await session.switchMode({ mode: 'other' });
+    await expect(session.message({ content: 'hi', admissionId: 'legacy-admission' })).rejects.toBeInstanceOf(
+      HarnessAdmissionConflictError,
+    );
+
+    expect(defaultAgent.calls).toHaveLength(0);
+    expect(otherAgent.calls).toHaveLength(0);
+  });
+
+  it('replays legacy duplicate admissions when the caller supplies the original effective mode', async () => {
+    const { harness, defaultAgent, otherAgent, storage } = setupTwoModes();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const legacyAdmissionHash = legacyMessageAdmissionHash({
+      content: 'hi',
+      modeId: 'default',
+      modelId: (session as any)._record.modelId,
+    });
+
+    await storage.writeMessageResultEvidence({
+      harnessName: (session as any)._record.harnessName,
+      sessionId: session.id,
+      resourceId: session.resourceId,
+      threadId: session.threadId,
+      status: 'completed',
+      signalId: 'legacy-signal',
+      runId: 'legacy-run',
+      result: defaultAgent.fullOutput,
+      admissionId: 'legacy-explicit-admission',
+      admissionHash: legacyAdmissionHash,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    await session.switchMode({ mode: 'other' });
+    const duplicate = await session.message({
+      content: 'hi',
+      mode: 'default',
+      admissionId: 'legacy-explicit-admission',
+    });
+
+    expect(duplicate.text).toBe('hello back');
+    expect(defaultAgent.calls).toHaveLength(0);
+    expect(otherAgent.calls).toHaveLength(0);
+  });
+
+  it('replays legacy duplicate admissions that race with the reservation write', async () => {
+    const { harness, defaultAgent, otherAgent, storage } = setupTwoModes();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const writeMessageResultEvidence = storage.writeMessageResultEvidence.bind(storage);
+    let raced = false;
+    storage.writeMessageResultEvidence = async record => {
+      if (!raced && record.status === 'pending' && record.admissionId === 'legacy-race') {
+        raced = true;
+        const legacyAdmissionHash = legacyMessageAdmissionHash({
+          content: 'hi',
+          modeId: 'default',
+          modelId: (session as any)._record.modelId,
+        });
+        await writeMessageResultEvidence({
+          ...record,
+          status: 'completed',
+          signalId: 'legacy-race-signal',
+          runId: 'legacy-race-run',
+          result: defaultAgent.fullOutput,
+          admissionHash: legacyAdmissionHash,
+        });
+        throw new HarnessStorageAdmissionConflictError(record.sessionId, 'message', record.admissionId);
+      }
+      return writeMessageResultEvidence(record);
+    };
+
+    const duplicate = await session.message({ content: 'hi', admissionId: 'legacy-race' });
+
+    expect(duplicate.text).toBe('hello back');
+    expect(defaultAgent.calls).toHaveLength(0);
+    expect(otherAgent.calls).toHaveLength(0);
   });
 
   it('does not convert completed admission evidence write failures into failed evidence', async () => {

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -134,7 +134,13 @@ type Deferred<T> = {
 
 type MessageAdmissionStart = {
   admissionHash: string;
+  modeId: string;
   promise: Promise<string>;
+};
+
+type MessageAdmissionHashes = {
+  primary: string;
+  legacyCompatible: readonly string[];
 };
 
 type QueueResumeRecoveryResult =
@@ -1941,18 +1947,21 @@ export class Session {
     const effectiveModeId = opts.mode ?? this._record.modeId;
     const mode = this._harness._getMode(effectiveModeId);
     const agent = this._harness.getAgentForMode(effectiveModeId);
-    const admissionHash =
+    const admissionHashes =
       opts.admissionId !== undefined
-        ? this._computeMessageAdmissionHash(opts, {
+        ? this._computeMessageAdmissionHashes(opts, {
             modeId: effectiveModeId,
             modelId: opts.model ?? this._record.modelId,
           })
         : undefined;
+    const admissionHash = admissionHashes?.primary;
+    const compatibleAdmissionHashes = admissionHashes?.legacyCompatible;
     const duplicate =
       opts.admissionId !== undefined
         ? await this._resolveMessageAdmissionDuplicate({
             admissionId: opts.admissionId,
             admissionHash: admissionHash!,
+            compatibleAdmissionHashes,
           })
         : undefined;
     if (duplicate) {
@@ -1995,7 +2004,11 @@ export class Session {
           opts,
         );
       }
-      this._messageAdmissionStarts.set(opts.admissionId!, { admissionHash, promise: admissionStart.promise });
+      this._messageAdmissionStarts.set(opts.admissionId!, {
+        admissionHash,
+        modeId: effectiveModeId,
+        promise: admissionStart.promise,
+      });
     }
 
     // Every turn runs under a session-owned AbortController so
@@ -2074,19 +2087,23 @@ export class Session {
 
     if (admissionIdentity !== undefined && admissionHash !== undefined && admissionStart !== undefined) {
       try {
-        const reservation = await this._writeMessageResultEvidence({
-          status: 'pending',
-          signalId: admissionIdentity.signalId,
-          runId: admissionIdentity.runId,
-          admissionId: opts.admissionId!,
-          admissionHash,
-        });
+        const reservation = await this._writeMessageResultEvidence(
+          {
+            status: 'pending',
+            signalId: admissionIdentity.signalId,
+            runId: admissionIdentity.runId,
+            admissionId: opts.admissionId!,
+            admissionHash,
+          },
+          { compatibleAdmissionHashes },
+        );
         if (!reservation.created) {
           this._messageAdmissionStarts.delete(opts.admissionId!);
           admissionStart.resolve(admissionIdentity.runId);
           const existing = await this._resolveMessageAdmissionDuplicate({
             admissionId: opts.admissionId!,
             admissionHash,
+            compatibleAdmissionHashes,
           });
           if (existing) {
             try {
@@ -2119,14 +2136,17 @@ export class Session {
       );
     } catch (err) {
       if (admissionIdentity !== undefined && admissionHash !== undefined) {
-        await this._writeMessageResultEvidence({
-          status: 'failed',
-          signalId: admissionIdentity.signalId,
-          runId: admissionIdentity.runId,
-          admissionId: opts.admissionId!,
-          admissionHash,
-          error: projectHarnessPublicError(err),
-        }).catch(() => {});
+        await this._writeMessageResultEvidence(
+          {
+            status: 'failed',
+            signalId: admissionIdentity.signalId,
+            runId: admissionIdentity.runId,
+            admissionId: opts.admissionId!,
+            admissionHash,
+            error: projectHarnessPublicError(err),
+          },
+          { compatibleAdmissionHashes },
+        ).catch(() => {});
       }
       failOwnedMessageTurnBeforeDispatch(err);
       throw err;
@@ -2140,13 +2160,16 @@ export class Session {
 
     const pendingEvidenceWrite =
       admissionIdentity !== undefined
-        ? this._writeMessageResultEvidence({
-            status: 'pending',
-            signalId: signal.signal.id,
-            runId: signal.runId,
-            ...(opts.admissionId !== undefined ? { admissionId: opts.admissionId } : {}),
-            ...(admissionHash !== undefined ? { admissionHash } : {}),
-          })
+        ? this._writeMessageResultEvidence(
+            {
+              status: 'pending',
+              signalId: signal.signal.id,
+              runId: signal.runId,
+              ...(opts.admissionId !== undefined ? { admissionId: opts.admissionId } : {}),
+              ...(admissionHash !== undefined ? { admissionHash } : {}),
+            },
+            { compatibleAdmissionHashes },
+          )
         : Promise.resolve();
 
     // Streaming path: hand the live `MastraModelOutput` back. The drain
@@ -2175,14 +2198,17 @@ export class Session {
           this._rememberCompletedRun(signal.runId, { ok: false, err });
           waiter?.reject(err);
           if (admissionIdentity !== undefined) {
-            await this._writeMessageResultEvidenceBestEffort({
-              status: 'failed',
-              signalId: signal.signal.id,
-              runId: signal.runId,
-              error: projectHarnessPublicError(err),
-              admissionId: opts.admissionId!,
-              admissionHash: admissionHash!,
-            });
+            await this._writeMessageResultEvidenceBestEffort(
+              {
+                status: 'failed',
+                signalId: signal.signal.id,
+                runId: signal.runId,
+                error: projectHarnessPublicError(err),
+                admissionId: opts.admissionId!,
+                admissionHash: admissionHash!,
+              },
+              { compatibleAdmissionHashes },
+            );
           }
           if (opts.admissionId !== undefined) this._messageAdmissionStarts.delete(opts.admissionId);
           void this._maybeDrainQueue();
@@ -2201,14 +2227,17 @@ export class Session {
         this._rememberCompletedRun(signal.runId, { ok: false, err });
         waiter?.reject(err);
         if (admissionIdentity !== undefined) {
-          await this._writeMessageResultEvidenceBestEffort({
-            status: 'failed',
-            signalId: signal.signal.id,
-            runId: signal.runId,
-            error: projectHarnessPublicError(err),
-            admissionId: opts.admissionId!,
-            admissionHash: admissionHash!,
-          });
+          await this._writeMessageResultEvidenceBestEffort(
+            {
+              status: 'failed',
+              signalId: signal.signal.id,
+              runId: signal.runId,
+              error: projectHarnessPublicError(err),
+              admissionId: opts.admissionId!,
+              admissionHash: admissionHash!,
+            },
+            { compatibleAdmissionHashes },
+          );
         }
         throw err;
       }
@@ -2218,14 +2247,17 @@ export class Session {
         .then(full => {
           this._recordTurnCompletion(full);
           if (admissionIdentity === undefined) return full;
-          return this._writeMessageResultEvidence({
-            status: 'completed',
-            signalId: signal.signal.id,
-            runId: signal.runId,
-            result: full,
-            admissionId: opts.admissionId!,
-            admissionHash: admissionHash!,
-          })
+          return this._writeMessageResultEvidence(
+            {
+              status: 'completed',
+              signalId: signal.signal.id,
+              runId: signal.runId,
+              result: full,
+              admissionId: opts.admissionId!,
+              admissionHash: admissionHash!,
+            },
+            { compatibleAdmissionHashes },
+          )
             .catch(err => {
               streamCompletedEvidenceWriteFailed = true;
               throw err;
@@ -2244,14 +2276,17 @@ export class Session {
         })
         .catch(err => {
           if (admissionIdentity !== undefined && !streamCompletedEvidenceWriteFailed) {
-            void this._writeMessageResultEvidence({
-              status: 'failed',
-              signalId: signal.signal.id,
-              runId: signal.runId,
-              error: projectHarnessPublicError(err),
-              admissionId: opts.admissionId!,
-              admissionHash: admissionHash!,
-            }).catch(() => {});
+            void this._writeMessageResultEvidence(
+              {
+                status: 'failed',
+                signalId: signal.signal.id,
+                runId: signal.runId,
+                error: projectHarnessPublicError(err),
+                admissionId: opts.admissionId!,
+                admissionHash: admissionHash!,
+              },
+              { compatibleAdmissionHashes },
+            ).catch(() => {});
           }
           // The caller owns the visible stream; swallow drain-side errors.
         })
@@ -2277,14 +2312,17 @@ export class Session {
       this._recordTurnCompletion(full);
       if (admissionIdentity !== undefined) {
         try {
-          await this._writeMessageResultEvidenceBestEffort({
-            status: 'completed',
-            signalId: signal.signal.id,
-            runId: signal.runId,
-            result: full,
-            admissionId: opts.admissionId!,
-            admissionHash: admissionHash!,
-          });
+          await this._writeMessageResultEvidenceBestEffort(
+            {
+              status: 'completed',
+              signalId: signal.signal.id,
+              runId: signal.runId,
+              result: full,
+              admissionId: opts.admissionId!,
+              admissionHash: admissionHash!,
+            },
+            { compatibleAdmissionHashes },
+          );
         } catch (err) {
           completedEvidenceWriteFailed = true;
           throw err;
@@ -2307,14 +2345,17 @@ export class Session {
         waiter?.reject(err);
       }
       if (admissionIdentity !== undefined && !completedEvidenceWriteFailed) {
-        await this._writeMessageResultEvidence({
-          status: 'failed',
-          signalId: signal.signal.id,
-          runId: signal.runId,
-          error: projectHarnessPublicError(err),
-          admissionId: opts.admissionId!,
-          admissionHash: admissionHash!,
-        }).catch(() => {});
+        await this._writeMessageResultEvidence(
+          {
+            status: 'failed',
+            signalId: signal.signal.id,
+            runId: signal.runId,
+            error: projectHarnessPublicError(err),
+            admissionId: opts.admissionId!,
+            admissionHash: admissionHash!,
+          },
+          { compatibleAdmissionHashes },
+        ).catch(() => {});
       }
       throw err;
     } finally {
@@ -2329,9 +2370,11 @@ export class Session {
   private async _resolveMessageAdmissionDuplicate({
     admissionId,
     admissionHash,
+    compatibleAdmissionHashes,
   }: {
     admissionId: string;
     admissionHash: string;
+    compatibleAdmissionHashes?: readonly string[];
   }): Promise<AgentSignalResultEvidence | OperationAdmissionTombstone | undefined> {
     const resolved = await this._storage.resolveOperationAdmissionEvidence({
       harnessName: this._record.harnessName,
@@ -2343,6 +2386,12 @@ export class Session {
     });
     if (resolved.status === 'none') return undefined;
     if (resolved.status === 'conflict') {
+      if (
+        resolved.storedAdmissionHash !== undefined &&
+        compatibleAdmissionHashes?.includes(resolved.storedAdmissionHash)
+      ) {
+        return resolved.evidence as AgentSignalResultEvidence | OperationAdmissionTombstone | undefined;
+      }
       throw new HarnessAdmissionConflictError(this.id, admissionId, resolved.storedAdmissionHash ?? '', admissionHash);
     }
     return resolved.evidence as AgentSignalResultEvidence | OperationAdmissionTombstone | undefined;
@@ -2355,7 +2404,7 @@ export class Session {
     if ('status' in evidence) {
       if (opts.stream === true) {
         if (evidence.status === 'pending') {
-          const agent = this._harness.getAgentForMode(opts.mode ?? this._record.modeId);
+          const agent = this._harness.getAgentForMode(this._messageDuplicateModeId(evidence, opts));
           await this._ensureThreadSubscription(agent);
           const runId = await this._pendingMessageRunId(evidence);
           if (runId && this._completedRuns.has(runId)) {
@@ -2413,7 +2462,7 @@ export class Session {
       if (evidence.status === 'failed') throw publicErrorProjectionToError(evidence.error);
       const runId = await this._pendingMessageRunId(evidence);
       if (runId) {
-        const agent = this._harness.getAgentForMode(opts.mode ?? this._record.modeId);
+        const agent = this._harness.getAgentForMode(this._messageDuplicateModeId(evidence, opts));
         await this._ensureThreadSubscription(agent);
         const cached = this._completedRuns.get(runId);
         if (cached) {
@@ -2448,6 +2497,11 @@ export class Session {
     } catch {
       return evidence.runId;
     }
+  }
+
+  private _messageDuplicateModeId(evidence: AgentSignalResultEvidence, opts: MessageOptions): string {
+    const starting = evidence.admissionId ? this._messageAdmissionStarts.get(evidence.admissionId) : undefined;
+    return starting?.modeId ?? opts.mode ?? this._record.modeId;
   }
 
   private _hasLiveMessageRun(agent: Agent, runId: string): boolean {
@@ -2503,6 +2557,7 @@ export class Session {
 
   private async _writeMessageResultEvidence(
     status: AgentSignalResultStatus & { admissionId?: string; admissionHash?: string },
+    options?: { compatibleAdmissionHashes?: readonly string[] },
   ): Promise<{ created: boolean }> {
     const now = Date.now();
     try {
@@ -2520,6 +2575,7 @@ export class Session {
         const duplicate = await this._resolveMessageAdmissionDuplicate({
           admissionId: status.admissionId,
           admissionHash: status.admissionHash,
+          compatibleAdmissionHashes: options?.compatibleAdmissionHashes,
         });
         if (duplicate) return { created: false };
         throw new HarnessAdmissionConflictError(this.id, status.admissionId, '', status.admissionHash);
@@ -2530,9 +2586,10 @@ export class Session {
 
   private async _writeMessageResultEvidenceBestEffort(
     status: AgentSignalResultStatus & { admissionId?: string; admissionHash?: string },
+    options?: { compatibleAdmissionHashes?: readonly string[] },
   ): Promise<void> {
     try {
-      await this._writeMessageResultEvidence(status);
+      await this._writeMessageResultEvidence(status, options);
     } catch (err) {
       if (status.admissionId !== undefined) throw err;
       // The initial pre-dispatch admission reservation is the durable barrier.
@@ -2541,12 +2598,33 @@ export class Session {
     }
   }
 
-  private _computeMessageAdmissionHash(opts: MessageOptions, stable: { modeId: string; modelId: string }): string {
-    return sha256CanonicalJson({
+  private _computeMessageAdmissionHashes(
+    opts: MessageOptions,
+    stable: { modeId: string; modelId: string },
+  ): MessageAdmissionHashes {
+    const primary = sha256CanonicalJson(this._messageAdmissionHashInput(opts, undefined, { hashVersion: 2 }));
+    // Pre-v2 evidence hashed the effective mode/model. Keep one exact legacy
+    // candidate for the current effective tuple only; old evidence does not
+    // persist enough metadata to safely infer previous defaults after drift.
+    const legacyCompatible = sha256CanonicalJson(this._messageAdmissionHashInput(opts, stable));
+    return { primary, legacyCompatible: legacyCompatible === primary ? [] : [legacyCompatible] };
+  }
+
+  private _messageAdmissionHashInput(
+    opts: MessageOptions,
+    stable?: { modeId: string; modelId: string },
+    options?: { hashVersion?: number },
+  ) {
+    return {
       kind: 'message',
+      ...(options?.hashVersion !== undefined ? { hashVersion: options.hashVersion } : {}),
       content: opts.content,
-      mode: stable.modeId,
-      model: stable.modelId,
+      ...(stable !== undefined
+        ? { mode: stable.modeId, model: stable.modelId }
+        : {
+            ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
+            ...(opts.model !== undefined ? { model: opts.model } : {}),
+          }),
       attachments: (opts.attachments ?? []).map(attachment => ({
         attachmentId: attachment.attachmentId,
         resourceId: attachment.resourceId,
@@ -2555,7 +2633,7 @@ export class Session {
         ...(attachment.sha256 !== undefined ? { sha256: attachment.sha256 } : {}),
         ...(attachment.source !== undefined ? { source: attachment.source } : {}),
       })),
-    });
+    };
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
Linear: https://linear.app/papersflow/issue/PF-533/harness-v1-verify-message-admission-hash-explicit-input-semantics

Summary:
- Hash message admissions from explicit caller inputs with a v2 hash shape so omitted mode/model retries stay stable across later default changes.
- Keep one exact pre-v2 legacy compatible hash for the current effective tuple, including reservation-write conflict fallback, without broad mode/model guessing.
- Preserve live stream duplicate routing after mode changes by remembering the original pending admission mode in-process.
- Add focused regression coverage and a patch changeset for @mastra/core.

Validation:
- node_modules/.bin/prettier --write packages/core/src/harness/v1/session.ts packages/core/src/harness/v1/session.message.test.ts .changeset/early-sheep-enter.md
- git diff --check
- pnpm --filter @mastra/core exec vitest run src/harness/v1/session.message.test.ts (33 passed)
- pnpm --filter @mastra/core exec eslint src/harness/v1/session.ts src/harness/v1/session.message.test.ts
- pnpm --filter @mastra/core run typecheck
- pnpm --filter ./packages/core check
- pnpm --filter @mastra/core run build:lib

Review evidence:
- Local Codex correctness review: no findings after the pending stream duplicate fix.
- Local Codex merge-readiness review: changeset finding addressed by .changeset/early-sheep-enter.md.
- CodeRabbit CLI: no findings on final diff.

Known unrelated limitation:
- pnpm --filter @mastra/core run lint still fails on pre-existing files outside this PR: packages/core/src/agent/agent.types.ts import/order, packages/core/src/agent/thread-stream-runtime.ts no-floating-promises, and packages/core/src/harness/v1/__test-utils__/setup.ts consistent-type-imports.

Scope notes:
- This PR only changes message admission hash semantics/tests plus the required changeset. It does not implement storage adapter schemas, server routes, channels, wakeups, R2, Docker, release, or production behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes duplicate-detection for messages smarter by creating a new, explicit "fingerprint" that records whether the caller explicitly set mode/model or relied on defaults, while still keeping one legacy-compatible fingerprint so old evidence keeps working. That prevents requests from being misrecognized as duplicates when defaults change, and keeps live streaming duplicates returning the original stream.

## Overview

Refactors message admission idempotency in the harness session layer to compute a primary v2 admission hash that encodes whether mode/model were explicitly provided, plus a single legacy-compatible hash for pre-v2 behavior. It tracks the effective mode used when admission started so duplicate resolution and live-stream replays use the original mode even if session defaults change.

## Technical Changes

- Introduced MessageAdmissionHashes to hold a primary v2 hash and an optional legacy-compatible hash.
- Replaced the single-hash computation with _computeMessageAdmissionHashes() and _messageAdmissionHashInput(hashVersion) to produce v2 vs legacy inputs.
- Admission bookkeeping (_messageAdmissionStarts) now stores the effective modeId used at start; _messageDuplicateModeId() chooses the agent mode from stored metadata for duplicate replays.
- Duplicate-resolution path (_resolveMessageAdmissionDuplicate) accepts compatibleAdmissionHashes?: readonly string[] so storage lookups can match legacy formats as a fallback.
- Evidence write helpers updated to accept compatibleAdmissionHashes and some writes upgraded from best-effort to durable on success.
- Live-stream duplicate handling preserves original pending admission mode in-process so duplicate streaming calls return the original live stream (object identity) after mode changes.

## Tests & Test Utilities

- Expanded session message tests (packages/core/src/harness/v1/session.message.test.ts):
  - Added LiveStreamFakeAgent to produce controllable live streams for duplicate routing tests.
  - Added legacyMessageAdmissionHash() and canonicalJsonForTest() helpers for deterministic legacy-hash tests.
  - Added setupTwoModes() helper to exercise default vs explicit mode scenarios.
  - New test coverage asserts:
    - Omitted-mode/model admissions remain stable across default changes.
    - Explicit-mode/model selections are treated as distinct from omissions.
    - Live-stream duplicate replays return the original stream after default mode drift.
    - Legacy-compatible duplicate acceptance and rejection behaviors, including replay during a racing reservation/evidence write (simulated via HarnessStorageAdmissionConflictError).

- Test results: the focused test suite referenced passed (33 tests in the message admission suite).

## Changeset

- .changeset/early-sheep-enter.md updated to document a patch for `@mastra/core` describing the duplicate-detection fix and the preserved legacy-compatible hash.

## Validation & CI Notes

- Prettier formatting run on modified files.
- git diff --check run.
- Unit tests for the modified suite passed (33 tests).
- ESLint/typecheck/build:
  - ESLint was run on modified files; however, repository-wide linting still reports pre-existing failures unrelated to this PR (files listed in PR notes).
  - Typecheck and package checks for `@mastra/core` passed.
  - Build (pkg `@mastra/core`) succeeded.
- Local correctness and merge-readiness reviews and CodeRabbit CLI checks reported no findings on the final diff.

## Scope & Limitations

- Changes limited to message admission hash semantics, related tests, and the required changeset for `@mastra/core`.
- This PR does not change storage adapter schemas, server routes, channels, wakeups, R2, Docker, release, or production behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->