### PR TITLE
[PF-542] Normalize agent network tool identity

### DIFF
--- a/.changeset/pf-542-network-tool-identity.md
+++ b/.changeset/pf-542-network-tool-identity.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed incorrect tool identification in agent network approval and suspension workflows when tools are registered using aliases.

--- a/packages/core/src/agent/agent-network.test.ts
+++ b/packages/core/src/agent/agent-network.test.ts
@@ -3980,6 +3980,30 @@ describe('Agent - network - tool approval and suspension', () => {
     },
   });
 
+  const createMemoryCapture = () => {
+    const capturedMemory = new MockMemory();
+    const savedMessages: any[] = [];
+    const originalSaveMessages = capturedMemory.saveMessages.bind(capturedMemory);
+    capturedMemory.saveMessages = async (params: any) => {
+      savedMessages.push(...params.messages);
+      return originalSaveMessages(params);
+    };
+    return { memory: capturedMemory, savedMessages };
+  };
+
+  const getParsedNetworkMessages = (savedMessages: any[]) => {
+    return savedMessages.flatMap(message => {
+      const text = message.content?.parts?.[0]?.text;
+      if (typeof text !== 'string') return [];
+      try {
+        const parsed = JSON.parse(text);
+        return parsed?.isNetwork ? [{ message, parsed }] : [];
+      } catch {
+        return [];
+      }
+    });
+  };
+
   describe('approveNetworkToolCall', () => {
     it('should approve a direct network tool call', async () => {
       mockToolExecute.mockClear();
@@ -4048,6 +4072,77 @@ describe('Agent - network - tool approval and suspension', () => {
 
       expect(toolExecutionEnded).toBe(true);
       expect(mockToolExecute).toHaveBeenCalled();
+    });
+
+    it('uses the declared tool id for direct approval events and metadata when registered by alias', async () => {
+      const { memory: capturedMemory, savedMessages } = createMemoryCapture();
+      const aliasToolExecute = vi.fn().mockResolvedValue({ result: 'Processed: aliased approval' });
+      const aliasApprovalTool = createTool({
+        id: 'approval-real-tool',
+        description: 'A tool registered under an alias that requires approval.',
+        inputSchema: z.object({ query: z.string() }),
+        requireApproval: true,
+        execute: aliasToolExecute,
+      });
+      const mockModel = createRoutingMockModel('approvalAlias', 'tool', JSON.stringify({ query: 'aliased approval' }));
+      const networkAgent = new Agent({
+        id: 'alias-approval-network-agent',
+        name: 'Alias Approval Network Agent',
+        instructions: 'Use the aliased approval tool.',
+        model: mockModel,
+        tools: { approvalAlias: aliasApprovalTool },
+        memory: capturedMemory,
+      });
+      const mastra = new Mastra({
+        agents: { networkAgent },
+        storage: new InMemoryStore(),
+        logger: false,
+      });
+      const registeredAgent = mastra.getAgent('networkAgent');
+
+      const anStream = await registeredAgent.network('Process the aliased approval query', {
+        memory: {
+          thread: 'test-thread-approve-alias',
+          resource: 'test-resource-approve-alias',
+        },
+      });
+
+      const chunks: any[] = [];
+      for await (const chunk of anStream) {
+        chunks.push(chunk);
+      }
+
+      const start = chunks.find(chunk => chunk.type === 'tool-execution-start');
+      const approval = chunks.find(chunk => chunk.type === 'tool-execution-approval');
+      expect(start?.payload?.args?.toolName).toBe('approval-real-tool');
+      expect(approval?.payload?.toolName).toBe('approval-real-tool');
+
+      const approvalNetworkMessage = getParsedNetworkMessages(savedMessages).find(({ message }) => {
+        return message.content?.metadata?.requireApprovalMetadata?.approvalAlias;
+      });
+      expect(approvalNetworkMessage?.parsed.primitiveId).toBe('approval-real-tool');
+      expect(approvalNetworkMessage?.message.content.metadata.requireApprovalMetadata.approvalAlias).toMatchObject({
+        toolName: 'approval-real-tool',
+        primitiveId: 'approval-real-tool',
+      });
+
+      const resumeStream = await registeredAgent.approveNetworkToolCall({
+        runId: anStream.runId,
+        memory: {
+          thread: 'test-thread-approve-alias',
+          resource: 'test-resource-approve-alias',
+        },
+      });
+
+      const resumeChunks: any[] = [];
+      for await (const chunk of resumeStream) {
+        resumeChunks.push(chunk);
+      }
+
+      const end = resumeChunks.find(chunk => chunk.type === 'tool-execution-end');
+      expect(end?.payload?.toolName).toBe('approval-real-tool');
+      expect(end?.payload?.result).toMatchObject({ result: 'Processed: aliased approval' });
+      expect(aliasToolExecute).toHaveBeenCalled();
     });
 
     it('should approve a nested agent tool call', async () => {
@@ -4199,6 +4294,68 @@ describe('Agent - network - tool approval and suspension', () => {
 
       expect(rejectionFound).toBe(true);
       expect(mockToolExecute).not.toHaveBeenCalled();
+    });
+
+    it('uses the declared tool id when declining an aliased direct approval', async () => {
+      const { memory: capturedMemory, savedMessages } = createMemoryCapture();
+      const aliasToolExecute = vi.fn().mockResolvedValue({ result: 'should not run' });
+      const aliasApprovalTool = createTool({
+        id: 'decline-real-tool',
+        description: 'A tool registered under an alias that can be declined.',
+        inputSchema: z.object({ query: z.string() }),
+        requireApproval: true,
+        execute: aliasToolExecute,
+      });
+      const mockModel = createRoutingMockModel('declineAlias', 'tool', JSON.stringify({ query: 'aliased decline' }));
+      const networkAgent = new Agent({
+        id: 'alias-decline-network-agent',
+        name: 'Alias Decline Network Agent',
+        instructions: 'Use the aliased decline tool.',
+        model: mockModel,
+        tools: { declineAlias: aliasApprovalTool },
+        memory: capturedMemory,
+      });
+      const mastra = new Mastra({
+        agents: { networkAgent },
+        storage: new InMemoryStore(),
+        logger: false,
+      });
+      const registeredAgent = mastra.getAgent('networkAgent');
+
+      const anStream = await registeredAgent.network('Process the aliased decline query', {
+        memory: {
+          thread: 'test-thread-decline-alias',
+          resource: 'test-resource-decline-alias',
+        },
+      });
+
+      for await (const _chunk of anStream) {
+        // Consume the approval stream.
+      }
+
+      const savedBeforeDecline = savedMessages.length;
+      const resumeStream = await registeredAgent.declineNetworkToolCall({
+        runId: anStream.runId,
+        memory: {
+          thread: 'test-thread-decline-alias',
+          resource: 'test-resource-decline-alias',
+        },
+      });
+
+      const resumeChunks: any[] = [];
+      for await (const chunk of resumeStream) {
+        resumeChunks.push(chunk);
+      }
+
+      const end = resumeChunks.find(chunk => chunk.type === 'tool-execution-end');
+      expect(end?.payload?.toolName).toBe('decline-real-tool');
+      expect(end?.payload?.result).toBe('Tool call was not approved by the user');
+
+      const rejectionNetworkMessage = getParsedNetworkMessages(savedMessages.slice(savedBeforeDecline)).find(
+        ({ parsed }) => parsed.finalResult?.result === 'Tool call was not approved by the user',
+      );
+      expect(rejectionNetworkMessage?.parsed.primitiveId).toBe('decline-real-tool');
+      expect(aliasToolExecute).not.toHaveBeenCalled();
     });
 
     it('should honor declined dynamic network tool calls even if approval later returns false', async () => {
@@ -4505,6 +4662,88 @@ describe('Agent - network - tool approval and suspension', () => {
       expect(resumeChunks[resumeChunks.length - 1].type).toBe('network-execution-event-finish');
       expect(toolResult).toBeDefined();
       expect(toolResult?.result).toContain('my additional info');
+    });
+
+    it('uses the declared tool id for direct suspension events and metadata when registered by alias', async () => {
+      const { memory: capturedMemory, savedMessages } = createMemoryCapture();
+      const aliasSuspendingTool = createTool({
+        id: 'suspend-real-tool',
+        description: 'A tool registered under an alias that suspends.',
+        inputSchema: z.object({ initialQuery: z.string() }),
+        suspendSchema: z.object({ message: z.string() }),
+        resumeSchema: z.object({ userResponse: z.string() }),
+        execute: async (input, context) => {
+          if (!context?.agent?.resumeData) {
+            return await context?.agent?.suspend({ message: 'Need aliased resume data' });
+          }
+          return { result: `Received: ${input.initialQuery} and ${context.agent.resumeData.userResponse}` };
+        },
+      });
+      const mockModel = createRoutingMockModel(
+        'suspendAlias',
+        'tool',
+        JSON.stringify({ initialQuery: 'aliased suspension' }),
+      );
+      const networkAgent = new Agent({
+        id: 'alias-suspend-network-agent',
+        name: 'Alias Suspend Network Agent',
+        instructions: 'Use the aliased suspending tool.',
+        model: mockModel,
+        tools: { suspendAlias: aliasSuspendingTool },
+        memory: capturedMemory,
+      });
+      const mastra = new Mastra({
+        agents: { networkAgent },
+        storage: new InMemoryStore(),
+        logger: false,
+      });
+      const registeredAgent = mastra.getAgent('networkAgent');
+
+      const anStream = await registeredAgent.network('Collect information with the aliased suspending tool', {
+        memory: {
+          thread: 'test-thread-suspend-alias',
+          resource: 'test-resource-suspend-alias',
+        },
+      });
+
+      const chunks: any[] = [];
+      for await (const chunk of anStream) {
+        chunks.push(chunk);
+      }
+
+      const start = chunks.find(chunk => chunk.type === 'tool-execution-start');
+      const suspended = chunks.find(chunk => chunk.type === 'tool-execution-suspended');
+      expect(start?.payload?.args?.toolName).toBe('suspend-real-tool');
+      expect(suspended?.payload?.toolName).toBe('suspend-real-tool');
+
+      const suspensionNetworkMessage = getParsedNetworkMessages(savedMessages).find(({ message }) => {
+        return message.content?.metadata?.suspendedTools?.suspendAlias;
+      });
+      expect(suspensionNetworkMessage?.parsed.primitiveId).toBe('suspend-real-tool');
+      expect(suspensionNetworkMessage?.message.content.metadata.suspendedTools.suspendAlias).toMatchObject({
+        toolName: 'suspend-real-tool',
+        primitiveId: 'suspend-real-tool',
+      });
+
+      const resumeStream = await registeredAgent.resumeNetwork(
+        { userResponse: 'aliased resume' },
+        {
+          runId: anStream.runId,
+          memory: {
+            thread: 'test-thread-suspend-alias',
+            resource: 'test-resource-suspend-alias',
+          },
+        },
+      );
+
+      const resumeChunks: any[] = [];
+      for await (const chunk of resumeStream) {
+        resumeChunks.push(chunk);
+      }
+
+      const end = resumeChunks.find(chunk => chunk.type === 'tool-execution-end');
+      expect(end?.payload?.toolName).toBe('suspend-real-tool');
+      expect(end?.payload?.result?.result).toContain('aliased resume');
     });
 
     it('should pass approved-shaped resume data to suspended dynamic-approval-capable direct network tools', async () => {

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -1573,7 +1573,7 @@ export async function createNetworkLoop({
                       isNetwork: true,
                       selectionReason: inputData.selectionReason,
                       primitiveType: inputData.primitiveType,
-                      primitiveId: inputData.primitiveId,
+                      primitiveId: toolId,
                       finalResult: { result: rejectionResult, toolCallId },
                       input: inputDataToUse,
                     }),
@@ -1740,7 +1740,7 @@ export async function createNetworkLoop({
                         isNetwork: true,
                         selectionReason: inputData.selectionReason,
                         primitiveType: inputData.primitiveType,
-                        primitiveId: inputData.primitiveId,
+                        primitiveId: toolId,
                         finalResult: { result: '', toolCallId },
                         input: inputDataToUse,
                       }),
@@ -1750,15 +1750,16 @@ export async function createNetworkLoop({
                   metadata: {
                     mode: 'network',
                     requireApprovalMetadata: {
+                      // Keep the lookup key on the registry primitive id so in-flight resumes stay compatible.
                       [inputData.primitiveId]: {
                         toolCallId,
-                        toolName: inputData.primitiveId,
+                        toolName: toolId,
                         args: inputDataToUse,
                         type: 'approval',
                         resumeSchema: requireApprovalResumeSchema,
                         runId,
                         primitiveType: 'tool',
-                        primitiveId: inputData.primitiveId,
+                        primitiveId: toolId,
                       },
                     },
                   },
@@ -1774,7 +1775,7 @@ export async function createNetworkLoop({
           await writer?.write({
             type: 'tool-execution-approval',
             payload: {
-              toolName: inputData.primitiveId,
+              toolName: toolId,
               toolCallId,
               args: inputDataToUse,
               selectionReason: inputData.selectionReason,
@@ -1785,7 +1786,7 @@ export async function createNetworkLoop({
 
           return suspend({
             requireToolApproval: {
-              toolName: inputData.primitiveId,
+              toolName: toolId,
               args: inputDataToUse,
               toolCallId,
             },
@@ -1848,9 +1849,10 @@ export async function createNetworkLoop({
                       metadata: {
                         mode: 'network',
                         suspendedTools: {
+                          // Keep the lookup key on the registry primitive id so in-flight resumes stay compatible.
                           [inputData.primitiveId]: {
                             toolCallId,
-                            toolName: inputData.primitiveId,
+                            toolName: toolId,
                             args: inputDataToUse,
                             suspendPayload,
                             type: 'suspension',
@@ -1859,7 +1861,7 @@ export async function createNetworkLoop({
                               JSON.stringify(schemaToJsonSchema((tool as any).resumeSchema)),
                             runId,
                             primitiveType: 'tool',
-                            primitiveId: inputData.primitiveId,
+                            primitiveId: toolId,
                           },
                         },
                       },
@@ -1875,7 +1877,7 @@ export async function createNetworkLoop({
               await writer?.write({
                 type: 'tool-execution-suspended',
                 payload: {
-                  toolName: inputData.primitiveId,
+                  toolName: toolId,
                   toolCallId,
                   args: inputDataToUse,
                   resumeSchema:
@@ -1903,7 +1905,7 @@ export async function createNetworkLoop({
       if (toolSuspendPayload) {
         return await suspend({
           toolCallSuspended: toolSuspendPayload,
-          toolName: inputData.primitiveId,
+          toolName: toolId,
           args: inputDataToUse,
           toolCallId,
         });


### PR DESCRIPTION
Linear: PF-542

Summary:
- Normalizes direct agent-network tool approval and suspension payloads so aliased tools surface the tool id consistently.
- Keeps persisted resume lookup keys on the registry alias for compatibility with in-flight approvals and suspensions.
- Adds focused coverage for aliased approval, decline, suspension, persisted metadata, and terminal events.

Validation:
- pnpm build:core (before tests, to restore internal test-utils artifacts)
- pnpm --filter ./packages/core exec vitest run src/agent/agent-network.test.ts -t "uses the declared tool id|Agent - network - tool context validation|approveNetworkToolCall|declineNetworkToolCall|resumeNetwork" (14 passed, 70 skipped, no type errors)
- pnpm --filter ./packages/core exec vitest run src/agent/agent-network.test.ts (84 passed, no type errors)
- git diff --check
- pnpm --filter ./packages/core check (fails on existing implicit-any errors in src/agent/__tests__/mock-model.ts and src/test-utils/llm-mock.ts; no PF-542 files reported)
- Local Codex review pass 1: no findings
- Local Codex review pass 2: no findings
- CodeRabbit CLI doctor: pass, with auth-environment warning only
- CodeRabbit CLI review: one changeset wording finding fixed; rerun returned no findings

Council:
- Claude review recommended using the declared tool id for public/persisted fields while retaining registry aliases as lookup keys for resume compatibility.
- opencode council was attempted but blocked because model openai/gpt-5.5-xhigh was unavailable locally.

Overlap:
- Open PRs #69 and #68 are stale/broad and conceptually adjacent but do not touch packages/core/src/loop/network/index.ts directly.
- Open PR #58 is ClickHouse memory only and does not overlap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When tools in an agent system are given an alternate name (called an "alias"), the system was confused about which name to use when approving or pausing them. This PR fixes that by making sure the system always uses the real tool name in public messages, while keeping track of the alternate name internally so existing paused jobs can still be resumed.

---

## Changes

**Changeset** (`pf-542-network-tool-identity.md`): Marks `@mastra/core` for a patch release documenting the fix for incorrect tool identification in agent network workflows.

**Test Coverage** (`agent-network.test.ts`): Adds helper utilities for test support and three new test suites validating the core fix:
- `approveNetworkToolCall`: Verifies that when a tool is alias-registered, approval events and persisted network metadata use the declared (real) tool ID
- `declineNetworkToolCall`: Verifies that decline outcomes correctly attribute the network metadata to the real tool ID, preventing the aliased tool execution
- `resumeNetwork`: Verifies that suspension events use the real tool ID in persisted metadata and validates resume functionality

**Implementation** (`packages/core/src/loop/network/index.ts`): Updated `tool-execution-step` to consistently use the resolved registry `toolId` (instead of `inputData.primitiveId`) for public-facing fields like `primitiveId` and `toolName` in approval/suspension metadata and writer events. The lookup map key is retained on `inputData.primitiveId` to preserve compatibility with in-flight resume operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->