### PR TITLE
[PF-543] Document Harness.session resolver

### DIFF
--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -583,6 +583,47 @@ const session = await harness.getSession()
 // { currentThreadId, currentModeId, threads }
 ```
 
+#### `session(options)`
+
+Resolve a durable Harness v1 `Session` from an existing session, a thread, or a resource. The resolver returns an active live session when one is already loaded, hydrates an active stored session when possible, or creates a fresh session when the selected resolver shape requires one.
+
+This method is available on the Harness v1 export, `@mastra/core/harness/v1`.
+
+Use `sessionId` to load an existing active session. Add `resourceId` to scope the lookup and avoid leaking session existence across resources.
+
+```typescript
+import { Harness } from '@mastra/core/harness/v1'
+
+const session = await harness.session({ sessionId: 'sess-abc123' })
+
+const scoped = await harness.session({
+  sessionId: 'sess-abc123',
+  resourceId: 'project-xyz',
+})
+```
+
+Use `threadId` with `resourceId` to resolve or create the active session bound to a thread. Pass `{ fresh: true }` to create a new owned thread and session for the resource.
+
+```typescript
+const existingThreadSession = await harness.session({
+  resourceId: 'project-xyz',
+  threadId: 'thread-abc123',
+})
+
+const freshThreadSession = await harness.session({
+  resourceId: 'project-xyz',
+  threadId: { fresh: true },
+})
+```
+
+Use `resourceId` by itself to hydrate the most recent active session for that resource, or create a fresh owned thread and session if none exists.
+
+```typescript
+const session = await harness.session({ resourceId: 'project-xyz' })
+```
+
+Resolver options also accept `parentSessionId`, `origin`, `modeId`, and `modelId`. These values apply when `session()` creates a new session. Existing live or stored sessions keep their persisted values. New sessions use the configured default mode unless `modeId` is provided.
+
 ### Messages
 
 #### `sendMessage({ content, files?, requestContext? })`


### PR DESCRIPTION
## Summary
- document the Harness v1 session(options) resolver in the Harness class reference
- cover sessionId, scoped sessionId, threadId, fresh thread, and resource-only resolution shapes
- call out the v1 export path and clarify that parent/origin/mode/model options apply to newly created sessions

Linear: PF-543

## Validation
- pnpm --dir docs validate
- pnpm --dir docs exec prettier --check src/content/en/reference/harness/harness-class.mdx
- pnpm --dir docs exec remark --no-stdout --frail --quiet --ext mdx src/content/en/reference/harness/harness-class.mdx
- pnpm --dir docs build
- git diff --check
- local Codex review pass 1: correctness/security/scope, fixed 2 findings, reran clean
- local Codex review pass 2: tests/maintainability/docs style/merge readiness, no actionable findings
- coderabbit doctor: authenticated and ready, 8 pass / 1 warning
- coderabbit review --plain: No findings

## Notes
- Vale could not run locally because docs/scripts/vale/bin/vale is missing in this checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR adds instructions for how to use a special feature called `session()` in the Harness framework. Think of a "session" like a saved conversation thread — you can grab an existing one, create a new one, or find your most recent one. The documentation shows different ways to do this with simple code examples so developers know exactly how to use it.

## Summary

Added documentation for the Harness v1 `session(options)` resolver method, which enables flexible session management in the Harness class.

### Documentation Added

The new section in the Harness class reference documents how the `session()` method (exported from `@mastra/core/harness/v1`) resolves active live sessions, hydrates stored sessions when available, or creates fresh sessions depending on the resolver inputs provided.

**Resolver shapes and usage patterns documented:**
- **By session ID**: Load an existing active session with optional resource scoping
- **By thread ID**: Resolve or create the active session bound to a specific thread, with option to create a fresh owned thread (`{ fresh: true }`)
- **By resource ID alone**: Hydrate the most recent active session for a resource, or create a fresh session if none exists

**Resolver options**: The documentation clarifies that `parentSessionId`, `origin`, `modeId`, and `modelId` apply when `session()` creates a new session, while existing live or stored sessions retain their persisted values.

### Changes

- **File**: `docs/src/content/en/reference/harness/harness-class.mdx`
- **Lines changed**: +41 (new documentation block)
- **Location**: Under the "Threads" methods section (lines 586-625)

### Validation Completed

- Markdown validation and formatting checks passed
- Remark linting passed
- Documentation build successful
- Local code review (Codex) passed
- CodeRabbit authentication and checks passed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->