### PR TITLE
[PF-535] Document Cloudflare KV resource binding readiness

### DIFF
--- a/.changeset/pf-535-cloudflare-kv-resource-readiness.md
+++ b/.changeset/pf-535-cloudflare-kv-resource-readiness.md
@@ -2,4 +2,5 @@
 "@mastra/cloudflare": patch
 ---
 
-Document the required Cloudflare Workers KV bindings, including `mastra_resources`, and clarify that Harness attachment primitive/element metadata is separate from R2-compatible object storage for attachment bytes.
+Added documentation for required Cloudflare Workers KV bindings, including `mastra_resources`.
+Clarified that attachment metadata is stored separately from object storage bytes.

--- a/.changeset/pf-535-cloudflare-kv-resource-readiness.md
+++ b/.changeset/pf-535-cloudflare-kv-resource-readiness.md
@@ -1,0 +1,5 @@
+---
+"@mastra/cloudflare": patch
+---
+
+Document the required Cloudflare Workers KV bindings, including `mastra_resources`, and clarify that Harness attachment primitive/element metadata is separate from R2-compatible object storage for attachment bytes.

--- a/docs/src/content/en/reference/storage/cloudflare.mdx
+++ b/docs/src/content/en/reference/storage/cloudflare.mdx
@@ -37,9 +37,12 @@ import { CloudflareKVStorage } from '@mastra/cloudflare/kv'
 const storageWorkers = new CloudflareKVStorage({
   id: 'cloudflare-workers-storage',
   bindings: {
-    threads: THREADS_KV, // KVNamespace binding for threads table
-    messages: MESSAGES_KV, // KVNamespace binding for messages table
-    // Add other tables as needed
+    mastra_threads: THREADS_KV,
+    mastra_messages: MESSAGES_KV,
+    mastra_resources: RESOURCES_KV,
+    mastra_workflow_snapshot: WORKFLOW_KV,
+    mastra_scorers: SCORERS_KV,
+    mastra_background_tasks: BACKGROUND_TASKS_KV,
   },
   keyPrefix: 'dev_', // Optional: isolate keys per environment
 })
