### PR TITLE
[PF-530] Bind agent resume runs to originating principal

### DIFF
--- a/.changeset/pf-530-agent-resume-owner.md
+++ b/.changeset/pf-530-agent-resume-owner.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed agent resume operations to prevent unauthorized access when fine-grained authorization is enabled.

--- a/packages/core/src/agent/__tests__/agent-fga.test.ts
+++ b/packages/core/src/agent/__tests__/agent-fga.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { FGADeniedError } from '../../auth/ee/fga-check';
 import type { IFGAProvider } from '../../auth/ee/interfaces/fga';
-import { RequestContext } from '../../request-context';
+import { MASTRA_RESOURCE_ID_KEY, RequestContext } from '../../request-context';
 import { Agent } from '../agent';
 
 function createMockFGAProvider(authorized = true): IFGAProvider {
@@ -50,6 +50,40 @@ function createMockModel() {
       content: [{ type: 'text', text: 'ok' }],
     }),
   });
+}
+
+function createWorkflowRunStorage({
+  resourceId,
+  snapshot = { context: {} },
+  loadedSnapshot = snapshot,
+}: {
+  resourceId?: string;
+  snapshot?: unknown;
+  loadedSnapshot?: unknown;
+}) {
+  const workflowsStore = {
+    getWorkflowRunById: vi.fn().mockResolvedValue({
+      workflowName: 'agentic-loop',
+      runId: 'suspended-run-id',
+      resourceId,
+      snapshot,
+    }),
+    loadWorkflowSnapshot: vi.fn().mockResolvedValue(loadedSnapshot),
+  };
+  const storage = {
+    getStore: vi.fn().mockReturnValue(workflowsStore),
+  };
+  return {
+    getStorage: vi.fn(() => storage),
+    storage,
+    workflowsStore,
+  };
+}
+
+function expectNoResumeOwnerError(error: unknown) {
+  if (error && typeof error === 'object' && 'id' in error) {
+    expect((error as { id?: string }).id?.startsWith('AGENT_RESUME_OWNER_')).toBe(false);
+  }
 }
 
 describe('Agent FGA checks', () => {
@@ -308,6 +342,107 @@ describe('Agent FGA checks', () => {
         { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
       );
     });
+
+    it('should reject callers whose resource does not own the suspended run', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const { getStorage } = createWorkflowRunStorage({ resourceId: 'resource-b' });
+      const mastra = createMockMastra(fgaProvider, getStorage);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'resource-a');
+
+      await expect(
+        agent.resumeStream({ approved: true }, { runId: 'suspended-run-id', requestContext: requestContext as any }),
+      ).rejects.toMatchObject({ id: 'AGENT_RESUME_OWNER_MISMATCH' });
+    });
+
+    it('should fail closed when FGA is configured and caller resource is missing for an owned run', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const { getStorage } = createWorkflowRunStorage({ resourceId: 'resource-b' });
+      const mastra = createMockMastra(fgaProvider, getStorage);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+
+      await expect(
+        agent.resumeStream({ approved: true }, { runId: 'suspended-run-id', requestContext: requestContext as any }),
+      ).rejects.toMatchObject({ id: 'AGENT_RESUME_OWNER_UNVERIFIED' });
+    });
+
+    it('should not trust caller-supplied memory resource as owner proof when FGA is configured', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const { getStorage } = createWorkflowRunStorage({ resourceId: 'resource-b' });
+      const mastra = createMockMastra(fgaProvider, getStorage);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+
+      await expect(
+        agent.resumeStream(
+          { approved: true },
+          {
+            runId: 'suspended-run-id',
+            requestContext: requestContext as any,
+            memory: { resource: 'resource-b' },
+          },
+        ),
+      ).rejects.toMatchObject({ id: 'AGENT_RESUME_OWNER_UNVERIFIED' });
+    });
+
+    it('should allow non-FGA local resume callers to prove ownership with memory resource', async () => {
+      const { getStorage } = createWorkflowRunStorage({ resourceId: 'resource-b' });
+      const mastra = createMockMastra(undefined, getStorage);
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: createMockModel() as any,
+      });
+      (agent as any).__registerMastra(mastra);
+
+      let resumeError: unknown;
+      try {
+        await agent.resumeGenerate(
+          { approved: true },
+          {
+            runId: 'suspended-run-id',
+            memory: { resource: 'resource-b' },
+          },
+        );
+      } catch (error) {
+        resumeError = error;
+      }
+
+      expectNoResumeOwnerError(resumeError);
+    });
+
+    it('should fail closed when FGA is configured and the persisted run has no owner resource', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const { getStorage } = createWorkflowRunStorage({});
+      const mastra = createMockMastra(fgaProvider, getStorage);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'resource-a');
+
+      await expect(
+        agent.resumeStream({ approved: true }, { runId: 'suspended-run-id', requestContext: requestContext as any }),
+      ).rejects.toMatchObject({ id: 'AGENT_RESUME_PERSISTED_RUN_NO_OWNER' });
+    });
   });
 
   describe('resumeStreamUntilIdle()', () => {
@@ -407,6 +542,26 @@ describe('Agent FGA checks', () => {
         { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
       );
     });
+
+    it('should enforce run owner checks through resumeStreamUntilIdle', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const { getStorage } = createWorkflowRunStorage({ resourceId: 'resource-b' });
+      const mastra = createMockMastra(fgaProvider, getStorage);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'resource-a');
+
+      await expect(
+        agent.resumeStreamUntilIdle(
+          { approved: true },
+          { runId: 'suspended-run-id', requestContext: requestContext as any },
+        ),
+      ).rejects.toMatchObject({ id: 'AGENT_RESUME_OWNER_MISMATCH' });
+    });
   });
 
   describe('resumeGenerate()', () => {
@@ -493,6 +648,91 @@ describe('Agent FGA checks', () => {
         { id: 'default-user', organizationMembershipId: 'default-om' },
         { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
       );
+    });
+
+    it('should reject callers whose resource does not own the suspended generate run', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const { getStorage } = createWorkflowRunStorage({ resourceId: 'resource-b' });
+      const mastra = createMockMastra(fgaProvider, getStorage);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'resource-a');
+
+      await expect(
+        agent.resumeGenerate({ approved: true }, { runId: 'suspended-run-id', requestContext: requestContext as any }),
+      ).rejects.toMatchObject({ id: 'AGENT_RESUME_OWNER_MISMATCH' });
+    });
+
+    it('should allow a caller whose resource owns the suspended generate run', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const { getStorage } = createWorkflowRunStorage({ resourceId: 'resource-a' });
+      const mastra = createMockMastra(fgaProvider, getStorage);
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: createMockModel() as any,
+      });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'resource-a');
+
+      let resumeError: unknown;
+      try {
+        await agent.resumeGenerate(
+          { approved: true },
+          { runId: 'suspended-run-id', requestContext: requestContext as any },
+        );
+      } catch (error) {
+        resumeError = error;
+      }
+
+      expectNoResumeOwnerError(resumeError);
+    });
+
+    it('should fall back to loadWorkflowSnapshot when getWorkflowRunById returns a serialized snapshot', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const { getStorage, workflowsStore } = createWorkflowRunStorage({
+        resourceId: 'resource-a',
+        snapshot: '{"context":{}}',
+        loadedSnapshot: { context: {} },
+      });
+      const mastra = createMockMastra(fgaProvider, getStorage);
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: createMockModel() as any,
+      });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'resource-a');
+
+      let resumeError: unknown;
+      try {
+        await agent.resumeGenerate(
+          { approved: true },
+          { runId: 'suspended-run-id', requestContext: requestContext as any },
+        );
+      } catch (error) {
+        resumeError = error;
+      }
+
+      expect(workflowsStore.loadWorkflowSnapshot).toHaveBeenCalledWith({
+        workflowName: 'agentic-loop',
+        runId: 'suspended-run-id',
+      });
+      expectNoResumeOwnerError(resumeError);
     });
   });
 });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -5480,10 +5480,18 @@ export class Agent<
    */
   async #loadAgenticLoopSnapshotOrThrow({ runId, method }: { runId: string; method: string }) {
     const workflowsStore = await this.#mastra?.getStorage()?.getStore('workflows');
