### PR TITLE
[PF-544] Move Agent.stream reservation behind preflight

### DIFF
--- a/.changeset/pf-544-agent-stream-preflight.md
+++ b/.changeset/pf-544-agent-stream-preflight.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed: `Agent.stream()` now avoids unnecessary thread allocations when request validation denies a run.

--- a/.changeset/pf-544-agent-stream-preflight.md
+++ b/.changeset/pf-544-agent-stream-preflight.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed: `Agent.stream()` now avoids unnecessary thread allocations when request validation denies a run.
+Fixed: `Agent.stream()` validation failures now abort without unnecessary resource work.

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -1,6 +1,7 @@
 import { MockLanguageModelV1 } from '@internal/ai-sdk-v4/test';
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod/v4';
 
 import { EventEmitterPubSub } from '../../events/event-emitter';
 import { PubSub } from '../../events/pubsub';
@@ -864,16 +865,13 @@ describe('Agent signals', () => {
       model: createTextStreamModel('stream options idle wake response'),
     });
 
-    const signalResult = runner.sendSignal(
-      { type: 'user-message', contents: 'Wake from streamOptions target' },
-      {
-        ifIdle: {
-          streamOptions: {
-            memory: { resource: 'stream-options-idle-wake-user', thread: 'stream-options-idle-wake-thread' },
-          },
+    const signalResult = runner.sendSignal({ type: 'user-message', contents: 'Wake from streamOptions target' }, {
+      ifIdle: {
+        streamOptions: {
+          memory: { resource: 'stream-options-idle-wake-user', thread: 'stream-options-idle-wake-thread' },
         },
-      } as any,
-    );
+      },
+    } as any);
     expect(signalResult.output).toBeDefined();
     await defaultOptionsStarted;
     runner.__setPubSub(swappedPubSub);
@@ -1174,6 +1172,490 @@ describe('Agent signals', () => {
 
     const stream = await streamPromise;
     expect(signalResult).toEqual(expect.objectContaining({ accepted: true, runId: stream.runId }));
+  });
+
+  it('does not expose explicit thread streams when request context preflight fails', async () => {
+    const requestContext = new RequestContext();
+    requestContext.set('allowed', false);
+
+    const runner = new Agent({
+      id: 'preflight-denied-reservation-agent',
+      name: 'Preflight Denied Reservation Agent',
+      instructions: 'Test',
+      requestContextSchema: z.object({ allowed: z.literal(true) }),
+      model: createTextStreamModel('unused denied response'),
+    });
+
+    await expect(
+      runner.stream('Hello', {
+        runId: 'preflight-denied-run',
+        memory: { resource: 'preflight-denied-user', thread: 'preflight-denied-thread' },
+        requestContext,
+      }),
+    ).rejects.toThrow('Request context validation failed');
+
+    const signalResult = runner.sendSignal(
+      { type: 'user-message', contents: 'Should not attach to denied setup run' },
+      {
+        resourceId: 'preflight-denied-user',
+        threadId: 'preflight-denied-thread',
+        ifIdle: { behavior: 'discard' },
+      },
+    );
+
+    expect(signalResult.runId).not.toBe('preflight-denied-run');
+  });
+
+  it('does not attach idle signals to explicit-context streams before preflight passes', async () => {
+    const requestContext = new RequestContext();
+    requestContext.set('allowed', false);
+
+    const runner = new Agent({
+      id: 'explicit-preflight-denied-reservation-agent',
+      name: 'Explicit Preflight Denied Reservation Agent',
+      instructions: 'Test',
+      requestContextSchema: z.object({ allowed: z.literal(true) }),
+      model: createTextStreamModel('unused denied explicit idle response'),
+    });
+
+    const wake = runner.sendSignal(
+      { type: 'user-message', contents: 'Start denied explicit-context idle stream' },
+      {
+        resourceId: 'explicit-preflight-denied-user',
+        threadId: 'explicit-preflight-denied-thread',
+        ifIdle: { behavior: 'wake', streamOptions: { requestContext } },
+      },
+    );
+    void wake.output?.catch(() => {});
+
+    const followUp = runner.sendSignal(
+      { type: 'user-message', contents: 'Should not attach before explicit preflight passes' },
+      {
+        resourceId: 'explicit-preflight-denied-user',
+        threadId: 'explicit-preflight-denied-thread',
+        ifIdle: { behavior: 'discard' },
+      },
+    );
+
+    expect(followUp.runId).not.toBe(wake.runId);
+    await expect(wake.output).rejects.toThrow('Request context validation failed');
+  });
+
+  it('does not reserve explicit-context streams before preflight passes', async () => {
+    let markPreflightStarted!: () => void;
+    let releasePreflight!: () => void;
+    const preflightStarted = new Promise<void>(resolve => {
+      markPreflightStarted = resolve;
+    });
+    const preflightReleased = new Promise<void>(resolve => {
+      releasePreflight = resolve;
+    });
+    const requestContext = new RequestContext();
+    requestContext.set('allowed', true);
+
+    const runner = new Agent({
+      id: 'explicit-preflight-allowed-reservation-agent',
+      name: 'Explicit Preflight Allowed Reservation Agent',
+      instructions: 'Test',
+      requestContextSchema: z.object({ allowed: z.literal(true) }).superRefine(async () => {
+        markPreflightStarted();
+        await preflightReleased;
+      }),
+      model: createTextStreamModel('allowed explicit preflight response'),
+    });
+
+    const streamPromise = runner.stream('Hello', {
+      memory: { resource: 'explicit-preflight-allowed-user', thread: 'explicit-preflight-allowed-thread' },
+      requestContext,
+    });
+    await preflightStarted;
+
+    const followUp = runner.sendSignal(
+      { type: 'user-message', contents: 'Should not attach before explicit preflight passes' },
+      {
+        resourceId: 'explicit-preflight-allowed-user',
+        threadId: 'explicit-preflight-allowed-thread',
+        ifIdle: { behavior: 'discard' },
+      },
+    );
+    expect(() =>
+      runner.sendSignal(
+        { type: 'user-message', contents: 'Thread-only signal should not see a pending reservation' },
+        {
+          threadId: 'explicit-preflight-allowed-thread',
+        },
+      ),
+    ).toThrow('No active agent run found for signal target');
+    const explicitActivePolicyFollowUp = runner.sendSignal(
+      { type: 'user-message', contents: 'Explicit active-deliver signal should not attach before preflight passes' },
+      {
+        resourceId: 'explicit-preflight-allowed-user',
+        threadId: 'explicit-preflight-allowed-thread',
+        ifActive: { behavior: 'deliver' },
+        ifIdle: { behavior: 'discard' },
+      },
+    );
+    releasePreflight();
+
+    const stream = await streamPromise;
+    expect(followUp.runId).not.toBe(stream.runId);
+    expect(explicitActivePolicyFollowUp.runId).not.toBe(stream.runId);
+    await expect(stream.text).resolves.toBe('allowed explicit preflight response');
+  });
+
+  it('reserves explicit-context streams after preflight passes before defaults finish', async () => {
+    let markPreflightStarted!: () => void;
+    let releasePreflight!: () => void;
+    let markDefaultOptionsStarted!: () => void;
+    let releaseDefaultOptions!: () => void;
+    const preflightStarted = new Promise<void>(resolve => {
+      markPreflightStarted = resolve;
+    });
+    const preflightReleased = new Promise<void>(resolve => {
+      releasePreflight = resolve;
+    });
+    const defaultOptionsStarted = new Promise<void>(resolve => {
+      markDefaultOptionsStarted = resolve;
+    });
+    const defaultOptionsReleased = new Promise<void>(resolve => {
+      releaseDefaultOptions = resolve;
+    });
+    const requestContext = new RequestContext();
+    requestContext.set('allowed', true);
+
+    const runner = new Agent({
+      id: 'explicit-preflight-defaults-pending-agent',
+      name: 'Explicit Preflight Defaults Pending Agent',
+      instructions: 'Test',
+      requestContextSchema: z.object({ allowed: z.literal(true) }).superRefine(async () => {
+        markPreflightStarted();
+        await preflightReleased;
+      }),
+      defaultOptions: async () => {
+        markDefaultOptionsStarted();
+        await defaultOptionsReleased;
+        return {};
+      },
+      model: createTextStreamModel('allowed explicit preflight defaults response'),
+    });
+
+    const streamPromise = runner.stream('Hello', {
+      runId: 'explicit-preflight-defaults-run',
+      memory: { resource: 'explicit-preflight-defaults-user', thread: 'explicit-preflight-defaults-thread' },
+      requestContext,
+    });
+    await preflightStarted;
+
+    const beforePreflightFollowUp = runner.sendSignal(
+      { type: 'user-message', contents: 'Should not attach before preflight passes' },
+      {
+        resourceId: 'explicit-preflight-defaults-user',
+        threadId: 'explicit-preflight-defaults-thread',
+        ifIdle: { behavior: 'discard' },
+      },
+    );
+    expect(beforePreflightFollowUp.runId).not.toBe('explicit-preflight-defaults-run');
+
+    releasePreflight();
+    await defaultOptionsStarted;
+
+    const afterPreflightFollowUp = runner.sendSignal(
+      { type: 'user-message', contents: 'Should attach after preflight passes while defaults are pending' },
+      {
+        resourceId: 'explicit-preflight-defaults-user',
+        threadId: 'explicit-preflight-defaults-thread',
+        ifIdle: { behavior: 'discard' },
+      },
+    );
+    releaseDefaultOptions();
+
+    expect(afterPreflightFollowUp.runId).toBe('explicit-preflight-defaults-run');
+    const stream = await streamPromise;
+    expect(stream.runId).toBe('explicit-preflight-defaults-run');
+    await expect(stream.text).resolves.toBe('allowed explicit preflight defaults response');
+  });
+
+  it('keeps direct preflight stream output waiters on the captured PubSub', async () => {
+    const initialPubSub = new EventEmitterPubSub();
+    const swappedPubSub = new EventEmitterPubSub();
+    let markPreflightStarted!: () => void;
+    let releasePreflight!: () => void;
+    const preflightStarted = new Promise<void>(resolve => {
+      markPreflightStarted = resolve;
+    });
+    const preflightReleased = new Promise<void>(resolve => {
+      releasePreflight = resolve;
+    });
+    const requestContext = new RequestContext();
+    requestContext.set('allowed', true);
+
+    const runner = new Agent({
+      id: 'direct-preflight-pubsub-agent',
+      name: 'Direct Preflight PubSub Agent',
+      instructions: 'Test',
+      requestContextSchema: z.object({ allowed: z.literal(true) }).superRefine(async () => {
+        markPreflightStarted();
+        await preflightReleased;
+      }),
+      model: createTextStreamModel('direct preflight pubsub response'),
+    });
+    runner.__setPubSub(initialPubSub);
+
+    const streamPromise = runner.stream('Hello', {
+      runId: 'direct-preflight-pubsub-run',
+      memory: { resource: 'direct-preflight-pubsub-user', thread: 'direct-preflight-pubsub-thread' },
+      requestContext,
+    });
+    await preflightStarted;
+
+    runner.__setPubSub(swappedPubSub);
+    const outputPromise = runner.waitForRunOutput('direct-preflight-pubsub-run');
+    releasePreflight();
+
+    const output = await Promise.race([
+      outputPromise,
+      new Promise<'timeout'>(resolve => setTimeout(() => resolve('timeout'), 500)),
+    ]);
+    expect(output).not.toBe('timeout');
+    if (output === 'timeout') return;
+    expect(output.runId).toBe('direct-preflight-pubsub-run');
+    await expect(output.text).resolves.toBe('direct preflight pubsub response');
+    await expect(streamPromise).resolves.toBe(output);
+  });
+
+  it('does not tombstone an admitted stream when a duplicate explicit run id is rejected', async () => {
+    let markModelStarted!: () => void;
+    let releaseModel!: () => void;
+    const modelStarted = new Promise<void>(resolve => {
+      markModelStarted = resolve;
+    });
+    const modelReleased = new Promise<void>(resolve => {
+      releaseModel = resolve;
+    });
+    const requestContext = new RequestContext();
+    requestContext.set('allowed', true);
+
+    const runner = new Agent({
+      id: 'duplicate-preflight-run-id-agent',
+      name: 'Duplicate Preflight Run Id Agent',
+      instructions: 'Test',
+      requestContextSchema: z.object({ allowed: z.literal(true) }),
+      model: new MockLanguageModelV2({
+        doStream: async () => {
+          markModelStarted();
+          await modelReleased;
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              {
+                type: 'response-metadata',
+                id: 'duplicate-preflight',
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              },
+              { type: 'text-start', id: 'text-1' },
+              { type: 'text-delta', id: 'text-1', delta: 'first admitted response' },
+              { type: 'text-end', id: 'text-1' },
+              {
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              },
+            ]),
+          };
+        },
+      }),
+    });
+
+    const firstStreamPromise = runner.stream('First', {
+      runId: 'duplicate-preflight-run',
+      memory: { resource: 'duplicate-preflight-user', thread: 'duplicate-preflight-thread' },
+      requestContext,
+    });
+    await modelStarted;
+
+    await expect(
+      runner.stream('Duplicate', {
+        runId: 'duplicate-preflight-run',
+        memory: { resource: 'duplicate-preflight-user', thread: 'duplicate-preflight-thread' },
+        requestContext,
+      }),
+    ).rejects.toThrow('already reserved');
+
+    releaseModel();
+    const firstStream = await firstStreamPromise;
+    expect(firstStream.runId).toBe('duplicate-preflight-run');
+    await expect(firstStream.text).resolves.toBe('first admitted response');
+  });
+
+  it('keeps explicit-context idle reservations when no preflight boundary is configured', async () => {
+    let markDefaultOptionsStarted!: () => void;
+    let releaseDefaultOptions!: () => void;
+    const defaultOptionsStarted = new Promise<void>(resolve => {
+      markDefaultOptionsStarted = resolve;
+    });
+    const defaultOptionsReleased = new Promise<void>(resolve => {
+      releaseDefaultOptions = resolve;
+    });
+    const requestContext = new RequestContext();
+
+    const runner = new Agent({
+      id: 'explicit-context-no-preflight-agent',
+      name: 'Explicit Context No Preflight Agent',
+      instructions: 'Test',
+      defaultOptions: async () => {
+        markDefaultOptionsStarted();
+        await defaultOptionsReleased;
+        return {};
+      },
+      model: createTextStreamModel('explicit context no preflight response'),
+    });
+
+    const wake = runner.sendSignal(
+      { type: 'user-message', contents: 'Start explicit-context idle stream' },
+      {
+        resourceId: 'explicit-context-no-preflight-user',
+        threadId: 'explicit-context-no-preflight-thread',
+        ifIdle: { behavior: 'wake', streamOptions: { requestContext } },
+      },
+    );
+    await defaultOptionsStarted;
+
+    const followUp = runner.sendSignal(
+      { type: 'user-message', contents: 'Should attach when preflight cannot reject' },
+      {
+        resourceId: 'explicit-context-no-preflight-user',
+        threadId: 'explicit-context-no-preflight-thread',
+        ifIdle: { behavior: 'discard' },
+      },
+    );
+    releaseDefaultOptions();
+
+    expect(followUp.runId).toBe(wake.runId);
+    await expect(wake.output).resolves.toMatchObject({ runId: wake.runId });
+  });
+
+  it('does not attach idle signals to default-context streams before preflight passes', async () => {
+    let markDefaultOptionsStarted!: () => void;
+    let releaseDefaultOptions!: () => void;
+    const defaultOptionsStarted = new Promise<void>(resolve => {
+      markDefaultOptionsStarted = resolve;
+    });
+    const defaultOptionsReleased = new Promise<void>(resolve => {
+      releaseDefaultOptions = resolve;
+    });
+    const requestContext = new RequestContext();
+    requestContext.set('allowed', false);
+
+    const runner = new Agent({
+      id: 'default-preflight-denied-reservation-agent',
+      name: 'Default Preflight Denied Reservation Agent',
+      instructions: 'Test',
+      requestContextSchema: z.object({ allowed: z.literal(true) }),
+      defaultOptions: async () => {
+        markDefaultOptionsStarted();
+        await defaultOptionsReleased;
+        return { requestContext };
+      },
+      model: createTextStreamModel('unused denied idle response'),
+    });
+
+    const wake = runner.sendSignal(
+      { type: 'user-message', contents: 'Start denied idle stream' },
+      {
+        resourceId: 'default-preflight-denied-user',
+        threadId: 'default-preflight-denied-thread',
+      },
+    );
+    await defaultOptionsStarted;
+    const outputPromise = runner.waitForRunOutput(wake.runId);
+    void wake.output?.catch(() => {});
+
+    const followUp = runner.sendSignal(
+      { type: 'user-message', contents: 'Should not attach before preflight passes' },
+      {
+        resourceId: 'default-preflight-denied-user',
+        threadId: 'default-preflight-denied-thread',
+        ifIdle: { behavior: 'discard' },
+      },
+    );
+    const activePolicyResult = runner.sendSignal(
+      { type: 'user-message', contents: 'Should not treat preflight-pending run as active' },
+      {
+        resourceId: 'default-preflight-denied-user',
+        threadId: 'default-preflight-denied-thread',
+        ifActive: { behavior: 'discard' },
+        ifIdle: { behavior: 'discard' },
+      },
+    );
+    const plainFollowUp = runner.sendSignal(
+      { type: 'user-message', contents: 'Plain signal should not attach before preflight passes' },
+      {
+        resourceId: 'default-preflight-denied-user',
+        threadId: 'default-preflight-denied-thread',
+      },
+    );
+    void plainFollowUp.output?.catch(() => {});
+    releaseDefaultOptions();
+
+    expect(followUp.runId).not.toBe(wake.runId);
+    expect(activePolicyResult.runId).not.toBe(wake.runId);
+    expect(plainFollowUp.runId).not.toBe(wake.runId);
+    await expect(outputPromise).rejects.toThrow(`Agent thread run id "${wake.runId}" was rejected`);
+    await expect(wake.output).rejects.toThrow('Request context validation failed');
+  });
+
+  it('keeps idle wake output waiters pending while default-context preflight is pending', async () => {
+    const initialPubSub = new EventEmitterPubSub();
+    const swappedPubSub = new EventEmitterPubSub();
+    let markDefaultOptionsStarted!: () => void;
+    let releaseDefaultOptions!: () => void;
+    const defaultOptionsStarted = new Promise<void>(resolve => {
+      markDefaultOptionsStarted = resolve;
+    });
+    const defaultOptionsReleased = new Promise<void>(resolve => {
+      releaseDefaultOptions = resolve;
+    });
+    const requestContext = new RequestContext();
+    requestContext.set('allowed', true);
+
+    const runner = new Agent({
+      id: 'default-preflight-valid-waiter-agent',
+      name: 'Default Preflight Valid Waiter Agent',
+      instructions: 'Test',
+      requestContextSchema: z.object({ allowed: z.literal(true) }),
+      defaultOptions: async () => {
+        markDefaultOptionsStarted();
+        await defaultOptionsReleased;
+        return { requestContext };
+      },
+      model: createTextStreamModel('valid default preflight response'),
+    });
+    runner.__setPubSub(initialPubSub);
+
+    const wake = runner.sendSignal(
+      { type: 'user-message', contents: 'Start valid idle stream' },
+      {
+        resourceId: 'default-preflight-valid-user',
+        threadId: 'default-preflight-valid-thread',
+      },
+    );
+    await defaultOptionsStarted;
+
+    runner.__setPubSub(swappedPubSub);
+    const outputPromise = runner.waitForRunOutput(wake.runId);
+    releaseDefaultOptions();
+
+    const output = await Promise.race([
+      outputPromise,
+      new Promise<'timeout'>(resolve => setTimeout(() => resolve('timeout'), 500)),
+    ]);
+    expect(output).not.toBe('timeout');
+    if (output === 'timeout') return;
+    expect(output.runId).toBe(wake.runId);
+    await expect(output.text).resolves.toBe('valid default preflight response');
   });
 
   it('reserves thread-only streams while default options are pending', async () => {
@@ -2058,7 +2540,160 @@ describe('Agent signals', () => {
     expect(waiterResolved).toBe(true);
   });
 
-  it('wakes reservation waiters when an immediate idle stream fails', async () => {
+  it('does not reserve queued idle streams before preflight when reservation is deferred', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    let finishActive!: () => void;
+    const activeFinished = new Promise<void>(resolve => {
+      finishActive = resolve;
+    });
+    let rejectFirstStream!: (error: Error) => void;
+
+    const completion = runtime.registerRun(
+      { id: 'active-agent' } as any,
+      {
+        runId: 'active-run',
+        status: 'running',
+        _waitUntilFinished: () => activeFinished,
+      } as any,
+      {
+        runId: 'active-run',
+        memory: { resource: 'queued-deferred-user', thread: 'queued-deferred-thread' },
+      } as any,
+    );
+    const stream = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectFirstStream = reject;
+          }),
+      )
+      .mockResolvedValueOnce({ runId: 'queued-deferred-second-run' })
+      .mockResolvedValueOnce({ runId: 'queued-deferred-retry-run' });
+
+    const firstResult = runtime.sendSignal(
+      { id: 'queued-deferred-agent', stream } as any,
+      { id: 'queued-deferred-signal', type: 'user-message', contents: 'queued deferred wake' },
+      {
+        resourceId: 'queued-deferred-user',
+        threadId: 'queued-deferred-thread',
+        ifIdle: {
+          _skipThreadRunReservationBeforePreflight: true,
+          streamOptions: { memory: { resource: 'queued-deferred-user', thread: 'queued-deferred-thread' } },
+        } as any,
+      },
+    );
+    runtime.sendSignal(
+      { id: 'queued-deferred-agent', stream } as any,
+      { type: 'user-message', contents: 'queued second deferred wake' },
+      {
+        resourceId: 'queued-deferred-user',
+        threadId: 'queued-deferred-thread',
+        ifIdle: {
+          _skipThreadRunReservationBeforePreflight: true,
+          streamOptions: { memory: { resource: 'queued-deferred-user', thread: 'queued-deferred-thread' } },
+        } as any,
+      },
+    );
+
+    finishActive();
+    await nextTick();
+    expect(stream).toHaveBeenCalledWith(
+      expect.objectContaining({ contents: 'queued deferred wake' }),
+      expect.not.objectContaining({ _threadRunReservationOwner: true }),
+    );
+
+    let waiterResolved = false;
+    await runtime
+      .waitForCrossAgentThreadRun(
+        { id: 'other-agent' } as any,
+        {
+          runId: 'other-run',
+          memory: { resource: 'queued-deferred-user', thread: 'queued-deferred-thread' },
+        } as any,
+      )
+      .then(() => {
+        waiterResolved = true;
+      });
+    expect(waiterResolved).toBe(true);
+
+    rejectFirstStream(new Error('queued deferred idle stream failed'));
+    await completion;
+    expect(stream).toHaveBeenCalledWith(
+      expect.objectContaining({ contents: 'queued second deferred wake' }),
+      expect.not.objectContaining({ _threadRunReservationOwner: true }),
+    );
+    expect(stream).toHaveBeenCalledTimes(2);
+
+    const retryResult = runtime.sendSignal(
+      { id: 'queued-deferred-agent', stream } as any,
+      { id: 'queued-deferred-signal', type: 'user-message', contents: 'queued deferred wake' },
+      {
+        resourceId: 'queued-deferred-user',
+        threadId: 'queued-deferred-thread',
+        ifIdle: {
+          _skipThreadRunReservationBeforePreflight: true,
+          streamOptions: { memory: { resource: 'queued-deferred-user', thread: 'queued-deferred-thread' } },
+        } as any,
+      },
+    );
+    expect(retryResult.runId).not.toBe(firstResult.runId);
+    expect(stream).toHaveBeenCalledTimes(3);
+  });
+
+  it('aborts queued deferred idle streams after they start preflight without reservation', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    let finishActive!: () => void;
+    const activeFinished = new Promise<void>(resolve => {
+      finishActive = resolve;
+    });
+    let rejectStream!: (error: Error) => void;
+
+    const completion = runtime.registerRun(
+      { id: 'active-agent' } as any,
+      {
+        runId: 'active-run',
+        status: 'running',
+        _waitUntilFinished: () => activeFinished,
+      } as any,
+      {
+        runId: 'active-run',
+        memory: { resource: 'queued-deferred-abort-user', thread: 'queued-deferred-abort-thread' },
+      } as any,
+    );
+    const stream = vi.fn(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectStream = reject;
+        }),
+    );
+
+    const result = runtime.sendSignal(
+      { id: 'queued-deferred-abort-agent', stream } as any,
+      { type: 'user-message', contents: 'queued deferred abort wake' },
+      {
+        resourceId: 'queued-deferred-abort-user',
+        threadId: 'queued-deferred-abort-thread',
+        ifIdle: {
+          _skipThreadRunReservationBeforePreflight: true,
+          streamOptions: { memory: { resource: 'queued-deferred-abort-user', thread: 'queued-deferred-abort-thread' } },
+        } as any,
+      },
+    );
+
+    finishActive();
+    await nextTick();
+    expect(stream).toHaveBeenCalledTimes(1);
+
+    const waiter = runtime.waitForRunOutput(result.runId);
+    expect(runtime.abortRun(result.runId)).toBe(true);
+    await expect(waiter).rejects.toThrow('has been aborted');
+
+    rejectStream(new Error('queued deferred abort stream stopped'));
+    await completion;
+  });
+
+  it('aborts immediate deferred idle streams while preflight is pending', async () => {
     const runtime = new AgentThreadStreamRuntime();
     let rejectStream!: (error: Error) => void;
     const stream = vi.fn(
@@ -2069,8 +2704,162 @@ describe('Agent signals', () => {
     );
 
     const result = runtime.sendSignal(
+      { id: 'immediate-deferred-abort-agent', stream } as any,
+      { type: 'user-message', contents: 'immediate deferred abort wake' },
+      {
+        resourceId: 'immediate-deferred-abort-user',
+        threadId: 'immediate-deferred-abort-thread',
+        ifIdle: {
+          _skipThreadRunReservationBeforePreflight: true,
+          streamOptions: {
+            memory: { resource: 'immediate-deferred-abort-user', thread: 'immediate-deferred-abort-thread' },
+          },
+        } as any,
+      },
+    );
+    void result.output?.catch(() => {});
+    expect(stream).toHaveBeenCalledTimes(1);
+
+    const waiter = runtime.waitForRunOutput(result.runId);
+    expect(runtime.abortRun(result.runId)).toBe(true);
+    await expect(waiter).rejects.toThrow('has been aborted');
+
+    rejectStream(new Error('immediate deferred abort stream stopped'));
+    await expect(result.output).rejects.toThrow('immediate deferred abort stream stopped');
+  });
+
+  it('blocks direct reservations while a deferred idle run id is inflight', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    let rejectStream!: (error: Error) => void;
+    const stream = vi.fn(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectStream = reject;
+        }),
+    );
+
+    const result = runtime.sendSignal(
+      { id: 'inflight-deferred-owner-agent', stream } as any,
+      { type: 'user-message', contents: 'inflight deferred wake' },
+      {
+        runId: 'inflight-deferred-run',
+        resourceId: 'inflight-deferred-user',
+        threadId: 'inflight-deferred-thread',
+        ifIdle: {
+          _skipThreadRunReservationBeforePreflight: true,
+          streamOptions: { memory: { resource: 'inflight-deferred-user', thread: 'inflight-deferred-thread' } },
+        } as any,
+      },
+      pubsub,
+    );
+    expect(stream).toHaveBeenCalledTimes(1);
+
+    expect(() =>
+      runtime.reserveRun(
+        {
+          runId: 'inflight-deferred-run',
+          memory: { resource: 'inflight-deferred-user', thread: 'inflight-deferred-thread' },
+        } as any,
+        pubsub,
+      ),
+    ).toThrow('already reserved');
+
+    const duplicateOutput = buildFakeOutput({
+      runId: 'inflight-deferred-run',
+      fullOutput: { text: 'duplicate response', finishReason: 'stop', usage: {} },
+      chunks: [{ runId: 'inflight-deferred-run', type: 'finish', payload: {} }],
+    });
+    expect(() =>
+      runtime.registerRun(
+        { id: 'duplicate-inflight-agent' } as any,
+        duplicateOutput,
+        {
+          runId: 'inflight-deferred-run',
+          memory: { resource: 'inflight-deferred-user', thread: 'inflight-deferred-thread' },
+        } as any,
+        pubsub,
+      ),
+    ).toThrow('already reserved');
+
+    rejectStream(new Error('inflight deferred stream stopped'));
+    await expect(result.output).rejects.toThrow('inflight deferred stream stopped');
+  });
+
+  it('keeps deferred idle run ids inflight when owner reservation waits for an active thread', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    const pubsub = new EventEmitterPubSub();
+    let rejectStream!: (error: Error) => void;
+    const stream = vi.fn((_signal, options) => {
+      runtime.registerRun(
+        { id: 'inflight-owner-blocking-agent' } as any,
+        {
+          runId: 'inflight-owner-blocking-active-run',
+          status: 'running',
+          fullStream: (async function* () {})(),
+          _waitUntilFinished: () => new Promise<void>(() => {}),
+        } as any,
+        {
+          runId: 'inflight-owner-blocking-active-run',
+          memory: { resource: 'inflight-owner-blocked-user', thread: 'inflight-owner-blocked-thread' },
+        } as any,
+        pubsub,
+      );
+      expect(runtime.reserveRun(options as any, pubsub, 'inflight-owner-blocked-agent')).toBeUndefined();
+      return new Promise((_resolve, reject) => {
+        rejectStream = reject;
+      });
+    });
+
+    const result = runtime.sendSignal(
+      { id: 'inflight-owner-blocked-agent', stream } as any,
+      { type: 'user-message', contents: 'inflight owner blocked wake' },
+      {
+        runId: 'inflight-owner-blocked-run',
+        resourceId: 'inflight-owner-blocked-user',
+        threadId: 'inflight-owner-blocked-thread',
+        ifIdle: {
+          _skipThreadRunReservationBeforePreflight: true,
+          streamOptions: {
+            memory: { resource: 'inflight-owner-blocked-user', thread: 'inflight-owner-blocked-thread' },
+          },
+        } as any,
+      },
+      pubsub,
+    );
+    expect(stream).toHaveBeenCalledTimes(1);
+
+    expect(() =>
+      runtime.reserveRun(
+        {
+          runId: 'inflight-owner-blocked-run',
+          memory: { resource: 'inflight-owner-blocked-user', thread: 'inflight-owner-blocked-thread' },
+        } as any,
+        pubsub,
+      ),
+    ).toThrow('already reserved');
+    expect(runtime.abortRun(result.runId, pubsub)).toBe(true);
+
+    rejectStream(new Error('inflight owner blocked stream stopped'));
+    await expect(result.output).rejects.toThrow('inflight owner blocked stream stopped');
+  });
+
+  it('wakes reservation waiters when an immediate idle stream fails', async () => {
+    const runtime = new AgentThreadStreamRuntime();
+    let rejectStream!: (error: Error) => void;
+    const stream = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectStream = reject;
+          }),
+      )
+      .mockResolvedValueOnce({ runId: 'immediate-retry-run' });
+
+    const result = runtime.sendSignal(
       { id: 'immediate-idle-agent', stream } as any,
-      { type: 'user-message', contents: 'immediate wake' },
+      { id: 'immediate-wake-signal', type: 'user-message', contents: 'immediate wake' },
       {
         resourceId: 'immediate-waiter-user',
         threadId: 'immediate-waiter-thread',
@@ -2101,6 +2890,20 @@ describe('Agent signals', () => {
     await expect(runtime.waitForRunOutput(result.runId)).rejects.toThrow('was rejected');
     await waiter;
     expect(waiterResolved).toBe(true);
+
+    const retryResult = runtime.sendSignal(
+      { id: 'immediate-idle-agent', stream } as any,
+      { id: 'immediate-wake-signal', type: 'user-message', contents: 'immediate wake' },
+      {
+        resourceId: 'immediate-waiter-user',
+        threadId: 'immediate-waiter-thread',
+        ifIdle: {
+          streamOptions: { memory: { resource: 'immediate-waiter-user', thread: 'immediate-waiter-thread' } },
+        } as any,
+      },
+    );
+    expect(retryResult.runId).not.toBe(result.runId);
+    expect(stream).toHaveBeenCalledTimes(2);
   });
 
   it('wakes waiters and drops queued signals when a reserved setup run is released', async () => {
@@ -2197,10 +3000,12 @@ describe('Agent signals', () => {
         pubsub,
       ),
     ).toThrow('already reserved for another thread');
-    expect(runtime.abortThread({ resourceId: 'second-reservation-user', threadId: 'second-reservation-thread' }, pubsub))
-      .toBe(false);
-    expect(runtime.abortThread({ resourceId: 'first-reservation-user', threadId: 'first-reservation-thread' }, pubsub))
-      .toBe(true);
+    expect(
+      runtime.abortThread({ resourceId: 'second-reservation-user', threadId: 'second-reservation-thread' }, pubsub),
+    ).toBe(false);
+    expect(
+      runtime.abortThread({ resourceId: 'first-reservation-user', threadId: 'first-reservation-thread' }, pubsub),
+    ).toBe(true);
   });
 
   it('rejects duplicate queued idle run ids before either idle wake starts', () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -6447,6 +6447,8 @@ export class Agent<
     const shouldSnapshotIdleWake =
       Boolean(idleThreadId) && target.ifIdle?.behavior !== 'persist' && target.ifIdle?.behavior !== 'discard';
     const shouldTrackIdleWake = shouldSnapshotIdleWake && (Boolean(target.ifIdle) || !target.runId);
+    const idleWakeCanRejectBeforeRegistration =
+      shouldTrackIdleWake && (Boolean(this.#requestContextSchema) || Boolean(this.#mastra?.getServer()?.fga));
     let acceptedIdleRunId: string | undefined;
     const forgetAcceptedIdleRunPubSub = () => {
       if (!acceptedIdleRunId) return;
@@ -6474,6 +6476,7 @@ export class Agent<
             ...(target.ifIdle ?? {}),
             _attachToReservedRun: !target.ifIdle,
             _onThreadStreamRunRejected: forgetAcceptedIdleRunPubSub,
+            _skipThreadRunReservationBeforePreflight: idleWakeCanRejectBeforeRegistration,
             streamOptions: {
               ...(target.ifIdle?.streamOptions ?? {}),
               _pubsub: requestedIdlePubSub ?? pubsub,
@@ -6532,19 +6535,28 @@ export class Agent<
     const initialThreadTarget = this.#getThreadTarget(streamOptionsBase);
     const canReserveBeforeDefaults = this.#hasExplicitThreadMemory(streamOptionsBase);
     const callerProvidedRunId = Boolean(streamOptionsBase.runId);
+    const requestContextToUse = streamOptionsBase.requestContext;
+    const hasExecutionPreflight = Boolean(this.#requestContextSchema) || Boolean(this.#mastra?.getServer()?.fga);
+    const needsDefaultRequestContextPreflight = !requestContextToUse && hasExecutionPreflight;
+    const staticDefaultOptions =
+      needsDefaultRequestContextPreflight && typeof this.#defaultOptions !== 'function'
+        ? (this.#defaultOptions as unknown as AgentExecutionOptions<OUTPUT>)
+        : undefined;
     const streamOptionsWithRunId = {
       ...streamOptionsBase,
       runId:
         streamOptionsBase.runId ??
         (canReserveBeforeDefaults ? this.#generateStreamRunId(initialThreadTarget) : undefined),
     };
-    let releaseReservedRun = canReserveBeforeDefaults
+    const ownsExternalReservation = Boolean((streamOptionsWithRunId as any)._threadRunReservationOwner);
+    const canReserveBeforePreflight = canReserveBeforeDefaults && !hasExecutionPreflight;
+    let releaseReservedRun = canReserveBeforePreflight
       ? agentThreadStreamRuntime.reserveRun(streamOptionsWithRunId as AgentExecutionOptions<OUTPUT>, pubsub, this.id)
       : undefined;
     let reservedThreadTarget = releaseReservedRun ? initialThreadTarget : undefined;
-    let ownsReservation =
-      Boolean(releaseReservedRun) || Boolean((streamOptionsWithRunId as any)._threadRunReservationOwner);
+    let ownsReservation = Boolean(releaseReservedRun) || ownsExternalReservation;
     let trackedThreadStreamPubSubTarget: { runId?: string; resourceId?: string; threadId?: string } | undefined;
+    let attemptedRunId = streamOptionsWithRunId.runId;
     if (ownsReservation) {
       this.#rememberThreadStreamPubSub(streamOptionsWithRunId, pubsub);
       trackedThreadStreamPubSubTarget = {
@@ -6552,25 +6564,52 @@ export class Agent<
         resourceId: initialThreadTarget.resourceId,
         threadId: initialThreadTarget.threadId,
       };
+    } else if (hasExecutionPreflight && streamOptionsWithRunId.runId) {
+      this.#threadStreamPubSubsByRunId.set(streamOptionsWithRunId.runId, pubsub);
+      trackedThreadStreamPubSubTarget = { runId: streamOptionsWithRunId.runId };
     }
     let preparedOptionsWithPubSub: (AgentExecutionOptionsBase<any> & { runId?: string; _pubsub: PubSub }) | undefined;
+    let preflightedRequestContext: RequestContext | undefined;
+    const reserveAdmittedRun = () => {
+      if (ownsReservation || !canReserveBeforeDefaults) return;
+      releaseReservedRun = agentThreadStreamRuntime.reserveRun(
+        streamOptionsWithRunId as AgentExecutionOptions<OUTPUT>,
+        pubsub,
+        this.id,
+      );
+      ownsReservation = Boolean(releaseReservedRun);
+      if (!ownsReservation) return;
+      reservedThreadTarget = initialThreadTarget;
+      this.#rememberThreadStreamPubSub(streamOptionsWithRunId, pubsub);
+      trackedThreadStreamPubSubTarget = {
+        runId: streamOptionsWithRunId.runId,
+        resourceId: initialThreadTarget.resourceId,
+        threadId: initialThreadTarget.threadId,
+      };
+    };
 
     try {
-      const requestContextToUse = streamOptionsWithRunId.requestContext;
       if (requestContextToUse) {
         await this.#assertAgentExecutionPreflight(requestContextToUse);
+        preflightedRequestContext = requestContextToUse;
+        reserveAdmittedRun();
+      } else if (staticDefaultOptions) {
+        await this.#assertAgentExecutionPreflight(staticDefaultOptions.requestContext);
+        preflightedRequestContext = staticDefaultOptions.requestContext;
+        reserveAdmittedRun();
       }
-
-      const defaultOptions = await this.getDefaultOptions({
-        requestContext: requestContextToUse,
-      });
+      const defaultOptions =
+        staticDefaultOptions ??
+        (await this.getDefaultOptions({
+          requestContext: requestContextToUse,
+        }));
       const mergedOptions = deepMerge(
         defaultOptions as Record<string, unknown>,
         streamOptionsWithRunId as Record<string, unknown>,
       ) as AgentExecutionOptions<OUTPUT> & { model?: DynamicArgument<MastraModelConfig> };
       if (requestContextToUse) {
         mergedOptions.requestContext = requestContextToUse;
-      } else {
+      } else if (mergedOptions.requestContext !== preflightedRequestContext) {
         await this.#assertAgentExecutionPreflight(mergedOptions.requestContext);
       }
 
@@ -6578,6 +6617,7 @@ export class Agent<
       if (!mergedOptions.runId) {
         mergedOptions.runId = this.#generateStreamRunId(mergedThreadTarget);
       }
+      attemptedRunId = mergedOptions.runId;
       if (ownsReservation && reservedThreadTarget) {
         if (!this.#sameThreadTarget(reservedThreadTarget, mergedThreadTarget)) {
           const retargetedReservation = agentThreadStreamRuntime.retargetReservedRun(
@@ -6805,7 +6845,11 @@ export class Agent<
       } else {
         this.#forgetThreadStreamPubSub(streamOptionsWithRunId);
       }
-      releaseReservedRun?.();
+      if (releaseReservedRun) {
+        releaseReservedRun();
+      } else {
+        agentThreadStreamRuntime.rejectUnregisteredRun(attemptedRunId, pubsub);
+      }
       throw error;
     }
   }

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -75,6 +75,7 @@ type PendingIdleSignal<OUTPUT = unknown> = {
   threadId: string;
   streamOptions?: AgentExecutionOptions<OUTPUT>;
   onRunRejected?: () => void;
+  reserveBeforePreflight?: boolean;
 };
 
 type AgentThreadRuntimeState = {
@@ -84,6 +85,8 @@ type AgentThreadRuntimeState = {
   pendingSignalsByThread: Map<string, CreatedAgentSignal[]>;
   pendingIdleSignalsByThread: Map<string, PendingIdleSignal<any>[]>;
   pendingIdleThreadKeysByRunId: Map<string, string>;
+  inflightIdleThreadKeysByRunId: Map<string, string>;
+  inflightIdleAgentIdsByRunId: Map<string, string>;
   watchedThreadRunIds: Set<string>;
   preparedRunsById: Map<string, PreparedThreadRun>;
   reservedAgentIdsByRunId: Map<string, string>;
@@ -123,6 +126,8 @@ function createRuntimeState(): AgentThreadRuntimeState {
     pendingSignalsByThread: new Map(),
     pendingIdleSignalsByThread: new Map(),
     pendingIdleThreadKeysByRunId: new Map(),
+    inflightIdleThreadKeysByRunId: new Map(),
+    inflightIdleAgentIdsByRunId: new Map(),
     watchedThreadRunIds: new Set(),
     preparedRunsById: new Map(),
     reservedAgentIdsByRunId: new Map(),
@@ -331,8 +336,28 @@ export class AgentThreadStreamRuntime {
         });
       };
     }
+    const inflightIdleKey = state.inflightIdleThreadKeysByRunId.get(runId);
+    let ownsInflightIdle = false;
+    if (inflightIdleKey) {
+      ownsInflightIdle =
+        inflightIdleKey === key &&
+        Boolean(agentId) &&
+        state.inflightIdleAgentIdsByRunId.get(runId) === agentId &&
+        Boolean((options as { _threadRunInflightIdleOwner?: unknown })._threadRunInflightIdleOwner);
+      if (!ownsInflightIdle) {
+        throw new Error(
+          inflightIdleKey === key
+            ? `Agent thread run id "${runId}" is already reserved`
+            : `Agent thread run id "${runId}" is already reserved for another thread`,
+        );
+      }
+    }
     if (state.activeThreadRunIds.has(key)) return;
 
+    if (ownsInflightIdle) {
+      state.inflightIdleThreadKeysByRunId.delete(runId);
+      state.inflightIdleAgentIdsByRunId.delete(runId);
+    }
     this.#forgetRejectedRunError(state, runId);
     state.activeThreadRunIds.set(key, runId);
     state.threadKeysByRunId.set(runId, key);
@@ -405,6 +430,23 @@ export class AgentThreadStreamRuntime {
     return true;
   }
 
+  rejectUnregisteredRun(runId: string | undefined, pubsub?: PubSub) {
+    if (!runId) return;
+
+    const state = this.#getState(pubsub);
+    if (
+      state.threadRunsById.has(runId) ||
+      state.threadKeysByRunId.has(runId) ||
+      state.pendingIdleThreadKeysByRunId.has(runId) ||
+      state.inflightIdleThreadKeysByRunId.has(runId) ||
+      state.preparedRunsById.has(runId)
+    ) {
+      return;
+    }
+    this.#forgetCallerSignalsForRun(state, runId);
+    this.#rejectPendingOutputWaiters(state, runId, new Error(`Agent thread run id "${runId}" was rejected`));
+  }
+
   abortRun(runId: string, pubsub?: PubSub): boolean {
     const state = this.#getState(pubsub);
     const preparedRun = state.preparedRunsById.get(runId);
@@ -420,6 +462,16 @@ export class AgentThreadStreamRuntime {
         this.#rememberAbortedRun(state, runId);
         this.#removePendingIdleRun(state, pendingIdleKey, runId, true);
         this.#publish(pubsub, pendingIdleKey, { type: 'run-aborted', runId });
+        return true;
+      }
+      const inflightIdleKey = state.inflightIdleThreadKeysByRunId.get(runId);
+      if (inflightIdleKey) {
+        this.#rememberAbortedRun(state, runId);
+        state.inflightIdleThreadKeysByRunId.delete(runId);
+        state.inflightIdleAgentIdsByRunId.delete(runId);
+        this.#forgetCallerSignalsForRun(state, runId);
+        this.#rejectPendingOutputWaiters(state, runId, new Error(`Agent thread run id "${runId}" has been aborted`));
+        this.#publish(pubsub, inflightIdleKey, { type: 'run-aborted', runId });
         return true;
       }
       return false;
@@ -477,6 +529,8 @@ export class AgentThreadStreamRuntime {
     state.pendingSignalsByThread.clear();
     state.pendingIdleSignalsByThread.clear();
     state.pendingIdleThreadKeysByRunId.clear();
+    state.inflightIdleThreadKeysByRunId.clear();
+    state.inflightIdleAgentIdsByRunId.clear();
     state.watchedThreadRunIds.clear();
     state.preparedRunsById.clear();
     state.reservedAgentIdsByRunId.clear();
@@ -671,7 +725,9 @@ export class AgentThreadStreamRuntime {
 
     const state = this.#getState(pubsub);
     const key = this.#threadKey(resourceId, threadId);
-    const existingKey = state.threadKeysByRunId.get(output.runId) ?? state.pendingIdleThreadKeysByRunId.get(output.runId);
+    const existingKey =
+      state.threadKeysByRunId.get(output.runId) ?? state.pendingIdleThreadKeysByRunId.get(output.runId);
+    const inflightIdleKey = state.inflightIdleThreadKeysByRunId.get(output.runId);
     const activeRunId = state.activeThreadRunIds.get(key);
     const reservedAgentId = state.reservedAgentIdsByRunId.get(output.runId);
     const rejectedRunError = state.rejectedRunErrorsByRunId.get(output.runId);
@@ -684,6 +740,19 @@ export class AgentThreadStreamRuntime {
     if (state.threadRunsById.has(output.runId)) {
       throw new Error(`Agent thread run id "${output.runId}" is already registered`);
     }
+    if (inflightIdleKey) {
+      const ownsInflightIdle =
+        inflightIdleKey === key &&
+        state.inflightIdleAgentIdsByRunId.get(output.runId) === agent.id &&
+        Boolean((streamOptions as { _threadRunInflightIdleOwner?: unknown })._threadRunInflightIdleOwner);
+      if (!ownsInflightIdle) {
+        throw new Error(
+          inflightIdleKey === key
+            ? `Agent thread run id "${output.runId}" is already reserved`
+            : `Agent thread run id "${output.runId}" is already reserved for another thread`,
+        );
+      }
+    }
     if (activeRunId && activeRunId !== output.runId) {
       throw new Error(`Agent thread run id "${activeRunId}" is already active for this thread`);
     }
@@ -692,6 +761,10 @@ export class AgentThreadStreamRuntime {
     }
     if (reservedAgentId && reservedAgentId !== agent.id) {
       throw new Error(`Agent thread run id "${output.runId}" is reserved by another agent`);
+    }
+    if (inflightIdleKey) {
+      state.inflightIdleThreadKeysByRunId.delete(output.runId);
+      state.inflightIdleAgentIdsByRunId.delete(output.runId);
     }
     const broadcastSource = this.#prepareBroadcastSource(output, pubsub, key);
     const record: AgentThreadRunRecord<OUTPUT> = {
@@ -899,16 +972,24 @@ export class AgentThreadStreamRuntime {
       });
       return;
     }
-    state.activeThreadRunIds.set(key, pendingIdle.runId);
-    state.threadKeysByRunId.set(pendingIdle.runId, key);
-    state.reservedAgentIdsByRunId.set(pendingIdle.runId, pendingIdle.agent.id);
+    const reserveBeforePreflight = pendingIdle.reserveBeforePreflight ?? true;
+    if (reserveBeforePreflight) {
+      state.activeThreadRunIds.set(key, pendingIdle.runId);
+      state.threadKeysByRunId.set(pendingIdle.runId, key);
+      state.reservedAgentIdsByRunId.set(pendingIdle.runId, pendingIdle.agent.id);
+    } else {
+      state.inflightIdleThreadKeysByRunId.set(pendingIdle.runId, key);
+      state.inflightIdleAgentIdsByRunId.set(pendingIdle.runId, pendingIdle.agent.id);
+    }
     try {
       const output = await pendingIdle.agent.stream(pendingIdle.signal, {
         ...(pendingIdle.streamOptions as any),
-        _threadRunReservationOwner: true,
+        ...(reserveBeforePreflight ? { _threadRunReservationOwner: true } : { _threadRunInflightIdleOwner: true }),
         runId: pendingIdle.runId,
         memory: withThreadMemory(pendingIdle.streamOptions?.memory, pendingIdle.resourceId, pendingIdle.threadId),
       });
+      state.inflightIdleThreadKeysByRunId.delete(pendingIdle.runId);
+      state.inflightIdleAgentIdsByRunId.delete(pendingIdle.runId);
 
       if ((idleQueue?.length ?? 0) > 0) {
         const nextRecord = state.threadRunsById.get(output.runId);
@@ -918,11 +999,18 @@ export class AgentThreadStreamRuntime {
       }
     } catch {
       pendingIdle.onRunRejected?.();
-      this.#releaseReservedRun(state, pubsub, key, pendingIdle.runId, {
-        cleanupPrepared: true,
-        clearAbort: true,
-        rejectOutputWaiters: true,
-      });
+      if (reserveBeforePreflight) {
+        this.#releaseReservedRun(state, pubsub, key, pendingIdle.runId, {
+          cleanupPrepared: true,
+          clearAbort: true,
+          rejectOutputWaiters: true,
+        });
+      } else {
+        state.inflightIdleThreadKeysByRunId.delete(pendingIdle.runId);
+        state.inflightIdleAgentIdsByRunId.delete(pendingIdle.runId);
+        this.rejectUnregisteredRun(pendingIdle.runId, pubsub);
+        await this.#drainPendingIdleSignals(state, pubsub, key);
+      }
     }
   }
 
@@ -967,7 +1055,10 @@ export class AgentThreadStreamRuntime {
       if (!activeRunId) return;
       if (activeRecord) {
         await activeRecord.output._waitUntilFinished().catch(() => {});
-        if (state.activeThreadRunIds.get(key) === activeRunId && state.threadRunsById.get(activeRunId) === activeRecord) {
+        if (
+          state.activeThreadRunIds.get(key) === activeRunId &&
+          state.threadRunsById.get(activeRunId) === activeRecord
+        ) {
           await new Promise<void>(resolve => {
             const waiters = state.reservationWaitersByRunId.get(activeRunId) ?? [];
             waiters.push(resolve);
@@ -1353,7 +1444,14 @@ export class AgentThreadStreamRuntime {
 
     key ??= this.#threadKey(resourceId, threadId);
     const onRunRejected = getIdleRunRejectedHandler(target.ifIdle);
-    const existingRunKey = state.threadKeysByRunId.get(runId) ?? state.pendingIdleThreadKeysByRunId.get(runId);
+    const reserveBeforeIdleWake = !Boolean(
+      (target.ifIdle as { _skipThreadRunReservationBeforePreflight?: unknown } | undefined)
+        ?._skipThreadRunReservationBeforePreflight,
+    );
+    const existingRunKey =
+      state.threadKeysByRunId.get(runId) ??
+      state.pendingIdleThreadKeysByRunId.get(runId) ??
+      state.inflightIdleThreadKeysByRunId.get(runId);
     if (existingRunKey) {
       throw new Error(
         existingRunKey === key
@@ -1373,6 +1471,7 @@ export class AgentThreadStreamRuntime {
         threadId,
         streamOptions: target.ifIdle?.streamOptions,
         onRunRejected,
+        reserveBeforePreflight: reserveBeforeIdleWake,
       });
       state.pendingIdleSignalsByThread.set(key, idleQueue);
       state.pendingIdleThreadKeysByRunId.set(runId, key);
@@ -1382,25 +1481,41 @@ export class AgentThreadStreamRuntime {
       return acceptSignal({ accepted: true, runId, signal });
     }
 
-    // No active same-agent run accepted the signal. Reserve the thread before starting
-    // the idle stream so concurrent callers do not launch duplicate runs.
-    state.activeThreadRunIds.set(key, runId);
-    state.threadKeysByRunId.set(runId, key);
-    state.reservedAgentIdsByRunId.set(runId, agent.id);
+    // No active same-agent run accepted the signal. Reserve early when the runtime owns
+    // admission; deferred starts let Agent.stream() claim the run under its own preflight rules.
+    if (reserveBeforeIdleWake) {
+      state.activeThreadRunIds.set(key, runId);
+      state.threadKeysByRunId.set(runId, key);
+      state.reservedAgentIdsByRunId.set(runId, agent.id);
+    } else {
+      state.inflightIdleThreadKeysByRunId.set(runId, key);
+      state.inflightIdleAgentIdsByRunId.set(runId, agent.id);
+    }
     const output = agent
       .stream(signal, {
         ...(target.ifIdle?.streamOptions as any),
-        _threadRunReservationOwner: true,
+        ...(reserveBeforeIdleWake ? { _threadRunReservationOwner: true } : { _threadRunInflightIdleOwner: true }),
         runId,
         memory: withThreadMemory(target.ifIdle?.streamOptions?.memory, resourceId, threadId),
       })
+      .then(output => {
+        state.inflightIdleThreadKeysByRunId.delete(runId);
+        state.inflightIdleAgentIdsByRunId.delete(runId);
+        return output;
+      })
       .catch(err => {
         onRunRejected?.();
-        this.#releaseReservedRun(state, pubsub, key, runId, {
-          cleanupPrepared: true,
-          clearAbort: true,
-          rejectOutputWaiters: true,
-        });
+        if (reserveBeforeIdleWake) {
+          this.#releaseReservedRun(state, pubsub, key, runId, {
+            cleanupPrepared: true,
+            clearAbort: true,
+            rejectOutputWaiters: true,
+          });
+        } else {
+          state.inflightIdleThreadKeysByRunId.delete(runId);
+          state.inflightIdleAgentIdsByRunId.delete(runId);
+          this.rejectUnregisteredRun(runId, pubsub);
+        }
         throw err;
       }) as Promise<MastraModelOutput<unknown>>;
     void output.catch(() => {});


### PR DESCRIPTION
## Linear

PF-544

## Summary

- Moves explicit thread-run reservation in Agent.stream behind request-context/FGA preflight when admission can reject.
- Keeps explicit-context streams unreserved before preflight, then reserves immediately after admission passes and before async defaults can create a follow-up race.
- Tracks preflight-pending run PubSub by run id so waitForRunOutput remains routed if the agent PubSub changes while admission is pending.
- Adds deferred idle-wake inflight ownership so aborts, output waiters, duplicate run ids, and direct reservations stay correct before the run registers.
- Keeps no-preflight idle wakes on the early-reservation path.

## Validation

- pnpm --filter ./packages/core exec vitest run src/agent/__tests__/agent-signals.test.ts -t "explicit-context idle reservations|inflight owner|inflight deferred|queued deferred|immediate deferred|captured PubSub|defaults finish|preflight"
- pnpm --filter ./packages/core exec vitest run src/agent/__tests__/agent-signals.test.ts
- pnpm --filter ./packages/core check
- pnpm exec prettier --check packages/core/src/agent/agent.ts packages/core/src/agent/thread-stream-runtime.ts packages/core/src/agent/__tests__/agent-signals.test.ts .changeset/pf-544-agent-stream-preflight.md
- git diff --check
- Two local Codex review passes: final correctness pass reported no findings; final merge-readiness pass found formatting/symlink issues, both resolved.
- CodeRabbit CLI: first pass found changeset wording and over-broad idle preflight skip; both fixed. Second pass reported no findings.

## Safety

No production Convex, Docker, secrets, signing, release, or publish actions touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Explanation

Instead of grabbing a thread for every incoming Agent.stream() request right away, this change waits until the request passes validation (preflight). That avoids allocating threads for requests that will be rejected and prevents races with async defaults.

## Summary of Changes

This PR refactors how Agent.stream() and Agent.sendSignal() handle thread-run reservations relative to request preflight/admission, and adds runtime tracking to preserve correctness when preflight is pending.

Core changes:
- Move explicit thread-run reservation in Agent.stream() to after request-context/FGA preflight when admission can reject, avoiding unnecessary thread allocation.
- Keep explicit-context streams unreserved during preflight and reserve immediately after admission passes to avoid races with async default resolution.
- Track preflight-pending run PubSub by runId so waitForRunOutput stays routed if the agent PubSub changes while admission is pending.
- Introduce deferred "inflight idle" ownership so aborts, output waiters, duplicate run-id handling, and direct reservations behave correctly before a run registers.
- Preserve the early-reservation (no-preflight) idle-wake path behavior.

Files changed (high-level):
1. .changeset/pf-544-agent-stream-preflight.md (+5)
   - New changeset noting the fix: Agent.stream() avoids unnecessary thread allocation when validation denies a run.

2. packages/core/src/agent/__tests__/agent-signals.test.ts (+820/-15)
   - Large set of new and adjusted tests covering request-context preflight, deferred idle reservation flows, inflight-idle behavior, and output-waiter routing.

3. packages/core/src/agent/agent.ts (+54/-10)
   - sendSignal(): conditionally set skip-reservation-before-preflight flag when idle-wake tracking + validation are present.
   - stream(): compute preflight needs up front, decide early vs deferred reservation, reuse static defaults when available, track pubsubs by runId for preflighted-but-not-reserved runs, and ensure proper cleanup (release vs rejectUnregisteredRun).

4. packages/core/src/agent/thread-stream-runtime.ts (+138/-23)
   - Add inflightIdleThreadKeysByRunId / inflightIdleAgentIdsByRunId to track deferred idle ownership.
   - New public method: rejectUnregisteredRun(runId, pubsub?) to cleanly reject runs not yet registered.
   - reserveRun(), registerRun(), abortRun(), drain logic, sendSignal(), and waitForCrossAgentThreadRun() updated to account for inflight-idle ownership, attach reserveBeforePreflight flags to idle requests, and maintain correct reservation/conflict semantics.
   - resetForTests() clears new inflight-idle state.

Testing & validation:
- Ran targeted and full vitest suites for agent-signals tests.
- TypeScript and Prettier checks on changed files.
- git diff --check executed.
- Two local Codex review passes and CodeRabbit CLI checks completed with fixes applied.

Safety:
- No production Convex, Docker, secrets, signing, release, or publish actions modified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->