### PR TITLE
[PF-537] Clean up Harness changeset wording

### DIFF
--- a/.changeset/pf-351-harness-storage-contract.md
+++ b/.changeset/pf-351-harness-storage-contract.md
@@ -3,13 +3,11 @@
 '@mastra/libsql': minor
 ---
 
-[PF-351] Add namespace-aware Harness v1 admission/result storage contracts.
+Added namespace-aware Harness v1 storage contracts for admission and result evidence.
 
-Added:
+Harness storage is now namespace-aware, so multiple Harness instances can isolate sessions and attachments without key collisions. Active sessions are created and loaded atomically for each `(harnessName, resourceId, threadId)`, and duplicate admissions can replay retained result evidence instead of starting conflicting work.
 
-- Namespace scoping for Harness session and attachment storage.
-- Atomic active-session create/load behavior for `(harnessName, resourceId, threadId)`.
-- Durable queue admission receipts, lifecycle timestamps, retained result/tombstone lookups, duplicate/conflict resolution, compaction, and session-scoped tombstone cleanup.
+Storage adapters also get durable cleanup hooks for completed results and session-scoped admission records, so in-memory and LibSQL backends share the same retry and cleanup behavior.
 
 ```ts
 const result = await harnessStorage.createOrLoadActiveSession(
@@ -18,4 +16,4 @@ const result = await harnessStorage.createOrLoadActiveSession(
 );
 ```
 
-Tests and projects can now use namespace-scoped Harness storage without key collisions, with in-memory and LibSQL backends covered by the same conformance behavior.
+Projects can now use namespace-scoped Harness storage without key collisions, with in-memory and LibSQL backends covered by the same conformance behavior.

--- a/.changeset/pf-352-harness-message-admission.md
+++ b/.changeset/pf-352-harness-message-admission.md
@@ -5,6 +5,11 @@
 
 Added retry-safe `session.message()` admission for Harness v1 using the `admissionId` parameter.
 
+Non-stream calls now fail when terminal evidence cannot be saved durably.
+Streaming calls still return live output, and terminal evidence is saved in the background.
+Non-idempotent follow-up writes remain best-effort after dispatch.
+Retries with the same hash are treated as duplicates, which avoids caller-visible conflicts during live runs.
+
 ```ts
 await session.message({ content: 'Summarize this issue', admissionId: 'msg-123' });
 await session.message({ content: 'Summarize this issue', admissionId: 'msg-123' }); // duplicate retry

--- a/.changeset/pf-356-harness-delete-lifecycle.md
+++ b/.changeset/pf-356-harness-delete-lifecycle.md
@@ -2,13 +2,13 @@
 "@mastra/core": minor
 ---
 
-Added guarded session deletion for Harness sessions.
+Added guarded deletion for Harness sessions.
 
-Deleting a thread now removes the owning session subtree after safely closing active work.
-Harness storage adapters now expose thread-scoped active session lookups and thread delete fences so global memory thread deletion is guarded across resources, concurrent admission, and adapter-visible Harness namespaces.
-Adapters that do not implement the new delete-safety hooks, memory-only harnesses without Harness session storage, and harnesses configured as a separate session-storage override now fail closed for their own `threads.delete(...)` calls instead of falling back to unsafe global memory deletion.
-When a separate session storage attaches to an existing memory thread, the thread is durably marked with reserved Harness metadata as externally owned so later deletion attempts in other processes fail closed instead of deleting global thread/message rows they cannot prove are unowned.
-Message admissions with an `admissionId` now fail if durable terminal result evidence cannot be written, while non-idempotent follow-up writes remain best-effort after dispatch. Same-hash races resolve as duplicate admissions instead of converting live runs into caller-visible conflicts.
+Thread deletion now removes the owning Harness session subtree only after active work has been closed and storage ownership has been verified.
+
+Deletion is now guarded across concurrent operations and storage backends.
+`threads.delete(...)` now fails when ownership cannot be proven, which prevents unsafe deletes.
+If a thread is attached to external session storage, it is marked as externally owned so other processes cannot delete it by mistake.
 
 ```ts
 await harness.threads.delete({

--- a/.changeset/pf-526-libsql-queue-compaction-errors.md
+++ b/.changeset/pf-526-libsql-queue-compaction-errors.md
@@ -1,3 +1,5 @@
+---
 '@mastra/libsql': patch
+---
 
 Improved queue compaction conflict errors with session and admission details so storage retry failures are easier to debug.


### PR DESCRIPTION
## Summary

- fix the PF-526 LibSQL changeset frontmatter so release tooling can parse it
- rewrite PF-351 storage-contract release notes around developer outcomes instead of implementation inventory
- keep PF-356 focused on guarded deletion, and move admission terminal-evidence wording into the existing PF-352 admission changeset

## Linear

PF-537

## Validation

- `pnpm install --offline --frozen-lockfile`
- `node_modules/.bin/prettier --write .changeset/pf-351-harness-storage-contract.md .changeset/pf-352-harness-message-admission.md .changeset/pf-356-harness-delete-lifecycle.md .changeset/pf-526-libsql-queue-compaction-errors.md`
- `git diff --check`
- `pnpm changeset status --since main`
- `node -e "...frontmatter fence scan over all unreleased changesets..."`
- `node ./packages/_changeset-cli/node_modules/@changesets/read parse check for touched changesets`
- two local Codex review passes on the final diff: no findings
- `coderabbit review --plain`: no findings

No runtime code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR cleans up and clarifies four release-note files so our release tooling and readers understand the changes better—no runtime code is altered.

## Changes Summary

Updates four .changeset files to improve wording, structure, and frontmatter so release tooling can parse them and developers get clearer, outcome-focused release notes.

- `.changeset/pf-351-harness-storage-contract.md`  
  Rewrote the storage-contract release notes to emphasize developer outcomes (namespace-scoped storage to avoid cross-instance key collisions, atomic active-session create/load keyed by (harnessName, resourceId, threadId), duplicate-admission replay of retained evidence, and durable cleanup hooks that keep in-memory and LibSQL backends aligned).

- `.changeset/pf-352-harness-message-admission.md`  
  Clarified retry-safe admission behavior via `admissionId` and the handling of terminal evidence: non-streaming admissions fail when terminal evidence cannot be durably saved; streaming admissions continue to return live output while terminal evidence is persisted asynchronously. (Admission terminal-evidence wording consolidated here.)

- `.changeset/pf-356-harness-delete-lifecycle.md`  
  Kept this changeset focused on guarded deletion: thread deletion only removes session-owned subtrees after active work is closed and ownership is verified, with fail-closed behavior when ownership cannot be proven and durable marking for externally owned threads to prevent accidental deletion.

- `.changeset/pf-526-libsql-queue-compaction-errors.md`  
  Fixed frontmatter formatting so release tooling can parse the changeset and clarified that queue compaction conflict errors now include session and admission details to make retry failures easier to debug.

No exported/public code entities were modified; only changeset metadata/content was edited.

## Validation

Performed local validation including:
- pnpm install --offline --frozen-lockfile
- Prettier formatting on touched changeset files
- git diff --check
- pnpm changeset status --since main
- Frontmatter fence scan across unreleased changesets (node script)
- Parse check of touched changesets with `@changesets/read`
- Two local Codex review passes and coderabbit review — no findings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->