### PR TITLE
[PF-540] Abort active turns before hard-delete

### DIFF
--- a/.changeset/pf-540-hard-delete-abort.md
+++ b/.changeset/pf-540-hard-delete-abort.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed: Active session operations are now aborted when the session is deleted.
+Fixed: Active session operations now reject with `HarnessSessionDeletedError` when the session is deleted.

--- a/.changeset/pf-540-hard-delete-abort.md
+++ b/.changeset/pf-540-hard-delete-abort.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed: Active session operations are now aborted when the session is deleted.

--- a/.changeset/pf-540-libsql-hard-delete-cleanup.md
+++ b/.changeset/pf-540-libsql-hard-delete-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@mastra/libsql': patch
+---
+
+Fixed: Session deletion cleans up storage records without affecting unrelated sessions.

--- a/packages/core/src/harness/v1/harness.test.ts
+++ b/packages/core/src/harness/v1/harness.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
 
 import { Agent } from '../../agent';
 import { Mastra } from '../../mastra';
@@ -70,6 +71,13 @@ async function waitFor(predicate: () => boolean, label: string, timeoutMs = 500)
 class AbortIgnoringMockAgent extends MockAgent {
   override async stream(messages: any, options?: any): Promise<any> {
     return super.stream(messages, { ...options, abortSignal: undefined });
+  }
+}
+
+class BlockingGenerateMockAgent extends MockAgent {
+  override async generate(messages: any, options?: any): Promise<any> {
+    this.streamCalls.push({ type: 'generate', messages, options });
+    return new Promise(() => {});
   }
 }
 
@@ -1430,6 +1438,257 @@ describe('Harness v1 — delete lifecycle', () => {
     expect(harness._internalLiveSessionCount()).toBe(0);
   });
 
