### PR TITLE
[PF-526] Improve LibSQL queue compaction diagnostics

### DIFF
--- a/.changeset/pf-526-libsql-queue-compaction-errors.md
+++ b/.changeset/pf-526-libsql-queue-compaction-errors.md
@@ -1,0 +1,3 @@
+'@mastra/libsql': patch
+
+Improved queue compaction conflict errors with session and admission details so storage retry failures are easier to debug.

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -16,7 +16,7 @@ import {
   HarnessStorageVersionConflictError,
 } from '@mastra/core/storage';
 import type { SessionRecord, HarnessStorageParentSessionUnavailableError } from '@mastra/core/storage';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { HarnessLibSQL } from './index';
 
@@ -771,9 +771,10 @@ describe('HarnessLibSQL message result evidence', () => {
 
 describe('HarnessLibSQL queue admission evidence', () => {
   let storage: HarnessLibSQL;
+  let client: Client;
 
   beforeEach(async () => {
-    const client = createHarnessTestClient();
+    client = createHarnessTestClient();
     storage = new HarnessLibSQL({ client });
     await storage.init();
   });
@@ -821,6 +822,50 @@ describe('HarnessLibSQL queue admission evidence', () => {
         queuedItemId: 'queued-1',
       }),
     ).resolves.toMatchObject({ admissionId: 'admission-1', status: 'queued' });
+  });
+
+  it('reports queue compaction retry conflicts with receipt context', async () => {
+    await storage.saveSession(
+      sampleSession({
+        queueAdmissionReceipts: {
+          'queued-1': {
+            admissionId: 'admission-1',
+            admissionHash: 'hash-1',
+            queuedItemId: 'queued-1',
+            status: 'completed',
+            attempts: 1,
+            enqueuedAt: 1000,
+            updatedAt: 2000,
+            completedAt: 3000,
+            result: { ok: true },
+          },
+        },
+      }),
+      { ownerId: 'h', ifVersion: 0 },
+    );
+
+    const originalExecute = client.execute.bind(client);
+    vi.spyOn(client, 'execute').mockImplementation(async (statement: Parameters<Client['execute']>[0]) => {
+      const sql = typeof statement === 'string' ? statement : statement.sql;
+      if (sql.includes(`UPDATE ${TABLE_HARNESS_SESSIONS}`) && sql.includes('queue_admission_receipts')) {
+        const result = await originalExecute('SELECT 1');
+        return { ...result, rowsAffected: 0 };
+      }
+      return originalExecute(statement);
+    });
+
+    await expect(
+      storage.compactOperationResultEvidence({
+        harnessName: 'default',
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        kind: 'queue',
+        queuedItemId: 'queued-1',
+        now: 4000,
+      }),
+    ).rejects.toThrow(
+      'Harness LibSQL queue compaction for harness "default" session "session-1" resource "resource-1" queued item "queued-1" admission "admission-1" conflicted after retries',
+    );
   });
 });
 

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -1502,6 +1502,7 @@ export class HarnessLibSQL extends HarnessStorage {
       return tombstone;
     }
     return this.#withCompactionLock(`${namespace}\0${sessionId}`, async () => {
+      let lastReceipt: QueueAdmissionReceipt | undefined;
       for (let attempt = 0; attempt < 3; attempt += 1) {
         const result = await this.#client.execute({
           sql: `SELECT * FROM ${TABLE_HARNESS_SESSIONS} WHERE harness_name = ? AND id = ?`,
@@ -1513,6 +1514,7 @@ export class HarnessLibSQL extends HarnessStorage {
         if (session.resourceId !== resourceId) return null;
         const receipt = queuedItemId ? session.queueAdmissionReceipts?.[queuedItemId] : undefined;
         if (!receipt || !isTerminalQueueReceipt(receipt)) return null;
+        lastReceipt = receipt;
         const tombstone: OperationAdmissionTombstone = {
           kind: 'queue',
           harnessName: namespace,
@@ -1545,7 +1547,12 @@ export class HarnessLibSQL extends HarnessStorage {
         });
         if (updateResult.rowsAffected > 0) return tombstone;
       }
-      throw new Error(`Harness LibSQL compaction for session "${sessionId}" conflicted after retries`);
+      const receiptDetails = lastReceipt
+        ? `queued item "${lastReceipt.queuedItemId}" admission "${lastReceipt.admissionId}"`
+        : `queued item "${queuedItemId ?? '<unknown>'}"`;
+      throw new Error(
+        `Harness LibSQL queue compaction for harness "${namespace}" session "${sessionId}" resource "${resourceId}" ${receiptDetails} conflicted after retries`,
+      );
     });
   }
 