-    const existingSnapshot = await workflowsStore?.loadWorkflowSnapshot({
-      workflowName: 'agentic-loop',
-      runId,
-    });
+    let workflowRun: { resourceId?: unknown; snapshot?: unknown } | null | undefined;
+    if (typeof workflowsStore?.getWorkflowRunById === 'function') {
+      workflowRun = await workflowsStore.getWorkflowRunById({ workflowName: 'agentic-loop', runId });
+    }
+    const workflowRunSnapshot =
+      workflowRun?.snapshot && typeof workflowRun.snapshot === 'object' ? workflowRun.snapshot : undefined;
+    const existingSnapshot =
+      workflowRunSnapshot ??
+      (await workflowsStore?.loadWorkflowSnapshot({
+        workflowName: 'agentic-loop',
+        runId,
+      }));
 
     if (!existingSnapshot) {
       const hasStorage = !!workflowsStore;
@@ -5505,7 +5513,84 @@ export class Agent<
       });
     }
 
-    return existingSnapshot;
+    return {
+      resourceId: typeof workflowRun?.resourceId === 'string' ? workflowRun.resourceId : undefined,
+      snapshot: existingSnapshot,
+    };
+  }
+
+  #getResumeCallerResourceId(
+    requestContext: RequestContext | undefined,
+    options: AgentExecutionOptionsBase<any> | undefined,
+    { trustMemoryResource = true }: { trustMemoryResource?: boolean } = {},
+  ): string | undefined {
+    const contextResourceId = requestContext?.get(MASTRA_RESOURCE_ID_KEY);
+    if (typeof contextResourceId === 'string' && contextResourceId.length > 0) {
+      return contextResourceId;
+    }
+    if (!trustMemoryResource) {
+      return undefined;
+    }
+    const memoryResourceId = options?.memory?.resource;
+    return typeof memoryResourceId === 'string' && memoryResourceId.length > 0 ? memoryResourceId : undefined;
+  }
+
+  #assertAgenticLoopResumeOwnership({
+    method,
+    runId,
+    runResourceId,
+    requestContext,
+    options,
+  }: {
+    method: string;
+    runId: string;
+    runResourceId?: string;
+    requestContext?: RequestContext;
+    options?: AgentExecutionOptionsBase<any>;
+  }): void {
+    const hasFga = Boolean(this.#mastra?.getServer()?.fga);
+    const callerResourceId = this.#getResumeCallerResourceId(requestContext, options, {
+      trustMemoryResource: !hasFga,
+    });
+
+    if (runResourceId && callerResourceId && runResourceId !== callerResourceId) {
+      throw new MastraError({
+        id: 'AGENT_RESUME_OWNER_MISMATCH',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        text: `Agent "${this.name}" ${method}() cannot resume runId "${runId}" from a different resource.`,
+        details: {
+          runId,
+          agentName: this.name,
+        },
+      });
+    }
+
+    if (hasFga && runResourceId && !callerResourceId) {
+      throw new MastraError({
+        id: 'AGENT_RESUME_OWNER_UNVERIFIED',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        text: `Agent "${this.name}" ${method}() requires a matching resource id to resume runId "${runId}".`,
+        details: {
+          runId,
+          agentName: this.name,
+        },
+      });
+    }
+
+    if (hasFga && !runResourceId) {
+      throw new MastraError({
+        id: 'AGENT_RESUME_PERSISTED_RUN_NO_OWNER',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        text: `Agent "${this.name}" ${method}() cannot verify ownership for runId "${runId}" because the persisted run has no resource id.`,
+        details: {
+          runId,
+          agentName: this.name,
+        },
+      });
+    }
   }
 
   #getAgenticLoopSnapshotMemoryInfo(existingSnapshot: any): { threadId?: string; resourceId?: string } | undefined {