@@ -66,7 +69,8 @@ const storageRest = new CloudflareKVStorage({
   {
     name: 'bindings',
     type: 'Record<string, KVNamespace>',
-    description: 'Cloudflare Workers KV bindings (for Workers runtime)',
+    description:
+      'Cloudflare Workers KV bindings. Workers deployments must provide mastra_threads, mastra_messages, mastra_resources, mastra_workflow_snapshot, mastra_scorers, and mastra_background_tasks.',
     isOptional: true,
   },
   {
@@ -100,11 +104,16 @@ const storageRest = new CloudflareKVStorage({
 
 ### Schema Management
 
-The storage implementation handles schema creation and updates automatically. It creates the following tables:
+Workers deployments must bind KV namespaces for the following runtime tables:
 
-- `threads`: Stores conversation threads
-- `messages`: Stores individual messages
-- `metadata`: Stores additional metadata for threads and messages
+- `mastra_threads`: Stores conversation threads
+- `mastra_messages`: Stores individual messages
+- `mastra_resources`: Stores resource records and working memory
+- `mastra_workflow_snapshot`: Stores workflow run state
+- `mastra_scorers`: Stores scorer/evaluation rows
+- `mastra_background_tasks`: Stores background task rows
+
+These bindings support the current Cloudflare KV memory, workflow, scoring, and background task domains. `CloudflareKVStorage` does not currently implement the Harness attachment storage domain or R2 byte storage. Harness attachment primitives/elements are separate from the memory `mastra_resources` namespace; a Harness attachment storage implementation should keep metadata in its attachment table family and use an R2-compatible object store for attachment bytes when object-backed attachments are enabled.
 
 ### Consistency & Propagation
 
@@ -112,7 +121,7 @@ Cloudflare KV is an eventually consistent store, meaning that data may not be im
 
 ### Key Structure & Namespacing
 
-Keys in Cloudflare KV are structured as a combination of a configurable prefix and a table-specific format (e.g., `threads:threadId`).
+Keys in Cloudflare KV are structured as a combination of a configurable prefix and a table-specific format (for example, `mastra_threads:threadId`).
 For Workers deployments, `keyPrefix` is used to isolate data within a namespace; for REST API deployments, `namespacePrefix` is used to isolate entire namespaces between environments or applications.
 
 ## Cloudflare Durable Objects Storage
@@ -181,11 +190,14 @@ Durable Objects storage uses SQLite under the hood, enabling efficient queries, 
 
 ## Schema Management
 
-Both storage implementations handle schema creation and updates automatically. They create the following tables:
+Both storage implementations handle schema creation and updates automatically. KV Workers deployments require these bindings:
 
-- `threads`: Stores conversation threads
-- `messages`: Stores individual messages
-- `workflow_snapshot`: Stores workflow run state
+- `mastra_threads`: Stores conversation threads
+- `mastra_messages`: Stores individual messages
+- `mastra_resources`: Stores resource records and working memory
+- `mastra_workflow_snapshot`: Stores workflow run state
+- `mastra_scorers`: Stores scorer/evaluation rows
+- `mastra_background_tasks`: Stores background task rows
 
 ## Deprecated Aliases
 

--- a/stores/cloudflare/README.md
+++ b/stores/cloudflare/README.md
@@ -1,6 +1,6 @@
 # @mastra/cloudflare
 
-Cloudflare KV store for Mastra, providing scalable and serverless storage for threads, messages, workflow snapshots, and evaluations. Supports both Cloudflare Workers KV Bindings and the REST API for flexible deployment in serverless and Node.js environments.
+Cloudflare KV store for Mastra, providing scalable and serverless storage for memory resources, threads, messages, workflow snapshots, scoring rows, and background tasks. Supports both Cloudflare Workers KV Bindings and the REST API for flexible deployment in serverless and Node.js environments.
 
 ## Installation
 
@@ -17,44 +17,59 @@ npm install @mastra/cloudflare
 ## Usage
 
 ```typescript
-import { CloudflareStore } from '@mastra/cloudflare';
+import { CloudflareKVStorage } from '@mastra/cloudflare';
 
 // Using Workers Binding API
-const store = new CloudflareStore({
+const store = new CloudflareKVStorage({
+  id: 'cloudflare-workers-storage',
   bindings: {
-    threads: THREADS_KV_NAMESPACE,
-    messages: MESSAGES_KV_NAMESPACE,
-    workflow_snapshot: WORKFLOW_KV_NAMESPACE,
-    traces: TRACES_KV_NAMESPACE,
+    mastra_threads: THREADS_KV_NAMESPACE,
+    mastra_messages: MESSAGES_KV_NAMESPACE,
+    mastra_resources: RESOURCES_KV_NAMESPACE,
+    mastra_workflow_snapshot: WORKFLOW_KV_NAMESPACE,
+    mastra_scorers: SCORERS_KV_NAMESPACE,
+    mastra_background_tasks: BACKGROUND_TASKS_KV_NAMESPACE,
   },
   keyPrefix: 'myapp_', // Optional
 });
 
 // Or using REST API
-const store = new CloudflareStore({
+const store = new CloudflareKVStorage({
+  id: 'cloudflare-rest-storage',
   accountId: process.env.CLOUDFLARE_ACCOUNT_ID!,
   apiToken: process.env.CLOUDFLARE_API_TOKEN!,
   namespacePrefix: 'myapp_', // Optional
 });
 
+const memory = await store.getStore('memory');
+if (!memory) {
+  throw new Error('Cloudflare memory storage is not configured');
+}
+
 // Save a thread
-await store.saveThread({
+await memory.saveThread({
   thread: {
     id: 'thread-123',
     resourceId: 'resource-456',
     title: 'My Thread',
     metadata: { key: 'value' },
     createdAt: new Date(),
+    updatedAt: new Date(),
   },
 });
 
 // Add messages
-await store.saveMessages({
+await memory.saveMessages({
   messages: [
     {
       id: 'msg-1',
       threadId: 'thread-123',
-      content: 'Hello Cloudflare!',
+      resourceId: 'resource-456',
+      content: {
+        format: 2,
+        parts: [{ type: 'text', text: 'Hello Cloudflare!' }],
+        content: 'Hello Cloudflare!',
+      },
       role: 'user',
       createdAt: new Date(),
     },
@@ -62,7 +77,7 @@ await store.saveMessages({
 });
 
 // Query messages
-const messages = await store.listMessages({ threadId: 'thread-123' });
+const messages = await memory.listMessages({ threadId: 'thread-123' });
 ```
 
 ## Configuration
@@ -70,6 +85,7 @@ const messages = await store.listMessages({ threadId: 'thread-123' });
 - **Workers API**: Use the `bindings` option to pass KV namespaces directly (for Cloudflare Workers).
 - **REST API**: Use `accountId`, `apiToken`, and (optionally) `namespacePrefix` for server-side usage.
 - `keyPrefix`/`namespacePrefix`: Useful for isolating environments (e.g., dev/test/prod).
+- `CloudflareStore` remains available as a deprecated alias for `CloudflareKVStorage`.
 
 ## Features
 
@@ -79,7 +95,7 @@ const messages = await store.listMessages({ threadId: 'thread-123' });
 - Rich metadata support (JSON-encoded)
 - Timestamp tracking for all records
 - Workflow snapshot persistence
-- Trace and evaluation storage
+- Scoring storage
 - Sorted message order using simulated sorted sets
 - Supports both Cloudflare Workers KV Bindings and REST API
 - Automatic JSON serialization/deserialization for metadata and custom fields
@@ -161,12 +177,21 @@ All records are stored as JSON in KV, with automatic serialization/deserializati
 Example:
 
 ```typescript
-const store = new CloudflareStore({
-  bindings: { ... }, // for Workers
+const store = new CloudflareKVStorage({
+  id: 'cloudflare-workers-storage',
+  bindings: {
+    mastra_threads: THREADS_KV_NAMESPACE,
+    mastra_messages: MESSAGES_KV_NAMESPACE,
+    mastra_resources: RESOURCES_KV_NAMESPACE,
+    mastra_workflow_snapshot: WORKFLOW_KV_NAMESPACE,
+    mastra_scorers: SCORERS_KV_NAMESPACE,
+    mastra_background_tasks: BACKGROUND_TASKS_KV_NAMESPACE,
+  },
   keyPrefix: 'dev_',
 });
 // or
-const store = new CloudflareStore({
+const store = new CloudflareKVStorage({
+  id: 'cloudflare-rest-storage',
   accountId: '...',
   apiToken: '...',
   namespacePrefix: 'prod_',
@@ -175,7 +200,11 @@ const store = new CloudflareStore({
 
 ## Table/Namespace Mapping
 
-Each logical Mastra table (threads, messages, workflow_snapshot, evals, traces) maps to a separate KV namespace. Keys are structured as `${prefix}${tableName}:${primaryKey}` or `${prefix}${tableName}:${threadId}:${messageId}` for messages. The prefix is set by `keyPrefix`/`namespacePrefix`.
+Workers Binding API deployments must provide KV namespaces for the required runtime tables: `mastra_threads`, `mastra_messages`, `mastra_resources`, `mastra_workflow_snapshot`, `mastra_scorers`, and `mastra_background_tasks`. These bindings support the current Cloudflare KV memory, workflow, scoring, and background task domains.
+
+`CloudflareKVStorage` does not currently implement the Harness attachment storage domain or R2 byte storage. Harness attachment primitives/elements are separate from the memory `mastra_resources` namespace; a Harness attachment storage implementation should keep metadata in its attachment table family and use Cloudflare R2-compatible object storage for attachment bytes when object-backed attachments are enabled.
+
+Each logical Mastra table maps to a separate KV namespace. Keys are structured as `${prefix}${tableName}:${primaryKey}` or `${prefix}${tableName}:${threadId}:${messageId}` for messages. The prefix is set by `keyPrefix`/`namespacePrefix`.
 
 ## Limitations
 
@@ -190,7 +219,7 @@ Each logical Mastra table (threads, messages, workflow_snapshot, evals, traces) 
 - **Workers Binding API** is recommended for production Workers deployments (low-latency, no API token required at runtime).
 - **REST API** is ideal for server-side Node.js or test environments.
 - Ensure your KV namespaces are provisioned and accessible by your Worker or API token.
-- Namespaces and keys are automatically created as needed.
+- REST namespaces and keys are automatically created as needed; Workers deployments must bind the required KV namespaces before startup.
 
 ## Cleanup/Disconnect
 

--- a/stores/cloudflare/src/kv/index.ts
+++ b/stores/cloudflare/src/kv/index.ts
@@ -9,7 +9,7 @@ import {
   TABLE_WORKFLOW_SNAPSHOT,
   TABLE_SCORERS,
 } from '@mastra/core/storage';
-import type { TABLE_NAMES, StorageDomains } from '@mastra/core/storage';
+import type { StorageDomains } from '@mastra/core/storage';
 import Cloudflare from 'cloudflare';
 import { BackgroundTasksStorageCloudflare } from './storage/domains/background-tasks';
 import { MemoryStorageCloudflare } from './storage/domains/memory';

--- a/stores/cloudflare/src/kv/storage/binding-api.test.ts
+++ b/stores/cloudflare/src/kv/storage/binding-api.test.ts
@@ -79,6 +79,22 @@ const TEST_CONFIG: CloudflareWorkersConfig = {
   keyPrefix: 'mastra-test',
 };
 
+const requiredBindingTables = [
+  TABLE_THREADS,
+  TABLE_MESSAGES,
+  TABLE_RESOURCES,
+  TABLE_WORKFLOW_SNAPSHOT,
+  TABLE_SCORERS,
+  TABLE_BACKGROUND_TASKS,
+] as const;
+
+const bindingsWithout = (missingTable: (typeof requiredBindingTables)[number]) =>
+  Object.fromEntries(
+    requiredBindingTables
+      .filter(table => table !== missingTable)
+      .map(table => [table, kvBindings[table]]),
+  );
+
 createTestSuite(new CloudflareStore(TEST_CONFIG));
 
 // Pre-configured client acceptance tests (using bindings)
@@ -136,11 +152,11 @@ createConfigValidationTests({
     { description: 'disableInit with bindings', config: { id: 'test-store', bindings: kvBindings, disableInit: true } },
   ],
   invalidConfigs: [
-    {
-      description: 'bindings missing required tables',
-      config: { id: 'test-store', bindings: { [TABLE_THREADS]: kvBindings[TABLE_THREADS] } },
-      expectedError: /Missing KV binding/,
-    },
+    ...requiredBindingTables.map(table => ({
+      description: `bindings missing required ${table} table`,
+      config: { id: 'test-store', bindings: bindingsWithout(table) },
+      expectedError: new RegExp(`Missing KV binding for table: ${table}`),
+    })),
     {
       description: 'empty accountId in REST API config',
       config: { id: 'test-store', accountId: '', apiToken: 'test-token' },


### PR DESCRIPTION
## Linear

Fixes PF-535.

## Summary

- Document the exact required Cloudflare Workers KV bindings for the current KV domains, including `mastra_resources` and `mastra_background_tasks`.
- Add config-validation coverage that omits each required binding one at a time and asserts the exact missing-table error.
- Refresh Cloudflare README/reference examples to use `CloudflareKVStorage`, required `id`, domain access via `getStore('memory')`, and current v2 message/thread shapes.
- Clarify that Harness attachment primitives/elements are separate from memory `mastra_resources`, and that current `CloudflareKVStorage` does not implement Harness attachment storage or R2 byte storage.
- Remove an unused Cloudflare KV type import that blocked package lint.

## Scope and safety

- No production Cloudflare, R2 bucket, secret, deploy, Docker, signing, or release action changes.
- This is readiness/docs/test cleanup only; it does not implement Harness storage, server routes, channels, wakeups, or attachment provider behavior.
- Open PR overlap checked before implementation: #116/PF-514, #115/PF-542, #69, #68, and #58 do not touch `stores/cloudflare` or this docs surface.

## Validation

- `git diff --check`
- `pnpm --filter ./stores/cloudflare lint`
- `pnpm --filter ./stores/cloudflare build:lib`
- `pnpm --filter @mastra/cloudflare exec tsc --noEmit`
- `pnpm --dir docs exec remark --no-stdout --frail --quiet --ext mdx src/content/en/reference/storage/cloudflare.mdx`
- `pnpm --filter ./stores/cloudflare exec vitest run src/kv/storage/binding-api.test.ts` (289 passed, 243 skipped)
- Final local Codex review pass 1: no findings
- Final local Codex review pass 2: no findings
- CodeRabbit CLI local review: no findings
- Claude council review before patching: no blockers; valid docs/test wording feedback applied


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR is a clear setup guide and safety check for Cloudflare KV storage: it documents exactly which KV namespaces must be bound, updates examples to match current usage, and adds tests that fail if any required binding is missing.

---

## Summary

### Documentation and Examples
- Documents required Workers KV binding namespaces: mastra_threads, mastra_messages, mastra_resources, mastra_workflow_snapshot, mastra_scorers, and mastra_background_tasks.
- Refreshes Cloudflare README and reference docs to:
  - Use CloudflareKVStorage (with CloudflareStore noted as a deprecated alias).
  - Require an id in examples and show domain access via store.getStore('memory').
  - Reflect current v2 thread/message shapes (e.g., thread.updatedAt, structured content with format/parts).
  - Clarify that Harness attachment primitives/elements are separate from memory mastra_resources and that CloudflareKVStorage does not implement Harness attachment storage or R2 byte storage.
  - Explain KV table↔namespace mapping and note Workers deployments must pre-bind KV namespaces (REST namespaces/keys auto-create).

### Testing
- Adds config-validation tests that derive requiredBindingTables and automatically generate one failing test per required table, asserting initialization errors match: Missing KV binding for table: ${table}.

### Code Changes
- Removes an unused TABLE_NAMES type import from stores/cloudflare/src/kv/index.ts (resolved a lint blockage).
- Adds a changeset documenting the required KV bindings and clarifying Harness/R2 limitations.

### Scope & Safety
- Docs/tests/readiness-only: no changes to production Cloudflare, R2 buckets, secrets, deploys, or runtime behavior (no implementation of Harness storage, server routes, channels, wakeups, or attachment provider behavior).
- Overlap with other open PRs was checked; none touch stores/cloudflare or the docs surface.

### Validation Performed
- lint/build/tsc for stores/cloudflare; remark lint for docs; vitest run for src/kv/storage/binding-api.test.ts (tests executed: 289 passed, 243 skipped); git diff --check and local reviews.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->