### PR TITLE
[PF-514] Reuse duplicate message admission evidence

### DIFF
--- a/.changeset/shaggy-boxes-nail.md
+++ b/.changeset/shaggy-boxes-nail.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'@mastra/libsql': patch
+---
+
+Fixed message admission retries so exact duplicate write races reuse the stored evidence without dispatching a second signal.

--- a/.changeset/shaggy-boxes-nail.md
+++ b/.changeset/shaggy-boxes-nail.md
@@ -3,4 +3,4 @@
 '@mastra/libsql': patch
 ---
 
-Fixed message admission retries so exact duplicate write races reuse the stored evidence without dispatching a second signal.
+Fixed duplicate message admission retries to reuse existing evidence, preventing duplicate processing during race conditions.

--- a/packages/core/src/harness/v1/session.message.test.ts
+++ b/packages/core/src/harness/v1/session.message.test.ts
@@ -393,6 +393,36 @@ describe('Session.message() — default path', () => {
     expect(otherAgent.calls).toHaveLength(0);
   });
 
+  it('replays exact duplicate admissions that race with the reservation write', async () => {
+    const { harness, agent, storage } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const writeMessageResultEvidence = storage.writeMessageResultEvidence.bind(storage);
+    const resolveOperationAdmissionEvidence = storage.resolveOperationAdmissionEvidence.bind(storage);
+    let raced = false;
+    storage.writeMessageResultEvidence = async record => {
+      if (!raced && record.status === 'pending' && record.admissionId === 'exact-race') {
+        raced = true;
+        await writeMessageResultEvidence({
+          ...record,
+          status: 'completed',
+          result: agent.fullOutput,
+        });
+      }
+      return writeMessageResultEvidence(record);
+    };
+    storage.resolveOperationAdmissionEvidence = async opts => {
+      if (raced && opts.kind === 'message' && opts.admissionId === 'exact-race') {
+        return { status: 'none' };
+      }
+      return resolveOperationAdmissionEvidence(opts);
+    };
+
+    const duplicate = await session.message({ content: 'hi', admissionId: 'exact-race' });
+
+    expect(duplicate.text).toBe('hello back');
+    expect(agent.calls).toHaveLength(0);
+  });
+
   it('replays legacy duplicate admissions that race with the reservation write', async () => {
     const { harness, defaultAgent, otherAgent, storage } = setupTwoModes();
     const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -135,7 +135,7 @@ type Deferred<T> = {
 type MessageAdmissionStart = {
   admissionHash: string;
   modeId: string;
-  promise: Promise<string>;
+  promise: Promise<AgentSignalResultEvidence | OperationAdmissionTombstone>;
 };
 
 type MessageAdmissionHashes = {
@@ -2062,7 +2062,10 @@ export class Session {
     // Per-turn additionalTools merge with the mode's surface, never replace.
     const toolsets = this._buildToolsets(mode, opts.additionalTools);
 
-    const admissionStart = opts.admissionId !== undefined ? createDeferred<string>() : undefined;
+    const admissionStart =
+      opts.admissionId !== undefined
+        ? createDeferred<AgentSignalResultEvidence | OperationAdmissionTombstone>()
+        : undefined;
     if (admissionStart) void admissionStart.promise.catch(() => {});
     if (admissionIdentity !== undefined && admissionHash !== undefined && admissionStart !== undefined) {
       const existingStart = this._messageAdmissionStarts.get(opts.admissionId!);
@@ -2075,23 +2078,8 @@ export class Session {
             admissionHash,
           );
         }
-        const runId = await existingStart.promise;
-        return this._returnDuplicateMessageResult(
-          {
-            status: 'pending',
-            harnessName: this._record.harnessName,
-            sessionId: this.id,
-            resourceId: this.resourceId,
-            threadId: this.threadId,
-            signalId: admissionIdentity.signalId,
-            runId,
-            admissionId: opts.admissionId!,
-            admissionHash,
-            createdAt: Date.now(),
-            updatedAt: Date.now(),
-          },
-          opts,
-        );
+        const evidence = await existingStart.promise;
+        return this._returnDuplicateMessageResult(evidence, opts);
       }
       this._messageAdmissionStarts.set(opts.admissionId!, {
         admissionHash,
@@ -2212,7 +2200,6 @@ export class Session {
         ]);
         if (!reservation.created) {
           this._messageAdmissionStarts.delete(opts.admissionId!);
-          admissionStart.resolve(admissionIdentity.runId);
           const existing =
             reservation.evidence ??
             (await this._resolveMessageAdmissionDuplicate({
@@ -2221,13 +2208,16 @@ export class Session {
               compatibleAdmissionHashes,
             }));
           if (existing) {
+            admissionStart.resolve(existing);
             try {
               return await this._returnDuplicateMessageResult(existing, opts);
             } finally {
               finishOwnedMessageTurn();
             }
           }
-          throw new HarnessAdmissionConflictError(this.id, opts.admissionId!, '', admissionHash);
+          const conflict = new HarnessAdmissionConflictError(this.id, opts.admissionId!, '', admissionHash);
+          admissionStart.reject(conflict);
+          throw conflict;
         }
       } catch (err) {
         failOwnedMessageTurnBeforeDispatch(err);
@@ -2282,7 +2272,22 @@ export class Session {
     // the wake path).
     const completion = this._awaitRunCompletion(signal.runId);
     void completion.catch(() => {});
-    admissionStart?.resolve(signal.runId);
+    if (admissionStart && admissionIdentity !== undefined && admissionHash !== undefined) {
+      const now = Date.now();
+      admissionStart.resolve({
+        status: 'pending',
+        harnessName: this._record.harnessName,
+        sessionId: this.id,
+        resourceId: this.resourceId,
+        threadId: this.threadId,
+        signalId: signal.signal.id,
+        runId: signal.runId,
+        admissionId: opts.admissionId!,
+        admissionHash,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
 
     const pendingEvidenceWrite =
       admissionIdentity !== undefined
@@ -2641,7 +2646,8 @@ export class Session {
     const starting = evidence.admissionId ? this._messageAdmissionStarts.get(evidence.admissionId) : undefined;
     if (!starting) return evidence.runId;
     try {
-      return await starting.promise;
+      const startingEvidence = await starting.promise;
+      return startingEvidence.runId ?? evidence.runId;
     } catch {
       return evidence.runId;
     }

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -2213,11 +2213,13 @@ export class Session {
         if (!reservation.created) {
           this._messageAdmissionStarts.delete(opts.admissionId!);
           admissionStart.resolve(admissionIdentity.runId);
-          const existing = await this._resolveMessageAdmissionDuplicate({
-            admissionId: opts.admissionId!,
-            admissionHash,
-            compatibleAdmissionHashes,
-          });
+          const existing =
+            reservation.evidence ??
+            (await this._resolveMessageAdmissionDuplicate({
+              admissionId: opts.admissionId!,
+              admissionHash,
+              compatibleAdmissionHashes,
+            }));
           if (existing) {
             try {
               return await this._returnDuplicateMessageResult(existing, opts);
@@ -2225,6 +2227,7 @@ export class Session {
               finishOwnedMessageTurn();
             }
           }
+          throw new HarnessAdmissionConflictError(this.id, opts.admissionId!, '', admissionHash);
         }
       } catch (err) {
         failOwnedMessageTurnBeforeDispatch(err);
@@ -2703,7 +2706,7 @@ export class Session {
   private async _writeMessageResultEvidence(
     status: AgentSignalResultStatus & { admissionId?: string; admissionHash?: string },
     options?: { compatibleAdmissionHashes?: readonly string[] },
-  ): Promise<{ created: boolean }> {
+  ): Promise<{ created: boolean; evidence?: AgentSignalResultEvidence | OperationAdmissionTombstone }> {
     const now = Date.now();
     this._operationEvidenceSignalIds.add(status.signalId);
     try {
@@ -2725,7 +2728,7 @@ export class Session {
           admissionHash: status.admissionHash,
           compatibleAdmissionHashes: options?.compatibleAdmissionHashes,
         });
-        if (duplicate) return { created: false };
+        if (duplicate) return { created: false, evidence: duplicate };
         throw new HarnessAdmissionConflictError(this.id, status.admissionId, '', status.admissionHash);
       }
       throw err;

--- a/packages/core/src/storage/domains/harness/base.ts
+++ b/packages/core/src/storage/domains/harness/base.ts
@@ -29,6 +29,11 @@ import type {
   WithThreadDeleteFenceInput,
 } from './types';
 
+export interface WriteMessageResultEvidenceResult {
+  created: boolean;
+  evidence?: AgentSignalResultEvidence;
+}
+
 /**
  * Thrown by `saveSession` when `ifVersion` does not match the record's
  * current `version`. The caller should rehydrate and retry once
@@ -472,7 +477,7 @@ export abstract class HarnessStorage extends StorageDomain {
     signalId: string;
   }): Promise<AgentSignalResultStatus | OperationAdmissionTombstone | null>;
 
-  abstract writeMessageResultEvidence(record: AgentSignalResultEvidence): Promise<{ created: boolean }>;
+  abstract writeMessageResultEvidence(record: AgentSignalResultEvidence): Promise<WriteMessageResultEvidenceResult>;
 
   abstract loadQueueResultEvidence(opts: {
     harnessName?: string;

--- a/packages/core/src/storage/domains/harness/inmemory.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.ts
@@ -13,6 +13,7 @@ import {
   HarnessStorageThreadDeleteFenceConflictError,
   HarnessStorageVersionConflictError,
 } from './base';
+import type { WriteMessageResultEvidenceResult } from './base';
 import type {
   AcquireSessionLeaseInput,
   AgentSignalResultEvidence,
@@ -674,7 +675,7 @@ export class InMemoryHarness extends HarnessStorage {
     return tombstone ? cloneJson(tombstone) : null;
   }
 
-  async writeMessageResultEvidence(record: AgentSignalResultEvidence): Promise<{ created: boolean }> {
+  async writeMessageResultEvidence(record: AgentSignalResultEvidence): Promise<WriteMessageResultEvidenceResult> {
     const namespacedRecord = {
       ...record,
       harnessName: resolveHarnessName(record.harnessName, this.harnessName),
@@ -689,16 +690,17 @@ export class InMemoryHarness extends HarnessStorage {
       );
     }
     if (existing && isTerminalMessageEvidence(existing)) {
-      return { created: false };
+      return { created: false, evidence: cloneJson(existing) };
     }
+    const stored = {
+      ...namespacedRecord,
+      createdAt: existing?.createdAt ?? namespacedRecord.createdAt,
+    };
     this.db.harnessMessageResultEvidence.set(
       key,
-      cloneJson({
-        ...namespacedRecord,
-        createdAt: existing?.createdAt ?? namespacedRecord.createdAt,
-      }),
+      cloneJson(stored),
     );
-    return { created: existing === undefined };
+    return existing === undefined ? { created: true } : { created: false, evidence: cloneJson(stored) };
   }
 
   async loadQueueResultEvidence({

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -630,7 +630,10 @@ describe('HarnessLibSQL message result evidence', () => {
         createdAt: 1000,
         updatedAt: 2000,
       }),
-    ).resolves.toEqual({ created: false });
+    ).resolves.toMatchObject({
+      created: false,
+      evidence: { admissionId: 'admission-1', admissionHash: 'hash-1', status: 'completed' },
+    });
 
     await expect(
       storage.writeMessageResultEvidence({
@@ -646,7 +649,10 @@ describe('HarnessLibSQL message result evidence', () => {
         createdAt: 3000,
         updatedAt: 3000,
       }),
-    ).resolves.toEqual({ created: false });
+    ).resolves.toMatchObject({
+      created: false,
+      evidence: { admissionId: 'admission-1', admissionHash: 'hash-1', status: 'completed' },
+    });
 
     await expect(
       storage.loadMessageResultEvidence({

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -12,6 +12,7 @@ import {
   HarnessStorageSessionNotFoundError,
   HarnessStorageThreadDeleteFenceConflictError,
   HarnessStorageVersionConflictError,
+  type WriteMessageResultEvidenceResult,
   TABLE_CONFIGS,
   TABLE_HARNESS_ATTACHMENT_REFERENCES,
   TABLE_HARNESS_ATTACHMENTS,
@@ -1213,7 +1214,7 @@ export class HarnessLibSQL extends HarnessStorage {
     return row ? rowToTombstone(row as Record<string, unknown>) : null;
   }
 
-  async writeMessageResultEvidence(record: AgentSignalResultEvidence): Promise<{ created: boolean }> {
+  async writeMessageResultEvidence(record: AgentSignalResultEvidence): Promise<WriteMessageResultEvidenceResult> {
     await this.#ensureMessageResultsTable();
     const namespacedRecord = { ...record, harnessName: this.#resolveHarnessName(record.harnessName) };
     if (namespacedRecord.status === 'completed') completedMessageEvidenceRunId(namespacedRecord);
@@ -1226,7 +1227,7 @@ export class HarnessLibSQL extends HarnessStorage {
         threadId: namespacedRecord.threadId,
         signalId: namespacedRecord.signalId,
       });
-      return current && 'status' in current ? current : null;
+      return current && 'status' in current ? (current as AgentSignalResultEvidence) : null;
     };
     const tx = await this.#client.transaction('write');
     let created = false;
@@ -1246,8 +1247,12 @@ export class HarnessLibSQL extends HarnessStorage {
         }
         if (isTerminalMessageEvidence(current)) {
           await tx.commit();
-          return { created: false };
+          return { created: false, evidence: current };
         }
+        const updated = {
+          ...namespacedRecord,
+          createdAt: current.createdAt,
+        };
         await tx.execute({
           sql: `UPDATE ${TABLE_HARNESS_MESSAGE_RESULTS}
                 SET run_id = ?, status = ?, result = ?, error = ?, updated_at = ?
@@ -1261,6 +1266,8 @@ export class HarnessLibSQL extends HarnessStorage {
             id,
           ],
         });
+        await tx.commit();
+        return { created: false, evidence: updated };
       } else {
         created = true;
         await tx.execute({
@@ -1293,7 +1300,7 @@ export class HarnessLibSQL extends HarnessStorage {
       if (isUniqueConstraintError(err)) {
         const current = await loadCurrent();
         if (current && sameMessageEvidenceIdentity(current as AgentSignalResultEvidence, namespacedRecord)) {
-          return { created: false };
+          return { created: false, evidence: current };
         }
         throw new HarnessStorageAdmissionConflictError(
           namespacedRecord.sessionId,


### PR DESCRIPTION
## Summary
- Fixes PF-514.
- Return inline duplicate message result evidence from HarnessStorage writeMessageResultEvidence when exact admissions lose the create race.
- Use the returned evidence in Session.message reservation collisions, with a fallback duplicate lookup for legacy/custom adapters before surfacing an admission conflict.
- Cover in-memory/session replay behavior and LibSQL duplicate evidence returns, plus patch changesets for @mastra/core and @mastra/libsql.

## Validation
- pnpm --filter ./packages/core exec vitest run src/harness/v1/session.message.test.ts
- pnpm --filter ./stores/libsql exec vitest run src/storage/domains/harness/index.test.ts
- pnpm --filter ./packages/core check
- pnpm --filter ./stores/libsql exec tsc --noEmit
- git -C /tmp/mastra-fork-pf-514 diff --check
- Two local Codex review passes: no findings
- coderabbit review --plain: no findings

## Coordination
- Linear PF-514 claimed by dev1/Codex.
- Rechecked origin/main at 109c3330b2412b34f5127ea2f68bf1de6004620c before push.
- Open PR overlap reviewed: #115/PF-542 touches agent-network files only; #69/#68/#58 remain stale/unrelated to this harness message evidence path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When two identical message requests race to be written at the same time, the system now hands the loser the result that the winner already stored so the duplicate gets the same answer without re-running the agent.

## Summary

This PR fixes PF-514 by returning duplicate admission evidence inline from storage when a message write loses the create race, and by having Session.message consume that returned evidence to replay the duplicate instead of re-invoking the agent or doing an extra lookup. If no evidence is returned, Session.message falls back to legacy/custom duplicate resolution and otherwise surfaces a HarnessAdmissionConflictError.

## Key Changes

- Storage contract
  - Added WriteMessageResultEvidenceResult: { created: boolean; evidence?: AgentSignalResultEvidence }.
  - Updated HarnessStorage.writeMessageResultEvidence signature to return the richer result.
  - InMemory and LibSQL adapters updated to return evidence when a write did not create (including terminal or overwritten records, and on unique-constraint conflicts, re-reading and returning current evidence).

- Session admission flow
  - Session.message now uses evidence returned by writeMessageResultEvidence when a reservation write indicates the message wasn't created, avoiding a separate duplicate resolution and preventing duplicate agent executions.
  - In-flight admission coordination updated so deferred in-flight values can carry resolved duplicate evidence for subsequent callers to replay.
  - If no evidence is present, Session.message falls back to _resolveMessageAdmissionDuplicate for legacy/custom adapters; if duplicate resolution yields nothing, the reservation is rejected with HarnessAdmissionConflictError.

- Tests & validation
  - Added a session.message.test that simulates an exact admission race and verifies the duplicate call replays stored evidence and does not call the agent again.
  - Updated LibSQL harness tests to assert that writeMessageResultEvidence returning created: false also returns the evidence payload.
  - Type checks and targeted unit tests reported passing in the author's validation steps.

## Changeset

- Bumped `@mastra/core` and `@mastra/libsql` patch versions with a note: "Fixed duplicate message admission retries to reuse existing evidence, preventing duplicate processing during race conditions."

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->