@@ -7097,7 +7182,35 @@ export class Agent<
         await this.#assertAgentExecutionPreflight(defaultOptions.requestContext, { requireFgaUser: true });
       }
     }
-    const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeStream' });
+    const { resourceId: runResourceId, snapshot: existingSnapshot } = await this.#loadAgenticLoopSnapshotOrThrow({
+      runId,
+      method: 'resumeStream',
+    });
+    defaultOptions ??= (await this.getDefaultOptions({
+      requestContext: requestContextToUse,
+    })) as AgentExecutionOptions<TOutput>;
+    const ownershipOptions = deepMerge(
+      defaultOptions as Record<string, unknown>,
+      (streamOptionsWithPubSub ?? {}) as Record<string, unknown>,
+    ) as typeof defaultOptions & { model?: DynamicArgument<MastraModelConfig> };
+    if (requestContextToUse) {
+      ownershipOptions.requestContext = requestContextToUse;
+    }
+    if (
+      streamOptionsWithPubSub?.[SKIP_AGENT_EXECUTION_PREFLIGHT] &&
+      !requestContextToUse &&
+      !preflightedDefaultOptions &&
+      (this.#requestContextSchema || this.#mastra?.getServer()?.fga)
+    ) {
+      await this.#assertAgentExecutionPreflight(ownershipOptions.requestContext, { requireFgaUser: true });
+    }
+    this.#assertAgenticLoopResumeOwnership({
+      method: 'resumeStream',
+      runId,
+      runResourceId,
+      requestContext: ownershipOptions.requestContext,
+      options: ownershipOptions,
+    });
     const streamOptionsWithSnapshotTarget = this.#withSnapshotThreadTarget(
       streamOptionsWithPubSub,
       this.#getAgenticLoopSnapshotMemoryInfo(existingSnapshot),
