### PR TITLE
[PF-360] Harden Harness route auth boundary

### DIFF
--- a/.changeset/eager-buckets-find.md
+++ b/.changeset/eager-buckets-find.md
@@ -1,0 +1,8 @@
+---
+'@mastra/express': patch
+'@mastra/fastify': patch
+'@mastra/hono': patch
+'@mastra/koa': patch
+---
+
+Fixed HTTP request logs to redact sensitive query parameters like tokens and API keys, preventing credential exposure in server logs.

--- a/.changeset/pf-360-harness-auth.md
+++ b/.changeset/pf-360-harness-auth.md
@@ -2,4 +2,6 @@
 '@mastra/server': patch
 ---
 
-Improved Harness route authentication security. Harness routes now require configured authentication, reject access tokens passed in URL query parameters, and keep event subscription tokens out of shared request state. Move clients that send access tokens in query parameters to `Authorization` headers.
+Improved Harness route authentication security. Client-facing `/harness` routes now require configured authentication, reject access tokens passed in URL query parameters, and keep event subscription tokens out of shared request state.
+
+Migration required: Move clients that send access tokens in query parameters to `Authorization` headers for all `/harness` routes.

--- a/.changeset/pf-360-harness-auth.md
+++ b/.changeset/pf-360-harness-auth.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Improved Harness route authentication security. Harness routes now require configured authentication, reject access tokens passed in URL query parameters, and keep event subscription tokens out of shared request state. Move clients that send access tokens in query parameters to `Authorization` headers.

