### PR TITLE
[PF-541] Allow pre-bound harness registration names

### DIFF
--- a/.changeset/pf-541-harness-registration.md
+++ b/.changeset/pf-541-harness-registration.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Harness v1 so registered harnesses respect their configured names when creating sessions, avoiding default-name conflicts and inconsistent session lookup.

--- a/packages/core/src/harness/v1/harness.test.ts
+++ b/packages/core/src/harness/v1/harness.test.ts
@@ -268,6 +268,123 @@ describe('Harness v1 — session(...) by thread', () => {
     });
   });
 
+  it('uses the first registered key for a harness pre-bound to the same Mastra', async () => {
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { default: makeAgent() },
+      storage,
+    });
+    const alpha = new Harness({
+      mastra,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+
+    expect(() => alpha.__registerMastra(mastra, 'alpha')).not.toThrow();
+
+    const session = await alpha.session({ threadId: 'shared-thread', resourceId: 'r1' });
+    expect(session.getRecord().harnessName).toBe('alpha');
+
+    const harnessStore = await storage.getStore('harness');
+    expect(harnessStore).toBeDefined();
+    await expect(harnessStore!.loadSession({ harnessName: 'alpha', sessionId: session.id })).resolves.toMatchObject({
+      harnessName: 'alpha',
+    });
+    await expect(harnessStore!.loadSession({ harnessName: 'default', sessionId: session.id })).resolves.toBeNull();
+  });
+
+  it('rejects registering a pre-bound harness on a different Mastra', () => {
+    const mastra = new Mastra({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+    });
+    const other = new Mastra({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+    });
+    const harness = new Harness({
+      mastra,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+
+    expect(() => harness.__registerMastra(other, 'alpha')).toThrow(HarnessConfigError);
+  });
+
+  it('rejects first non-default registration after a pre-bound harness created sessions', async () => {
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { default: makeAgent() },
+      storage,
+    });
+    const harness = new Harness({
+      mastra,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+    const session = await harness.session({ threadId: 'shared-thread', resourceId: 'r1' });
+    await harness.shutdown();
+
+    expect(() => harness.__registerMastra(mastra, 'alpha')).toThrow(HarnessConfigError);
+
+    const harnessStore = await storage.getStore('harness');
+    await expect(harnessStore!.loadSession({ harnessName: 'default', sessionId: session.id })).resolves.toMatchObject({
+      harnessName: 'default',
+    });
+  });
+
+  it('fails closed instead of shadowing active default sessions after restart', async () => {
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { default: makeAgent() },
+      storage,
+    });
+    const defaultHarness = new Harness({
+      mastra,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+    const defaultSession = await defaultHarness.session({ threadId: 'shared-thread', resourceId: 'r1' });
+    await defaultHarness.shutdown();
+
+    const alpha = new Harness({
+      mastra,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+    expect(() => alpha.__registerMastra(mastra, 'alpha')).not.toThrow();
+
+    await expect(alpha.session({ threadId: 'shared-thread', resourceId: 'r1' })).rejects.toThrow(HarnessConfigError);
+
+    const harnessStore = await storage.getStore('harness');
+    await expect(
+      harnessStore!.loadSession({ harnessName: 'default', sessionId: defaultSession.id }),
+    ).resolves.toMatchObject({
+      harnessName: 'default',
+    });
+
+    const alphaSession = await alpha.session({ threadId: 'alpha-thread', resourceId: 'r1' });
+    expect(alphaSession.getRecord().harnessName).toBe('alpha');
+  });
+
+  it('rolls back the first registered key if Mastra binding validation fails', () => {
+    const invalid = new Mastra({
+      agents: { other: makeAgent() },
+      storage: new InMemoryStore(),
+    });
+    const valid = new Mastra({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+    });
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+
+    expect(() => harness.__registerMastra(invalid, 'bad')).toThrow(HarnessConfigError);
+    expect(() => harness.__registerMastra(valid, 'alpha')).not.toThrow();
+  });
+
   it('rejects re-registering the same Mastra under a different harness key', async () => {
     const storage = new InMemoryStore();
     const alpha = new Harness({

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -303,6 +303,9 @@ export class Harness {
    */
   private _mastra?: Mastra;
   private _harnessName = 'default';
+  private _registeredHarnessName?: string;
+  private _hasAdoptedSessions = false;
+  private _guardPreboundDefaultNamespace = false;
   private readonly _storageOverride?: HarnessStorage;
   private readonly _modesById: Map<string, HarnessMode>;
   private readonly _defaultModeId?: string;
@@ -602,16 +605,45 @@ export class Harness {
     if (this._mastra && this._mastra !== mastra) {
       throw new HarnessConfigError('mastra', 'harness is already bound to a different Mastra instance');
     }
-    if (this._mastra === mastra) {
-      if (harnessName !== undefined && harnessName !== this._harnessName) {
+
+    if (harnessName !== undefined) {
+      if (this._registeredHarnessName !== undefined && harnessName !== this._registeredHarnessName) {
         throw new HarnessConfigError('mastra', 'harness is already registered under a different harness name');
+      }
+      if (this._registeredHarnessName === undefined && harnessName !== this._harnessName && this._hasAdoptedSessions) {
+        throw new HarnessConfigError(
+          'mastra',
+          'harness already has sessions under the default harness name and cannot be renamed',
+        );
+      }
+    }
+
+    if (this._mastra === mastra) {
+      if (harnessName !== undefined) {
+        if (this._registeredHarnessName === undefined && this._harnessName === 'default' && harnessName !== 'default') {
+          this._guardPreboundDefaultNamespace = true;
+        }
+        this._harnessName = harnessName;
+        this._registeredHarnessName = harnessName;
       }
       return;
     }
+
+    const previousHarnessName = this._harnessName;
+    const previousRegisteredHarnessName = this._registeredHarnessName;
+    const previousGuardPreboundDefaultNamespace = this._guardPreboundDefaultNamespace;
     if (harnessName !== undefined) {
       this._harnessName = harnessName;
+      this._registeredHarnessName = harnessName;
     }
-    this._bindMastra(mastra);
+    try {
+      this._bindMastra(mastra);
+    } catch (err) {
+      this._harnessName = previousHarnessName;
+      this._registeredHarnessName = previousRegisteredHarnessName;
+      this._guardPreboundDefaultNamespace = previousGuardPreboundDefaultNamespace;
+      throw err;
+    }
   }
 
   /**
@@ -925,6 +957,8 @@ export class Harness {
       return this._hydrate(storage, stored);
     }
 
+    await this._assertNoPreboundDefaultNamespaceShadow(storage, threadId, resourceId);
+
     // No active record — create a fresh session bound to this thread.
     return this._createFresh(storage, {
       resourceId,
@@ -1094,8 +1128,26 @@ export class Harness {
     return undefined;
   }
 
+  private async _assertNoPreboundDefaultNamespaceShadow(
+    storage: HarnessStorage,
+    threadId: string,
+    resourceId: string,
+  ): Promise<void> {
+    if (!this._guardPreboundDefaultNamespace || this._harnessName === 'default') return;
+    const existingDefault = await storage.loadSessionByThread({
+      harnessName: 'default',
+      threadId,
+      resourceId,
+    });
+    if (!existingDefault) return;
+    throw new HarnessConfigError(
+      'session().threadId',
+      'cannot create a registered harness session for a thread/resource with an active default-namespace session; close or migrate the default session first',
+    );
+  }
+
   private async _hydrate(storage: HarnessStorage, stored: SessionRecord): Promise<Session> {
-    const lease = await this._acquireLease(storage, stored.id);
+    const lease = await this._acquireLease(storage, stored.harnessName, stored.id);
     const record: SessionRecord = {
       ...stored,
       ownerId: this.ownerId,
@@ -1139,6 +1191,7 @@ export class Harness {
       leaseExpiresAt: record.leaseExpiresAt ?? Date.now() + this._leaseTtlMs,
     });
     if (workspaceLost) session._markWorkspaceLost();
+    this._hasAdoptedSessions = true;
     this._liveSessions.set(record.id, session);
 
     // Bridge the session's events onto the harness-level emitter so a single
@@ -1181,10 +1234,10 @@ export class Harness {
     return session;
   }
 
-  private async _acquireLease(storage: HarnessStorage, sessionId: string) {
+  private async _acquireLease(storage: HarnessStorage, harnessName: string, sessionId: string) {
     try {
       return await storage.acquireSessionLease({
-        harnessName: this._harnessName,
+        harnessName,
         sessionId,
         ownerId: this.ownerId,
         ttlMs: this._leaseTtlMs,
@@ -1366,7 +1419,7 @@ export class Harness {
       };
     }
 
-    const lease = await this._acquireLease(storage, record.id);
+    const lease = await this._acquireLease(storage, record.harnessName, record.id);
     const leasedRecord = {
       ...record,
       ownerId: this.ownerId,

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -275,10 +275,10 @@ export type HarnessConfig = HarnessConfigCommon &
          * Pre-built Mastra instance to drive this harness. Mutually
          * exclusive with top-level `agents` / `storage`.
          *
-         * If you want to register the harness on a Mastra (so it lives in
-         * `mastra.harnesses.*`), omit this field and pass the harness to
-         * `new Mastra({ harnesses })` instead — the parent will install
-         * itself onto the harness automatically.
+         * Prefer omitting this field when you want the parent `Mastra` to own
+         * registration (`new Mastra({ harnesses })`). A harness that is already
+         * bound to the same `Mastra` may still be registered there under a
+         * configured harness name.
          */
         mastra: Mastra;
         agents?: never;


### PR DESCRIPTION
Linear: PF-541

## Summary
- Allows a Harness already bound to the same Mastra instance to adopt the configured `harnesses.<name>` registration name before it has created/adopted sessions.
- Keeps registration fail-closed after session adoption, rejects different-Mastra registration, and rolls back the configured name if Mastra binding validation fails.
- Prevents restarted pre-bound harnesses from silently shadowing an active `default` namespace session for the same thread/resource; callers must close or migrate the default row first.
- Updates the HarnessConfig comment and adds an `@mastra/core` patch changeset.

## Overlap checked
- #113 (`PF-543`) docs-only Harness.session reference; no source overlap.
- #112 (`PF-544`) Agent.stream preflight reservation; no source overlap.
- #69/#68/#58 are stale or different areas; no direct PF-541 path overlap.

## Validation
- `pnpm --filter ./packages/core exec prettier --write src/harness/v1/harness.ts src/harness/v1/harness.test.ts src/harness/v1/types.ts ../../.changeset/pf-541-harness-registration.md`
- `git diff --check`
- `pnpm --filter ./packages/core exec vitest run src/harness/v1/harness.test.ts` passed: 90 passed, 1 todo, no type errors.
- `pnpm --filter ./packages/core check` still fails on existing baseline implicit-any errors in `src/agent/__tests__/mock-model.ts` and `src/test-utils/llm-mock.ts`, outside this diff.
- Local Codex review pass 1: no findings after the default-namespace shadowing guard.
- Local Codex review pass 2: found one stale HarnessConfig comment nit; fixed in this PR.
- Local Codex follow-up review after the comment fix: no findings.
- `coderabbit doctor`: 8 passed, 1 auth-environment warning.
- `coderabbit review --plain`: no findings.

## Council note
Gemini council review was attempted earlier for this runtime change but did not complete in the local environment; the PR compensates with focused local tests, two Codex review passes plus follow-up, and CodeRabbit CLI review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR allows harnesses (components that handle conversations) that are already connected to a Mastra system to register with a custom name before they create any conversation sessions. It also adds safety checks to prevent accidentally overwriting existing conversations or creating conflicts when restarting these harnesses.

## Changes Overview

This PR implements stricter harness registration rules for pre-bound instances, with four key files modified:

### Changeset
- Added patch version bump for `@mastra/core` documenting the harness v1 registration fix

### Implementation (`harness.ts`)
The `Harness` v1 class now:
- Tracks whether a harness has adopted a configured registration name and adopted sessions
- Enforces stricter rename/adoption rules in `__registerMastra` with new internal state flags and rollback-on-bind-failure support
- Checks for active default-namespace sessions before creating non-default harness sessions, preventing shadowing of existing sessions when a harness is restarted
- Refactored lease acquisition to accept an explicit `harnessName` parameter and uses it in `acquireSessionLease`
- Updates close-tree lease acquisition to pass `record.harnessName` instead of relying on the current harness name

### Documentation (`types.ts`)
Updated `HarnessConfig` JSDoc to clarify:
- Preference for omitting the `mastra` field and letting the parent `Mastra` own harness registration
- Notes that a harness already bound to the same `Mastra` instance may still be registered under a configured harness name

### Test Coverage (`harness.test.ts`)
Added five new test cases under "Harness v1 — session(...) by thread" covering:
1. Pre-bound harness uses first registered Mastra key for sessions and storage
2. Registering same pre-bound harness with different Mastra throws `HarnessConfigError`
3. Post-session registration attempts fail closed while preserving default-session behavior
4. Failed Mastra binding validation triggers rollback of first registered key
5. Restart scenarios where re-registration fails closed while stored sessions remain loadable

## Testing & Validation
- Unit tests: 90 passed, 1 todo in harness test suite
- No type errors in changed files
- Prettier formatting applied
- Local Codex reviews completed with findings addressed
- `coderabbit doctor` validation passed (8/9 checks, 1 auth warning)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->