### PR DESCRIPTION
[Linear PF-526](https://linear.app/papersflow/issue/PF-526/harness-v1-triage-pf-524-local-coderabbit-out-of-scope-findings)

## Summary

- Adds session/resource/queue/admission context to LibSQL queue compaction retry exhaustion errors.
- Covers the retry-conflict path with a focused harness storage regression test.
- Adds a patch changeset for `@mastra/libsql`.

## Scope and overlap

- Scoped to the PF-526 triage item for LibSQL queue compaction diagnostics.
- Does not implement storage/server/channel behavior beyond this diagnostic hardening.
- Open PR overlap checked before work:
  - #69 is broad stale revert work on older core/tool/workflow paths; this PR does not stack on it.
  - #68 touches legacy harness/tool-gate paths; this PR avoids that area.
  - #58 touches ClickHouse memory storage only; no overlap.

## Validation

- `pnpm install --offline --frozen-lockfile`
- `pnpm --filter @internal/ai-sdk-v5 run build`
- `pnpm --filter @internal/ai-sdk-v4 run build`
- `pnpm --filter @internal/ai-v6 run build`
- `pnpm --filter @mastra/core run build:lib`
- `pnpm --filter @mastra/schema-compat run build`
- `pnpm --filter @internal/external-types run build:lib`
- `node_modules/.bin/prettier --write .changeset/pf-526-libsql-queue-compaction-errors.md stores/libsql/src/storage/domains/harness/index.ts stores/libsql/src/storage/domains/harness/index.test.ts`
- `git diff --check`
- `pnpm exec vitest run src/storage/domains/harness/index.test.ts` from `stores/libsql` (22 passed)
- `pnpm --filter @mastra/libsql exec eslint src/storage/domains/harness/index.ts src/storage/domains/harness/index.test.ts`
- `pnpm --filter @mastra/libsql run build:lib`
- Two local Codex review passes; final findings were the package-test caveat and changeset wording. The wording was fixed.
- `coderabbit review --plain` after the wording fix: no findings.

## Known validation caveat

`pnpm --filter ./stores/libsql test -- src/storage/domains/harness/index.test.ts` currently fans out to all `stores/libsql/src/**/*.test.ts` because of the package Vitest config. After the same dependency/build bootstrap, a clean `origin/main` worktree at `368a31d4e6746af0df288ae7639b3b5bd4643553` reproduces the same 7 unrelated `src/storage/local-performance.test.ts` failures:

`Cannot create Harness active-session uniqueness index while duplicate active rows exist. Close or migrate duplicate active rows for: undefined:undefined:undefined (0)`

The directly targeted changed-path harness suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When LibSQL tries to organize its queue and something goes wrong, the error message it shows now tells you which specific queue and item caused the problem. This makes it much easier for developers to figure out what went wrong and fix it.

## Changes Overview

This PR hardens diagnostics for LibSQL queue compaction by enriching error messages with session, resource, queue, and admission context when retry exhaustion occurs.

## Files Changed

**`.changeset/pf-526-libsql-queue-compaction-errors.md`**
- Adds a changeset for `@mastra/libsql` with a patch version bump
- Documents the improvement to queue compaction conflict error messaging for better debuggability

**`stores/libsql/src/storage/domains/harness/index.ts`**
- In `compactOperationResultEvidence` method, now tracks the most recently observed `QueueAdmissionReceipt` during retry attempts
- Enriches the failure error message with `queuedItemId` and `admissionId` from the tracked receipt, or falls back to provided `queuedItemId` and `<unknown>` when not available
- Retry loop behavior unchanged; only error message enhancement on conflict-after-retries

**`stores/libsql/src/storage/domains/harness/index.test.ts`**
- Imports `vi` from vitest for spy/mock capabilities
- Refactors `beforeEach` setup to reuse a shared `client` variable
- Adds new test case verifying that queue compaction retry conflicts produce error messages including receipt context (session/resource/queued item/admission identifiers)
- Test implements spy on `client.execute` to simulate zero `rowsAffected` for the session/queue receipt update path

## Scope

Purely diagnostic improvements with no changes to storage, server, or channel behavior. The PR avoids overlap with other open PRs (`#69`, `#68`, `#58`) and includes comprehensive validation: dependency installation, multi-package builds, formatting checks, lint passes, and targeted test suite verification (22 tests passed in the harness suite).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->