### PR TITLE
[PF-534] Return Convex workflow JSON parse errors

### DIFF
--- a/.changeset/pf-534-convex-workflow-json.md
+++ b/.changeset/pf-534-convex-workflow-json.md
@@ -1,0 +1,5 @@
+---
+'@mastra/convex': patch
+---
+
+Convex workflow storage now returns error objects when it receives invalid workflow JSON, so callers get a normal failed storage response instead of an uncaught mutation error.

--- a/.changeset/pf-534-convex-workflow-json.md
+++ b/.changeset/pf-534-convex-workflow-json.md
@@ -2,4 +2,4 @@
 '@mastra/convex': patch
 ---
 
-Convex workflow storage now returns error objects when it receives invalid workflow JSON, so callers get a normal failed storage response instead of an uncaught mutation error.
+Fixed Convex workflow storage to return an error when workflow JSON is invalid instead of throwing an uncaught mutation error.

--- a/stores/convex/src/server/storage.test.ts
+++ b/stores/convex/src/server/storage.test.ts
@@ -201,6 +201,67 @@ describe('mastraStorage workflow snapshot merge operations', () => {
     expect(testCtx.patch).not.toHaveBeenCalled();
   });
 
+  it('returns an error when a step result merge finds malformed stored snapshot JSON', async () => {
+    const testCtx = createWorkflowSnapshotCtx('{bad snapshot json');
+
+    const result = await handleTypedOperation(testCtx.ctx, 'mastra_workflow_snapshots', {
+      op: 'mergeWorkflowStepResult',
+      tableName: TABLE_WORKFLOW_SNAPSHOT,
+      workflowName: 'workflow-a',
+      runId: 'run-1',
+      stepId: 'step-1',
+      result: JSON.stringify({ status: 'success' }),
+      requestContext: JSON.stringify({}),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected malformed snapshot JSON to fail');
+    expect(result.error).toContain('Invalid workflow snapshot JSON for runId run-1');
+    expect(testCtx.patch).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when a step result merge receives malformed result JSON', async () => {
+    const testCtx = createWorkflowSnapshotCtx(
+      JSON.stringify({ runId: 'run-1', status: 'running', context: { step: { status: 'running' } } }),
+    );
+
+    const result = await handleTypedOperation(testCtx.ctx, 'mastra_workflow_snapshots', {
+      op: 'mergeWorkflowStepResult',
+      tableName: TABLE_WORKFLOW_SNAPSHOT,
+      workflowName: 'workflow-a',
+      runId: 'run-1',
+      stepId: 'step-1',
+      result: '{bad result json',
+      requestContext: JSON.stringify({}),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected malformed result JSON to fail');
+    expect(result.error).toContain('Invalid workflow result JSON for runId run-1');
+    expect(testCtx.patch).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when a step result merge receives malformed request context JSON', async () => {
+    const testCtx = createWorkflowSnapshotCtx(
+      JSON.stringify({ runId: 'run-1', status: 'running', context: { step: { status: 'running' } } }),
+    );
+
+    const result = await handleTypedOperation(testCtx.ctx, 'mastra_workflow_snapshots', {
+      op: 'mergeWorkflowStepResult',
+      tableName: TABLE_WORKFLOW_SNAPSHOT,
+      workflowName: 'workflow-a',
+      runId: 'run-1',
+      stepId: 'step-1',
+      result: JSON.stringify({ status: 'success' }),
+      requestContext: '{bad request context json',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected malformed requestContext JSON to fail');
+    expect(result.error).toContain('Invalid workflow requestContext JSON for runId run-1');
+    expect(testCtx.patch).not.toHaveBeenCalled();
+  });
+
   it('atomically merges workflow state and preserves existing context', async () => {
     const snapshot = {
       runId: 'run-1',
@@ -261,6 +322,29 @@ describe('mastraStorage workflow snapshot merge operations', () => {
     expect(testCtx.patch).toHaveBeenCalledTimes(1);
   });
 
+  it('returns an error when an object snapshot cannot be serialized for workflow state merge', async () => {
+    const snapshot: Record<string, unknown> = {
+      runId: 'run-1',
+      status: 'running',
+      context: { step: { status: 'success' } },
+    };
+    snapshot.self = snapshot;
+    const testCtx = createWorkflowSnapshotCtx(snapshot);
+
+    const result = await handleTypedOperation(testCtx.ctx, 'mastra_workflow_snapshots', {
+      op: 'mergeWorkflowState',
+      tableName: TABLE_WORKFLOW_SNAPSHOT,
+      workflowName: 'workflow-a',
+      runId: 'run-1',
+      opts: JSON.stringify({ status: 'success' }),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected unserializable snapshot to fail');
+    expect(result.error).toContain('Invalid workflow snapshot JSON for runId run-1');
+    expect(testCtx.patch).not.toHaveBeenCalled();
+  });
+
   it('returns an error when workflow state update has no snapshot row', async () => {
     const testCtx = createWorkflowSnapshotCtx(null, { missing: true });
 
@@ -273,6 +357,42 @@ describe('mastraStorage workflow snapshot merge operations', () => {
     });
 
     expect(result).toEqual({ ok: false, error: 'Workflow snapshot not found for runId run-1' });
+    expect(testCtx.patch).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when a workflow state merge finds malformed stored snapshot JSON', async () => {
+    const testCtx = createWorkflowSnapshotCtx('{bad snapshot json');
+
+    const result = await handleTypedOperation(testCtx.ctx, 'mastra_workflow_snapshots', {
+      op: 'mergeWorkflowState',
+      tableName: TABLE_WORKFLOW_SNAPSHOT,
+      workflowName: 'workflow-a',
+      runId: 'run-1',
+      opts: JSON.stringify({ status: 'success' }),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected malformed snapshot JSON to fail');
+    expect(result.error).toContain('Invalid workflow snapshot JSON for runId run-1');
+    expect(testCtx.patch).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when a workflow state merge receives malformed opts JSON', async () => {
+    const testCtx = createWorkflowSnapshotCtx(
+      JSON.stringify({ runId: 'run-1', status: 'running', context: { step: { status: 'success' } } }),
+    );
+
+    const result = await handleTypedOperation(testCtx.ctx, 'mastra_workflow_snapshots', {
+      op: 'mergeWorkflowState',
+      tableName: TABLE_WORKFLOW_SNAPSHOT,
+      workflowName: 'workflow-a',
+      runId: 'run-1',
+      opts: '{bad opts json',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected malformed opts JSON to fail');
+    expect(result.error).toContain('Invalid workflow opts JSON for runId run-1');
     expect(testCtx.patch).not.toHaveBeenCalled();
   });
 

--- a/stores/convex/src/server/storage.ts
+++ b/stores/convex/src/server/storage.ts
@@ -21,6 +21,32 @@ const STORAGE_MUTATION_BATCH_SIZE = 25;
 
 type ConvexDocWithId = { _id: GenericId<string> };
 type StorageRecord = Record<string, unknown> & { id?: unknown };
+type JsonParseResult = { ok: true; value: any } | { ok: false; error: string };
+
+function parseWorkflowJson(value: string, field: string, runId: string): JsonParseResult {
+  try {
+    return { ok: true, value: JSON.parse(value) };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, error: `Invalid workflow ${field} JSON for runId ${runId}: ${message}` };
+  }
+}
+
+function parseStoredWorkflowSnapshot(existing: any, runId: string): JsonParseResult {
+  if (typeof existing.snapshot === 'string') {
+    return parseWorkflowJson(existing.snapshot, 'snapshot', runId);
+  }
+
+  try {
+    return {
+      ok: true,
+      value: JSON.parse(JSON.stringify(existing.snapshot ?? createEmptyWorkflowSnapshot(runId))),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, error: `Invalid workflow snapshot JSON for runId ${runId}: ${message}` };
+  }
+}
 
 async function mapInBatches<TInput, TOutput>(
   inputs: TInput[],
@@ -301,20 +327,31 @@ export async function handleTypedOperation(
         return { ok: false, error: `Workflow snapshot not found for runId ${request.runId}` };
       }
 
-      const snapshot =
-        typeof existing.snapshot === 'string'
-          ? JSON.parse(existing.snapshot)
-          : JSON.parse(JSON.stringify(existing.snapshot ?? createEmptyWorkflowSnapshot(request.runId)));
+      const parsedSnapshot = parseStoredWorkflowSnapshot(existing, request.runId);
+      if (!parsedSnapshot.ok) {
+        return { ok: false, error: parsedSnapshot.error };
+      }
+      const snapshot = parsedSnapshot.value;
 
       if (!snapshot.context) {
         throw new Error(`Snapshot for runId ${request.runId} is missing or has invalid context`);
       }
 
+      const parsedResult = parseWorkflowJson(request.result, 'result', request.runId);
+      if (!parsedResult.ok) {
+        return { ok: false, error: parsedResult.error };
+      }
+
+      const parsedRequestContext = parseWorkflowJson(request.requestContext, 'requestContext', request.runId);
+      if (!parsedRequestContext.ok) {
+        return { ok: false, error: parsedRequestContext.error };
+      }
+
       const context = mergeWorkflowStepResult({
         snapshot,
         stepId: request.stepId,
-        result: JSON.parse(request.result),
-        requestContext: JSON.parse(request.requestContext),
+        result: parsedResult.value,
+        requestContext: parsedRequestContext.value,
       });
 
       await ctx.db.patch(existing._id, {
@@ -341,16 +378,22 @@ export async function handleTypedOperation(
         return { ok: false, error: `Workflow snapshot not found for runId ${request.runId}` };
       }
 
-      const snapshot =
-        typeof existing.snapshot === 'string'
-          ? JSON.parse(existing.snapshot)
-          : JSON.parse(JSON.stringify(existing.snapshot ?? createEmptyWorkflowSnapshot(request.runId)));
+      const parsedSnapshot = parseStoredWorkflowSnapshot(existing, request.runId);
+      if (!parsedSnapshot.ok) {
+        return { ok: false, error: parsedSnapshot.error };
+      }
+      const snapshot = parsedSnapshot.value;
 
       if (!snapshot.context) {
         throw new Error(`Snapshot for runId ${request.runId} is missing or has invalid context`);
       }
 
-      const mergedSnapshot = { ...snapshot, ...JSON.parse(request.opts) };
+      const parsedOpts = parseWorkflowJson(request.opts, 'opts', request.runId);
+      if (!parsedOpts.ok) {
+        return { ok: false, error: parsedOpts.error };
+      }
+
+      const mergedSnapshot = { ...snapshot, ...parsedOpts.value };
       await ctx.db.patch(existing._id, {
         snapshot: JSON.stringify(mergedSnapshot),
         updatedAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- Return structured Convex storage errors for malformed workflow snapshot, step result, request context, and state opts JSON before patching storage.
- Guard object-snapshot cloning failures so Convex workflow merge mutations fail through the storage response envelope instead of throwing.
- Add focused storage tests and a patch changeset for @mastra/convex.

## Linear
- PF-534

## Validation
- pnpm --filter ./stores/convex exec vitest run src/server/storage.test.ts (27 tests passed)
- pnpm --filter ./stores/convex exec eslint src/server/storage.ts src/server/storage.test.ts
- git diff --check
- Local Codex review pass 1: no findings
- Local Codex review pass 2: fixed malformed changeset blocker and added symmetric state malformed-snapshot test
- Claude read-only council review: fixed object snapshot serialization error handling; remaining shape-validation comments are pre-existing/non-JSON scope
- coderabbit review --plain: first pass findings fixed; second pass no findings

## Known limitation
- pnpm --filter ./stores/convex exec tsc --noEmit -p tsconfig.json still fails on existing stores/_test-utils/src/domains/harness/index.ts harness possibly undefined errors at 603, 608, 1675, and 1678. No PF-534 changed-file type errors were reported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This change makes the Convex workflow storage stop crashing when it sees bad JSON and instead return clear error responses, so callers get a structured error and storage mutations don't throw.

## Changes Overview

- Added a changeset for `@mastra/convex` (patch) documenting this behavior change.
- stores/convex/src/server/storage.ts
  - Added JSON parsing helpers (JsonParseResult, parseWorkflowJson, parseStoredWorkflowSnapshot).
  - Updated mergeWorkflowStepResult to parse and validate existing.snapshot, request.result, and request.requestContext; return { ok: false, error: ... } on parse failures; and only patch when parsing succeeds.
  - Updated mergeWorkflowState to parse and validate existing.snapshot and request.opts; guard against unserializable object snapshots and malformed opts; return structured errors and only patch on success.
  - Guarded object-snapshot cloning/serialization to ensure merge mutations surface errors through the storage response envelope rather than throwing.
- stores/convex/src/server/storage.test.ts
  - Added focused negative tests for:
    - mergeWorkflowStepResult: malformed stored snapshot, malformed result, malformed requestContext, missing snapshot row — asserting { ok: false } and that patch is not called.
    - mergeWorkflowState: unserializable object snapshot, malformed stored snapshot, malformed opts, missing snapshot row — asserting { ok: false } and that patch is not called.
  - Retained and expanded positive tests to confirm snapshots are stored as JSON strings and merged state/context behavior.

## Validation

- Unit tests: 27 tests passed (local vitest run reported in PR validation).
- Linting: eslint run for the convex store files succeeded as part of validation.
- Diff check and code reviews: passes (local Codex passes, Claude/coderabbit feedback addressed).
- Changeset added for `@mastra/convex` (patch).

## Known limitation

- Type checking (tsc) still fails in unrelated harness files under stores/_test-utils/src/domains/harness; no new type errors introduced by these changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->