--- a/packages/server/src/server/auth/helpers.test.ts
+++ b/packages/server/src/server/auth/helpers.test.ts
@@ -3,11 +3,16 @@ import type { MastraAuthConfig } from '@mastra/core/server';
 import { describe, expect, it } from 'vitest';
 
 import {
+  allowsHarnessSseSubscriptionToken,
   canAccessPublicly,
   checkRules,
+  findBearerEquivalentHarnessQueryParam,
+  getHarnessSseSubscriptionTokenQueryParam,
+  hasHarnessSseSubscriptionToken,
   coreAuthMiddleware,
   isCustomRoutePublic,
   isDevPlaygroundRequest,
+  isHarnessClientRoute,
   isProtectedCustomRoute,
   isProtectedPath,
   matchesOrIncludes,
@@ -17,6 +22,45 @@ import {
 } from './helpers';
 
 describe('auth helpers', () => {
+  describe('Harness route auth helpers', () => {
+    function getQuery(params: Record<string, unknown>) {
+      return (name: string) => params[name];
+    }
+
+    it('detects built-in Harness route paths as client routes', () => {
+      expect(isHarnessClientRoute({ path: '/harness/:harnessName/sessions' })).toBe(true);
+      expect(isHarnessClientRoute({ path: '/agents/:agentId' })).toBe(false);
+    });
+
+    it('allows route metadata to mark future mounted Harness routes', () => {
+      expect(isHarnessClientRoute({ path: '/events', harnessAuth: { clientRoute: true } })).toBe(true);
+    });
+
+    it('finds bearer-equivalent query credentials for Harness rejection', () => {
+      expect(findBearerEquivalentHarnessQueryParam(getQuery({ apiKey: 'secret' }))).toBe('apiKey');
+      expect(findBearerEquivalentHarnessQueryParam(getQuery({ access_token: 'secret' }))).toBe('access_token');
+      expect(findBearerEquivalentHarnessQueryParam(getQuery({ token: [' ', 'secret'] }))).toBe('token');
+      expect(findBearerEquivalentHarnessQueryParam(getQuery({ apiKey: { nested: 'secret' } }))).toBeNull();
+      expect(findBearerEquivalentHarnessQueryParam(getQuery({ subscriptionToken: 'scoped' }))).toBeNull();
+    });
+
+    it('keeps the scoped SSE token on the session events route or explicit metadata', () => {
+      const route = { path: '/harness/:harnessName/sessions/:sessionId/events' };
+      expect(getHarnessSseSubscriptionTokenQueryParam(route)).toBe('subscriptionToken');
+      expect(hasHarnessSseSubscriptionToken(route, getQuery({ subscriptionToken: 'scoped' }))).toBe(true);
+      expect(allowsHarnessSseSubscriptionToken(route)).toBe(true);
+      expect(allowsHarnessSseSubscriptionToken({ path: '/harness/:name/sessions/:sessionId/events' })).toBe(true);
+      expect(allowsHarnessSseSubscriptionToken({ path: '/harness/:harnessName/sessions/:sessionId' })).toBe(false);
+
+      expect(
+        allowsHarnessSseSubscriptionToken({
+          path: '/future-harness-events',
+          harnessAuth: { allowSseSubscriptionToken: true },
+        }),
+      ).toBe(true);
+    });
+  });
+
   describe('pathMatchesPattern', () => {
     it('should match exact paths', () => {
       expect(pathMatchesPattern('/api/users', '/api/users')).toBe(true);
@@ -614,6 +658,25 @@ describe('auth helpers', () => {
 
       expect(requestContext.get(MASTRA_RESOURCE_ID_KEY)).toBe('org-456:user-123');
     });
+
+    it('should prefer the auth-derived resource ID over caller-supplied context', async () => {
+      const requestContext = createRequestContext();
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'caller-resource');
+
+      await coreAuthMiddleware({
+        ...baseCtx,
+        mastra: createMockMastra(),
+        authConfig: {
+          protected: ['/api/*'],
+          authenticateToken: async () => ({ id: 'user-123' }),
+          mapUserToResourceId: () => 'auth-resource',
+        },
+        requestContext,
+      });
+
+      expect(requestContext.get(MASTRA_RESOURCE_ID_KEY)).toBe('auth-resource');
+    });
+
     it('should not set resource ID when mapUserToResourceId returns null', async () => {
       const requestContext = createRequestContext();
 

--- a/packages/server/src/server/auth/helpers.test.ts
+++ b/packages/server/src/server/auth/helpers.test.ts
@@ -39,6 +39,8 @@ describe('auth helpers', () => {
     it('finds bearer-equivalent query credentials for Harness rejection', () => {
       expect(findBearerEquivalentHarnessQueryParam(getQuery({ apiKey: 'secret' }))).toBe('apiKey');
       expect(findBearerEquivalentHarnessQueryParam(getQuery({ access_token: 'secret' }))).toBe('access_token');
+      expect(findBearerEquivalentHarnessQueryParam(getQuery({ apikey: 'secret' }))).toBe('apikey');
+      expect(findBearerEquivalentHarnessQueryParam(getQuery({ authtoken: 'secret' }))).toBe('authtoken');
       expect(findBearerEquivalentHarnessQueryParam(getQuery({ token: [' ', 'secret'] }))).toBe('token');
       expect(findBearerEquivalentHarnessQueryParam(getQuery({ apiKey: { nested: 'secret' } }))).toBeNull();
       expect(findBearerEquivalentHarnessQueryParam(getQuery({ subscriptionToken: 'scoped' }))).toBeNull();

--- a/packages/server/src/server/auth/helpers.ts
+++ b/packages/server/src/server/auth/helpers.ts
@@ -13,7 +13,7 @@ export const HARNESS_SSE_SUBSCRIPTION_TOKEN_QUERY_PARAM = 'subscriptionToken';
 const HARNESS_ROUTE_PREFIX = '/harness/';
 const HARNESS_SESSION_EVENTS_ROUTE_PATTERN = /^\/harness\/:[^/]+\/sessions\/:sessionId\/events$/;
 
-const BEARER_EQUIVALENT_QUERY_PARAMS = [
+const BEARER_EQUIVALENT_QUERY_PARAM_NAMES = [
   'apiKey',
   'access_token',
   'accessToken',
@@ -63,7 +63,13 @@ export function isHarnessClientRoute(route: HarnessRouteAuthShape): boolean {
 }
 
 export function findBearerEquivalentHarnessQueryParam(getQuery: (name: string) => unknown): string | null {
-  for (const name of BEARER_EQUIVALENT_QUERY_PARAMS) {
+  const names = new Set<string>();
+  for (const name of BEARER_EQUIVALENT_QUERY_PARAM_NAMES) {
+    names.add(name);
+    names.add(name.toLowerCase());
+  }
+
+  for (const name of names) {
     if (getQueryValue(getQuery, name)) {
       return name;
     }

--- a/packages/server/src/server/auth/helpers.ts
+++ b/packages/server/src/server/auth/helpers.ts
@@ -8,6 +8,88 @@ import { MASTRA_RESOURCE_ID_KEY, MASTRA_AUTH_TOKEN_KEY } from '../constants';
 import { defaultAuthConfig } from './defaults';
 import { parse } from './path-pattern';
 
+export const HARNESS_SSE_SUBSCRIPTION_TOKEN_QUERY_PARAM = 'subscriptionToken';
+
+const HARNESS_ROUTE_PREFIX = '/harness/';
+const HARNESS_SESSION_EVENTS_ROUTE_PATTERN = /^\/harness\/:[^/]+\/sessions\/:sessionId\/events$/;
+
+const BEARER_EQUIVALENT_QUERY_PARAMS = [
+  'apiKey',
+  'access_token',
+  'accessToken',
+  'authToken',
+  'authorization',
+  'bearer',
+  'token',
+] as const;
+
+export interface HarnessRouteAuthConfig {
+  /**
+   * Marks a route as part of the client-facing Harness wire surface. Routes
+   * whose path starts with `/harness/` are treated as client routes even when
+   * this flag is omitted.
+   */
+  clientRoute?: boolean;
+  /**
+   * Allows the EventSource fallback token only for the per-session events SSE
+   * route. The token remains in the raw request for the deployment auth
+   * provider to validate and is never copied into MASTRA_AUTH_TOKEN_KEY.
+   */
+  allowSseSubscriptionToken?: boolean;
+}
+
+export interface HarnessRouteAuthShape {
+  path?: string;
+  harnessAuth?: HarnessRouteAuthConfig;
+}
+
+function getQueryValue(getQuery: (name: string) => unknown, name: string): string | undefined {
+  const value = getQuery(name);
+  if (typeof value === 'string') {
+    return value.trim() ? value : undefined;
+  }
+  if (Array.isArray(value)) {
+    return value.find((item): item is string => typeof item === 'string' && item.trim().length > 0);
+  }
+  return undefined;
+}
+
+export function isHarnessClientRoute(route: HarnessRouteAuthShape): boolean {
+  if (route.harnessAuth?.clientRoute === true) {
+    return true;
+  }
+
+  return typeof route.path === 'string' && route.path.startsWith(HARNESS_ROUTE_PREFIX);
+}
+
+export function findBearerEquivalentHarnessQueryParam(getQuery: (name: string) => unknown): string | null {
+  for (const name of BEARER_EQUIVALENT_QUERY_PARAMS) {
+    if (getQueryValue(getQuery, name)) {
+      return name;
+    }
+  }
+
+  return null;
+}
+
+export function getHarnessSseSubscriptionTokenQueryParam(_route: HarnessRouteAuthShape): string {
+  return HARNESS_SSE_SUBSCRIPTION_TOKEN_QUERY_PARAM;
+}
+
+export function hasHarnessSseSubscriptionToken(
+  route: HarnessRouteAuthShape,
+  getQuery: (name: string) => unknown,
+): boolean {
+  return Boolean(getQueryValue(getQuery, getHarnessSseSubscriptionTokenQueryParam(route)));
+}
+
+export function allowsHarnessSseSubscriptionToken(route: HarnessRouteAuthShape): boolean {
+  return (
+    route.harnessAuth?.allowSseSubscriptionToken === true ||
+    (typeof route.path === 'string' && HARNESS_SESSION_EVENTS_ROUTE_PATTERN.test(route.path))
+  );
+}
+
 /**
  * Check if a route is a registered custom route that requires authentication.
  * Returns true only if the route is explicitly registered with requiresAuth: true.
@@ -268,6 +350,7 @@ export interface AuthMiddlewareContext {
   requestContext: { get: (key: string) => unknown; set: (key: string, value: unknown) => void };
   rawRequest: unknown;
   token: string | null;
+  forceAuth?: boolean;
   buildAuthorizeContext: () => unknown;
 }
 
@@ -321,7 +404,18 @@ export function supportsSessionRefresh(
  * Skip checks (dev playground, unprotected path, public path) are evaluated once.
  */
 export const coreAuthMiddleware = async (ctx: AuthMiddlewareContext): Promise<AuthResult> => {
-  const { path, method, getHeader, mastra, authConfig, customRouteAuthConfig, requestContext, rawRequest, token } = ctx;
+  const {
+    path,
+    method,
+    getHeader,
+    mastra,
+    authConfig,
+    customRouteAuthConfig,
+    requestContext,
+    rawRequest,
+    token,
+    forceAuth,
+  } = ctx;
 
   // ── Skip checks (evaluated once) ──
 
@@ -329,15 +423,15 @@ export const coreAuthMiddleware = async (ctx: AuthMiddlewareContext): Promise<Au
   // When auth IS configured (has authenticateToken), we need the full auth flow
   // so user/roles/permissions are set in requestContext.
   const hasAuthProvider = typeof authConfig.authenticateToken === 'function';
-  if (!hasAuthProvider && isDevPlaygroundRequest(path, method, getHeader, authConfig, customRouteAuthConfig)) {
+  if (!forceAuth && !hasAuthProvider && isDevPlaygroundRequest(path, method, getHeader, authConfig, customRouteAuthConfig)) {
     return pass;
   }
 
-  if (!isProtectedPath(path, method, authConfig, customRouteAuthConfig)) {
+  if (!forceAuth && !isProtectedPath(path, method, authConfig, customRouteAuthConfig)) {
     return pass;
   }
 
-  if (canAccessPublicly(path, method, authConfig)) {
+  if (!forceAuth && canAccessPublicly(path, method, authConfig)) {
     return pass;
   }
 

--- a/packages/server/src/server/server-adapter/http-logging.test.ts
+++ b/packages/server/src/server/server-adapter/http-logging.test.ts
@@ -1,7 +1,7 @@
 import { Mastra } from '@mastra/core/mastra';
 import type { HttpLoggingConfig } from '@mastra/core/server';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { MastraServer } from './index';
+import { MastraServer, redactSensitiveQueryParams } from './index';
 
 // Mock server adapter for testing
 class TestMastraServer extends MastraServer<any, any, any> {
@@ -246,6 +246,24 @@ describe('HTTP Logging Configuration', () => {
       await adapter.init();
 
       expect(adapter.registerHttpLoggingMiddleware).toHaveBeenCalled();
+    });
+  });
+
+  describe('redactSensitiveQueryParams', () => {
+    it('redacts credential-like query params while preserving ordinary params', () => {
+      expect(
+        redactSensitiveQueryParams({
+          foo: 'bar',
+          subscriptionToken: 'scoped',
+          apiKey: 'secret',
+          access_token: 'secret',
+        }),
+      ).toEqual({
+        foo: 'bar',
+        subscriptionToken: '[REDACTED]',
+        apiKey: '[REDACTED]',
+        access_token: '[REDACTED]',
+      });
     });
   });
 });

--- a/packages/server/src/server/server-adapter/http-logging.test.ts
+++ b/packages/server/src/server/server-adapter/http-logging.test.ts
@@ -257,12 +257,18 @@ describe('HTTP Logging Configuration', () => {
           subscriptionToken: 'scoped',
           apiKey: 'secret',
           access_token: 'secret',
+          'apiKey[0]': 'secret',
+          'token.value': 'secret',
+          'access_token[1]': 'secret',
         }),
       ).toEqual({
         foo: 'bar',
         subscriptionToken: '[REDACTED]',
         apiKey: '[REDACTED]',
         access_token: '[REDACTED]',
+        'apiKey[0]': '[REDACTED]',
+        'token.value': '[REDACTED]',
+        'access_token[1]': '[REDACTED]',
       });
     });
   });

--- a/packages/server/src/server/server-adapter/index.test.ts
+++ b/packages/server/src/server/server-adapter/index.test.ts
@@ -3,7 +3,9 @@
  */
 import type { IFGAProvider } from '@mastra/core/auth/ee';
 import { Mastra } from '@mastra/core/mastra';
+import { RequestContext } from '@mastra/core/request-context';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MASTRA_AUTH_TOKEN_KEY, MASTRA_RESOURCE_ID_KEY } from '../constants';
 import { MastraServer } from './index';
 
 class TestMastraServer extends MastraServer<any, any, any> {
@@ -14,6 +16,10 @@ class TestMastraServer extends MastraServer<any, any, any> {
   registerContextMiddleware = vi.fn();
   registerAuthMiddleware = vi.fn();
   registerHttpLoggingMiddleware = vi.fn();
+
+  checkAuthForTest(route: any, context: any) {
+    return this.checkRouteAuth(route, context);
+  }
 }
 
 function createMockFGAProvider(authorized = true): IFGAProvider {
@@ -192,6 +198,267 @@ describe('FGA Middleware - checkRouteFGA', () => {
         context: { resourceId: 'tenant-1:resource-1', requestContext },
       },
     );
+  });
+});
+
+describe('Harness route auth boundary', () => {
+  function makeRoute(path: string, extra: Record<string, unknown> = {}) {
+    return {
+      method: 'GET',
+      path,
+      responseType: 'json',
+      handler: async () => ({}),
+      ...extra,
+    } as any;
+  }
+
+  function makeContext({
+    path,
+    query = {},
+    headers = {},
+    request = new Request(`http://localhost${path}`),
+    requestContext = new RequestContext(),
+  }: {
+    path: string;
+    query?: Record<string, unknown>;
+    headers?: Record<string, string | undefined>;
+    request?: Request;
+    requestContext?: RequestContext;
+  }) {
+    return {
+      path,
+      method: 'GET',
+      getHeader: (name: string) => headers[name.toLowerCase()],
+      getQuery: (name: string) => query[name],
+      requestContext,
+      request,
+      buildAuthorizeContext: () => null,
+    };
+  }
+
+  it('rejects bearer-equivalent query credentials on Harness routes before principal resolution', async () => {
+    const authenticateToken = vi.fn(async () => ({ id: 'user-1' }));
+    const mastra = new Mastra({
+      server: {
+        auth: {
+          protected: ['/api/*'],
+          authenticateToken,
+          mapUserToResourceId: () => 'resource-1',
+        },
+      },
+    });
+    const adapter = new TestMastraServer({ app: {}, mastra });
+    const requestContext = new RequestContext();
+
+    const result = await adapter.checkAuthForTest(
+      makeRoute('/harness/:harnessName/sessions'),
+      makeContext({
+        path: '/api/harness/default/sessions',
+        query: { apiKey: 'secret' },
+        requestContext,
+      }),
+    );
+
+    expect(result).toEqual({
+      status: 400,
+      error: 'Bearer-equivalent query credentials are not accepted on Harness routes: apiKey',
+    });
+    expect(authenticateToken).not.toHaveBeenCalled();
+    expect(requestContext.get(MASTRA_AUTH_TOKEN_KEY)).toBeUndefined();
+    expect(requestContext.get(MASTRA_RESOURCE_ID_KEY)).toBeUndefined();
+  });
+
+  it('rejects Harness query credentials even when an Authorization header is present', async () => {
+    const authenticateToken = vi.fn(async () => ({ id: 'user-1' }));
+    const mastra = new Mastra({
+      server: {
+        auth: {
+          protected: ['/api/*'],
+          authenticateToken,
+        },
+      },
+    });
+    const adapter = new TestMastraServer({ app: {}, mastra });
+
+    const result = await adapter.checkAuthForTest(
+      makeRoute('/harness/:harnessName/sessions'),
+      makeContext({
+        path: '/api/harness/default/sessions',
+        query: { apiKey: 'secret' },
+        headers: { authorization: 'Bearer header-secret' },
+      }),
+    );
+
+    expect(result).toEqual({
+      status: 400,
+      error: 'Bearer-equivalent query credentials are not accepted on Harness routes: apiKey',
+    });
+    expect(authenticateToken).not.toHaveBeenCalled();
+  });
+
+  it('forces auth for Harness routes outside the protected API prefix', async () => {
+    const authenticateToken = vi.fn(async (token: string) => (token === 'header-secret' ? { id: 'user-1' } : null));
+    const mastra = new Mastra({
+      server: {
+        auth: {
+          protected: ['/api/*'],
+          public: ['/harness/*'],
+          authenticateToken,
+          mapUserToResourceId: () => 'resource-1',
+        },
+      },
+    });
+    const adapter = new TestMastraServer({ app: {}, mastra });
+    const requestContext = new RequestContext();
+    const request = new Request('http://localhost/harness/default/sessions', {
+      headers: { authorization: 'Bearer header-secret' },
+    });
+
+    const result = await adapter.checkAuthForTest(
+      makeRoute('/harness/:harnessName/sessions'),
+      makeContext({
+        path: '/harness/default/sessions',
+        headers: { authorization: 'Bearer header-secret' },
+        request,
+        requestContext,
+      }),
+    );
+
+    expect(result).toBeNull();
+    expect(authenticateToken).toHaveBeenCalledWith('header-secret', request);
+    expect(requestContext.get(MASTRA_AUTH_TOKEN_KEY)).toBe('header-secret');
+    expect(requestContext.get(MASTRA_RESOURCE_ID_KEY)).toBe('resource-1');
+  });
+
+  it('preserves the legacy apiKey query fallback for non-Harness routes', async () => {
+    const authenticateToken = vi.fn(async (token: string) => (token === 'secret' ? { id: 'user-1' } : null));
+    const mastra = new Mastra({
+      server: {
+        auth: {
+          protected: ['/api/*'],
+          authenticateToken,
+          mapUserToResourceId: () => 'resource-1',
+        },
+      },
+    });
+    const adapter = new TestMastraServer({ app: {}, mastra });
+    const requestContext = new RequestContext();
+
+    const result = await adapter.checkAuthForTest(
+      makeRoute('/agents/:agentId'),
+      makeContext({
+        path: '/api/agents/agent-1',
+        query: { apiKey: 'secret' },
+        requestContext,
+      }),
+    );
+
+    expect(result).toBeNull();
+    expect(authenticateToken).toHaveBeenCalledWith('secret', expect.any(Request));
+    expect(requestContext.get(MASTRA_AUTH_TOKEN_KEY)).toBe('secret');
+    expect(requestContext.get(MASTRA_RESOURCE_ID_KEY)).toBe('resource-1');
+  });
+
+  it('allows scoped SSE subscription tokens only when route metadata opts in', async () => {
+    const authenticateToken = vi.fn(async (token: string, request: Request) => {
+      const url = new URL(request.url);
+      return !token && url.searchParams.get('subscriptionToken') === 'scoped' ? { id: 'user-1' } : null;
+    });
+    const mastra = new Mastra({
+      server: {
+        auth: {
+          protected: ['/api/*'],
+          authenticateToken,
+          mapUserToResourceId: () => 'resource-1',
+        },
+      },
+    });
+    const adapter = new TestMastraServer({ app: {}, mastra });
+    const requestContext = new RequestContext();
+    const request = new Request('http://localhost/api/harness/default/sessions/session-1/events?subscriptionToken=scoped');
+
+    const result = await adapter.checkAuthForTest(
+      makeRoute('/harness/:harnessName/sessions/:sessionId/events', {
+        harnessAuth: { allowSseSubscriptionToken: true },
+      }),
+      makeContext({
+        path: '/api/harness/default/sessions/session-1/events',
+        query: { subscriptionToken: 'scoped' },
+        request,
+        requestContext,
+      }),
+    );
+
+    expect(result).toBeNull();
+    expect(authenticateToken).toHaveBeenCalledWith('', request);
+    expect(requestContext.get(MASTRA_AUTH_TOKEN_KEY)).toBeUndefined();
+    expect(requestContext.get(MASTRA_RESOURCE_ID_KEY)).toBe('resource-1');
+  });
+
+  it('rejects scoped SSE subscription tokens on other Harness routes', async () => {
+    const authenticateToken = vi.fn(async () => ({ id: 'user-1' }));
+    const mastra = new Mastra({
+      server: {
+        auth: {
+          protected: ['/api/*'],
+          authenticateToken,
+        },
+      },
+    });
+    const adapter = new TestMastraServer({ app: {}, mastra });
+
+    const result = await adapter.checkAuthForTest(
+      makeRoute('/harness/:harnessName/sessions/:sessionId'),
+      makeContext({
+        path: '/api/harness/default/sessions/session-1',
+        query: { subscriptionToken: 'scoped' },
+      }),
+    );
+
+    expect(result).toEqual({
+      status: 400,
+      error: 'Scoped Harness SSE subscription tokens are only accepted on the session events route',
+    });
+    expect(authenticateToken).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when a Harness route has no server auth configuration', async () => {
+    const mastra = new Mastra({});
+    const adapter = new TestMastraServer({ app: {}, mastra });
+
+    const result = await adapter.checkAuthForTest(
+      makeRoute('/harness/:harnessName/sessions'),
+      makeContext({ path: '/api/harness/default/sessions' }),
+    );
+
+    expect(result).toEqual({
+      status: 500,
+      error: 'Harness routes require server auth configuration',
+    });
+  });
+
+  it('fails closed when a Harness route opts out of auth', async () => {
+    const authenticateToken = vi.fn(async () => ({ id: 'user-1' }));
+    const mastra = new Mastra({
+      server: {
+        auth: {
+          protected: ['/api/*'],
+          authenticateToken,
+        },
+      },
+    });
+    const adapter = new TestMastraServer({ app: {}, mastra });
+
+    const result = await adapter.checkAuthForTest(
+      makeRoute('/harness/:harnessName/sessions', { requiresAuth: false }),
+      makeContext({ path: '/api/harness/default/sessions' }),
+    );
+
+    expect(result).toEqual({
+      status: 500,
+      error: 'Harness routes require authentication',
+    });
+    expect(authenticateToken).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -10,7 +10,14 @@ import type { ZodError } from 'zod/v4';
 import { z } from 'zod/v4';
 
 import type { InMemoryTaskStore } from '../a2a/store';
-import { coreAuthMiddleware } from '../auth/helpers';
+import {
+  allowsHarnessSseSubscriptionToken,
+  coreAuthMiddleware,
+  findBearerEquivalentHarnessQueryParam,
+  HARNESS_SSE_SUBSCRIPTION_TOKEN_QUERY_PARAM,
+  hasHarnessSseSubscriptionToken,
+  isHarnessClientRoute,
+} from '../auth/helpers';
 import {
   MASTRA_CLIENT_TYPE_HEADER,
   MASTRA_IS_STUDIO_KEY,
@@ -98,6 +105,29 @@ export interface ParsedRequestParams {
   bodyParseError?: {
     message: string;
   };
+}
+
+const SENSITIVE_QUERY_PARAMS = new Set([
+  HARNESS_SSE_SUBSCRIPTION_TOKEN_QUERY_PARAM.toLowerCase(),
+  'access_token',
+  'accesstoken',
+  'apikey',
+  'authorization',
+  'authtoken',
+  'bearer',
+  'token',
+]);
+
+export function redactSensitiveQueryParams<T extends Record<string, unknown>>(queryParams: T): T {
+  const redacted: Record<string, unknown> = { ...queryParams };
+
+  for (const key of Object.keys(redacted)) {
+    if (SENSITIVE_QUERY_PARAMS.has(key.toLowerCase())) {
+      redacted[key] = '[REDACTED]';
+    }
+  }
+
+  return redacted as T;
 }
 
 function isAbortSignalError(error: unknown): boolean {
@@ -423,22 +453,56 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     },
   ): Promise<{ status: number; error: string; headers?: Record<string, string> } | null> {
     const authConfig = this.mastra.getServer()?.auth;
+    const harnessClientRoute = isHarnessClientRoute(route);
 
-    // No auth config means no auth required
+    if (harnessClientRoute) {
+      const queryCredential = findBearerEquivalentHarnessQueryParam(context.getQuery);
+      if (queryCredential) {
+        return {
+          status: 400,
+          error: `Bearer-equivalent query credentials are not accepted on Harness routes: ${queryCredential}`,
+        };
+      }
+
+      if (hasHarnessSseSubscriptionToken(route, context.getQuery) && !allowsHarnessSseSubscriptionToken(route)) {
+        return {
+          status: 400,
+          error: 'Scoped Harness SSE subscription tokens are only accepted on the session events route',
+        };
+      }
+
+      if (route.requiresAuth === false) {
+        return {
+          status: 500,
+          error: 'Harness routes require authentication',
+        };
+      }
+
+      if (!authConfig) {
+        return {
+          status: 500,
+          error: 'Harness routes require server auth configuration',
+        };
+      }
+    }
+
+    // No auth config means no auth required for legacy/non-Harness routes.
     if (!authConfig) {
       return null;
     }
 
-    // Check route-level requiresAuth flag first (explicit per-route setting)
-    // This opt-out is route-specific and not available in the global middleware
+    // Check route-level requiresAuth flag first (explicit per-route setting).
+    // This opt-out is route-specific and not available in the global middleware.
     if (route.requiresAuth === false) {
       return null;
     }
 
-    // Extract token from headers/query
+    // Extract token from headers/query. Harness routes intentionally skip the
+    // legacy apiKey query fallback; scoped SSE tokens stay in the raw request
+    // for route-scoped auth providers and are never forwarded as auth context.
     const authHeader = context.getHeader('authorization');
     let token: string | null = authHeader ? authHeader.replace('Bearer ', '') : null;
-    if (!token) {
+    if (!token && !harnessClientRoute) {
       token = context.getQuery('apiKey') || null;
     }
 
@@ -453,6 +517,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
       requestContext: context.requestContext,
       rawRequest: context.request,
       token,
+      forceAuth: harnessClientRoute,
       buildAuthorizeContext: context.buildAuthorizeContext ?? (() => null),
     });
 

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -118,11 +118,17 @@ const SENSITIVE_QUERY_PARAMS = new Set([
   'token',
 ]);
 
+function normalizeSensitiveQueryParamKey(key: string): string {
+  return key.toLowerCase().split('[')[0]?.split('.')[0] ?? key.toLowerCase();
+}
+
 export function redactSensitiveQueryParams<T extends Record<string, unknown>>(queryParams: T): T {
   const redacted: Record<string, unknown> = { ...queryParams };
 
   for (const key of Object.keys(redacted)) {
-    if (SENSITIVE_QUERY_PARAMS.has(key.toLowerCase())) {
+    const normalizedKey = key.toLowerCase();
+    const baseKey = normalizeSensitiveQueryParamKey(key);
+    if (SENSITIVE_QUERY_PARAMS.has(normalizedKey) || SENSITIVE_QUERY_PARAMS.has(baseKey)) {
       redacted[key] = '[REDACTED]';
     }
   }

--- a/packages/server/src/server/server-adapter/routes/index.ts
+++ b/packages/server/src/server/server-adapter/routes/index.ts
@@ -5,6 +5,7 @@ import type { RequestContext } from '@mastra/core/request-context';
 import type { ApiRoute, ValidationErrorHook } from '@mastra/core/server';
 import type * as z from 'zod/v4';
 import type { InMemoryTaskStore } from '../../a2a/store';
+import type { HarnessRouteAuthConfig } from '../../auth/helpers';
 import type { OpenAPIRoute } from '../openapi-utils';
 import { A2A_ROUTES } from './a2a';
 import type { AGENT_BUILDER_ROUTES } from './agent-builder';
@@ -154,6 +155,12 @@ export type ServerRoute<
       | ((params: Record<string, unknown>, context: { requestContext?: RequestContext }) => string | undefined);
     permission?: MastraFGAPermissionInput;
   };
+  /**
+   * Harness-specific route auth metadata. The server auth boundary uses this
+   * to reject bearer-equivalent query credentials and to keep the optional SSE
+   * subscription-token fallback route-scoped.
+   */
+  harnessAuth?: HarnessRouteAuthConfig;
   onValidationError?: ValidationErrorHook;
   /** @internal Phantom type — not present at runtime. Used for type-level schema inference. */
   readonly __schemas?: TSchemas;

--- a/packages/server/src/server/server-adapter/routes/route-builder.ts
+++ b/packages/server/src/server/server-adapter/routes/route-builder.ts
@@ -3,6 +3,7 @@ import type { RequestContext } from '@mastra/core/request-context';
 import type { ValidationErrorHook } from '@mastra/core/server';
 import type { ZodRawShape, ZodTypeAny } from 'zod/v4';
 import { z, ZodObject, ZodOptional, ZodNullable, ZodArray, ZodRecord } from 'zod/v4';
+import type { HarnessRouteAuthConfig } from '../../auth/helpers';
 import { generateRouteOpenAPI } from '../openapi-utils';
 import type { InferParams, ResponseType, RouteSchemas, ServerRoute, ServerRouteHandler } from './index';
 
@@ -186,6 +187,7 @@ interface RouteConfig<
       | ((params: Record<string, unknown>, context: { requestContext?: RequestContext }) => string | undefined);
     permission?: MastraFGAPermissionInput;
   };
+  harnessAuth?: HarnessRouteAuthConfig;
   onValidationError?: ValidationErrorHook;
 }
 

--- a/server-adapters/_test-utils/src/http-logging-test-suite.ts
+++ b/server-adapters/_test-utils/src/http-logging-test-suite.ts
@@ -196,6 +196,39 @@ export function createHttpLoggingTestSuite<TApp>(config: HttpLoggingTestSuiteCon
       );
     });
 
+    it('should redact credential-like query params when configured', async () => {
+      const mastra = new Mastra({
+        server: {
+          build: {
+            apiReqLogs: {
+              enabled: true,
+              includeQueryParams: true,
+            },
+          },
+        },
+      });
+      const { adapter } = await setupAdapter(app, mastra);
+
+      logSpy = vi.spyOn(adapter.logger, 'info');
+
+      await adapter.init();
+
+      await addRoute(app, 'GET', '/test', () => ({ message: 'success' }));
+
+      await executeRequest(app, 'GET', 'http://localhost/test?foo=bar&subscriptionToken=scoped&apiKey=secret');
+
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          query: expect.objectContaining({
+            foo: 'bar',
+            subscriptionToken: '[REDACTED]',
+            apiKey: '[REDACTED]',
+          }),
+        }),
+      );
+    });
+
     it('should include headers when configured', async () => {
       const mastra = new Mastra({
         server: {

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -10,6 +10,7 @@ import {
   MastraServer as MastraServerBase,
   checkRouteFGA,
   normalizeQueryParams,
+  redactSensitiveQueryParams,
   redactStreamChunk,
 } from '@mastra/server/server-adapter';
 import type { Application, NextFunction, Request, Response } from 'express';
@@ -717,7 +718,7 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
         };
 
         if (this.httpLoggingConfig?.includeQueryParams) {
-          logData.query = req.query;
+          logData.query = redactSensitiveQueryParams(req.query);
         }
 
         if (this.httpLoggingConfig?.includeHeaders) {

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -9,6 +9,7 @@ import {
   MastraServer as MastraServerBase,
   checkRouteFGA,
   normalizeQueryParams,
+  redactSensitiveQueryParams,
   redactStreamChunk,
 } from '@mastra/server/server-adapter';
 import type { FastifyInstance, FastifyReply, FastifyRequest, preHandlerHookHandler, RouteHandlerMethod } from 'fastify';
@@ -886,7 +887,7 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
         };
 
         if (this.httpLoggingConfig?.includeQueryParams) {
-          logData.query = request.query;
+          logData.query = redactSensitiveQueryParams(request.query as Record<string, unknown>);
         }
 
         if (this.httpLoggingConfig?.includeHeaders) {

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -9,6 +9,7 @@ import {
   MastraServer as MastraServerBase,
   checkRouteFGA,
   normalizeQueryParams,
+  redactSensitiveQueryParams,
   redactStreamChunk,
 } from '@mastra/server/server-adapter';
 import { toReqRes, toFetchResponse } from 'fetch-to-node';
@@ -737,7 +738,7 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
       };
 
       if (this.httpLoggingConfig?.includeQueryParams) {
-        logData.query = c.req.query();
+        logData.query = redactSensitiveQueryParams(c.req.query());
       }
 
       if (this.httpLoggingConfig?.includeHeaders) {

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -10,6 +10,7 @@ import {
   MastraServer as MastraServerBase,
   checkRouteFGA,
   normalizeQueryParams,
+  redactSensitiveQueryParams,
   redactStreamChunk,
 } from '@mastra/server/server-adapter';
 import type Koa from 'koa';
@@ -1004,7 +1005,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
       };
 
       if (server.httpLoggingConfig?.includeQueryParams) {
-        logData.query = ctx.query;
+        logData.query = redactSensitiveQueryParams(ctx.query);
       }
 
       if (server.httpLoggingConfig?.includeHeaders) {


### PR DESCRIPTION
## Summary
- Adds Harness-aware server route auth metadata and fail-closed handling for client-facing /harness routes.
- Rejects bearer-equivalent query credentials before principal resolution while preserving the legacy apiKey query fallback for non-Harness routes.
- Allows the scoped EventSource subscription token only on the canonical session events route or explicit route metadata, without copying it into shared auth context.
- Redacts credential-like query parameters from HTTP request logs across Express, Fastify, Hono, and Koa adapters.

## Linear
- PF-360

## Coordination / overlap
- Checked open mbenhamd/mastra PRs before implementation: #116 PF-514, #117 PF-535, #115 PF-542, #68/#69 stale, #58 ClickHouse. No direct overlap with server auth/resource route boundary files.

## Validation
- git diff --check
- pnpm --filter ./packages/server exec vitest run src/server/auth/helpers.test.ts src/server/server-adapter/index.test.ts src/server/server-adapter/http-logging.test.ts
- pnpm --filter ./packages/server exec tsc --noEmit -p tsconfig.json
- pnpm --filter ./packages/server exec eslint src/server/auth/helpers.ts src/server/auth/helpers.test.ts src/server/server-adapter/index.ts src/server/server-adapter/index.test.ts src/server/server-adapter/http-logging.test.ts src/server/server-adapter/routes/index.ts src/server/server-adapter/routes/route-builder.ts
- pnpm --filter ./packages/server run check:core-imports
- pnpm --filter ./server-adapters/express exec eslint src/index.ts
- pnpm --filter ./server-adapters/hono exec eslint src/index.ts
- pnpm --filter ./server-adapters/fastify exec eslint src/index.ts
- pnpm --filter ./server-adapters/koa exec eslint src/index.ts
- CodeRabbit CLI local review: final pass no findings
- Local Codex review passes: final pass no findings / no blocker

## Known local validation limits
- Adapter HTTP logging test suites were attempted, but this throwaway worktree cannot resolve built @mastra/server subpath exports for adapter package tests without the broader generated dist artifact chain.
- pnpm --filter ./packages/server run build:lib was attempted and failed before this PR's code path because @mastra/agent-builder dist imports @mastra/memory, whose local dist is missing in this fresh worktree.

## Notes
- No production Convex, Docker, secrets, signing, or release/publish actions touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR locks down client-facing /harness routes by rejecting secret tokens passed in URLs, requires explicit auth configuration for those routes, and hides credential-like query values from server logs so secrets don't leak.

## Overview

Harden authentication boundaries for Harness client-facing routes (/harness/*): fail-closed enforcement when routes are declared as Harness client routes, reject bearer-equivalent credentials supplied via query parameters prior to principal resolution (while preserving legacy apiKey query fallback for non-Harness routes), restrict session-scoped SSE subscription tokens to explicit session-events routes or opted-in routes, and redact credential-like query parameters from HTTP request logs across Express, Fastify, Hono, and Koa adapters.

## Key Changes

- packages/server/src/server/auth/helpers.ts
  - Added HARNESS_SSE_SUBSCRIPTION_TOKEN_QUERY_PARAM constant and Harness-specific helpers:
    - isHarnessClientRoute(route)
    - findBearerEquivalentHarnessQueryParam(getQuery)
    - getHarnessSseSubscriptionTokenQueryParam(route)
    - hasHarnessSseSubscriptionToken(route, getQuery)
    - allowsHarnessSseSubscriptionToken(route)
  - Exported HarnessRouteAuthConfig / HarnessRouteAuthShape interfaces.
  - AuthMiddlewareContext now includes optional forceAuth?: boolean to support fail-closed enforcement.

- packages/server/src/server/server-adapter/index.ts
  - Enforced Harness-route auth in checkRouteAuth(): rejects bearer-equivalent query credentials on Harness routes, disallows scoped SSE subscription tokens unless route opt-in or canonical session-events route, errors for Harness routes lacking server auth or explicitly disabling auth, and calls coreAuthMiddleware with forceAuth for Harness routes.
  - Added redactSensitiveQueryParams<T>(queryParams) exported helper and SENSITIVE_QUERY_PARAMS handling to shallow-clone and redact credential-like query values (case-insensitive normalization → "[REDACTED]").

- Route typing and builder
  - packages/server/src/server/server-adapter/routes/index.ts: ServerRoute now accepts optional harnessAuth?: HarnessRouteAuthConfig.
  - packages/server/src/server/server-adapter/routes/route-builder.ts: Route config extended to accept harnessAuth?: HarnessRouteAuthConfig.

- Server adapters HTTP logging
  - server-adapters/{express,fastify,hono,koa}/src/index.ts: Use redactSensitiveQueryParams when including query parameters in HTTP access logs to prevent logging credential-like values.

- Tests
  - packages/server/src/server/auth/helpers.test.ts: Added Vitest coverage for Harness route detection, bearer-equivalent query param resolution, SSE subscription-token behaviors, and a test ensuring coreAuthMiddleware overwrites MASTRA_RESOURCE_ID_KEY from authenticated user mapping.
  - packages/server/src/server/server-adapter/index.test.ts: New "Harness route auth boundary" suite covering rejection of bearer-equivalent query credentials on Harness routes (including when Authorization header present), enforcement outside /api/*, preservation of legacy apiKey query fallback for non-Harness routes, scoped SSE token opt-in behavior, and fail-closed errors for unconfigured or auth-disabled Harness routes.
  - packages/server/src/server/server-adapter/http-logging.test.ts and server-adapters/_test-utils/http-logging-test-suite.ts: Added tests asserting redactSensitiveQueryParams preserves non-sensitive keys while redacting credential-like values.

- Changesets / Changelog
  - .changeset/pf-360-harness-auth.md: Documents `@mastra/server` patch with Harness route auth hardening and migration guidance (move auth tokens from query → Authorization header).
  - .changeset/eager-buckets-find.md: Patch bumps for adapter packages documenting HTTP logging redaction fix.

## Validation Performed

- git diff --check
- Vitest suites for auth helpers and server-adapter tests
- TypeScript typecheck (tsc --noEmit)
- ESLint across server and adapter files
- Core-import checks; CodeRabbit CLI and local code review

Known local limits: adapter HTTP logging tests could not run end-to-end due to missing built `@mastra/server` subpath exports; full build blocked by missing local dist of `@mastra/memory` for `@mastra/agent-builder`.

## Notes

- Legacy apiKey query fallback preserved for non-Harness routes only.
- SSE subscription token is scoped and not copied into shared auth context unless route explicitly allows it or matches the canonical session-events route.
- No runtime, deployment, or release/publish changes included.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->