### PR TITLE
[PF-539] Fix LibSQL local performance test mock

### DIFF
--- a/stores/libsql/src/storage/local-performance.test.ts
+++ b/stores/libsql/src/storage/local-performance.test.ts
@@ -21,6 +21,10 @@ function createMockClient() {
       if (/PRAGMA\s+table_info/i.test(sql)) {
         return { rows: [], rowsAffected: 0 };
       }
+      // Harness duplicate-active-session detection returns no grouped rows when there are no duplicate sessions.
+      if (/FROM\s+mastra_harness_sessions/i.test(sql) && /HAVING\s+COUNT\(\*\)\s*>\s*1/i.test(sql)) {
+        return { rows: [], rowsAffected: 0 };
+      }
       if (/duplicate_count/i.test(sql)) {
         return { rows: [{ duplicate_count: 0 }], rowsAffected: 0 };
       }


### PR DESCRIPTION
[Linear PF-539](https://linear.app/papersflow/issue/PF-539/harness-v1-fix-libsql-local-performance-tests-after-active-session)

## Summary

- Fixes the LibSQL local-performance mock so the Harness active-session duplicate scan returns zero rows when there are no duplicate active sessions.
- Restores the broader `@mastra/libsql` package test command that was failing unrelated `local-performance` tests during PF-526 validation.

## Scope and overlap

- Test-fixture-only change in `stores/libsql/src/storage/local-performance.test.ts`.
- No changeset: no runtime/package behavior changes.
- Open PR overlap checked before work:
  - #69 touches broad core agent/tool/workflow paths; no LibSQL local-performance overlap.
  - #68 touches legacy core harness/tool-gate paths; no LibSQL local-performance overlap.
  - #58 touches ClickHouse memory storage only; no overlap.

## Validation

- Reproduced on current main (`6a758e204acc946644fad259cfbb392b6746e6e7`): `pnpm --filter ./stores/libsql test -- src/storage/domains/harness/index.test.ts` failed 7 `src/storage/local-performance.test.ts` tests because the mock returned a row for the Harness duplicate active-session query.
- `pnpm install --offline --frozen-lockfile`
- Bootstrap builds:
  - `pnpm --filter @internal/ai-sdk-v5 run build`
  - `pnpm --filter @internal/ai-sdk-v4 run build`
  - `pnpm --filter @internal/ai-v6 run build`
  - `pnpm --filter @internal/core run build:lib`
  - `pnpm --filter @mastra/schema-compat run build`
  - `pnpm --filter @internal/external-types run build:lib`
  - `pnpm --filter @mastra/core run build:lib`
- `node_modules/.bin/prettier --write stores/libsql/src/storage/local-performance.test.ts`
- `git diff --check`
- `pnpm --filter ./stores/libsql exec vitest run src/storage/local-performance.test.ts` (8 passed)
- `pnpm --filter ./stores/libsql test -- src/storage/domains/harness/index.test.ts` (10 files passed, 766 passed, 17 skipped)
- `pnpm --filter @mastra/libsql exec eslint src/storage/local-performance.test.ts`
- `pnpm --filter @mastra/libsql run build:lib`
- Two local Codex review passes: no findings.
- `coderabbit review --plain`: no findings.

## Notes

The production Harness duplicate-active-session query uses grouped rows with `HAVING COUNT(*) > 1`; an empty result set means no duplicates. The test mock previously treated any query containing `duplicate_count` as a scalar count query and returned one row with `duplicate_count: 0`, which falsely triggered the Harness guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes a test mock so the LibSQL tests correctly report "no duplicate sessions" by returning an empty result for the duplicate-detection query, matching how the real database behaves.

## Summary of Changes

Updated the LibSQL local-performance test mock to recognize the harness duplicate-active-session SQL pattern that uses "HAVING COUNT(*) > 1" and return an empty result set for that query. This prevents the mock from incorrectly simulating a duplicate row and resolves failing local-performance tests.

Files modified
- stores/libsql/src/storage/local-performance.test.ts (+4 lines, test-only)

## Testing & Validation

- Reproduced failure on main: 7 failing tests in local-performance prior to fix.
- Ran pnpm install (offline, frozen lockfile) and bootstrap builds.
- Formatted with Prettier; ran ESLint and package build for `@mastra/libsql`.
- Ran targeted vitest: updated local-performance test file passed (8 tests).
- Ran harness domain tests: 10 files passed, 766 passed, 17 skipped.
- Two local Codex review passes and coderabbit review --plain: no findings.

## Impact

Test-fixture-only change. No runtime behavior, exports, or production code changes; no changelog required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->