+  it('aborts an active turn when hard-delete marks a live session deleted', async () => {
+    class GatedEvidenceStorage extends InMemoryHarness {
+      gatedSignalId?: string;
+      private gated = false;
+      private releasedDuringDeleteCleanup = false;
+      private release!: () => void;
+      private start!: () => void;
+      private finish!: () => void;
+      readonly started = new Promise<void>(resolve => {
+        this.start = resolve;
+      });
+      readonly finished = new Promise<void>(resolve => {
+        this.finish = resolve;
+      });
+      private readonly gate = new Promise<void>(resolve => {
+        this.release = resolve;
+      });
+
+      override async writeMessageResultEvidence(
+        record: Parameters<InMemoryHarness['writeMessageResultEvidence']>[0],
+      ): Promise<{ created: boolean }> {
+        if (!this.gated && record.status === 'pending') {
+          this.gated = true;
+          this.gatedSignalId = record.signalId;
+          this.start();
+          await this.gate;
+        }
+        try {
+          return await super.writeMessageResultEvidence(record);
+        } finally {
+          if (record.signalId === this.gatedSignalId) this.finish();
+        }
+      }
+
+      override async deleteOperationAdmissionTombstonesForSession(
+        opts: Parameters<InMemoryHarness['deleteOperationAdmissionTombstonesForSession']>[0],
+      ): Promise<void> {
+        await super.deleteOperationAdmissionTombstonesForSession(opts);
+        if (!this.releasedDuringDeleteCleanup && this.gatedSignalId !== undefined) {
+          this.releasedDuringDeleteCleanup = true;
+          this.release();
+          await this.finished;
+        }
+      }
+    }
+    const storage = new GatedEvidenceStorage({ db: new InMemoryDB() });
+    const agent = new MockAgent({ id: 'default' });
+    const hold = deferred();
+    agent.enqueueRun({
+      holdUntil: hold.promise,
+    });
+    const harness = new Harness({
+      agents: { default: agent } as any,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      sessions: { storage },
+    });
+    const session = await harness.session({ threadId: { fresh: true }, resourceId: 'r1' });
+    const message = session.message({ content: 'slow', admissionId: 'delete-active-turn' });
+    const messageSettled = message.then(
+      value => ({ ok: true as const, value }),
+      err => ({ ok: false as const, err }),
+    );
+    await waitFor(() => session.isRunning(), 'active turn start');
+    await storage.started;
+    const idleSettled = session.waitForIdle().then(
+      () => ({ ok: true as const }),
+      err => ({ ok: false as const, err }),
+    );
+
+    const stored = (await storage.loadSession({ sessionId: session.id, harnessName: 'default' }))!;
+    // Simulate an out-of-band close marker so this live instance reaches hard-delete while still running.
+    await storage.saveSession(
+      {
+        ...stored,
+        closedAt: Date.now(),
+      },
+      { harnessName: 'default', ownerId: harness.ownerId, ifVersion: stored.version },
+    );
+
+    await harness.deleteSession({ sessionId: session.id, resourceId: 'r1' });
+
+    expect(session.isRunning()).toBe(false);
+    await expect(idleSettled).resolves.toMatchObject({ ok: false, err: expect.any(HarnessSessionDeletedError) });
+    await expect(messageSettled).resolves.toMatchObject({ ok: false, err: expect.any(HarnessSessionDeletedError) });
+    await storage.finished;
+    await expect(storage.loadSession({ sessionId: session.id, harnessName: 'default' })).resolves.toBeNull();
+    await expect(
+      storage.loadMessageResultEvidence({
+        sessionId: session.id,
+        resourceId: session.resourceId,
+        threadId: session.threadId,
+        signalId: storage.gatedSignalId!,
+      }),
+    ).resolves.toBeNull();
+    await expect(session.setState({ afterDelete: true })).rejects.toBeInstanceOf(HarnessSessionDeletedError);
+  });
+
+  it('rejects an active structured sync turn when hard-delete marks a live session deleted', async () => {
+    const storage = makeStorage();
+    const agent = new BlockingGenerateMockAgent({ id: 'default' });
+    const harness = new Harness({
+      agents: { default: agent } as any,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      sessions: { storage },
+    });
+    const session = await harness.session({ threadId: { fresh: true }, resourceId: 'r1' });
+    const messageRejected = expect(
+      session.message({ content: 'slow', output: z.object({ ok: z.boolean() }), sync: true }),
+    ).rejects.toBeInstanceOf(HarnessSessionDeletedError);
+    await waitFor(() => session.isRunning(), 'structured turn start');
+    const idleRejected = expect(session.waitForIdle()).rejects.toBeInstanceOf(HarnessSessionDeletedError);
+
+    const stored = (await storage.loadSession({ sessionId: session.id, harnessName: 'default' }))!;
+    await storage.saveSession(
+      {
+        ...stored,
+        closedAt: Date.now(),
+      },
+      { harnessName: 'default', ownerId: harness.ownerId, ifVersion: stored.version },
+    );
+
+    await harness.deleteSession({ sessionId: session.id, resourceId: 'r1' });
+
+    expect(session.isRunning()).toBe(false);
+    await messageRejected;
+    await idleRejected;
+  });
+
+  it('aborts an active streamed turn when hard-delete marks a live session deleted', async () => {
+    const storage = makeStorage();
+    const writeMessageResultEvidence = storage.writeMessageResultEvidence.bind(storage);
+    let signalId: string | undefined;
+    storage.writeMessageResultEvidence = async record => {
+      if (record.admissionId === 'delete-active-stream') {
+        signalId = record.signalId;
+      }
+      return writeMessageResultEvidence(record);
+    };
+    const agent = new MockAgent({ id: 'default' });
+    const hold = deferred();
+    agent.enqueueRun({ holdUntil: hold.promise, text: 'streamed after delete' });
+    const harness = new Harness({
+      agents: { default: agent } as any,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      sessions: { storage },
+    });
+    const session = await harness.session({ threadId: { fresh: true }, resourceId: 'r1' });
+
+    await session.message({ content: 'slow', admissionId: 'delete-active-stream', stream: true });
+    await waitFor(() => session.isRunning() && signalId !== undefined, 'stream turn start');
+    const idleSettled = session.waitForIdle().then(
+      () => ({ ok: true as const }),
+      err => ({ ok: false as const, err }),
+    );
+
+    const stored = (await storage.loadSession({ sessionId: session.id, harnessName: 'default' }))!;
+    await storage.saveSession(
+      {
+        ...stored,
+        closedAt: Date.now(),
+      },
+      { harnessName: 'default', ownerId: harness.ownerId, ifVersion: stored.version },
+    );
+
+    await harness.deleteSession({ sessionId: session.id, resourceId: 'r1' });
+
+    expect(session.isRunning()).toBe(false);
+    await expect(idleSettled).resolves.toMatchObject({ ok: false, err: expect.any(HarnessSessionDeletedError) });
+    await expect(
+      storage.loadMessageResultEvidence({
+        sessionId: session.id,
+        resourceId: session.resourceId,
+        threadId: session.threadId,
+        signalId: signalId!,
+      }),
+    ).resolves.toBeNull();
+    hold.resolve();
+    await new Promise(resolve => setImmediate(resolve));
+  });
+
+  it('scopes late deleted-session evidence cleanup to the deleted turn identity', async () => {
+    const storage = makeStorage();
+    const harness = makeHarness({ sessions: { storage } });
+    const oldSession = await harness.session({ threadId: 'old-thread', resourceId: 'r1', sessionId: 'sess-reused' });
+    const now = Date.now();
+    await storage.writeMessageResultEvidence({
+      harnessName: 'default',
+      sessionId: oldSession.id,
+      resourceId: oldSession.resourceId,
+      threadId: oldSession.threadId,
+      signalId: 'old-signal',
+      status: 'pending',
+      createdAt: now,
+      updatedAt: now,
+    });
+    await storage.writeMessageResultEvidence({
+      harnessName: 'default',
+      sessionId: oldSession.id,
+      resourceId: oldSession.resourceId,
+      threadId: oldSession.threadId,
+      signalId: 'same-thread-new-signal',
+      status: 'pending',
+      createdAt: now,
+      updatedAt: now,
+    });
+    await storage.writeMessageResultEvidence({
+      harnessName: 'default',
+      sessionId: oldSession.id,
+      resourceId: oldSession.resourceId,
+      threadId: 'new-thread',
+      signalId: 'new-signal',
+      status: 'pending',
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    (oldSession as any)._markDeleted();
+    await (oldSession as any)._cleanupOperationEvidenceIfDeleted({ signalId: 'old-signal' });
+
+    await expect(
+      storage.loadMessageResultEvidence({
+        harnessName: 'default',
+        sessionId: oldSession.id,
+        resourceId: oldSession.resourceId,
+        threadId: oldSession.threadId,
+        signalId: 'old-signal',
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      storage.loadMessageResultEvidence({
+        harnessName: 'default',
+        sessionId: oldSession.id,
+        resourceId: oldSession.resourceId,
+        threadId: oldSession.threadId,
+        signalId: 'same-thread-new-signal',
+      }),
+    ).resolves.toMatchObject({ status: 'pending' });
+    await expect(
+      storage.loadMessageResultEvidence({
+        harnessName: 'default',
+        sessionId: oldSession.id,
+        resourceId: oldSession.resourceId,
+        threadId: 'new-thread',
+        signalId: 'new-signal',
+      }),
+    ).resolves.toMatchObject({ status: 'pending' });
+  });
+
   it('marks live descendants created during force-delete discovery as deleted', async () => {
     const storage = makeStorage();
     const harness = makeHarness({ sessions: { storage } });
@@ -1476,10 +1735,43 @@ describe('Harness v1 — delete lifecycle', () => {
     await waitFor(() => agent.streamCalls.length === 1, 'queued run start');
 
     await harness.deleteSession({ sessionId: session.id, resourceId: 'r1', force: true });
+    expect(session.isRunning()).toBe(false);
     await expect(storage.loadSession({ sessionId: session.id, harnessName: 'default' })).resolves.toBeNull();
 
     hold.resolve();
     await expect(queued).rejects.toBeInstanceOf(HarnessSessionClosingError);
+    await new Promise(resolve => setImmediate(resolve));
+  });
+
+  it('rejects an active queued turn when hard-delete marks the live session deleted', async () => {
+    const storage = makeStorage();
+    const agent = new AbortIgnoringMockAgent({ id: 'default' });
+    const hold = deferred();
+    agent.enqueueRun({ holdUntil: hold.promise, text: 'queued after delete' });
+    const harness = new Harness({
+      agents: { default: agent } as any,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      sessions: { storage },
+    });
+    const session = await harness.session({ threadId: { fresh: true }, resourceId: 'r1' });
+    const queued = session.queue({ content: 'queued' });
+    const queuedSettled = queued.then(
+      value => ({ ok: true as const, value }),
+      err => ({ ok: false as const, err }),
+    );
+    await waitFor(() => agent.streamCalls.length === 1 && session.isRunning(), 'queued run start');
+    const idleSettled = session.waitForIdle().then(
+      () => ({ ok: true as const }),
+      err => ({ ok: false as const, err }),
+    );
+
+    (session as any)._markDeleted();
+    expect(session.isRunning()).toBe(false);
+
+    hold.resolve();
+    await expect(queuedSettled).resolves.toMatchObject({ ok: false, err: expect.any(HarnessSessionDeletedError) });
+    await expect(idleSettled).resolves.toMatchObject({ ok: false, err: expect.any(HarnessSessionDeletedError) });
     await new Promise(resolve => setImmediate(resolve));
   });
 

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -1679,22 +1679,44 @@ export class Harness {
             continue;
           }
           if (stillExists) continue;
-          this._markDeletedSession(node, deletedLiveSessions);
+          const live = this._markDeletedSession(node, deletedLiveSessions);
+          // Preserve the original guarded-delete error; the caller already sees
+          // this delete attempt as failed, and retry/reconciliation can clean up
+          // any remaining operation evidence from this live session's active turn.
+          await this._cleanupDeletedOperationEvidence(storage, node.record, live).catch(() => {});
         }
         throw err;
       }
       for (const node of bottomUp) {
-        this._markDeletedSession(node, deletedLiveSessions);
+        const live = this._markDeletedSession(node, deletedLiveSessions);
+        await this._cleanupDeletedOperationEvidence(storage, node.record, live).catch(() => {});
       }
       return;
     }
     for (let index = 0; index < bottomUp.length; index++) {
       await storage.deleteSession(sessions[index]!);
-      this._markDeletedSession(bottomUp[index]!, deletedLiveSessions);
+      const live = this._markDeletedSession(bottomUp[index]!, deletedLiveSessions);
+      await this._cleanupDeletedOperationEvidence(storage, bottomUp[index]!.record, live).catch(() => {});
     }
   }
 
-  private _markDeletedSession(node: CloseTreeNode, deletedLiveSessions: Map<string, Session>): void {
+  private async _cleanupDeletedOperationEvidence(
+    storage: HarnessStorage,
+    record: SessionRecord,
+    live: Session | undefined,
+  ): Promise<void> {
+    for (const signalId of live?._deletedOperationEvidenceSignalIds() ?? []) {
+      await storage.deleteOperationAdmissionTombstonesForSession({
+        harnessName: record.harnessName,
+        sessionId: record.id,
+        resourceId: record.resourceId,
+        threadId: record.threadId,
+        signalId,
+      });
+    }
+  }
+
+  private _markDeletedSession(node: CloseTreeNode, deletedLiveSessions: Map<string, Session>): Session | undefined {
     const live = this._liveSessions.get(node.record.id) ?? deletedLiveSessions.get(node.record.id);
     live?._markDeleted();
     const bridge = this._sessionEventBridges.get(node.record.id);
@@ -1703,6 +1725,7 @@ export class Harness {
       this._sessionEventBridges.delete(node.record.id);
     }
     this._liveSessions.delete(node.record.id);
+    return live;
   }
 
   /**

--- a/packages/core/src/harness/v1/session.injectSystemReminder.test.ts
+++ b/packages/core/src/harness/v1/session.injectSystemReminder.test.ts
@@ -10,8 +10,14 @@ import { describe, expect, it } from 'vitest';
 
 import { MockAgent } from './__test-utils__/mock-agent';
 import { setupHarness } from './__test-utils__/setup';
-import { HarnessSessionClosedError, HarnessValidationError } from './errors';
+import { HarnessSessionClosedError, HarnessSessionDeletedError, HarnessValidationError } from './errors';
 import type { HarnessEvent } from './events';
+
+async function waitForRunning(session: { isRunning: () => boolean }): Promise<void> {
+  for (let i = 0; i < 100 && !session.isRunning(); i++) {
+    await new Promise<void>(resolve => setImmediate(resolve));
+  }
+}
 
 describe('Session.injectSystemReminder()', () => {
   it('dispatches a system-reminder signal on an idle thread (willInterleave: false)', async () => {
@@ -78,6 +84,53 @@ describe('Session.injectSystemReminder()', () => {
     await new Promise<void>(resolve => setImmediate(resolve));
     await new Promise<void>(resolve => setImmediate(resolve));
     expect(agent.streamCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('settles the owned idle-wake turn when the live session is marked deleted', async () => {
+    const agent = new MockAgent({ id: 'default' });
+    let release!: () => void;
+    const hold = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    agent.enqueueRun({ holdUntil: hold });
+
+    const { harness } = setupHarness({ agents: { default: agent } });
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await session.injectSystemReminder('hi');
+    await waitForRunning(session);
+    expect(session.isRunning()).toBe(true);
+    const idle = session.waitForIdle();
+
+    (session as any)._markDeleted();
+
+    expect(session.isRunning()).toBe(false);
+    try {
+      await expect(idle).rejects.toBeInstanceOf(HarnessSessionDeletedError);
+    } finally {
+      release();
+    }
+  });
+
+  it('rejects when the live session is marked deleted while opening the thread subscription', async () => {
+    const agent = new MockAgent({ id: 'default' });
+    let started!: () => void;
+    const subscribeStarted = new Promise<void>(resolve => {
+      started = resolve;
+    });
+    agent.subscribeToThread = async () => {
+      started();
+      return new Promise(() => {}) as any;
+    };
+
+    const { harness } = setupHarness({ agents: { default: agent } });
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const reminder = session.injectSystemReminder('hi');
+    await subscribeStarted;
+
+    (session as any)._markDeleted();
+
+    await expect(reminder).rejects.toBeInstanceOf(HarnessSessionDeletedError);
   });
 
   it('rejects empty content', async () => {

--- a/packages/core/src/harness/v1/session.queue.test.ts
+++ b/packages/core/src/harness/v1/session.queue.test.ts
@@ -25,7 +25,12 @@ import { InMemoryDB } from '../../storage/domains/inmemory-db';
 import { InMemoryStore } from '../../storage/mock';
 
 import { extractSignalContents, MockAgent, setupHarness } from './__test-utils__';
-import { HarnessAdmissionConflictError, HarnessQueueFullError, HarnessValidationError } from './errors';
+import {
+  HarnessAdmissionConflictError,
+  HarnessQueueFullError,
+  HarnessSessionDeletedError,
+  HarnessValidationError,
+} from './errors';
 import type { HarnessEvent } from './events';
 import { Harness } from './harness';
 
@@ -127,6 +132,62 @@ describe('Session.queue() — admission', () => {
       runId: expect.any(String),
     });
     await session.close();
+  });
+
+  it('keeps durable duplicate queue waiters deletion-aware after close starts', async () => {
+    const { harness, storage, agent } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const now = Date.now();
+    const evidence = {
+      admissionId: 'queue-delete-duplicate',
+      admissionHash: 'stored-hash',
+      queuedItemId: 'q-durable-duplicate-without-local-resolver',
+      modeId: 'default',
+      status: 'queued',
+      attempts: 0,
+      enqueuedAt: now,
+      updatedAt: now,
+    };
+    let releaseEvidenceLoad!: () => void;
+    const evidenceLoadGate = new Promise<void>(resolve => {
+      releaseEvidenceLoad = resolve;
+    });
+    const evidenceLoadStarted = new Promise<void>(resolve => {
+      const loadQueueResultEvidence = storage.loadQueueResultEvidence.bind(storage);
+      storage.loadQueueResultEvidence = (async (...args: Parameters<typeof storage.loadQueueResultEvidence>) => {
+        const [opts] = args;
+        if (opts.queuedItemId === evidence.queuedItemId) {
+          resolve();
+          await evidenceLoadGate;
+        }
+        return loadQueueResultEvidence(...args);
+      }) as typeof storage.loadQueueResultEvidence;
+    });
+    (session as any)._resolveQueueAdmissionDuplicate = async () => {
+      const record = session.getRecord();
+      (session as any)._record = {
+        ...record,
+        closingAt: record.closingAt ?? Date.now(),
+        closeDeadlineAt: record.closeDeadlineAt ?? Date.now() + 1000,
+      };
+      return evidence;
+    };
+
+    const duplicate = session.queue({ content: 'do work', admissionId: 'queue-delete-duplicate' });
+    const duplicateSettled = duplicate.then(
+      value => ({ ok: true as const, value }),
+      err => ({ ok: false as const, err }),
+    );
+    await evidenceLoadStarted;
+
+    (session as any)._markDeleted();
+
+    try {
+      await expect(duplicateSettled).resolves.toMatchObject({ ok: false, err: expect.any(HarnessSessionDeletedError) });
+    } finally {
+      releaseEvidenceLoad();
+    }
+    expect(agent.streamCalls).toHaveLength(0);
   });
 
   it('keeps a completed admission receipt if completed signal evidence cannot be written', async () => {

--- a/packages/core/src/harness/v1/session.signal.test.ts
+++ b/packages/core/src/harness/v1/session.signal.test.ts
@@ -23,7 +23,7 @@ import { describe, expect, it } from 'vitest';
 
 import { MockAgent } from './__test-utils__/mock-agent';
 import { setupHarness } from './__test-utils__/setup';
-import { HarnessOverrideConflictError, HarnessSessionClosedError } from './errors';
+import { HarnessOverrideConflictError, HarnessSessionClosedError, HarnessSessionDeletedError } from './errors';
 import type { HarnessEvent } from './events';
 
 /**
@@ -159,6 +159,52 @@ describe('Session.signal()', () => {
     const types = events.map(e => e.type);
     expect(types).toContain('agent_start');
     expect(types).toContain('agent_end');
+  });
+
+  it('rejects an owned idle-wake result when the live session is marked deleted', async () => {
+    const agent = new MockAgent({ id: 'default' });
+    let release!: () => void;
+    const hold = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    agent.enqueueRun({ holdUntil: hold });
+
+    const { harness } = setupHarness({ agents: { default: agent } });
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    const handle = await session.signal({ content: 'hi' });
+    await waitForStreamCalls(agent, 1);
+    expect(session.isRunning()).toBe(true);
+
+    (session as any)._markDeleted();
+
+    expect(session.isRunning()).toBe(false);
+    try {
+      await expect(handle.result).rejects.toBeInstanceOf(HarnessSessionDeletedError);
+    } finally {
+      release();
+    }
+  });
+
+  it('rejects when the live session is marked deleted while opening the thread subscription', async () => {
+    const agent = new MockAgent({ id: 'default' });
+    let started!: () => void;
+    const subscribeStarted = new Promise<void>(resolve => {
+      started = resolve;
+    });
+    agent.subscribeToThread = async () => {
+      started();
+      return new Promise(() => {}) as any;
+    };
+
+    const { harness } = setupHarness({ agents: { default: agent } });
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const signal = session.signal({ content: 'hi' });
+    await subscribeStarted;
+
+    (session as any)._markDeleted();
+
+    await expect(signal).rejects.toBeInstanceOf(HarnessSessionDeletedError);
   });
 
   it('does not emit agent_start for active-delivery (the live run owns the lifecycle)', async () => {

--- a/packages/core/src/harness/v1/session.suspend.test.ts
+++ b/packages/core/src/harness/v1/session.suspend.test.ts
@@ -17,7 +17,7 @@ import { InMemoryDB } from '../../storage/domains/inmemory-db';
 import type { MastraModelOutput } from '../../stream/base/output';
 import { buildFakeOutput } from './__test-utils__/fake-output';
 
-import { HarnessInboxResponseConflictError, HarnessValidationError } from './errors';
+import { HarnessInboxResponseConflictError, HarnessSessionDeletedError, HarnessValidationError } from './errors';
 import { Harness } from './harness';
 
 // ---------------------------------------------------------------------------
@@ -138,6 +138,16 @@ function setup(modes?: any) {
     sessions: { storage },
   });
   return { harness, agent, storage };
+}
+
+async function waitFor(predicate: () => boolean, label: string, timeoutMs = 500): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${label}`);
+    }
+    await new Promise(resolve => setImmediate(resolve));
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -492,6 +502,44 @@ describe('Session — respondToToolApproval / Suspension / Question / PlanApprov
     await session.respondToQuestion({ answer: 'red' });
 
     expect(agent.resumeCalls[0]!.resumeData).toEqual({ answer: 'red' });
+  });
+
+  it('rejects an active question resume when the live session is marked deleted', async () => {
+    const { harness, agent } = setup();
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'run-Q',
+      suspendPayload: {
+        toolCallId: 'tc-Q',
+        toolName: 'ask_user',
+        args: { question: 'pick' },
+      },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'go' });
+
+    let releaseFullOutput!: () => void;
+    const fullOutput = new Promise<unknown>(resolve => {
+      releaseFullOutput = () => resolve({});
+    });
+    agent.resumeStream = async (resumeData: any, options?: any) => {
+      agent.resumeCalls.push({ resumeData, options });
+      return { getFullOutput: () => fullOutput };
+    };
+    const response = session.respondToQuestion({ itemId: 'question:tc-Q', responseId: 'answer-1', answer: 'red' });
+    await waitFor(() => session.isRunning(), 'active resume turn start');
+    const idle = session.waitForIdle();
+
+    (session as any)._markDeleted();
+
+    expect(session.isRunning()).toBe(false);
+    try {
+      await expect(response).rejects.toBeInstanceOf(HarnessSessionDeletedError);
+      await expect(idle).rejects.toBeInstanceOf(HarnessSessionDeletedError);
+      await expect(session.setState({ afterDelete: true })).rejects.toBeInstanceOf(HarnessSessionDeletedError);
+    } finally {
+      releaseFullOutput();
+    }
   });
 
   it('respondToQuestion returns duplicate receipt without resuming twice', async () => {

--- a/packages/core/src/harness/v1/session.test.ts
+++ b/packages/core/src/harness/v1/session.test.ts
@@ -197,13 +197,9 @@ describe('Session — internal accessors', () => {
 });
 
 describe('Session — surface area (M1)', () => {
-  // The §4.2 surface is mostly unimplemented in M1. We only ship identity +
-  // lifecycle on the Session class; pin that here so a future commit that
-  // adds one of the stubs has to update both the class and this assertion
-  // deliberately.
-  it('exposes only identity / lifecycle / record getters and the close hook', () => {
+  it('exposes the expected public session methods and getters', () => {
     const { session } = makeStandaloneSession();
-    const proto = Object.getOwnPropertyNames(Session.prototype).filter(n => n !== 'constructor');
+    const proto = Object.getOwnPropertyNames(Session.prototype).filter(n => n !== 'constructor' && !n.startsWith('_'));
     // Sorted for stability across edits.
     expect([...proto].sort()).toEqual(
       [
@@ -221,22 +217,10 @@ describe('Session — surface area (M1)', () => {
         'injectSystemReminder',
         'getCurrentMode',
         'switchMode',
-        '_modelsCurrent',
-        '_modelsHasSelected',
-        '_modelsCurrentAuthStatus',
-        '_modelsSwitch',
-        '_modelsSetSubagent',
-        '_modelsGetSubagent',
         'getState',
         'setState',
         'getDisplayState',
         'getWorkspace',
-        '_skillsList',
-        '_skillsGet',
-        '_skillsRefresh',
-        '_skillsUse',
-        '_extractRequiredArgKeys',
-        '_buildSkillPrompt',
         'setGoal',
         'getGoal',
         'pauseGoal',
@@ -247,64 +231,13 @@ describe('Session — surface area (M1)', () => {
         'respondToToolSuspension',
         'respondToQuestion',
         'respondToPlanApproval',
-        '_permGrantCategory',
-        '_permGrantTool',
-        '_permRevokeCategory',
-        '_permRevokeTool',
-        '_permGetGrants',
-        '_permGetRules',
-        '_permSetPolicy',
         'subscribe',
-        '_assertLive',
-        '_awaitRunCompletion',
-        '_beginTurn',
-        '_buildToolsets',
-        '_buildRequestContext',
-        '_buildResumePayload',
-        '_callJudge',
-        '_classifyResumeKind',
-        '_completeQueuedTurn',
-        '_createJudgeAgent',
-        '_drainSubscriptionStream',
-        '_emit',
-        '_emitForChunk',
-        '_emitSubagentEvent',
-        '_ensureThreadSubscription',
-        '_emitTurnEvent',
-        '_endTurn',
-        '_enqueueGoalContinuation',
-        '_extractTextContent',
-        '_failQueuedTurn',
-        '_flushUpdate',
-        '_getJudgeContext',
-        '_handleRunTerminal',
-        '_internalEmitterEpoch',
-        '_internalListenerCount',
-        '_kickQueueDrain',
-        '_markClosed',
-        '_markEvicted',
-        '_markWorkspaceLost',
-        '_maybeCaptureSuspend',
-        '_maybeDrainQueue',
-        '_notifyMaybeIdle',
-        '_persistWorkspaceState',
-        '_recordTurnCompletion',
-        '_rejectIdleWaiters',
-        '_resetTurnTracking',
-        '_resolveSkills',
-        '_resume',
-        '_runGoalJudge',
-        '_runQueuedTurn',
-        '_tearDownThreadSubscription',
-        '_watchRunCompletion',
         // Getters land in the prototype as own names too.
         'lastActivityAt',
         'lifecycleState',
         'isClosed',
+        'isClosing',
         'getRecord',
-        '_internalOwnerId',
-        '_internalRecordVersion',
-        '_internalStorage',
       ].sort(),
     );
     // Sanity check on instance-side identity readonly fields.

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -335,6 +335,12 @@ interface IdleWaiter {
   cleanup: () => void;
 }
 
+interface ActiveTurnWaiter {
+  promise: Promise<never>;
+  reject: (err: unknown) => void;
+  cleanup: () => void;
+}
+
 /**
  * Point-in-time snapshot returned by `getDisplayState()` (§4.2). Reads off
  * the in-memory `SessionRecord` plus a few transient run-only fields.
@@ -449,6 +455,8 @@ export class Session {
   private _currentRunId?: string;
   private _currentMessageId?: string;
   private _currentTraceId?: string;
+  private readonly _activeTurnWaiters = new Set<ActiveTurnWaiter>();
+  private readonly _operationEvidenceSignalIds = new Set<string>();
   private readonly _activeTools = new Map<string, ActiveToolState>();
   private readonly _toolInputBuffers = new Map<string, { toolName: string; text: string }>();
   private readonly _activeSubagents = new Map<string, ActiveSubagentState>();
@@ -691,6 +699,52 @@ export class Session {
     this._notifyMaybeIdle();
   }
 
+  private _createActiveTurnWaiter(): ActiveTurnWaiter {
+    let reject!: (err: unknown) => void;
+    const waiter: ActiveTurnWaiter = {
+      promise: new Promise<never>((_, rej) => {
+        reject = rej;
+      }),
+      reject: err => reject(err),
+      cleanup: () => {
+        this._activeTurnWaiters.delete(waiter);
+      },
+    };
+    this._activeTurnWaiters.add(waiter);
+    if (this._state === 'deleted') {
+      this._activeTurnWaiters.delete(waiter);
+      waiter.reject(new HarnessSessionDeletedError(this.id));
+    }
+    return waiter;
+  }
+
+  private _rejectActiveTurnWaiters(reason: unknown): void {
+    if (this._activeTurnWaiters.size === 0) return;
+    const waiters = Array.from(this._activeTurnWaiters);
+    this._activeTurnWaiters.clear();
+    for (const waiter of waiters) {
+      waiter.reject(reason);
+    }
+  }
+
+  private _raceActiveTurnWaiter<T>(promise: Promise<T>, activeTurnWaiter?: Promise<never>): Promise<T> {
+    return activeTurnWaiter ? Promise.race([promise, activeTurnWaiter]) : promise;
+  }
+
+  private _shouldWriteTurnFailureEvidence(err: unknown): boolean {
+    return this._state !== 'deleted' && !(err instanceof HarnessSessionDeletedError);
+  }
+
+  private async _withActiveDeletedWaiter<T>(fn: (activeTurnWaiter: Promise<never>) => Promise<T>): Promise<T> {
+    const activeTurnWaiter = this._createActiveTurnWaiter();
+    void activeTurnWaiter.promise.catch(() => {});
+    try {
+      return await fn(activeTurnWaiter.promise);
+    } finally {
+      activeTurnWaiter.cleanup();
+    }
+  }
+
   /**
    * Fold the `FullOutput` from a completed (or suspended) agent run into the
    * session's transient display state: capture `runId` if not yet set and
@@ -777,8 +831,9 @@ export class Session {
    *
    * Rejects with `HarnessValidationError` if `timeoutMs` is provided and
    * elapses before the session becomes idle. Rejects with
-   * `HarnessSessionClosingError` if close starts while waiting, or
-   * `HarnessSessionClosedError` if the session reaches a terminal state first.
+   * `HarnessSessionClosingError` if close starts while waiting,
+   * `HarnessSessionClosedError` if the session closes first, or
+   * `HarnessSessionDeletedError` if hard-delete removes the session first.
    *
    * Useful in tests and TUI flows that want to await a clean boundary
    * before tearing down or asserting final state.
@@ -1576,6 +1631,12 @@ export class Session {
    */
   private async _ensureThreadSubscription(agent: Agent): Promise<AgentThreadSubscription<unknown>> {
     if (this._threadSubscriptionClosed) {
+      if (this._state === 'deleted') {
+        throw new HarnessSessionDeletedError(this.id);
+      }
+      if (this._state === 'closed' || this._state === 'evicted') {
+        throw new HarnessSessionClosedError(this.id);
+      }
       throw new HarnessValidationError(
         '_ensureThreadSubscription()',
         'Session is closed; cannot re-open thread subscription.',
@@ -1596,6 +1657,23 @@ export class Session {
       this._threadSubscriptionDrain = undefined;
     }
     const sub = await agent.subscribeToThread({ resourceId: this.resourceId, threadId: this.threadId });
+    if (this._threadSubscriptionClosed) {
+      try {
+        sub.unsubscribe();
+      } catch {
+        // Best-effort — hard-delete or close won while subscribeToThread was pending.
+      }
+      if (this._state === 'deleted') {
+        throw new HarnessSessionDeletedError(this.id);
+      }
+      if (this._state === 'closed' || this._state === 'evicted') {
+        throw new HarnessSessionClosedError(this.id);
+      }
+      throw new HarnessValidationError(
+        '_ensureThreadSubscription()',
+        'Session is closed; cannot install thread subscription.',
+      );
+    }
     this._threadSubscription = sub;
     this._threadSubscriptionAgent = agent;
     this._threadSubscriptionDrain = this._drainSubscriptionStream(sub);
@@ -1603,6 +1681,16 @@ export class Session {
     // swallows them in its `finally` block.
     void this._threadSubscriptionDrain.catch(() => {});
     return sub;
+  }
+
+  private async _ensureThreadSubscriptionOrDeleted(agent: Agent): Promise<AgentThreadSubscription<unknown>> {
+    const activeTurnWaiter = this._createActiveTurnWaiter();
+    void activeTurnWaiter.promise.catch(() => {});
+    try {
+      return await this._raceActiveTurnWaiter(this._ensureThreadSubscription(agent), activeTurnWaiter.promise);
+    } finally {
+      activeTurnWaiter.cleanup();
+    }
   }
 
   /**
@@ -1965,6 +2053,7 @@ export class Session {
           })
         : undefined;
     if (duplicate) {
+      this._assertOpenForTurn('message()');
       return this._returnDuplicateMessageResult(duplicate, opts);
     }
     const admissionIdentity =
@@ -2017,21 +2106,38 @@ export class Session {
     // both paths converge on a single signal handed to the agent.
     const turnAbortController = this._beginTurn(opts.abortSignal);
     const turnAbortSignal = turnAbortController.signal;
-    const failOwnedMessageTurnBeforeDispatch = (err: unknown) => {
+    const activeTurnWaiter = this._createActiveTurnWaiter();
+    void activeTurnWaiter.promise.catch(() => {});
+    const finishOwnedMessageTurn = () => {
+      activeTurnWaiter.cleanup();
       this._endTurn(turnAbortController);
+    };
+    const failOwnedMessageTurnBeforeDispatch = (err: unknown) => {
+      finishOwnedMessageTurn();
       admissionStart?.reject(err);
       if (opts.admissionId !== undefined) this._messageAdmissionStarts.delete(opts.admissionId);
     };
+    const assertOwnedMessageTurnNotDeleted = () => {
+      if (this._state === 'deleted') {
+        const err = new HarnessSessionDeletedError(this.id);
+        failOwnedMessageTurnBeforeDispatch(err);
+        throw err;
+      }
+    };
     let requestContext;
     try {
-      requestContext = await this._buildRequestContext({
-        modeId: effectiveModeId,
-        abortSignal: turnAbortSignal,
-      });
+      requestContext = await Promise.race([
+        this._buildRequestContext({
+          modeId: effectiveModeId,
+          abortSignal: turnAbortSignal,
+        }),
+        activeTurnWaiter.promise,
+      ]);
     } catch (err) {
       failOwnedMessageTurnBeforeDispatch(err);
       throw err;
     }
+    assertOwnedMessageTurnNotDeleted();
 
     const baseExecOptions: AgentExecutionOptionsBase<unknown> = {
       memory: { thread: this.threadId, resource: this.resourceId },
@@ -2049,22 +2155,25 @@ export class Session {
     // Structured + sync path: agent.generate with structuredOutput.
     if (opts.output !== undefined && opts.sync === true) {
       try {
-        const result = await agent.generate(opts.content, {
-          ...baseExecOptions,
-          structuredOutput: { schema: opts.output as never },
-        });
+        const result = await Promise.race([
+          agent.generate(opts.content, {
+            ...baseExecOptions,
+            structuredOutput: { schema: opts.output as never },
+          }),
+          activeTurnWaiter.promise,
+        ]);
         const full = result as FullOutput<unknown>;
         this._recordTurnCompletion(full);
-        await this._maybeCaptureSuspend(full, undefined, effectiveModeId);
+        await Promise.race([this._maybeCaptureSuspend(full, undefined, effectiveModeId), activeTurnWaiter.promise]);
         this._emitTurnEvent({
           type: 'agent_end',
           reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
           runId: full.runId,
         });
-        await this._runGoalJudge(full, false);
+        await Promise.race([this._runGoalJudge(full, false), activeTurnWaiter.promise]);
         return full.object;
       } finally {
-        this._endTurn(turnAbortController);
+        finishOwnedMessageTurn();
       }
     }
 
@@ -2079,24 +2188,28 @@ export class Session {
     // the signal drains mid-flight into the running execution loop. Both
     // paths surface chunks through the same subscription stream.
     try {
-      await this._ensureThreadSubscription(agent);
+      await Promise.race([this._ensureThreadSubscription(agent), activeTurnWaiter.promise]);
     } catch (err) {
       failOwnedMessageTurnBeforeDispatch(err);
       throw err;
     }
+    assertOwnedMessageTurnNotDeleted();
 
     if (admissionIdentity !== undefined && admissionHash !== undefined && admissionStart !== undefined) {
       try {
-        const reservation = await this._writeMessageResultEvidence(
-          {
-            status: 'pending',
-            signalId: admissionIdentity.signalId,
-            runId: admissionIdentity.runId,
-            admissionId: opts.admissionId!,
-            admissionHash,
-          },
-          { compatibleAdmissionHashes },
-        );
+        const reservation = await Promise.race([
+          this._writeMessageResultEvidence(
+            {
+              status: 'pending',
+              signalId: admissionIdentity.signalId,
+              runId: admissionIdentity.runId,
+              admissionId: opts.admissionId!,
+              admissionHash,
+            },
+            { compatibleAdmissionHashes },
+          ),
+          activeTurnWaiter.promise,
+        ]);
         if (!reservation.created) {
           this._messageAdmissionStarts.delete(opts.admissionId!);
           admissionStart.resolve(admissionIdentity.runId);
@@ -2109,7 +2222,7 @@ export class Session {
             try {
               return await this._returnDuplicateMessageResult(existing, opts);
             } finally {
-              this._endTurn(turnAbortController);
+              finishOwnedMessageTurn();
             }
           }
         }
@@ -2117,6 +2230,7 @@ export class Session {
         failOwnedMessageTurnBeforeDispatch(err);
         throw err;
       }
+      assertOwnedMessageTurnNotDeleted();
     }
 
     let signal;
@@ -2135,27 +2249,36 @@ export class Session {
         },
       );
     } catch (err) {
+      let thrown = err;
       if (admissionIdentity !== undefined && admissionHash !== undefined) {
-        await this._writeMessageResultEvidence(
-          {
-            status: 'failed',
-            signalId: admissionIdentity.signalId,
-            runId: admissionIdentity.runId,
-            admissionId: opts.admissionId!,
-            admissionHash,
-            error: projectHarnessPublicError(err),
-          },
-          { compatibleAdmissionHashes },
-        ).catch(() => {});
+        try {
+          await Promise.race([
+            this._writeMessageResultEvidence(
+              {
+                status: 'failed',
+                signalId: admissionIdentity.signalId,
+                runId: admissionIdentity.runId,
+                admissionId: opts.admissionId!,
+                admissionHash,
+                error: projectHarnessPublicError(err),
+              },
+              { compatibleAdmissionHashes },
+            ).catch(() => {}),
+            activeTurnWaiter.promise,
+          ]);
+        } catch (evidenceErr) {
+          if (evidenceErr instanceof HarnessSessionDeletedError) thrown = evidenceErr;
+        }
       }
-      failOwnedMessageTurnBeforeDispatch(err);
-      throw err;
+      failOwnedMessageTurnBeforeDispatch(thrown);
+      throw thrown;
     }
 
     // Register the completion waiter BEFORE the drain has a chance to see
     // a terminal chunk for this runId (the run can start synchronously on
     // the wake path).
     const completion = this._awaitRunCompletion(signal.runId);
+    void completion.catch(() => {});
     admissionStart?.resolve(signal.runId);
 
     const pendingEvidenceWrite =
@@ -2178,12 +2301,13 @@ export class Session {
     if (opts.stream === true) {
       let out = agent.getRunOutput(signal.runId) as MastraModelOutput<unknown> | undefined;
       if (!out && (signal.output || admissionIdentity !== undefined)) {
-        await pendingEvidenceWrite.catch(() => {});
+        await Promise.race([pendingEvidenceWrite.catch(() => {}), activeTurnWaiter.promise]);
         try {
           out = signal.output
-            ? ((await signal.output) as MastraModelOutput<unknown>)
+            ? ((await Promise.race([signal.output, activeTurnWaiter.promise])) as MastraModelOutput<unknown>)
             : ((await Promise.race([
                 agent.waitForRunOutput(signal.runId) as Promise<MastraModelOutput<unknown>>,
+                activeTurnWaiter.promise,
                 completion.then(
                   () => undefined,
                   () => undefined,
@@ -2191,13 +2315,13 @@ export class Session {
                 delay(MESSAGE_ADMISSION_DURABLE_WAIT_TIMEOUT_MS).then(() => undefined),
               ])) as MastraModelOutput<unknown> | undefined);
         } catch (err) {
-          this._endTurn(turnAbortController);
+          finishOwnedMessageTurn();
           void completion.catch(() => {});
           const waiter = this._runCompletionPromises.get(signal.runId);
           this._runCompletionPromises.delete(signal.runId);
           this._rememberCompletedRun(signal.runId, { ok: false, err });
           waiter?.reject(err);
-          if (admissionIdentity !== undefined) {
+          if (admissionIdentity !== undefined && this._shouldWriteTurnFailureEvidence(err)) {
             await this._writeMessageResultEvidenceBestEffort(
               {
                 status: 'failed',
@@ -2216,7 +2340,7 @@ export class Session {
         }
       }
       if (!out) {
-        this._endTurn(turnAbortController);
+        finishOwnedMessageTurn();
         void pendingEvidenceWrite.catch(() => {});
         const err = new HarnessConfigError('message()', 'agent did not register a run for the dispatched signal');
         // Drop the completion waiter so duplicate retries do not treat an
@@ -2241,41 +2365,46 @@ export class Session {
         }
         throw err;
       }
-      await pendingEvidenceWrite.catch(() => {});
+      await Promise.race([pendingEvidenceWrite.catch(() => {}), activeTurnWaiter.promise]);
       let streamCompletedEvidenceWriteFailed = false;
-      void completion
-        .then(full => {
+      void Promise.race([completion, activeTurnWaiter.promise])
+        .then(async full => {
           this._recordTurnCompletion(full);
           if (admissionIdentity === undefined) return full;
-          return this._writeMessageResultEvidence(
-            {
-              status: 'completed',
-              signalId: signal.signal.id,
-              runId: signal.runId,
-              result: full,
-              admissionId: opts.admissionId!,
-              admissionHash: admissionHash!,
-            },
-            { compatibleAdmissionHashes },
-          )
-            .catch(err => {
+          await Promise.race([
+            this._writeMessageResultEvidence(
+              {
+                status: 'completed',
+                signalId: signal.signal.id,
+                runId: signal.runId,
+                result: full,
+                admissionId: opts.admissionId!,
+                admissionHash: admissionHash!,
+              },
+              { compatibleAdmissionHashes },
+            ).catch(err => {
               streamCompletedEvidenceWriteFailed = true;
               throw err;
-            })
-            .then(() => full);
+            }),
+            activeTurnWaiter.promise,
+          ]);
+          return full;
         })
-        .then(full => {
-          return this._maybeCaptureSuspend(full, undefined, effectiveModeId).then(() => {
-            this._emitTurnEvent({
-              type: 'agent_end',
-              reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
-              runId: full.runId,
-            });
-            return this._runGoalJudge(full, false);
+        .then(async full => {
+          await Promise.race([this._maybeCaptureSuspend(full, undefined, effectiveModeId), activeTurnWaiter.promise]);
+          this._emitTurnEvent({
+            type: 'agent_end',
+            reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
+            runId: full.runId,
           });
+          await Promise.race([this._runGoalJudge(full, false), activeTurnWaiter.promise]);
         })
         .catch(err => {
-          if (admissionIdentity !== undefined && !streamCompletedEvidenceWriteFailed) {
+          if (
+            admissionIdentity !== undefined &&
+            !streamCompletedEvidenceWriteFailed &&
+            this._shouldWriteTurnFailureEvidence(err)
+          ) {
             void this._writeMessageResultEvidence(
               {
                 status: 'failed',
@@ -2292,7 +2421,7 @@ export class Session {
         })
         .finally(() => {
           if (opts.admissionId !== undefined) this._messageAdmissionStarts.delete(opts.admissionId);
-          this._endTurn(turnAbortController);
+          finishOwnedMessageTurn();
           void this._maybeDrainQueue();
         });
       return out;
@@ -2303,38 +2432,41 @@ export class Session {
     let streamStarted = signal.output === undefined;
     let completedEvidenceWriteFailed = false;
     try {
-      await pendingEvidenceWrite.catch(() => {});
+      await Promise.race([pendingEvidenceWrite.catch(() => {}), activeTurnWaiter.promise]);
       if (signal.output) {
-        await signal.output;
+        await Promise.race([signal.output, activeTurnWaiter.promise]);
         streamStarted = true;
       }
-      const full = await completion;
+      const full = await Promise.race([completion, activeTurnWaiter.promise]);
       this._recordTurnCompletion(full);
       if (admissionIdentity !== undefined) {
         try {
-          await this._writeMessageResultEvidenceBestEffort(
-            {
-              status: 'completed',
-              signalId: signal.signal.id,
-              runId: signal.runId,
-              result: full,
-              admissionId: opts.admissionId!,
-              admissionHash: admissionHash!,
-            },
-            { compatibleAdmissionHashes },
-          );
+          await Promise.race([
+            this._writeMessageResultEvidenceBestEffort(
+              {
+                status: 'completed',
+                signalId: signal.signal.id,
+                runId: signal.runId,
+                result: full,
+                admissionId: opts.admissionId!,
+                admissionHash: admissionHash!,
+              },
+              { compatibleAdmissionHashes },
+            ),
+            activeTurnWaiter.promise,
+          ]);
         } catch (err) {
           completedEvidenceWriteFailed = true;
           throw err;
         }
       }
-      await this._maybeCaptureSuspend(full, undefined, effectiveModeId);
+      await Promise.race([this._maybeCaptureSuspend(full, undefined, effectiveModeId), activeTurnWaiter.promise]);
       this._emitTurnEvent({
         type: 'agent_end',
         reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
         runId: full.runId,
       });
-      await this._runGoalJudge(full, false);
+      await Promise.race([this._runGoalJudge(full, false), activeTurnWaiter.promise]);
       return full;
     } catch (err) {
       if (!streamStarted) {
@@ -2344,23 +2476,30 @@ export class Session {
         this._rememberCompletedRun(signal.runId, { ok: false, err });
         waiter?.reject(err);
       }
-      if (admissionIdentity !== undefined && !completedEvidenceWriteFailed) {
-        await this._writeMessageResultEvidence(
-          {
-            status: 'failed',
-            signalId: signal.signal.id,
-            runId: signal.runId,
-            error: projectHarnessPublicError(err),
-            admissionId: opts.admissionId!,
-            admissionHash: admissionHash!,
-          },
-          { compatibleAdmissionHashes },
-        ).catch(() => {});
+      if (
+        admissionIdentity !== undefined &&
+        !completedEvidenceWriteFailed &&
+        this._shouldWriteTurnFailureEvidence(err)
+      ) {
+        await Promise.race([
+          this._writeMessageResultEvidence(
+            {
+              status: 'failed',
+              signalId: signal.signal.id,
+              runId: signal.runId,
+              error: projectHarnessPublicError(err),
+              admissionId: opts.admissionId!,
+              admissionHash: admissionHash!,
+            },
+            { compatibleAdmissionHashes },
+          ).catch(() => {}),
+          activeTurnWaiter.promise,
+        ]);
       }
       throw err;
     } finally {
       if (opts.admissionId !== undefined) this._messageAdmissionStarts.delete(opts.admissionId);
-      this._endTurn(turnAbortController);
+      finishOwnedMessageTurn();
       // Now that the manual turn has cleared the in-flight guard, kick
       // the queue drain so any item that was admitted mid-turn can run.
       void this._maybeDrainQueue();
@@ -2380,6 +2519,7 @@ export class Session {
       harnessName: this._record.harnessName,
       sessionId: this.id,
       resourceId: this.resourceId,
+      threadId: this.threadId,
       kind: 'message',
       admissionId,
       attemptedAdmissionHash: admissionHash,
@@ -2401,15 +2541,77 @@ export class Session {
     evidence: AgentSignalResultEvidence | OperationAdmissionTombstone,
     opts: MessageOptions,
   ): Promise<AgentResult | AgentStream | unknown> {
-    if ('status' in evidence) {
-      if (opts.stream === true) {
-        if (evidence.status === 'pending') {
+    return this._withActiveDeletedWaiter(async activeDeleted => {
+      if ('status' in evidence) {
+        if (opts.stream === true) {
+          if (evidence.status === 'pending') {
+            const agent = this._harness.getAgentForMode(this._messageDuplicateModeId(evidence, opts));
+            await this._raceActiveTurnWaiter(this._ensureThreadSubscription(agent), activeDeleted);
+            const runId = await this._pendingMessageRunId(evidence);
+            if (runId && this._completedRuns.has(runId)) {
+              const cached = this._completedRuns.get(runId);
+              if (cached?.ok && evidence.admissionId !== undefined && evidence.admissionHash !== undefined) {
+                await this._writeMessageResultEvidenceBestEffort({
+                  status: 'completed',
+                  signalId: evidence.signalId,
+                  runId,
+                  result: cached.full,
+                  admissionId: evidence.admissionId,
+                  admissionHash: evidence.admissionHash,
+                });
+              }
+              throw new HarnessValidationError('message().admissionId', 'duplicate stream is no longer live');
+            }
+            let output = runId ? (agent.getRunOutput(runId) as AgentStream | undefined) : undefined;
+            let retainedCompletedOutput = false;
+            if (
+              output &&
+              (output as { status?: string }).status !== undefined &&
+              (output as { status?: string }).status !== 'running'
+            ) {
+              retainedCompletedOutput = true;
+              output = undefined;
+            }
+            if (runId && !output && !retainedCompletedOutput) {
+              const waitAbortController = new AbortController();
+              const completion = this._runCompletionPromises.get(runId)?.promise.then(
+                () => undefined,
+                () => undefined,
+              );
+              try {
+                output = (await Promise.race([
+                  this._raceActiveTurnWaiter(
+                    (
+                      agent.waitForRunOutput(runId, { abortSignal: waitAbortController.signal }) as Promise<AgentStream>
+                    ).catch(() => undefined),
+                    activeDeleted,
+                  ),
+                  ...(completion ? [completion] : []),
+                  delay(MESSAGE_ADMISSION_DURABLE_WAIT_TIMEOUT_MS, waitAbortController.signal).then(
+                    () => undefined,
+                    () => undefined,
+                  ),
+                ])) as AgentStream | undefined;
+              } finally {
+                waitAbortController.abort(
+                  new HarnessValidationError('message().admissionId', 'duplicate stream wait ended'),
+                );
+              }
+            }
+            if (output) return output;
+          }
+          throw new HarnessValidationError('message().admissionId', 'duplicate stream is no longer live');
+        }
+        if (evidence.status === 'completed') return evidence.result as AgentResult;
+        if (evidence.status === 'failed') throw publicErrorProjectionToError(evidence.error);
+        const runId = await this._pendingMessageRunId(evidence);
+        if (runId) {
           const agent = this._harness.getAgentForMode(this._messageDuplicateModeId(evidence, opts));
-          await this._ensureThreadSubscription(agent);
-          const runId = await this._pendingMessageRunId(evidence);
-          if (runId && this._completedRuns.has(runId)) {
-            const cached = this._completedRuns.get(runId);
-            if (cached?.ok && evidence.admissionId !== undefined && evidence.admissionHash !== undefined) {
+          await this._raceActiveTurnWaiter(this._ensureThreadSubscription(agent), activeDeleted);
+          const cached = this._completedRuns.get(runId);
+          if (cached) {
+            if (!cached.ok) throw cached.err;
+            if (evidence.admissionId !== undefined && evidence.admissionHash !== undefined) {
               await this._writeMessageResultEvidenceBestEffort({
                 status: 'completed',
                 signalId: evidence.signalId,
@@ -2419,73 +2621,16 @@ export class Session {
                 admissionHash: evidence.admissionHash,
               });
             }
-            throw new HarnessValidationError('message().admissionId', 'duplicate stream is no longer live');
+            return cached.full;
           }
-          let output = runId ? (agent.getRunOutput(runId) as AgentStream | undefined) : undefined;
-          let retainedCompletedOutput = false;
-          if (
-            output &&
-            (output as { status?: string }).status !== undefined &&
-            (output as { status?: string }).status !== 'running'
-          ) {
-            retainedCompletedOutput = true;
-            output = undefined;
+          if (!this._hasLiveMessageRun(agent, runId)) {
+            return this._raceActiveTurnWaiter(this._awaitDurableMessageResult(evidence, opts), activeDeleted);
           }
-          if (runId && !output && !retainedCompletedOutput) {
-            const waitAbortController = new AbortController();
-            const completion = this._runCompletionPromises.get(runId)?.promise.then(
-              () => undefined,
-              () => undefined,
-            );
-            try {
-              output = (await Promise.race([
-                (
-                  agent.waitForRunOutput(runId, { abortSignal: waitAbortController.signal }) as Promise<AgentStream>
-                ).catch(() => undefined),
-                ...(completion ? [completion] : []),
-                delay(MESSAGE_ADMISSION_DURABLE_WAIT_TIMEOUT_MS, waitAbortController.signal).then(
-                  () => undefined,
-                  () => undefined,
-                ),
-              ])) as AgentStream | undefined;
-            } finally {
-              waitAbortController.abort(
-                new HarnessValidationError('message().admissionId', 'duplicate stream wait ended'),
-              );
-            }
-          }
-          if (output) return output;
+          return this._raceActiveTurnWaiter(this._awaitRunCompletion(runId), activeDeleted);
         }
-        throw new HarnessValidationError('message().admissionId', 'duplicate stream is no longer live');
       }
-      if (evidence.status === 'completed') return evidence.result as AgentResult;
-      if (evidence.status === 'failed') throw publicErrorProjectionToError(evidence.error);
-      const runId = await this._pendingMessageRunId(evidence);
-      if (runId) {
-        const agent = this._harness.getAgentForMode(this._messageDuplicateModeId(evidence, opts));
-        await this._ensureThreadSubscription(agent);
-        const cached = this._completedRuns.get(runId);
-        if (cached) {
-          if (!cached.ok) throw cached.err;
-          if (evidence.admissionId !== undefined && evidence.admissionHash !== undefined) {
-            await this._writeMessageResultEvidenceBestEffort({
-              status: 'completed',
-              signalId: evidence.signalId,
-              runId,
-              result: cached.full,
-              admissionId: evidence.admissionId,
-              admissionHash: evidence.admissionHash,
-            });
-          }
-          return cached.full;
-        }
-        if (!this._hasLiveMessageRun(agent, runId)) {
-          return this._awaitDurableMessageResult(evidence, opts);
-        }
-        return this._awaitRunCompletion(runId);
-      }
-    }
-    throw new HarnessValidationError('message().admissionId', 'duplicate message result evidence has expired');
+      throw new HarnessValidationError('message().admissionId', 'duplicate message result evidence has expired');
+    });
   }
 
   private async _pendingMessageRunId(evidence: AgentSignalResultEvidence): Promise<string | undefined> {
@@ -2560,8 +2705,9 @@ export class Session {
     options?: { compatibleAdmissionHashes?: readonly string[] },
   ): Promise<{ created: boolean }> {
     const now = Date.now();
+    this._operationEvidenceSignalIds.add(status.signalId);
     try {
-      return await this._storage.writeMessageResultEvidence({
+      const result = await this._storage.writeMessageResultEvidence({
         ...status,
         harnessName: this._record.harnessName,
         sessionId: this.id,
@@ -2570,6 +2716,8 @@ export class Session {
         createdAt: now,
         updatedAt: now,
       });
+      await this._cleanupOperationEvidenceIfDeleted(status);
+      return result;
     } catch (err) {
       if (err instanceof HarnessStorageAdmissionConflictError && status.admissionId && status.admissionHash) {
         const duplicate = await this._resolveMessageAdmissionDuplicate({
@@ -2582,6 +2730,19 @@ export class Session {
       }
       throw err;
     }
+  }
+
+  private async _cleanupOperationEvidenceIfDeleted(status: { signalId: string }): Promise<void> {
+    if (this._state !== 'deleted') return;
+    await this._storage
+      .deleteOperationAdmissionTombstonesForSession({
+        harnessName: this._record.harnessName,
+        sessionId: this.id,
+        resourceId: this.resourceId,
+        threadId: this.threadId,
+        signalId: status.signalId,
+      })
+      .catch(() => {});
   }
 
   private async _writeMessageResultEvidenceBestEffort(
@@ -2673,7 +2834,14 @@ export class Session {
 
     // Open the thread subscription before reading `activeRunId()` so the
     // routing decision sees the live runtime state.
-    const sub = await this._ensureThreadSubscription(agent);
+    const subscriptionWaiter = this._createActiveTurnWaiter();
+    void subscriptionWaiter.promise.catch(() => {});
+    const subscription = this._ensureThreadSubscription(agent);
+    void subscription.catch(() => {});
+    const sub = await Promise.race([subscription, subscriptionWaiter.promise]).finally(() => {
+      subscriptionWaiter.cleanup();
+    });
+    this._assertLive('signal()');
 
     const activeRunId = sub.activeRunId();
     const willInterleave = activeRunId !== null;
@@ -2700,13 +2868,27 @@ export class Session {
       // Owned-turn path: same bookkeeping as the message() default path.
       const turnAbortController = this._beginTurn(opts.abortSignal);
       const turnAbortSignal = turnAbortController.signal;
+      const activeTurnWaiter = this._createActiveTurnWaiter();
+      void activeTurnWaiter.promise.catch(() => {});
+      const finishOwnedSignalTurn = () => {
+        activeTurnWaiter.cleanup();
+        this._endTurn(turnAbortController);
+      };
+      const assertOwnedSignalTurnNotDeleted = () => {
+        if (this._state === 'deleted') {
+          throw new HarnessSessionDeletedError(this.id);
+        }
+      };
       let dispatched;
       try {
         const toolsets = this._buildToolsets(mode, opts.additionalTools);
-        const requestContext = await this._buildRequestContext({
-          modeId: effectiveModeId,
-          abortSignal: turnAbortSignal,
-        });
+        const requestContext = await Promise.race([
+          this._buildRequestContext({
+            modeId: effectiveModeId,
+            abortSignal: turnAbortSignal,
+          }),
+          activeTurnWaiter.promise,
+        ]);
         const baseExecOptions: AgentExecutionOptionsBase<unknown> = {
           memory: { thread: this.threadId, resource: this.resourceId },
           abortSignal: turnAbortSignal,
@@ -2714,6 +2896,7 @@ export class Session {
           ...(toolsets ? { toolsets } : {}),
           ...(mode.instructions ? { instructions: mode.instructions } : {}),
         };
+        assertOwnedSignalTurnNotDeleted();
         this._emitTurnEvent({ type: 'agent_start' });
 
         dispatched = agent.sendSignal(
@@ -2725,29 +2908,30 @@ export class Session {
           },
         );
       } catch (err) {
-        this._endTurn(turnAbortController);
+        finishOwnedSignalTurn();
         throw err;
       }
 
       // Register the completion waiter before any terminal chunks land.
       const completion = this._awaitRunCompletion(dispatched.runId);
+      const completionOrDelete = Promise.race([completion, activeTurnWaiter.promise]);
 
       // Background continuation runs the post-turn bookkeeping so the
       // caller's `result` promise resolves with the final AgentResult.
-      const result: Promise<AgentResult> = completion
+      const result: Promise<AgentResult> = completionOrDelete
         .then(async full => {
           this._recordTurnCompletion(full);
-          await this._maybeCaptureSuspend(full, undefined, effectiveModeId);
+          await Promise.race([this._maybeCaptureSuspend(full, undefined, effectiveModeId), activeTurnWaiter.promise]);
           this._emitTurnEvent({
             type: 'agent_end',
             reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
             runId: full.runId,
           });
-          await this._runGoalJudge(full, false);
+          await Promise.race([this._runGoalJudge(full, false), activeTurnWaiter.promise]);
           return full as AgentResult;
         })
         .finally(() => {
-          this._endTurn(turnAbortController);
+          finishOwnedSignalTurn();
           void this._maybeDrainQueue();
         });
 
@@ -2817,7 +3001,14 @@ export class Session {
     const mode = this._harness._getMode(effectiveModeId);
     const agent = this._harness.getAgentForMode(effectiveModeId);
 
-    const sub = await this._ensureThreadSubscription(agent);
+    const subscriptionWaiter = this._createActiveTurnWaiter();
+    void subscriptionWaiter.promise.catch(() => {});
+    const subscription = this._ensureThreadSubscription(agent);
+    void subscription.catch(() => {});
+    const sub = await Promise.race([subscription, subscriptionWaiter.promise]).finally(() => {
+      subscriptionWaiter.cleanup();
+    });
+    this._assertLive('injectSystemReminder()');
     const activeRunId = sub.activeRunId();
     const willInterleave = activeRunId !== null;
 
@@ -2826,13 +3017,27 @@ export class Session {
       // continuation. Caller doesn't get a result handle.
       const turnAbortController = this._beginTurn(undefined);
       const turnAbortSignal = turnAbortController.signal;
+      const activeTurnWaiter = this._createActiveTurnWaiter();
+      void activeTurnWaiter.promise.catch(() => {});
+      const finishOwnedReminderTurn = () => {
+        activeTurnWaiter.cleanup();
+        this._endTurn(turnAbortController);
+      };
+      const assertOwnedReminderTurnNotDeleted = () => {
+        if (this._state === 'deleted') {
+          throw new HarnessSessionDeletedError(this.id);
+        }
+      };
       let dispatched;
       try {
         const toolsets = this._buildToolsets(mode, undefined);
-        const requestContext = await this._buildRequestContext({
-          modeId: effectiveModeId,
-          abortSignal: turnAbortSignal,
-        });
+        const requestContext = await Promise.race([
+          this._buildRequestContext({
+            modeId: effectiveModeId,
+            abortSignal: turnAbortSignal,
+          }),
+          activeTurnWaiter.promise,
+        ]);
         const baseExecOptions: AgentExecutionOptionsBase<unknown> = {
           memory: { thread: this.threadId, resource: this.resourceId },
           abortSignal: turnAbortSignal,
@@ -2840,6 +3045,7 @@ export class Session {
           ...(toolsets ? { toolsets } : {}),
           ...(mode.instructions ? { instructions: mode.instructions } : {}),
         };
+        assertOwnedReminderTurnNotDeleted();
         this._emitTurnEvent({ type: 'agent_start' });
 
         dispatched = agent.sendSignal(
@@ -2856,24 +3062,25 @@ export class Session {
           },
         );
       } catch (err) {
-        this._endTurn(turnAbortController);
+        finishOwnedReminderTurn();
         throw err;
       }
 
       const completion = this._awaitRunCompletion(dispatched.runId);
-      const result = completion
+      const completionOrDelete = Promise.race([completion, activeTurnWaiter.promise]);
+      const result = completionOrDelete
         .then(async full => {
           this._recordTurnCompletion(full);
-          await this._maybeCaptureSuspend(full, undefined, effectiveModeId);
+          await Promise.race([this._maybeCaptureSuspend(full, undefined, effectiveModeId), activeTurnWaiter.promise]);
           this._emitTurnEvent({
             type: 'agent_end',
             reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
             runId: full.runId,
           });
-          await this._runGoalJudge(full, false);
+          await Promise.race([this._runGoalJudge(full, false), activeTurnWaiter.promise]);
         })
         .finally(() => {
-          this._endTurn(turnAbortController);
+          finishOwnedReminderTurn();
           void this._maybeDrainQueue();
         });
       void result.catch(() => {});
@@ -4281,25 +4488,49 @@ export class Session {
     // `session.abort()` can cancel an in-flight resume (e.g. ESC after the
     // user approved a tool that's now grinding through a long workflow).
     const turnAbortController = this._beginTurn(undefined);
+    const activeTurnWaiter = this._createActiveTurnWaiter();
+    void activeTurnWaiter.promise.catch(() => {});
+    const finishResumedTurn = () => {
+      activeTurnWaiter.cleanup();
+      this._endTurn(turnAbortController);
+    };
+    const assertResumedTurnNotDeleted = () => {
+      if (this._state === 'deleted') {
+        throw new HarnessSessionDeletedError(this.id);
+      }
+    };
     const agent = this._harness.getAgentForMode(resumeModeId);
     let full: FullOutput<unknown>;
     try {
-      const out = await agent.resumeStream(resumeData, {
+      assertResumedTurnNotDeleted();
+      const resumeStream = agent.resumeStream(resumeData, {
         runId: pending.runId,
         toolCallId: pending.toolCallId,
         abortSignal: turnAbortController.signal,
       });
-      full = (await out.getFullOutput()) as FullOutput<unknown>;
+      void resumeStream.catch(() => {});
+      const out = await Promise.race([resumeStream, activeTurnWaiter.promise]);
+      const fullOutput = out.getFullOutput() as Promise<FullOutput<unknown>>;
+      void fullOutput.catch(() => {});
+      full = await Promise.race([fullOutput, activeTurnWaiter.promise]);
       const resumedQueuedItemId = this._queuedItemIdForPendingResume(pending);
       if (full.finishReason !== 'suspended' && resumedQueuedItemId !== undefined) {
-        await this._markQueuedTurnCompleted(resumedQueuedItemId, full, { modeId: modeFlipTarget });
+        await Promise.race([
+          this._markQueuedTurnCompleted(resumedQueuedItemId, full, { modeId: modeFlipTarget }),
+          activeTurnWaiter.promise,
+        ]);
       }
     } catch (err) {
-      this._endTurn(turnAbortController);
+      let thrown = err;
       if (responseId !== undefined) {
-        await this._markInboxResponseFailed(responseId, err);
+        try {
+          await Promise.race([this._markInboxResponseFailed(responseId, err), activeTurnWaiter.promise]);
+        } catch (responseErr) {
+          thrown = responseErr;
+        }
       }
-      throw err;
+      finishResumedTurn();
+      throw thrown;
     }
 
     // Clear pending + apply any remaining mode flip in a single CAS write. A
@@ -4310,13 +4541,17 @@ export class Session {
     try {
       if (completingQueuedItemId !== undefined) {
         if (modeFlipTarget && modeFlipTarget !== previousModeId) {
-          await this._flushUpdate(prev => ({ ...prev, modeId: modeFlipTarget }));
+          await Promise.race([
+            this._flushUpdate(prev => ({ ...prev, modeId: modeFlipTarget })),
+            activeTurnWaiter.promise,
+          ]);
         }
         const queuedItem = this._record.pendingQueue.find(item => item.id === completingQueuedItemId);
         if (queuedItem) {
           try {
-            await this._markQueuedPostRunFinalized(completingQueuedItemId);
+            await Promise.race([this._markQueuedPostRunFinalized(completingQueuedItemId), activeTurnWaiter.promise]);
           } catch (err) {
+            if (err instanceof HarnessSessionDeletedError) throw err;
             throw new QueuePostRunFinalizationPendingError(Date.now() + QUEUE_POST_RUN_FINALIZATION_RETRY_MS, err);
           }
         }
@@ -4326,42 +4561,45 @@ export class Session {
       }
       const queueCompletedAt = Date.now();
       const responseAppliedAt = queueCompletedAt;
-      await this._flushUpdate(prev => {
-        const next: SessionRecord = { ...prev };
-        delete next.pendingResume;
-        const receipt =
-          responseId !== undefined ? getOwnRecordValue(prev.inboxResponseReceipts, responseId) : undefined;
-        if (receipt) {
-          next.inboxResponseReceipts = {
-            ...(prev.inboxResponseReceipts ?? {}),
-            [receipt.responseId]: {
-              ...receipt,
-              status: 'applied',
-              result: full,
-              appliedAt: receipt.appliedAt ?? responseAppliedAt,
-              updatedAt: responseAppliedAt,
-            },
-          };
-        }
-        if (modeFlipTarget) next.modeId = modeFlipTarget;
-        if (completingQueuedItemId !== undefined) {
-          next.pendingQueue = (prev.pendingQueue ?? []).filter(x => x.id !== completingQueuedItemId);
-          const receipt = prev.queueAdmissionReceipts?.[completingQueuedItemId];
+      await Promise.race([
+        this._flushUpdate(prev => {
+          const next: SessionRecord = { ...prev };
+          delete next.pendingResume;
+          const receipt =
+            responseId !== undefined ? getOwnRecordValue(prev.inboxResponseReceipts, responseId) : undefined;
           if (receipt) {
-            next.queueAdmissionReceipts = {
-              ...(prev.queueAdmissionReceipts ?? {}),
-              [completingQueuedItemId]: {
+            next.inboxResponseReceipts = {
+              ...(prev.inboxResponseReceipts ?? {}),
+              [receipt.responseId]: {
                 ...receipt,
-                status: 'completed',
+                status: 'applied',
                 result: full,
-                completedAt: receipt.completedAt ?? queueCompletedAt,
-                updatedAt: queueCompletedAt,
+                appliedAt: receipt.appliedAt ?? responseAppliedAt,
+                updatedAt: responseAppliedAt,
               },
             };
           }
-        }
-        return next;
-      });
+          if (modeFlipTarget) next.modeId = modeFlipTarget;
+          if (completingQueuedItemId !== undefined) {
+            next.pendingQueue = (prev.pendingQueue ?? []).filter(x => x.id !== completingQueuedItemId);
+            const receipt = prev.queueAdmissionReceipts?.[completingQueuedItemId];
+            if (receipt) {
+              next.queueAdmissionReceipts = {
+                ...(prev.queueAdmissionReceipts ?? {}),
+                [completingQueuedItemId]: {
+                  ...receipt,
+                  status: 'completed',
+                  result: full,
+                  completedAt: receipt.completedAt ?? queueCompletedAt,
+                  updatedAt: queueCompletedAt,
+                },
+              };
+            }
+          }
+          return next;
+        }),
+        activeTurnWaiter.promise,
+      ]);
 
       // Pending resolved — emit before the (optional) re-suspension capture
       // so subscribers see ordering: resolved → (mode_changed?) → required?.
@@ -4382,7 +4620,10 @@ export class Session {
       // The resumed run can itself suspend again (multi-step approval chains).
       // Mirror message()'s post-run hook so the next respond* call sees the
       // new pending record.
-      await this._maybeCaptureSuspend(full, pendingQueuedItemId, resumeModeId);
+      await Promise.race([
+        this._maybeCaptureSuspend(full, pendingQueuedItemId, resumeModeId),
+        activeTurnWaiter.promise,
+      ]);
 
       // If the resumed run did NOT suspend again, the turn is complete from
       // the harness's perspective. Surface that to subscribers via agent_end.
@@ -4397,7 +4638,7 @@ export class Session {
         // resolver, remove the head item, clear current, then kick the drain
         // for the next item.
         const wasGoalDriven = (this._currentQueuedItemSource ?? 'user') === 'goal';
-        await this._runGoalJudge(full, wasGoalDriven);
+        await Promise.race([this._runGoalJudge(full, wasGoalDriven), activeTurnWaiter.promise]);
         if (completingQueuedItemId !== undefined) {
           this._currentQueuedItemId = undefined;
           this._currentQueuedItemSource = undefined;
@@ -4416,7 +4657,7 @@ export class Session {
       }
       throw err;
     } finally {
-      this._endTurn(turnAbortController);
+      finishResumedTurn();
     }
     if (responseMode === 'inbox-receipt') {
       const receipt =
@@ -4810,7 +5051,10 @@ export class Session {
     const duplicate = opts.admissionId
       ? await this._resolveQueueAdmissionDuplicate({ admissionId, admissionHash })
       : undefined;
-    if (duplicate) return this._returnDuplicateQueueResult(duplicate);
+    if (duplicate) {
+      this._assertLive('queue()');
+      return this._returnDuplicateQueueResult(duplicate);
+    }
 
     const cap = this._harness._internalMaxQueueDepth;
     if ((this._record.pendingQueue?.length ?? 0) >= cap) {
@@ -4912,6 +5156,7 @@ export class Session {
       harnessName: this._record.harnessName,
       sessionId: this.id,
       resourceId: this.resourceId,
+      threadId: this.threadId,
       kind: 'queue',
       admissionId,
       attemptedAdmissionHash: admissionHash,
@@ -5233,27 +5478,48 @@ export class Session {
     // Queued turns run under a session-owned AbortController so
     // `session.abort()` can cancel an in-flight queued run too.
     const turnAbortController = this._beginTurn(undefined);
-    const requestContext = await this._buildRequestContext({
-      modeId: effectiveModeId,
-      abortSignal: turnAbortController.signal,
-    });
-    const baseExecOptions: AgentExecutionOptionsBase<unknown> = {
-      memory: { thread: this.threadId, resource: this.resourceId },
-      abortSignal: turnAbortController.signal,
-      requestContext,
-      ...(toolsets ? { toolsets } : {}),
-      ...(mode.instructions ? { instructions: mode.instructions } : {}),
+    const activeTurnWaiter = this._createActiveTurnWaiter();
+    void activeTurnWaiter.promise.catch(() => {});
+    const finishQueuedTurn = () => {
+      activeTurnWaiter.cleanup();
+      this._endTurn(turnAbortController);
+    };
+    const assertQueuedTurnNotDeleted = () => {
+      if (this._state === 'deleted') {
+        throw new HarnessSessionDeletedError(this.id);
+      }
     };
 
-    this._emitTurnEvent({ type: 'agent_start' });
-
     try {
-      await this._ensureThreadSubscription(agent);
-      await this._writeQueueSignalResultEvidence({
-        status: 'pending',
-        signalId: identity.signalId,
-        runId: identity.runId,
-      });
+      const requestContext = await Promise.race([
+        this._buildRequestContext({
+          modeId: effectiveModeId,
+          abortSignal: turnAbortController.signal,
+        }),
+        activeTurnWaiter.promise,
+      ]);
+      assertQueuedTurnNotDeleted();
+      const baseExecOptions: AgentExecutionOptionsBase<unknown> = {
+        memory: { thread: this.threadId, resource: this.resourceId },
+        abortSignal: turnAbortController.signal,
+        requestContext,
+        ...(toolsets ? { toolsets } : {}),
+        ...(mode.instructions ? { instructions: mode.instructions } : {}),
+      };
+
+      this._emitTurnEvent({ type: 'agent_start' });
+
+      await Promise.race([this._ensureThreadSubscription(agent), activeTurnWaiter.promise]);
+      assertQueuedTurnNotDeleted();
+      await Promise.race([
+        this._writeQueueSignalResultEvidence({
+          status: 'pending',
+          signalId: identity.signalId,
+          runId: identity.runId,
+        }),
+        activeTurnWaiter.promise,
+      ]);
+      assertQueuedTurnNotDeleted();
       const signal = agent.sendSignal(
         { id: identity.signalId, type: 'user-message', contents: item.content as never },
         {
@@ -5272,26 +5538,34 @@ export class Session {
         signalIdentity.runId,
         signalIdentity.signalId,
         effectiveModeId,
+        activeTurnWaiter.promise,
       );
+      void completion.catch(() => {});
       if (signalIdentity !== identity) {
-        await this._writeQueueSignalResultEvidence({
-          status: 'pending',
-          signalId: signalIdentity.signalId,
-          runId: signalIdentity.runId,
-        });
+        await Promise.race([
+          this._writeQueueSignalResultEvidence({
+            status: 'pending',
+            signalId: signalIdentity.signalId,
+            runId: signalIdentity.runId,
+          }),
+          activeTurnWaiter.promise,
+        ]);
       }
-      await this._updateQueueAdmissionReceipt(item.id, (receipt, now) => ({
-        ...receipt,
-        status: 'accepted',
-        runId: signalIdentity.runId,
-        signalId: signalIdentity.signalId,
-        modeId: receipt.modeId ?? effectiveModeId,
-        acceptedAt: receipt.acceptedAt ?? now,
-        updatedAt: now,
-      })).catch(() => {});
-      return await completion;
+      await Promise.race([
+        this._updateQueueAdmissionReceipt(item.id, (receipt, now) => ({
+          ...receipt,
+          status: 'accepted',
+          runId: signalIdentity.runId,
+          signalId: signalIdentity.signalId,
+          modeId: receipt.modeId ?? effectiveModeId,
+          acceptedAt: receipt.acceptedAt ?? now,
+          updatedAt: now,
+        })).catch(() => {}),
+        activeTurnWaiter.promise,
+      ]);
+      return await Promise.race([completion, activeTurnWaiter.promise]);
     } finally {
-      this._endTurn(turnAbortController);
+      finishQueuedTurn();
     }
   }
 
@@ -5303,35 +5577,37 @@ export class Session {
   ): Promise<FullOutput<unknown> | undefined> {
     if (!receipt.runId || !receipt.signalId) return undefined;
 
-    await this._ensureThreadSubscription(agent);
-    if (this._hasLiveMessageRun(agent, receipt.runId)) {
-      return this._awaitQueuedRunCompletion(item, receipt.runId, receipt.signalId, modeId);
-    }
-
-    const evidence = await this._loadQueueSignalResultEvidence(receipt);
-    if (evidence.status === 'completed') {
-      const full = evidence.result as FullOutput<unknown>;
-      await this._markQueuedTurnCompleted(item.id, full);
-      if (receipt.postRunFinalizedAt === undefined) {
-        await this._finalizeCompletedQueuedTurn(item, full, modeId);
+    return this._withActiveDeletedWaiter(async activeDeleted => {
+      await this._raceActiveTurnWaiter(this._ensureThreadSubscription(agent), activeDeleted);
+      if (this._hasLiveMessageRun(agent, receipt.runId!)) {
+        return this._awaitQueuedRunCompletion(item, receipt.runId!, receipt.signalId!, modeId, activeDeleted);
       }
-      return full;
-    }
-    if (evidence.status === 'failed') {
-      throw publicErrorProjectionToError(
-        evidence.error ?? { code: 'harness.queue_failed', message: 'queued turn failed' },
-      );
-    }
 
-    const recovery = await this._inspectQueueReceiptMemory(receipt);
-    if (recovery.status === 'pending') {
-      const dispatchAt = receipt.acceptedAt ?? receipt.admittingAt ?? receipt.updatedAt;
-      const retryAt = dispatchAt + QUEUE_ACCEPTED_RECOVERY_STALE_MS;
-      if (Date.now() >= retryAt) throw new QueueRecoveryStaleError();
-      throw new QueueRecoveryPendingError(retryAt);
-    }
+      const evidence = await this._raceActiveTurnWaiter(this._loadQueueSignalResultEvidence(receipt), activeDeleted);
+      if (evidence.status === 'completed') {
+        const full = evidence.result as FullOutput<unknown>;
+        await this._raceActiveTurnWaiter(this._markQueuedTurnCompleted(item.id, full), activeDeleted);
+        if (receipt.postRunFinalizedAt === undefined) {
+          await this._finalizeCompletedQueuedTurn(item, full, modeId, activeDeleted);
+        }
+        return full;
+      }
+      if (evidence.status === 'failed') {
+        throw publicErrorProjectionToError(
+          evidence.error ?? { code: 'harness.queue_failed', message: 'queued turn failed' },
+        );
+      }
 
-    return undefined;
+      const recovery = await this._raceActiveTurnWaiter(this._inspectQueueReceiptMemory(receipt), activeDeleted);
+      if (recovery.status === 'pending') {
+        const dispatchAt = receipt.acceptedAt ?? receipt.admittingAt ?? receipt.updatedAt;
+        const retryAt = dispatchAt + QUEUE_ACCEPTED_RECOVERY_STALE_MS;
+        if (Date.now() >= retryAt) throw new QueueRecoveryStaleError();
+        throw new QueueRecoveryPendingError(retryAt);
+      }
+
+      return undefined;
+    });
   }
 
   private _queueReceiptTerminalFailureError(queuedItemId: string): Error | undefined {
@@ -5358,17 +5634,23 @@ export class Session {
     runId: string,
     signalId: string,
     modeId: string,
+    activeTurnWaiter?: Promise<never>,
   ): Promise<FullOutput<unknown>> {
     let full: FullOutput<unknown>;
     try {
-      full = await this._awaitRunCompletion(runId);
+      full = await this._raceActiveTurnWaiter(this._awaitRunCompletion(runId), activeTurnWaiter);
     } catch (err) {
-      await this._writeQueueSignalResultEvidence({
-        status: 'failed',
-        signalId,
-        runId,
-        error: projectHarnessPublicError(err),
-      }).catch(() => {});
+      if (this._shouldWriteTurnFailureEvidence(err)) {
+        await this._raceActiveTurnWaiter(
+          this._writeQueueSignalResultEvidence({
+            status: 'failed',
+            signalId,
+            runId,
+            error: projectHarnessPublicError(err),
+          }).catch(() => {}),
+          activeTurnWaiter,
+        );
+      }
       throw err;
     }
 
@@ -5376,16 +5658,19 @@ export class Session {
     if (terminalFailure) throw terminalFailure;
 
     if (full.finishReason !== 'suspended') {
-      await this._markQueuedTurnCompleted(item.id, full);
-      await this._finalizeCompletedQueuedTurn(item, full, modeId);
-      await this._writeQueueSignalResultEvidence({
-        status: 'completed',
-        signalId,
-        runId,
-        result: full,
-      }).catch(() => {});
+      await this._raceActiveTurnWaiter(this._markQueuedTurnCompleted(item.id, full), activeTurnWaiter);
+      await this._finalizeCompletedQueuedTurn(item, full, modeId, activeTurnWaiter);
+      await this._raceActiveTurnWaiter(
+        this._writeQueueSignalResultEvidence({
+          status: 'completed',
+          signalId,
+          runId,
+          result: full,
+        }).catch(() => {}),
+        activeTurnWaiter,
+      );
     } else {
-      await this._finalizeQueuedRunCompletion(item, full, modeId);
+      await this._finalizeQueuedRunCompletion(item, full, modeId, activeTurnWaiter);
     }
     return full;
   }
@@ -5394,18 +5679,20 @@ export class Session {
     item: QueuedItem,
     full: FullOutput<unknown>,
     modeId: string,
+    activeTurnWaiter?: Promise<never>,
   ): Promise<void> {
     if (this._record.queueAdmissionReceipts?.[item.id]?.postRunFinalizedAt === undefined) {
       // Mark before running non-idempotent post-run side effects. Recovery may
       // retry a failed marker write, but must not replay goal continuations,
       // token accounting, or terminal turn events after the marker persists.
       try {
-        await this._markQueuedPostRunFinalized(item.id);
+        await this._raceActiveTurnWaiter(this._markQueuedPostRunFinalized(item.id), activeTurnWaiter);
       } catch (err) {
+        if (err instanceof HarnessSessionDeletedError) throw err;
         throw new QueuePostRunFinalizationPendingError(Date.now() + QUEUE_POST_RUN_FINALIZATION_RETRY_MS, err);
       }
     }
-    await this._finalizeQueuedRunCompletion(item, full, modeId);
+    await this._finalizeQueuedRunCompletion(item, full, modeId, activeTurnWaiter);
   }
 
   private async _markQueuedTurnCompleted(
@@ -5449,15 +5736,19 @@ export class Session {
     item: QueuedItem,
     full: FullOutput<unknown>,
     modeId?: string,
+    activeTurnWaiter?: Promise<never>,
   ): Promise<FullOutput<unknown>> {
     this._recordTurnCompletion(full);
-    await this._maybeCaptureSuspend(full, item.id, modeId ?? item.mode ?? this._record.modeId);
+    await this._raceActiveTurnWaiter(
+      this._maybeCaptureSuspend(full, item.id, modeId ?? item.mode ?? this._record.modeId),
+      activeTurnWaiter,
+    );
     this._emitTurnEvent({
       type: 'agent_end',
       reason: full.finishReason === 'suspended' ? 'suspended' : full.finishReason === 'error' ? 'error' : 'complete',
       runId: full.runId,
     });
-    await this._runGoalJudge(full, (item.source ?? 'user') === 'goal');
+    await this._raceActiveTurnWaiter(this._runGoalJudge(full, (item.source ?? 'user') === 'goal'), activeTurnWaiter);
     return full;
   }
 
@@ -5490,6 +5781,7 @@ export class Session {
 
   private async _writeQueueSignalResultEvidence(status: AgentSignalResultStatus): Promise<void> {
     const now = Date.now();
+    this._operationEvidenceSignalIds.add(status.signalId);
     await this._storage.writeMessageResultEvidence({
       ...status,
       harnessName: this._record.harnessName,
@@ -5499,6 +5791,7 @@ export class Session {
       createdAt: now,
       updatedAt: now,
     });
+    await this._cleanupOperationEvidenceIfDeleted(status);
   }
 
   private async _inspectQueueReceiptMemory(
@@ -6138,6 +6431,13 @@ export class Session {
   _markDeleted(): void {
     const err = new HarnessSessionDeletedError(this.id);
     this._state = 'deleted';
+    this._rejectIdleWaiters(err);
+    this._rejectActiveTurnWaiters(err);
+    const activeTurn = this._currentTurnAbortController;
+    if (activeTurn) {
+      activeTurn.abort('session_deleted');
+      this._endTurn(activeTurn);
+    }
     if (this._queuedResumeRecoveryTimer !== undefined) {
       clearTimeout(this._queuedResumeRecoveryTimer);
       this._queuedResumeRecoveryTimer = undefined;
@@ -6149,8 +6449,11 @@ export class Session {
       resolver.reject(err);
     }
     this._tearDownThreadSubscription(err);
-    this._rejectIdleWaiters(err);
-    this._notifyMaybeIdle();
+  }
+
+  /** @internal — signal identities that may have written operation evidence for this live session. */
+  _deletedOperationEvidenceSignalIds(): string[] {
+    return Array.from(this._operationEvidenceSignalIds);
   }
 
   /** @internal — harness bridge subscription that remains valid while closing. */
@@ -6186,8 +6489,8 @@ export class Session {
   }
 
   /**
-   * Synchronous teardown for the thread subscription on close/evict. Unsubscribes,
-   * marks the subscription closed, and rejects every outstanding entry in
+   * Synchronous teardown for the thread subscription on close/evict/delete.
+   * Unsubscribes, marks the subscription closed, and rejects every outstanding entry in
    * `_runCompletionPromises` so awaiters don't hang on a dead subscription.
    * The drain loop's `for-await` exits naturally once `unsubscribe()` wakes it.
    */

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -5052,8 +5052,10 @@ export class Session {
       ? await this._resolveQueueAdmissionDuplicate({ admissionId, admissionHash })
       : undefined;
     if (duplicate) {
-      this._assertLive('queue()');
-      return this._returnDuplicateQueueResult(duplicate);
+      this._assertOpenForTurn('queue()');
+      return this._withActiveDeletedWaiter(activeDeleted =>
+        this._raceActiveTurnWaiter(this._returnDuplicateQueueResult(duplicate, activeDeleted), activeDeleted),
+      );
     }
 
     const cap = this._harness._internalMaxQueueDepth;
@@ -5133,7 +5135,12 @@ export class Session {
       throw err;
     }
 
-    if (admittedReceipt) return this._returnDuplicateQueueResult(admittedReceipt);
+    if (admittedReceipt) {
+      this._assertOpenForTurn('queue()');
+      return this._withActiveDeletedWaiter(activeDeleted =>
+        this._raceActiveTurnWaiter(this._returnDuplicateQueueResult(admittedReceipt!, activeDeleted), activeDeleted),
+      );
+    }
 
     const queued = createDeferred<AgentResult>();
     const promise = queued.promise;
@@ -5170,6 +5177,7 @@ export class Session {
 
   private async _returnDuplicateQueueResult(
     evidence: QueueAdmissionReceipt | OperationAdmissionTombstone,
+    activeDeleted?: Promise<never>,
   ): Promise<AgentResult> {
     if ('kind' in evidence) {
       throw new HarnessValidationError('queue().admissionId', 'duplicate queue result evidence has expired');
@@ -5188,20 +5196,28 @@ export class Session {
       );
     }
     const resolver = this._queueResolvers.get(evidence.queuedItemId);
-    if (resolver) return resolver.promise;
+    if (resolver) return this._raceActiveTurnWaiter(resolver.promise, activeDeleted);
     void this._maybeDrainQueue();
-    return this._awaitDurableQueueResult(evidence);
+    return this._awaitDurableQueueResult(evidence, activeDeleted);
   }
 
-  private async _awaitDurableQueueResult(receipt: QueueAdmissionReceipt): Promise<AgentResult> {
+  private async _awaitDurableQueueResult(
+    receipt: QueueAdmissionReceipt,
+    activeDeleted?: Promise<never>,
+  ): Promise<AgentResult> {
     const deadline = Date.now() + MESSAGE_ADMISSION_DURABLE_WAIT_TIMEOUT_MS;
     while (true) {
-      const latest = await this._storage.loadQueueResultEvidence({
-        harnessName: this._record.harnessName,
-        sessionId: this.id,
-        resourceId: this.resourceId,
-        queuedItemId: receipt.queuedItemId,
-      });
+      this._assertNotDeleted();
+      const latest = await this._raceActiveTurnWaiter(
+        this._storage.loadQueueResultEvidence({
+          harnessName: this._record.harnessName,
+          sessionId: this.id,
+          resourceId: this.resourceId,
+          queuedItemId: receipt.queuedItemId,
+        }),
+        activeDeleted,
+      );
+      this._assertNotDeleted();
       if (!latest) {
         throw new HarnessValidationError('queue().admissionId', 'duplicate queue result evidence has expired');
       }
@@ -5223,7 +5239,7 @@ export class Session {
       if (waitMs === 0) {
         throw new HarnessValidationError('queue().admissionId', 'duplicate queue result evidence has expired');
       }
-      await delay(waitMs);
+      await this._raceActiveTurnWaiter(delay(waitMs), activeDeleted);
     }
   }
 
@@ -6177,6 +6193,12 @@ export class Session {
     }
     if (this._state !== 'live') {
       throw new HarnessSessionClosedError(this.id);
+    }
+  }
+
+  private _assertNotDeleted(): void {
+    if (this._state === 'deleted') {
+      throw new HarnessSessionDeletedError(this.id);
     }
   }
 

--- a/packages/core/src/storage/domains/harness/base.ts
+++ b/packages/core/src/storage/domains/harness/base.ts
@@ -485,6 +485,7 @@ export abstract class HarnessStorage extends StorageDomain {
     harnessName?: string;
     sessionId: string;
     resourceId: string;
+    threadId?: string;
     kind: 'message' | 'queue';
     admissionId: string;
     attemptedAdmissionHash: string;
@@ -510,6 +511,8 @@ export abstract class HarnessStorage extends StorageDomain {
     harnessName?: string;
     sessionId: string;
     resourceId: string;
+    threadId?: string;
+    signalId?: string;
   }): Promise<void>;
 
   // -------------------------------------------------------------------------

--- a/packages/core/src/storage/domains/harness/inmemory.test.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.test.ts
@@ -533,6 +533,7 @@ describe('InMemoryHarness admission storage contract', () => {
       storage.resolveOperationAdmissionEvidence({
         sessionId: 'session-1',
         resourceId: 'resource-1',
+        threadId: 'thread-1',
         kind: 'queue',
         admissionId: 'admission-1',
         attemptedAdmissionHash: 'hash-1',
@@ -542,6 +543,7 @@ describe('InMemoryHarness admission storage contract', () => {
       storage.resolveOperationAdmissionEvidence({
         sessionId: 'session-1',
         resourceId: 'resource-1',
+        threadId: 'thread-1',
         kind: 'queue',
         admissionId: 'admission-1',
         attemptedAdmissionHash: 'different-hash',
@@ -554,6 +556,82 @@ describe('InMemoryHarness admission storage contract', () => {
         queuedItemId: 'queued-1',
       }),
     ).resolves.toMatchObject({ admissionId: 'admission-1', status: 'queued' });
+  });
+
+  it('scopes admission resolution and hard-delete evidence cleanup by thread', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    await storage.saveSession(sampleSession({ closedAt: 2000, lastActivityAt: 2000 }), {
+      ownerId: 'h',
+      ifVersion: 0,
+    });
+    await storage.writeMessageResultEvidence({
+      harnessName: 'default',
+      sessionId: 'session-1',
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      signalId: 'signal-1',
+      runId: 'run-1',
+      admissionId: 'admission-1',
+      admissionHash: 'hash-1',
+      status: 'completed',
+      result: { text: 'old' },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+    await storage.writeMessageResultEvidence({
+      harnessName: 'default',
+      sessionId: 'session-1',
+      resourceId: 'resource-1',
+      threadId: 'thread-2',
+      signalId: 'signal-2',
+      runId: 'run-2',
+      admissionId: 'admission-1',
+      admissionHash: 'hash-2',
+      status: 'completed',
+      result: { text: 'new' },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+
+    await expect(
+      storage.resolveOperationAdmissionEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-2',
+        kind: 'message',
+        admissionId: 'admission-1',
+        attemptedAdmissionHash: 'hash-2',
+      }),
+    ).resolves.toMatchObject({ status: 'duplicate', storedAdmissionHash: 'hash-2' });
+
+    const stored = await storage.loadSession({ sessionId: 'session-1' });
+    if (!stored) throw new Error('expected session');
+    await storage.deleteSession({
+      sessionId: 'session-1',
+      ifVersion: stored.version,
+      expectedResourceId: stored.resourceId,
+      expectedThreadId: stored.threadId,
+      expectedParentSessionId: stored.parentSessionId ?? null,
+      expectedCreatedAt: stored.createdAt,
+      requireClosed: true,
+    });
+
+    await expect(
+      storage.loadMessageResultEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        signalId: 'signal-1',
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      storage.loadMessageResultEvidence({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-2',
+        signalId: 'signal-2',
+      }),
+    ).resolves.toMatchObject({ status: 'completed', result: { text: 'new' } });
   });
 });
 

--- a/packages/core/src/storage/domains/harness/inmemory.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.ts
@@ -377,7 +377,12 @@ export class InMemoryHarness extends HarnessStorage {
     }
 
     for (const { namespace, sessionId, record } of existingSessions.values()) {
-      await this.cleanupDeletedSession({ namespace, sessionId, resourceId: record.resourceId });
+      await this.cleanupDeletedSession({
+        namespace,
+        sessionId,
+        resourceId: record.resourceId,
+        threadId: record.threadId,
+      });
     }
   }
 
@@ -385,15 +390,18 @@ export class InMemoryHarness extends HarnessStorage {
     namespace,
     sessionId,
     resourceId,
+    threadId,
   }: {
     namespace: string;
     sessionId: string;
     resourceId: string;
+    threadId: string;
   }): Promise<void> {
     await this.deleteOperationAdmissionTombstonesForSession({
       harnessName: namespace,
       sessionId,
       resourceId,
+      threadId,
     });
     const refPrefix = `${namespace}\u0000${sessionId}\u0000`;
     for (const key of this.db.harnessAttachmentReferences.keys()) {
@@ -724,6 +732,7 @@ export class InMemoryHarness extends HarnessStorage {
     harnessName,
     sessionId,
     resourceId,
+    threadId,
     kind,
     admissionId,
     attemptedAdmissionHash,
@@ -731,6 +740,7 @@ export class InMemoryHarness extends HarnessStorage {
     harnessName?: string;
     sessionId: string;
     resourceId: string;
+    threadId?: string;
     kind: 'message' | 'queue';
     admissionId: string;
     attemptedAdmissionHash: string;
@@ -746,6 +756,7 @@ export class InMemoryHarness extends HarnessStorage {
           evidence.harnessName !== namespace ||
           evidence.sessionId !== sessionId ||
           evidence.resourceId !== resourceId ||
+          (threadId !== undefined && evidence.threadId !== threadId) ||
           evidence.admissionId !== admissionId
         ) {
           continue;
@@ -758,7 +769,9 @@ export class InMemoryHarness extends HarnessStorage {
     }
     if (kind === 'queue') {
       const session = this.db.harnessSessions.get(sessionKey(namespace, sessionId));
-      if (session && session.resourceId !== resourceId) return { status: 'none' };
+      if (session && (session.resourceId !== resourceId || (threadId !== undefined && session.threadId !== threadId))) {
+        return { status: 'none' };
+      }
       for (const receipt of Object.values(session?.queueAdmissionReceipts ?? {})) {
         if (receipt.admissionId !== admissionId) continue;
         if (receipt.admissionHash !== attemptedAdmissionHash) {
@@ -773,6 +786,7 @@ export class InMemoryHarness extends HarnessStorage {
         t.harnessName === namespace &&
         t.sessionId === sessionId &&
         t.resourceId === resourceId &&
+        (threadId === undefined || t.threadId === threadId) &&
         t.kind === kind &&
         t.admissionId === admissionId,
     );
@@ -878,17 +892,23 @@ export class InMemoryHarness extends HarnessStorage {
     harnessName,
     sessionId,
     resourceId,
+    threadId,
+    signalId,
   }: {
     harnessName?: string;
     sessionId: string;
     resourceId: string;
+    threadId?: string;
+    signalId?: string;
   }): Promise<void> {
     const namespace = resolveHarnessName(harnessName, this.harnessName);
     for (const [key, evidence] of this.db.harnessMessageResultEvidence) {
       if (
         evidence.harnessName === namespace &&
         evidence.sessionId === sessionId &&
-        evidence.resourceId === resourceId
+        evidence.resourceId === resourceId &&
+        (threadId === undefined || evidence.threadId === threadId) &&
+        (signalId === undefined || evidence.signalId === signalId)
       ) {
         this.db.harnessMessageResultEvidence.delete(key);
       }
@@ -897,7 +917,9 @@ export class InMemoryHarness extends HarnessStorage {
       if (
         tombstone.harnessName === namespace &&
         tombstone.sessionId === sessionId &&
-        tombstone.resourceId === resourceId
+        tombstone.resourceId === resourceId &&
+        (threadId === undefined || tombstone.threadId === threadId) &&
+        (signalId === undefined || tombstone.signalId === signalId)
       ) {
         this.db.harnessOperationTombstones.delete(key);
       }

--- a/stores/_test-utils/src/domains/harness/index.ts
+++ b/stores/_test-utils/src/domains/harness/index.ts
@@ -1271,6 +1271,7 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           harness.resolveOperationAdmissionEvidence({
             sessionId: 'session-1',
             resourceId: 'resource-1',
+            threadId: 'thread-1',
             kind: 'queue',
             admissionId: 'admission-1',
             attemptedAdmissionHash: 'hash-1',
@@ -1280,6 +1281,7 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           harness.resolveOperationAdmissionEvidence({
             sessionId: 'session-1',
             resourceId: 'resource-1',
+            threadId: 'thread-1',
             kind: 'queue',
             admissionId: 'admission-1',
             attemptedAdmissionHash: 'different-hash',
@@ -1289,6 +1291,7 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           harness.resolveOperationAdmissionEvidence({
             sessionId: 'session-1',
             resourceId: 'other-resource',
+            threadId: 'thread-1',
             kind: 'queue',
             admissionId: 'admission-1',
             attemptedAdmissionHash: 'hash-1',
@@ -1328,6 +1331,7 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           harness.resolveOperationAdmissionEvidence({
             sessionId: 'session-1',
             resourceId: 'resource-1',
+            threadId: 'thread-1',
             kind: 'message',
             admissionId: 'admission-1',
             attemptedAdmissionHash: 'hash-1',
@@ -1380,6 +1384,7 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           harness.resolveOperationAdmissionEvidence({
             sessionId: 'session-1',
             resourceId: 'resource-1',
+            threadId: 'thread-1',
             kind: 'message',
             admissionId: 'admission-1',
             attemptedAdmissionHash: 'hash-1',
@@ -1389,6 +1394,7 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
           harness.resolveOperationAdmissionEvidence({
             sessionId: 'session-1',
             resourceId: 'resource-1',
+            threadId: 'thread-1',
             kind: 'message',
             admissionId: 'admission-1',
             attemptedAdmissionHash: 'different-hash',
@@ -1437,6 +1443,65 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
             signalId: 'signal-1',
           }),
         ).resolves.toEqual(compacted);
+      });
+
+      it('scopes operation evidence deletion by thread and signal when provided', async () => {
+        if (!harness) return;
+        const base = {
+          harnessName: 'default',
+          sessionId: 'session-1',
+          resourceId: 'resource-1',
+          status: 'pending' as const,
+          createdAt: 1000,
+          updatedAt: 1000,
+        };
+        await harness.writeMessageResultEvidence({
+          ...base,
+          threadId: 'thread-1',
+          signalId: 'signal-1',
+        });
+        await harness.writeMessageResultEvidence({
+          ...base,
+          threadId: 'thread-1',
+          signalId: 'signal-2',
+        });
+        await harness.writeMessageResultEvidence({
+          ...base,
+          threadId: 'thread-2',
+          signalId: 'signal-3',
+        });
+
+        await harness.deleteOperationAdmissionTombstonesForSession({
+          sessionId: 'session-1',
+          resourceId: 'resource-1',
+          threadId: 'thread-1',
+          signalId: 'signal-1',
+        });
+
+        await expect(
+          harness.loadMessageResultEvidence({
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            threadId: 'thread-1',
+            signalId: 'signal-1',
+          }),
+        ).resolves.toBeNull();
+        await expect(
+          harness.loadMessageResultEvidence({
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            threadId: 'thread-1',
+            signalId: 'signal-2',
+          }),
+        ).resolves.toMatchObject({ status: 'pending' });
+        await expect(
+          harness.loadMessageResultEvidence({
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            threadId: 'thread-2',
+            signalId: 'signal-3',
+          }),
+        ).resolves.toMatchObject({ status: 'pending' });
       });
 
       it('compacts terminal queue receipts into tombstones', async () => {

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -660,6 +660,7 @@ describe('HarnessLibSQL message result evidence', () => {
       storage.resolveOperationAdmissionEvidence({
         sessionId: 'session-1',
         resourceId: 'resource-1',
+        threadId: 'thread-1',
         kind: 'message',
         admissionId: 'admission-1',
         attemptedAdmissionHash: 'hash-1',
@@ -669,6 +670,7 @@ describe('HarnessLibSQL message result evidence', () => {
       storage.resolveOperationAdmissionEvidence({
         sessionId: 'session-1',
         resourceId: 'resource-1',
+        threadId: 'thread-1',
         kind: 'message',
         admissionId: 'admission-1',
         attemptedAdmissionHash: 'different-hash',
@@ -801,6 +803,7 @@ describe('HarnessLibSQL queue admission evidence', () => {
       storage.resolveOperationAdmissionEvidence({
         sessionId: 'session-1',
         resourceId: 'resource-1',
+        threadId: 'thread-1',
         kind: 'queue',
         admissionId: 'admission-1',
         attemptedAdmissionHash: 'hash-1',
@@ -810,6 +813,7 @@ describe('HarnessLibSQL queue admission evidence', () => {
       storage.resolveOperationAdmissionEvidence({
         sessionId: 'session-1',
         resourceId: 'resource-1',
+        threadId: 'thread-1',
         kind: 'queue',
         admissionId: 'admission-1',
         attemptedAdmissionHash: 'different-hash',

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -772,7 +772,10 @@ export class HarnessLibSQL extends HarnessStorage {
   async deleteSessions({ sessions }: { sessions: DeleteSessionOptions[] }): Promise<void> {
     await this.#ensureMessageResultsTable();
     const tx = await this.#client.transaction('write');
-    const deleteCandidates = new Map<string, { namespace: string; sessionId: string; resourceId: string }>();
+    const deleteCandidates = new Map<
+      string,
+      { namespace: string; sessionId: string; resourceId: string; threadId: string }
+    >();
     try {
       for (const opts of sessions) {
         const { sessionId } = opts;
@@ -797,10 +800,15 @@ export class HarnessLibSQL extends HarnessStorage {
             record.version,
           );
         }
-        deleteCandidates.set(`${namespace}\u0000${sessionId}`, { namespace, sessionId, resourceId: record.resourceId });
+        deleteCandidates.set(`${namespace}\u0000${sessionId}`, {
+          namespace,
+          sessionId,
+          resourceId: record.resourceId,
+          threadId: record.threadId,
+        });
       }
 
-      for (const { namespace, sessionId, resourceId } of deleteCandidates.values()) {
+      for (const { namespace, sessionId, resourceId, threadId } of deleteCandidates.values()) {
         const result = await tx.execute({
           sql: `DELETE FROM ${TABLE_HARNESS_SESSIONS}
                 WHERE harness_name = ? AND id = ?`,
@@ -811,13 +819,13 @@ export class HarnessLibSQL extends HarnessStorage {
         }
         await tx.execute({
           sql: `DELETE FROM ${TABLE_HARNESS_MESSAGE_RESULTS}
-                WHERE harness_name = ? AND session_id = ? AND resource_id = ?`,
-          args: [namespace, sessionId, resourceId],
+                WHERE harness_name = ? AND session_id = ? AND resource_id = ? AND thread_id = ?`,
+          args: [namespace, sessionId, resourceId, threadId],
         });
         await tx.execute({
           sql: `DELETE FROM ${TABLE_HARNESS_OPERATION_TOMBSTONES}
-                WHERE harness_name = ? AND session_id = ? AND resource_id = ?`,
-          args: [namespace, sessionId, resourceId],
+                WHERE harness_name = ? AND session_id = ? AND resource_id = ? AND thread_id = ?`,
+          args: [namespace, sessionId, resourceId, threadId],
         });
         await tx.execute({
           sql: `DELETE FROM ${TABLE_HARNESS_ATTACHMENT_REFERENCES}
@@ -1328,6 +1336,7 @@ export class HarnessLibSQL extends HarnessStorage {
     harnessName,
     sessionId,
     resourceId,
+    threadId,
     kind,
     admissionId,
     attemptedAdmissionHash,
@@ -1335,6 +1344,7 @@ export class HarnessLibSQL extends HarnessStorage {
     harnessName?: string;
     sessionId: string;
     resourceId: string;
+    threadId?: string;
     kind: 'message' | 'queue';
     admissionId: string;
     attemptedAdmissionHash: string;
@@ -1346,12 +1356,17 @@ export class HarnessLibSQL extends HarnessStorage {
     const namespace = this.#resolveHarnessName(harnessName);
     if (kind === 'message') await this.#ensureMessageResultsTable();
     if (kind === 'message') {
+      const filters = ['harness_name = ?', 'session_id = ?', 'resource_id = ?', 'admission_id = ?'];
+      const args = [namespace, sessionId, resourceId, admissionId];
+      if (threadId !== undefined) {
+        filters.splice(3, 0, 'thread_id = ?');
+        args.splice(3, 0, threadId);
+      }
       const retained = await this.#client.execute({
         sql: `SELECT * FROM ${TABLE_HARNESS_MESSAGE_RESULTS}
-              WHERE harness_name = ? AND session_id = ? AND resource_id = ?
-                AND admission_id = ?
+              WHERE ${filters.join(' AND ')}
               LIMIT 1`,
-        args: [namespace, sessionId, resourceId, admissionId],
+        args,
       });
       const row = retained.rows[0];
       if (row) {
@@ -1365,7 +1380,9 @@ export class HarnessLibSQL extends HarnessStorage {
     }
     if (kind === 'queue') {
       const session = await this.loadSession({ harnessName: namespace, sessionId });
-      if (session && session.resourceId !== resourceId) return { status: 'none' };
+      if (session && (session.resourceId !== resourceId || (threadId !== undefined && session.threadId !== threadId))) {
+        return { status: 'none' };
+      }
       const receipts = Object.values(session?.queueAdmissionReceipts ?? {}) as QueueAdmissionReceipt[];
       for (const receipt of receipts) {
         if (receipt.admissionId !== admissionId) continue;
@@ -1377,12 +1394,17 @@ export class HarnessLibSQL extends HarnessStorage {
       }
     }
 
+    const tombstoneFilters = ['harness_name = ?', 'session_id = ?', 'resource_id = ?', 'kind = ?', 'admission_id = ?'];
+    const tombstoneArgs = [namespace, sessionId, resourceId, kind, admissionId];
+    if (threadId !== undefined) {
+      tombstoneFilters.splice(3, 0, 'thread_id = ?');
+      tombstoneArgs.splice(3, 0, threadId);
+    }
     const result = await this.#client.execute({
       sql: `SELECT * FROM ${TABLE_HARNESS_OPERATION_TOMBSTONES}
-            WHERE harness_name = ? AND session_id = ? AND resource_id = ?
-              AND kind = ? AND admission_id = ?
+            WHERE ${tombstoneFilters.join(' AND ')}
             LIMIT 1`,
-      args: [namespace, sessionId, resourceId, kind, admissionId],
+      args: tombstoneArgs,
     });
     const row = result.rows[0];
     if (!row) return { status: 'none' };
@@ -1560,21 +1582,37 @@ export class HarnessLibSQL extends HarnessStorage {
     harnessName,
     sessionId,
     resourceId,
+    threadId,
+    signalId,
   }: {
     harnessName?: string;
     sessionId: string;
     resourceId: string;
+    threadId?: string;
+    signalId?: string;
   }): Promise<void> {
+    const namespace = this.#resolveHarnessName(harnessName);
+    const filters = ['harness_name = ?', 'session_id = ?', 'resource_id = ?'];
+    const args: string[] = [namespace, sessionId, resourceId];
+    if (threadId !== undefined) {
+      filters.push('thread_id = ?');
+      args.push(threadId);
+    }
+    if (signalId !== undefined) {
+      filters.push('signal_id = ?');
+      args.push(signalId);
+    }
+    const where = filters.join(' AND ');
     await this.#ensureMessageResultsTable();
     await this.#client.execute({
       sql: `DELETE FROM ${TABLE_HARNESS_MESSAGE_RESULTS}
-            WHERE harness_name = ? AND session_id = ? AND resource_id = ?`,
-      args: [this.#resolveHarnessName(harnessName), sessionId, resourceId],
+            WHERE ${where}`,
+      args,
     });
     await this.#client.execute({
       sql: `DELETE FROM ${TABLE_HARNESS_OPERATION_TOMBSTONES}
-            WHERE harness_name = ? AND session_id = ? AND resource_id = ?`,
-      args: [this.#resolveHarnessName(harnessName), sessionId, resourceId],
+            WHERE ${where}`,
+      args,
     });
   }
 


### PR DESCRIPTION
## Summary
- Abort active message, stream, signal, reminder, resume, and queue paths when a live session is hard-deleted.
- Race active-turn storage and subscription waits against hard-delete so callers receive HarnessSessionDeletedError instead of hanging.
- Scope operation admission evidence by thread and clean up only exact signal ids written by the deleted live session.
- Add focused in-memory/core and libsql coverage plus changesets for @mastra/core and @mastra/libsql.

## Linear
- PF-540

## Local validation
- pnpm --filter ./packages/core test src/harness/v1/harness.test.ts src/harness/v1/session.signal.test.ts src/harness/v1/session.injectSystemReminder.test.ts src/harness/v1/session.suspend.test.ts src/harness/v1/session.test.ts src/storage/domains/harness/inmemory.test.ts
  - Passed: 6 files, 190 tests, 1 todo, no type errors.
- pnpm --filter ./packages/core check
  - Passed.
- pnpm build:core
  - Passed.
- pnpm --filter ./stores/libsql exec vitest run src/storage/domains/harness/index.test.ts
  - Passed: 1 file, 22 tests.
- pnpm --filter ./stores/libsql exec tsc --noEmit -p tsconfig.json
  - Passed.
- git diff --check
  - Passed.
- Commit hook lint-staged
  - Passed.

## Local review evidence
- Codex correctness/data-loss/API review: no actionable BLOCKER/REVIEW findings after fixes.
- Codex merge-readiness/test/changeset review: no actionable BLOCKER/REVIEW findings.
- CodeRabbit CLI was run locally before PR creation; it flagged changeset wording only, and both changesets were rewritten to short user-facing wording before push.

## Notes
- The first libsql test attempt failed before running tests because @mastra/core/storage was not resolvable until core artifacts existed. After pnpm build:core, the libsql focused test passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When a live session is hard-deleted, this PR makes sure any ongoing work (sending messages, streams, signals, reminders, resumes, or queued tasks) is stopped right away and callers get a clear "session deleted" error instead of hanging. It also cleans up only the exact bookkeeping records created by that deleted session so other sessions remain unaffected.

## Overview
Adds deletion-aware active-turn lifecycle management to the Harness session layer so hard-deletes abort in-flight operations and return HarnessSessionDeletedError. Admission/evidence cleanup is scoped by thread and signal ID to avoid removing evidence belonging to other sessions/threads.

## Core Changes

- Session active-turn concurrency control
  - Per-turn waiters and deletion-aware races added; critical async steps (request building, thread subscription, admission-evidence writes, run output waits, and post-run bookkeeping) are raced against an active-turn waiter so deletion aborts the operation deterministically.
  - message(), signal(), injectSystemReminder(), _resume(), and queue handling (_runQueuedTurn, _recoverQueuedDispatch, _awaitQueuedRunCompletion, finalizers) refactored to use the waiter/race model and ensure _endTurn runs in finally paths.
  - Hard delete (_markDeleted) rejects active-turn waiters, aborts current turn controller, and clears in-flight run tracking.
  - New internal accessor: _deletedOperationEvidenceSignalIds(): string[] to expose tracked signal IDs for cleanup.

- Harness delete lifecycle
  - Harness hard-delete now runs a best-effort cleanup helper to remove operation-admission tombstones associated with the deleted live session; cleanup failures are swallowed so delete outcome is preserved.

- Storage API & implementations
  - HarnessStorage abstract methods extended: resolveOperationAdmissionEvidence accepts optional threadId; deleteOperationAdmissionTombstonesForSession accepts optional threadId and signalId.
  - InMemoryHarness and HarnessLibSQL updated to filter admission evidence and tombstones by threadId and signalId when provided; deleteSessions now passes threadId to scoped tombstone cleanup.

- Race fix
  - Includes explicit fix for duplicate queue delete race (resolve duplicate queue delete race).

## Tests & Validation

- Core tests
  - New and extended delete-lifecycle tests covering hard-delete aborts for pending turns (message, structured sync, streamed), queued turns, injected reminders, signals, and resumes; assertions expect HarnessSessionDeletedError and verify targeted evidence cleanup and session row removal.
  - Tests verify late evidence cleanup is scoped to the deleted turn identity (signalId) and that unrelated threads' evidence is preserved.
  - Added BlockingGenerateMockAgent for holding active structured-sync runs during deletion scenarios.
  - Surface-area test updated to assert only public Session prototype members (exclude underscore-prefixed internals).

- Storage tests
  - In-memory and libsql harness conformance tests updated to pass threadId into admission resolution and to assert deleteOperationAdmissionTombstonesForSession scoped deletion by threadId and signalId.
  - libsql tests reformatted where needed; behavior expectations unchanged.

- Local validation
  - Core tests: 6 files, 190 tests (1 todo) passed; type checks and core build passed.
  - libsql store tests: 1 file, 22 tests passed after building core; TypeScript checks passed.
  - lint/git hooks passed; code reviews and changesets validated.

## Changesets
- `@mastra/core` (patch): active session operations now reject with HarnessSessionDeletedError when the session is deleted.
- `@mastra/libsql` (patch): session deletion cleans up storage records without affecting unrelated sessions.

## Public API surface
- New internal method on Session: _deletedOperationEvidenceSignalIds(): string[]
- Storage method signatures updated to accept optional threadId and optional signalId for tombstone deletion/resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->