@@ -7127,17 +7240,6 @@ export class Agent<
     let preparedOptionsWithPubSub: (AgentExecutionOptionsBase<any> & { runId?: string; _pubsub: PubSub }) | undefined;
 
     try {
-      defaultOptions ??= (await this.getDefaultOptions({
-        requestContext: requestContextToUse,
-      })) as AgentExecutionOptions<TOutput>;
-      if (
-        streamOptionsWithPubSub?.[SKIP_AGENT_EXECUTION_PREFLIGHT] &&
-        !requestContextToUse &&
-        !preflightedDefaultOptions &&
-        (this.#requestContextSchema || this.#mastra?.getServer()?.fga)
-      ) {
-        await this.#assertAgentExecutionPreflight(defaultOptions.requestContext, { requireFgaUser: true });
-      }
       let mergedStreamOptions = deepMerge(
         defaultOptions as Record<string, unknown>,
         (streamOptionsWithSnapshotTarget ?? {}) as Record<string, unknown>,
@@ -7438,7 +7540,10 @@ export class Agent<
     }
 
     const runId = options?.runId ?? '';
-    const existingSnapshot = await this.#loadAgenticLoopSnapshotOrThrow({ runId, method: 'resumeGenerate' });
+    const { resourceId: runResourceId, snapshot: existingSnapshot } = await this.#loadAgenticLoopSnapshotOrThrow({
+      runId,
+      method: 'resumeGenerate',
+    });
 
     defaultOptions ??= (await this.getDefaultOptions({
       requestContext: requestContextToUse,
@@ -7451,6 +7556,13 @@ export class Agent<
     if (requestContextToUse) {
       mergedOptions.requestContext = requestContextToUse;
     }
+    this.#assertAgenticLoopResumeOwnership({
+      method: 'resumeGenerate',
+      runId,
+      runResourceId,
+      requestContext: mergedOptions.requestContext,
+      options: mergedOptions,
+    });
 
     const llm = await this.getLLM({
       requestContext: mergedOptions.requestContext,


### PR DESCRIPTION
## Summary
- Load the persisted agentic-loop workflow run before resume and compare its resource owner with the caller resource from request context or memory options.
- Reject cross-resource resume attempts and fail closed under FGA when the run owner or caller owner cannot be verified.
- Preserve non-FGA local resume compatibility and fall back to loadWorkflowSnapshot when getWorkflowRunById exposes a serialized snapshot.

## Validation
- pnpm --filter ./packages/core exec vitest run src/agent/__tests__/agent-fga.test.ts
- pnpm --filter ./packages/core exec eslint src/agent/agent.ts src/agent/__tests__/agent-fga.test.ts
- pnpm --filter ./packages/core check
- pnpm build:core
- git diff --check
- Claude council review: addressed snapshot normalization/fallback, coverage, and option-source findings.
- CodeRabbit CLI: no findings.
- Local Codex review pass 1 and pass 2 were attempted but blocked by current Codex usage quota.

## Notes
- Rebasing/fast-forwarded onto origin/main at 49e22e0b83006d05f0d104c274a2c65bf3e6efed before push.
- Related coordination: PF-369/#120 and PF-360/#118 review threads were fixed and resolved before this PR was opened.

Linear: PF-530

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When you pause an AI workflow and later try to resume it, this change ensures only the same person or organization that started the run can resume it—blocking anyone else from continuing it.

## Summary

This PR enforces ownership checks for resuming agentic-loop workflow runs so that resume operations (`resumeStream()`, `resumeStreamUntilIdle()`, and `resumeGenerate()`) are only allowed to the originating principal (the caller's resource ID). Under Fine-Grained Authorization (FGA), resume attempts fail closed when ownership cannot be verified; non-FGA local resume behavior is preserved, with backward-compatible fallback for serialized snapshots.

## Changes

### Core Implementation (packages/core/src/agent/agent.ts)
- Added snapshot loader: `#loadAgenticLoopSnapshotOrThrow()`  
  - Preferentially uses `workflowsStore.getWorkflowRunById()` to obtain both the run snapshot and persisted `resourceId`.  
  - Falls back to `workflowsStore.loadWorkflowSnapshot()` for serialized snapshots to preserve non-FGA/local behavior.  
  - Returns `{ resourceId, snapshot }` instead of just snapshot.
- Added caller/resource helpers and assertions:
  - `#getResumeCallerResourceId()` — derives the caller's intended `resourceId` from `requestContext` (and only from memory options when FGA is not enabled).
  - `#assertAgenticLoopResumeOwnership()` — enforces resume ownership under FGA by checking for: persisted-run vs caller `resourceId` mismatch, missing caller resource when FGA is enabled, and persisted runs lacking an owner. Throws MastraError with targeted IDs on violation.
- Resume flows updated:
  - `resumeStream()` and `resumeGenerate()` now load `{ resourceId, snapshot }`, merge ownership-related options and request-context defaults (including handling of skip-preflight markers), call `#assertAgenticLoopResumeOwnership()` when appropriate, and proceed only after owner verification.
  - Removed a duplicated default-options/preflight block from `resumeStream()` since ownership/preflight handling is centralized earlier.

### Tests (packages/core/src/agent/__tests__/agent-fga.test.ts)
- Extensive new/updated tests covering FGA and resume ownership scenarios:
  - Ensure FGA authorization runs before accessing persisted snapshots.
  - Deny resume when caller resource differs from persisted run owner.
  - Fail closed when caller resource is missing while FGA is enabled.
  - Reject attempts that rely on caller-supplied memory.resource as owner proof when FGA is enabled.
  - Confirm fallback to `loadWorkflowSnapshot()` for serialized snapshots while still enforcing ownership checks.
- Added helpers: `createWorkflowRunStorage()` to mock persisted runs (with configurable `resourceId` and snapshot) and `expectNoResumeOwnerError()` to assert other errors are not misclassified.

### Changelog (.changeset)
- Patch-note documenting fix: "Fixed agent resume operations to prevent unauthorized access when fine-grained authorization is enabled."

## Error Codes Introduced / Used
- AGENT_RESUME_OWNER_MISMATCH — caller's resource does not match persisted run owner
- AGENT_RESUME_OWNER_UNVERIFIED — ownership cannot be verified (missing caller resource for owned run or persisted run lacks owner) under FGA
- AGENT_RESUME_NO_SNAPSHOT_FOUND — no snapshot found for provided run ID

## Validation
- Unit tests (FGA/resume scenarios) executed.
- Linting and typecheck/build completed.
- Backward compatibility: non-FGA local resume preserved via fallback to serialized snapshot loader.
- Rebased onto main before push; related coordination with PF-369/#120 and PF-360/#118; Linear: PF-530.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->