### PR TITLE
[PF-371] Add Harness channel action token and receipt storage

### DIFF
--- a/.changeset/cyan-zoos-say.md
+++ b/.changeset/cyan-zoos-say.md
@@ -1,0 +1,5 @@
+---
+'@mastra/libsql': minor
+---
+
+Added LibSQL storage for Harness channel action tokens and receipts.

--- a/.changeset/cyan-zoos-say.md
+++ b/.changeset/cyan-zoos-say.md
@@ -2,4 +2,14 @@
 '@mastra/libsql': minor
 ---
 
-Added LibSQL storage for Harness channel action tokens and receipts.
+Harness channel action tokens and receipts now persist in LibSQL, so channel callback retries can be deduped and recovered across process restarts.
+
+```ts
+const stores = await libsqlStore.getStores();
+const harnessStore = stores.harness;
+
+const { token } = await harnessStore.createOrLoadChannelActionToken(channelActionToken);
+const { receipt } = await harnessStore.createOrLoadChannelActionReceipt(channelActionReceipt, {
+  initialClaim: { claimId: workerId, now: Date.now(), claimTtlMs: 30_000 },
+});
+```

--- a/.changeset/funny-comics-boil.md
+++ b/.changeset/funny-comics-boil.md
@@ -2,4 +2,17 @@
 '@mastra/core': minor
 ---
 
-Added durable Harness channel action token and receipt storage.
+Harness storage adapters can now persist channel action tokens and receipts, verify duplicate callbacks, and claim receipt work for retry-safe channel action processing.
+
+```ts
+const token = await harnessStore.createOrLoadChannelActionToken(channelActionToken);
+const retryBatch = await harnessStore.claimChannelActionReceipts({
+  harnessName: 'default',
+  channelId: 'support',
+  statuses: ['received', 'failed'],
+  claimId: workerId,
+  limit: 25,
+  now: Date.now(),
+  claimTtlMs: 30_000,
+});
+```

--- a/.changeset/funny-comics-boil.md
+++ b/.changeset/funny-comics-boil.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added durable Harness channel action token and receipt storage.

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -52,6 +52,8 @@ export const TABLE_HARNESS_MESSAGE_RESULTS = 'mastra_harness_message_results';
 export const TABLE_HARNESS_OPERATION_TOMBSTONES = 'mastra_harness_operation_tombstones';
 export const TABLE_HARNESS_THREAD_DELETE_FENCES = 'mastra_harness_thread_delete_fences';
 export const TABLE_HARNESS_CHANNEL_INBOX = 'mastra_harness_channel_inbox';
+export const TABLE_HARNESS_CHANNEL_ACTION_TOKENS = 'mastra_harness_channel_action_tokens';
+export const TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS = 'mastra_harness_channel_action_receipts';
 
 /** Union of all core table name constants. */
 export type TABLE_NAMES =
@@ -93,7 +95,9 @@ export type TABLE_NAMES =
   | typeof TABLE_HARNESS_MESSAGE_RESULTS
   | typeof TABLE_HARNESS_OPERATION_TOMBSTONES
   | typeof TABLE_HARNESS_THREAD_DELETE_FENCES
-  | typeof TABLE_HARNESS_CHANNEL_INBOX;
+  | typeof TABLE_HARNESS_CHANNEL_INBOX
+  | typeof TABLE_HARNESS_CHANNEL_ACTION_TOKENS
+  | typeof TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS;
 
 export const SCORERS_SCHEMA: Record<string, StorageColumn> = {
   id: { type: 'text', nullable: false, primaryKey: true },
@@ -782,6 +786,63 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
     attachments: { type: 'jsonb', nullable: false },
     last_error: { type: 'jsonb', nullable: true },
   },
+  [TABLE_HARNESS_CHANNEL_ACTION_TOKENS]: {
+    action_token_id: { type: 'text', nullable: false },
+    harness_name: { type: 'text', nullable: false },
+    channel_id: { type: 'text', nullable: false },
+    provider_id: { type: 'text', nullable: false },
+    resource_id: { type: 'text', nullable: false },
+    owning_session_id: { type: 'text', nullable: false },
+    item_id: { type: 'text', nullable: false },
+    kind: { type: 'text', nullable: false },
+    binding_id: { type: 'text', nullable: false },
+    binding_generation: { type: 'integer', nullable: false },
+    run_id: { type: 'text', nullable: false },
+    pending_requested_at: { type: 'bigint', nullable: false },
+    audience: { type: 'jsonb', nullable: false },
+    metadata_hash: { type: 'text', nullable: false },
+    transport_hash: { type: 'text', nullable: false },
+    key_id: { type: 'text', nullable: true },
+    expires_at: { type: 'bigint', nullable: true },
+    revoked_at: { type: 'bigint', nullable: true },
+    revoked_reason: { type: 'text', nullable: true },
+    created_at: { type: 'bigint', nullable: false },
+    updated_at: { type: 'bigint', nullable: false },
+  },
+  [TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS]: {
+    id: { type: 'text', nullable: false, primaryKey: true },
+    harness_name: { type: 'text', nullable: false },
+    channel_id: { type: 'text', nullable: false },
+    provider_id: { type: 'text', nullable: false },
+    action_token_id: { type: 'text', nullable: false },
+    action_id: { type: 'text', nullable: false },
+    binding_id: { type: 'text', nullable: false },
+    binding_generation: { type: 'integer', nullable: false },
+    resource_id: { type: 'text', nullable: false },
+    owning_session_id: { type: 'text', nullable: false },
+    item_id: { type: 'text', nullable: false },
+    kind: { type: 'text', nullable: false },
+    run_id: { type: 'text', nullable: false },
+    pending_requested_at: { type: 'bigint', nullable: false },
+    audience: { type: 'jsonb', nullable: false },
+    verified_actor: { type: 'jsonb', nullable: true },
+    response_hash: { type: 'text', nullable: false },
+    response: { type: 'jsonb', nullable: false },
+    status: { type: 'text', nullable: false },
+    conflict_reason: { type: 'text', nullable: true },
+    attempts: { type: 'integer', nullable: false },
+    claim_id: { type: 'text', nullable: true },
+    claim_expires_at: { type: 'bigint', nullable: true },
+    next_attempt_at: { type: 'bigint', nullable: true },
+    accepted_at: { type: 'bigint', nullable: true },
+    applied_at: { type: 'bigint', nullable: true },
+    failed_at: { type: 'bigint', nullable: true },
+    dead_at: { type: 'bigint', nullable: true },
+    result: { type: 'jsonb', nullable: true },
+    last_error: { type: 'jsonb', nullable: true },
+    created_at: { type: 'bigint', nullable: false },
+    updated_at: { type: 'bigint', nullable: false },
+  },
 };
 
 /**
@@ -813,6 +874,13 @@ export const TABLE_CONFIGS: Partial<Record<TABLE_NAMES, StorageTableConfig>> = {
   },
   [TABLE_HARNESS_CHANNEL_INBOX]: {
     columns: TABLE_SCHEMAS[TABLE_HARNESS_CHANNEL_INBOX],
+  },
+  [TABLE_HARNESS_CHANNEL_ACTION_TOKENS]: {
+    columns: TABLE_SCHEMAS[TABLE_HARNESS_CHANNEL_ACTION_TOKENS],
+    compositePrimaryKey: ['harness_name', 'channel_id', 'action_token_id'],
+  },
+  [TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS]: {
+    columns: TABLE_SCHEMAS[TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS],
   },
 };
 

--- a/packages/core/src/storage/domains/harness/base.ts
+++ b/packages/core/src/storage/domains/harness/base.ts
@@ -5,8 +5,13 @@ import type {
   AgentSignalResultStatus,
   AttachmentReference,
   AttachmentRecord,
+  ChannelActionInitialClaim,
+  ChannelActionReceipt,
+  ChannelActionToken,
   ChannelInboxInitialClaim,
   ChannelInboxItem,
+  CreateOrLoadChannelActionReceiptResult,
+  CreateOrLoadChannelActionTokenResult,
   CreateOrLoadChannelInboxItemResult,
   CreateOrLoadActiveSessionOptions,
   CreateOrLoadActiveSessionResult,
@@ -198,6 +203,43 @@ export class HarnessStorageChannelInboxTransitionError extends Error {
   ) {
     super(
       `Channel inbox item "${inboxItemId}" cannot transition from "${fromStatus ?? '<missing>'}" to "${toStatus}": ${reason}`,
+    );
+  }
+}
+
+export class HarnessStorageChannelActionClaimConflictError extends Error {
+  readonly name = 'HarnessStorageChannelActionClaimConflictError';
+  readonly code = 'harness.storage.channel_action_claim_conflict' as const;
+  constructor(
+    public readonly receiptId: string,
+    public readonly claimId?: string,
+  ) {
+    super(`Channel action receipt "${receiptId}" is not held by claim "${claimId ?? '<none>'}"`);
+  }
+}
+
+export class HarnessStorageChannelActionTokenConflictError extends Error {
+  readonly name = 'HarnessStorageChannelActionTokenConflictError';
+  readonly code = 'harness.storage.channel_action_token_conflict' as const;
+  constructor(
+    public readonly actionTokenId: string,
+    reason: string,
+  ) {
+    super(`Channel action token "${actionTokenId}" conflicts with stored token: ${reason}`);
+  }
+}
+
+export class HarnessStorageChannelActionReceiptTransitionError extends Error {
+  readonly name = 'HarnessStorageChannelActionReceiptTransitionError';
+  readonly code = 'harness.storage.channel_action_receipt_transition_invalid' as const;
+  constructor(
+    public readonly receiptId: string,
+    public readonly fromStatus: ChannelActionReceipt['status'] | undefined,
+    public readonly toStatus: ChannelActionReceipt['status'],
+    reason: string,
+  ) {
+    super(
+      `Channel action receipt "${receiptId}" cannot transition from "${fromStatus ?? '<missing>'}" to "${toStatus}": ${reason}`,
     );
   }
 }
@@ -592,6 +634,83 @@ export abstract class HarnessStorage extends StorageDomain {
   }): Promise<{ claimExpiresAt: number; storageNow: number }>;
 
   abstract updateChannelInboxItem(record: ChannelInboxItem, opts: { claimId: string }): Promise<void>;
+
+  // -------------------------------------------------------------------------
+  // Channel action token and receipt ledger
+  // -------------------------------------------------------------------------
+
+  abstract createOrLoadChannelActionToken(record: ChannelActionToken): Promise<CreateOrLoadChannelActionTokenResult>;
+
+  abstract loadChannelActionTokenById(opts: {
+    harnessName: string;
+    channelId: string;
+    actionTokenId: string;
+  }): Promise<ChannelActionToken | null>;
+
+  abstract loadChannelActionTokenByTransportHash(opts: {
+    harnessName: string;
+    channelId: string;
+    transportHash: string;
+  }): Promise<ChannelActionToken | null>;
+
+  abstract loadChannelActionTokenForPendingItem(opts: {
+    harnessName: string;
+    channelId: string;
+    bindingId: string;
+    bindingGeneration: number;
+    owningSessionId: string;
+    itemId: string;
+    kind: ChannelActionToken['kind'];
+    runId: string;
+    pendingRequestedAt: number;
+    metadataHash: string;
+  }): Promise<ChannelActionToken | null>;
+
+  abstract revokeChannelActionToken(opts: {
+    harnessName: string;
+    channelId: string;
+    actionTokenId: string;
+    revokedAt?: number;
+    revokedReason?: ChannelActionToken['revokedReason'];
+  }): Promise<ChannelActionToken>;
+
+  abstract saveChannelActionReceipt(record: ChannelActionReceipt): Promise<void>;
+
+  abstract createOrLoadChannelActionReceipt(
+    record: ChannelActionReceipt,
+    opts?: { initialClaim?: ChannelActionInitialClaim },
+  ): Promise<CreateOrLoadChannelActionReceiptResult>;
+
+  abstract loadChannelActionReceiptByActionId(opts: {
+    harnessName: string;
+    channelId: string;
+    actionId: string;
+  }): Promise<ChannelActionReceipt | null>;
+
+  abstract loadChannelActionReceiptByTokenId(opts: {
+    harnessName: string;
+    channelId: string;
+    actionTokenId: string;
+  }): Promise<ChannelActionReceipt | null>;
+
+  abstract claimChannelActionReceipts(opts: {
+    harnessName: string;
+    channelId?: string;
+    statuses: Array<'received' | 'accepted' | 'failed'>;
+    claimId: string;
+    limit: number;
+    now: number;
+    claimTtlMs: number;
+  }): Promise<ChannelActionReceipt[]>;
+
+  abstract renewChannelActionReceiptClaim(opts: {
+    receiptId: string;
+    claimId: string;
+    now: number;
+    claimTtlMs: number;
+  }): Promise<{ claimExpiresAt: number; storageNow: number }>;
+
+  abstract updateChannelActionReceipt(record: ChannelActionReceipt, opts: { claimId: string }): Promise<void>;
 
   // -------------------------------------------------------------------------
   // Test-only

--- a/packages/core/src/storage/domains/harness/inmemory.test.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { InMemoryDB } from '../inmemory-db';
 import type { HarnessStorageParentSessionUnavailableError } from './base';
 import {
+  HarnessStorageChannelActionClaimConflictError,
+  HarnessStorageChannelActionReceiptTransitionError,
   HarnessStorageChannelInboxClaimConflictError,
   HarnessStorageChannelInboxTransitionError,
   HarnessStorageDeleteGuardConflictError,
@@ -10,7 +12,7 @@ import {
   HarnessStorageVersionConflictError,
 } from './base';
 import { InMemoryHarness } from './inmemory';
-import type { ChannelInboxItem, SessionRecord } from './types';
+import type { ChannelActionReceipt, ChannelActionToken, ChannelInboxItem, SessionRecord } from './types';
 
 describe('InMemoryHarness admission storage contract', () => {
   it('creates or returns one active session for a namespace/resource/thread key', async () => {
@@ -906,6 +908,209 @@ describe('InMemoryHarness channel inbox ledger', () => {
   });
 });
 
+describe('InMemoryHarness channel action ledger', () => {
+  it('dedupes exact action tokens and flags immutable token mismatches', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    await expect(storage.createOrLoadChannelActionToken(sampleChannelActionToken())).resolves.toMatchObject({
+      duplicate: false,
+      conflict: false,
+    });
+
+    await expect(storage.createOrLoadChannelActionToken(sampleChannelActionToken())).resolves.toMatchObject({
+      duplicate: true,
+      conflict: false,
+      token: { actionTokenId: 'action-token-1', metadataHash: 'metadata-hash-1' },
+    });
+    await expect(
+      storage.createOrLoadChannelActionToken(sampleChannelActionToken({ metadataHash: 'metadata-hash-2' })),
+    ).resolves.toMatchObject({
+      duplicate: true,
+      conflict: true,
+      token: { actionTokenId: 'action-token-1', metadataHash: 'metadata-hash-1' },
+    });
+    await expect(
+      storage.createOrLoadChannelActionToken(
+        sampleChannelActionToken({ actionTokenId: 'action-token-2', transportHash: 'transport-hash-1' }),
+      ),
+    ).resolves.toMatchObject({
+      duplicate: true,
+      conflict: true,
+      token: { actionTokenId: 'action-token-1', transportHash: 'transport-hash-1' },
+    });
+  });
+
+  it('dedupes exact action receipts and does not steal an active initial claim', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    const first = await storage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt(), {
+      initialClaim: { claimId: 'claim-1', now: 1000, claimTtlMs: 5000 },
+    });
+    const duplicate = await storage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt({ id: 'receipt-2' }), {
+      initialClaim: { claimId: 'claim-2', now: 2000, claimTtlMs: 5000 },
+    });
+
+    expect(first).toMatchObject({ duplicate: false, conflict: false, claimed: true });
+    expect(duplicate).toMatchObject({
+      duplicate: true,
+      conflict: false,
+      claimed: false,
+      receipt: { id: 'receipt-1', claimId: 'claim-1', claimExpiresAt: 6000 },
+    });
+  });
+
+  it('flags same action token with a different response hash as a conflict', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    await storage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt());
+
+    await expect(
+      storage.createOrLoadChannelActionReceipt(
+        sampleChannelActionReceipt({ id: 'receipt-2', responseHash: 'response-hash-2' }),
+      ),
+    ).resolves.toMatchObject({
+      duplicate: true,
+      conflict: true,
+      claimed: false,
+      receipt: { id: 'receipt-1', responseHash: 'response-hash-1' },
+    });
+  });
+
+  it('treats action receipt provider action ids as immutable identity', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    await storage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt());
+
+    await expect(
+      storage.createOrLoadChannelActionReceipt(
+        sampleChannelActionReceipt({ id: 'receipt-2', actionId: 'provider-action-2' }),
+      ),
+    ).resolves.toMatchObject({
+      duplicate: true,
+      conflict: true,
+      claimed: false,
+      receipt: { id: 'receipt-1', actionId: 'provider-action-1' },
+    });
+    await expect(
+      storage.saveChannelActionReceipt(sampleChannelActionReceipt({ actionId: 'provider-action-2', updatedAt: 1200 })),
+    ).rejects.toBeInstanceOf(HarnessStorageChannelActionReceiptTransitionError);
+  });
+
+  it('reclaims crashed action receipts after claim expiry but respects nextAttemptAt backoff', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    await storage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt({ nextAttemptAt: 7000 }), {
+      initialClaim: { claimId: 'claim-1', now: 1000, claimTtlMs: 1000 },
+    });
+
+    await expect(
+      storage.claimChannelActionReceipts({
+        harnessName: 'default',
+        statuses: ['received'],
+        claimId: 'early',
+        limit: 10,
+        now: 6500,
+        claimTtlMs: 1000,
+      }),
+    ).resolves.toEqual([]);
+    await expect(
+      storage.claimChannelActionReceipts({
+        harnessName: 'default',
+        statuses: ['received'],
+        claimId: 'recovery',
+        limit: 10,
+        now: 7000,
+        claimTtlMs: 1000,
+      }),
+    ).resolves.toEqual([expect.objectContaining({ id: 'receipt-1', claimId: 'recovery', claimExpiresAt: 8000 })]);
+  });
+
+  it('guards action receipt renewal and applied updates by owner claim', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    const now = 10_000;
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now);
+    try {
+      await storage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt(), {
+        initialClaim: { claimId: 'claim-1', now, claimTtlMs: 5000 },
+      });
+
+      await expect(
+        storage.renewChannelActionReceiptClaim({
+          receiptId: 'receipt-1',
+          claimId: 'other',
+          now: now + 100,
+          claimTtlMs: 5000,
+        }),
+      ).rejects.toBeInstanceOf(HarnessStorageChannelActionClaimConflictError);
+      await expect(
+        storage.renewChannelActionReceiptClaim({
+          receiptId: 'receipt-1',
+          claimId: 'claim-1',
+          now: now + 100,
+          claimTtlMs: 5000,
+        }),
+      ).resolves.toEqual({ claimExpiresAt: now + 5100, storageNow: now + 100 });
+
+      await storage.updateChannelActionReceipt(
+        sampleChannelActionReceipt({
+          status: 'accepted',
+          acceptedAt: now + 200,
+          updatedAt: now + 200,
+          claimId: 'claim-1',
+          claimExpiresAt: now + 5100,
+        }),
+        { claimId: 'claim-1' },
+      );
+      await storage.updateChannelActionReceipt(
+        sampleChannelActionReceipt({
+          status: 'applied',
+          acceptedAt: now + 200,
+          appliedAt: now + 300,
+          result: { ok: true },
+          updatedAt: now + 300,
+          claimId: undefined,
+          claimExpiresAt: undefined,
+        }),
+        { claimId: 'claim-1' },
+      );
+      await expect(
+        storage.renewChannelActionReceiptClaim({
+          receiptId: 'receipt-1',
+          claimId: 'claim-1',
+          now: now + 400,
+          claimTtlMs: 5000,
+        }),
+      ).rejects.toBeInstanceOf(HarnessStorageChannelActionClaimConflictError);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
+  it('validates new action receipt rows before insert and keeps terminal saves idempotent', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    await expect(
+      storage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt({ status: 'accepted' })),
+    ).rejects.toBeInstanceOf(HarnessStorageChannelActionReceiptTransitionError);
+    await expect(
+      storage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt({ status: 'mystery' as any })),
+    ).rejects.toBeInstanceOf(HarnessStorageChannelActionReceiptTransitionError);
+    await expect(
+      storage.createOrLoadChannelActionReceipt(
+        sampleChannelActionReceipt({ status: 'conflict', conflictReason: 'mystery' as any }),
+      ),
+    ).rejects.toBeInstanceOf(HarnessStorageChannelActionReceiptTransitionError);
+    const terminal = sampleChannelActionReceipt({
+      status: 'applied',
+      acceptedAt: 1200,
+      appliedAt: 1300,
+      result: { b: 2, a: 1 },
+      updatedAt: 1300,
+    });
+    const replay = { ...terminal, result: { a: 1, b: 2 } };
+
+    await storage.saveChannelActionReceipt(terminal);
+    await expect(storage.saveChannelActionReceipt(replay)).resolves.toBeUndefined();
+    await expect(
+      storage.saveChannelActionReceipt({ ...terminal, result: { changed: true }, updatedAt: 1400 }),
+    ).rejects.toBeInstanceOf(HarnessStorageChannelActionReceiptTransitionError);
+  });
+});
+
 function sampleSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
   return {
     harnessName: 'default',
@@ -956,6 +1161,59 @@ function sampleChannelInbox(overrides: Partial<ChannelInboxItem> = {}): ChannelI
     },
     content: 'hello',
     attachments: [],
+    ...overrides,
+  };
+}
+
+function sampleChannelActionToken(overrides: Partial<ChannelActionToken> = {}): ChannelActionToken {
+  return {
+    actionTokenId: 'action-token-1',
+    harnessName: 'default',
+    channelId: 'support',
+    providerId: 'slack',
+    resourceId: 'resource-1',
+    owningSessionId: 'session-1',
+    itemId: 'question-1',
+    kind: 'question',
+    bindingId: 'binding-1',
+    bindingGeneration: 1,
+    runId: 'run-1',
+    pendingRequestedAt: 1000,
+    audience: { platformUserIds: ['user-1'] },
+    metadataHash: 'metadata-hash-1',
+    transportHash: 'transport-hash-1',
+    keyId: 'key-1',
+    expiresAt: 10_000,
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function sampleChannelActionReceipt(overrides: Partial<ChannelActionReceipt> = {}): ChannelActionReceipt {
+  return {
+    id: 'receipt-1',
+    harnessName: 'default',
+    channelId: 'support',
+    providerId: 'slack',
+    actionTokenId: 'action-token-1',
+    actionId: 'provider-action-1',
+    bindingId: 'binding-1',
+    bindingGeneration: 1,
+    resourceId: 'resource-1',
+    owningSessionId: 'session-1',
+    itemId: 'question-1',
+    kind: 'question',
+    runId: 'run-1',
+    pendingRequestedAt: 1000,
+    audience: { platformUserIds: ['user-1'] },
+    verifiedActor: { platformUserId: 'user-1', displayName: 'User One' },
+    responseHash: 'response-hash-1',
+    response: { answer: 'approved' },
+    status: 'received',
+    attempts: 0,
+    createdAt: 1100,
+    updatedAt: 1100,
     ...overrides,
   };
 }

--- a/packages/core/src/storage/domains/harness/inmemory.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.ts
@@ -6,6 +6,9 @@ import {
   HarnessStorageAdmissionConflictError,
   HarnessStorageAttachmentInUseError,
   HarnessStorageAttachmentUnavailableError,
+  HarnessStorageChannelActionClaimConflictError,
+  HarnessStorageChannelActionReceiptTransitionError,
+  HarnessStorageChannelActionTokenConflictError,
   HarnessStorageChannelInboxClaimConflictError,
   HarnessStorageChannelInboxTransitionError,
   HarnessStorageDeleteGuardConflictError,
@@ -23,8 +26,12 @@ import type {
   AttachmentReference,
   AttachmentRecord,
   AttachmentSemanticMetadata,
+  ChannelActionReceipt,
+  ChannelActionToken,
   ChannelInboxItem,
   CreateOrLoadActiveSessionOptions,
+  CreateOrLoadChannelActionReceiptResult,
+  CreateOrLoadChannelActionTokenResult,
   CreateOrLoadChannelInboxItemResult,
   CreateOrLoadActiveSessionResult,
   DeleteSessionOptions,
@@ -1103,6 +1110,296 @@ export class InMemoryHarness extends HarnessStorage {
     this.db.harnessChannelInbox.set(channelInboxKey(namespace, record.id), cloneJson(next));
   }
 
+  // -------------------------------------------------------------------------
+  // Channel action token and receipt ledger
+  // -------------------------------------------------------------------------
+
+  async createOrLoadChannelActionToken(record: ChannelActionToken): Promise<CreateOrLoadChannelActionTokenResult> {
+    const token = { ...record, harnessName: resolveHarnessName(record.harnessName, this.harnessName) };
+    const existing = this.findChannelActionTokenById({
+      harnessName: token.harnessName,
+      channelId: token.channelId,
+      actionTokenId: token.actionTokenId,
+    });
+    if (existing) {
+      return { token: cloneJson(existing), duplicate: true, conflict: !channelActionTokensEquivalent(existing, token) };
+    }
+    const transportOwner = this.findChannelActionTokenByTransportHash({
+      harnessName: token.harnessName,
+      channelId: token.channelId,
+      transportHash: token.transportHash,
+    });
+    if (transportOwner) {
+      return { token: cloneJson(transportOwner), duplicate: true, conflict: true };
+    }
+    const pendingOwner = this.findChannelActionTokenForPendingItem({
+      harnessName: token.harnessName,
+      channelId: token.channelId,
+      bindingId: token.bindingId,
+      bindingGeneration: token.bindingGeneration,
+      owningSessionId: token.owningSessionId,
+      itemId: token.itemId,
+      kind: token.kind,
+      runId: token.runId,
+      pendingRequestedAt: token.pendingRequestedAt,
+      metadataHash: token.metadataHash,
+    });
+    if (pendingOwner) {
+      return { token: cloneJson(pendingOwner), duplicate: true, conflict: true };
+    }
+    this.db.harnessChannelActionTokens.set(
+      channelActionTokenKey(token.harnessName, token.channelId, token.actionTokenId),
+      cloneJson(token),
+    );
+    return { token: cloneJson(token), duplicate: false, conflict: false };
+  }
+
+  async loadChannelActionTokenById(opts: {
+    harnessName: string;
+    channelId: string;
+    actionTokenId: string;
+  }): Promise<ChannelActionToken | null> {
+    const token = this.findChannelActionTokenById({
+      ...opts,
+      harnessName: resolveHarnessName(opts.harnessName, this.harnessName),
+    });
+    return token ? cloneJson(token) : null;
+  }
+
+  async loadChannelActionTokenByTransportHash(opts: {
+    harnessName: string;
+    channelId: string;
+    transportHash: string;
+  }): Promise<ChannelActionToken | null> {
+    const token = this.findChannelActionTokenByTransportHash({
+      ...opts,
+      harnessName: resolveHarnessName(opts.harnessName, this.harnessName),
+    });
+    return token ? cloneJson(token) : null;
+  }
+
+  async loadChannelActionTokenForPendingItem(opts: {
+    harnessName: string;
+    channelId: string;
+    bindingId: string;
+    bindingGeneration: number;
+    owningSessionId: string;
+    itemId: string;
+    kind: ChannelActionToken['kind'];
+    runId: string;
+    pendingRequestedAt: number;
+    metadataHash: string;
+  }): Promise<ChannelActionToken | null> {
+    const token = this.findChannelActionTokenForPendingItem({
+      ...opts,
+      harnessName: resolveHarnessName(opts.harnessName, this.harnessName),
+    });
+    return token ? cloneJson(token) : null;
+  }
+
+  async revokeChannelActionToken(opts: {
+    harnessName: string;
+    channelId: string;
+    actionTokenId: string;
+    revokedAt?: number;
+    revokedReason?: ChannelActionToken['revokedReason'];
+  }): Promise<ChannelActionToken> {
+    const namespace = resolveHarnessName(opts.harnessName, this.harnessName);
+    const key = channelActionTokenKey(namespace, opts.channelId, opts.actionTokenId);
+    const token = this.db.harnessChannelActionTokens.get(key);
+    if (!token) throw new HarnessStorageChannelActionTokenConflictError(opts.actionTokenId, 'token was not found');
+    const revokedAt = opts.revokedAt ?? Date.now();
+    const next = { ...token, revokedAt, revokedReason: opts.revokedReason, updatedAt: revokedAt };
+    this.db.harnessChannelActionTokens.set(key, cloneJson(next));
+    return cloneJson(next);
+  }
+
+  async saveChannelActionReceipt(record: ChannelActionReceipt): Promise<void> {
+    const receipt = { ...record, harnessName: resolveHarnessName(record.harnessName, this.harnessName) };
+    assertValidChannelActionReceiptState(receipt);
+    const existing = this.findChannelActionReceiptById(receipt.id);
+    if (existing) {
+      if (channelActionReceiptsEqual(existing, receipt)) return;
+      assertLegalChannelActionReceiptUpdate(existing, receipt);
+    }
+    const existingByToken = this.findChannelActionReceiptByTokenId({
+      harnessName: receipt.harnessName,
+      channelId: receipt.channelId,
+      actionTokenId: receipt.actionTokenId,
+    });
+    if (existingByToken && existingByToken.id !== receipt.id) {
+      throw new HarnessStorageChannelActionReceiptTransitionError(
+        receipt.id,
+        existingByToken.status,
+        receipt.status,
+        'action token is already owned by another receipt',
+      );
+    }
+    this.db.harnessChannelActionReceipts.set(
+      channelActionReceiptKey(receipt.harnessName, receipt.id),
+      cloneJson(receipt),
+    );
+  }
+
+  async createOrLoadChannelActionReceipt(
+    record: ChannelActionReceipt,
+    opts?: { initialClaim?: { claimId: string; now: number; claimTtlMs: number } },
+  ): Promise<CreateOrLoadChannelActionReceiptResult> {
+    const namespace = resolveHarnessName(record.harnessName, this.harnessName);
+    const incoming: ChannelActionReceipt = { ...record, harnessName: namespace };
+    assertValidChannelActionReceiptState(incoming);
+    const existing = this.findChannelActionReceiptByTokenId({
+      harnessName: namespace,
+      channelId: incoming.channelId,
+      actionTokenId: incoming.actionTokenId,
+    });
+    if (existing) {
+      const conflict = !channelActionReceiptsEquivalentForCreate(existing, incoming);
+      let claimed = false;
+      let receipt = existing;
+      if (!conflict && opts?.initialClaim && isChannelActionReceiptClaimable(existing, opts.initialClaim.now)) {
+        receipt = {
+          ...existing,
+          claimId: opts.initialClaim.claimId,
+          claimExpiresAt: opts.initialClaim.now + opts.initialClaim.claimTtlMs,
+          updatedAt: opts.initialClaim.now,
+        };
+        this.db.harnessChannelActionReceipts.set(channelActionReceiptKey(namespace, receipt.id), cloneJson(receipt));
+        claimed = true;
+      }
+      return { receipt: cloneJson(receipt), duplicate: true, conflict, claimed };
+    }
+    const existingById = this.findChannelActionReceiptById(incoming.id);
+    if (existingById) {
+      throw new HarnessStorageChannelActionReceiptTransitionError(
+        incoming.id,
+        existingById.status,
+        incoming.status,
+        'id is already owned by another action receipt',
+      );
+    }
+    const receipt =
+      opts?.initialClaim === undefined
+        ? incoming
+        : {
+            ...incoming,
+            claimId: opts.initialClaim.claimId,
+            claimExpiresAt: opts.initialClaim.now + opts.initialClaim.claimTtlMs,
+            updatedAt: opts.initialClaim.now,
+          };
+    this.db.harnessChannelActionReceipts.set(channelActionReceiptKey(namespace, receipt.id), cloneJson(receipt));
+    return {
+      receipt: cloneJson(receipt),
+      duplicate: false,
+      conflict: false,
+      claimed: opts?.initialClaim !== undefined,
+    };
+  }
+
+  async loadChannelActionReceiptByActionId(opts: {
+    harnessName: string;
+    channelId: string;
+    actionId: string;
+  }): Promise<ChannelActionReceipt | null> {
+    const namespace = resolveHarnessName(opts.harnessName, this.harnessName);
+    const receipt = Array.from(this.db.harnessChannelActionReceipts.values())
+      .filter(
+        item => item.harnessName === namespace && item.channelId === opts.channelId && item.actionId === opts.actionId,
+      )
+      .sort((a, b) => a.createdAt - b.createdAt)[0];
+    return receipt ? cloneJson(receipt) : null;
+  }
+
+  async loadChannelActionReceiptByTokenId(opts: {
+    harnessName: string;
+    channelId: string;
+    actionTokenId: string;
+  }): Promise<ChannelActionReceipt | null> {
+    const receipt = this.findChannelActionReceiptByTokenId({
+      ...opts,
+      harnessName: resolveHarnessName(opts.harnessName, this.harnessName),
+    });
+    return receipt ? cloneJson(receipt) : null;
+  }
+
+  async claimChannelActionReceipts({
+    harnessName,
+    channelId,
+    statuses,
+    claimId,
+    limit,
+    now,
+    claimTtlMs,
+  }: {
+    harnessName: string;
+    channelId?: string;
+    statuses: Array<'received' | 'accepted' | 'failed'>;
+    claimId: string;
+    limit: number;
+    now: number;
+    claimTtlMs: number;
+  }): Promise<ChannelActionReceipt[]> {
+    const namespace = resolveHarnessName(harnessName, this.harnessName);
+    const claimed: ChannelActionReceipt[] = [];
+    const sorted = Array.from(this.db.harnessChannelActionReceipts.values()).sort((a, b) => a.createdAt - b.createdAt);
+    for (const receipt of sorted) {
+      if (claimed.length >= limit) break;
+      if (receipt.harnessName !== namespace) continue;
+      if (channelId !== undefined && receipt.channelId !== channelId) continue;
+      if (!statuses.includes(receipt.status as 'received' | 'accepted' | 'failed')) continue;
+      if (!isChannelActionReceiptClaimable(receipt, now)) continue;
+      const next = { ...receipt, claimId, claimExpiresAt: now + claimTtlMs, updatedAt: now };
+      this.db.harnessChannelActionReceipts.set(channelActionReceiptKey(namespace, next.id), cloneJson(next));
+      claimed.push(cloneJson(next));
+    }
+    return claimed;
+  }
+
+  async renewChannelActionReceiptClaim({
+    receiptId,
+    claimId,
+    now,
+    claimTtlMs,
+  }: {
+    receiptId: string;
+    claimId: string;
+    now: number;
+    claimTtlMs: number;
+  }): Promise<{ claimExpiresAt: number; storageNow: number }> {
+    const current = this.findChannelActionReceiptById(receiptId);
+    if (
+      !current ||
+      current.claimId !== claimId ||
+      current.claimExpiresAt === undefined ||
+      current.claimExpiresAt <= now ||
+      isTerminalChannelActionReceiptStatus(current.status)
+    ) {
+      throw new HarnessStorageChannelActionClaimConflictError(receiptId, claimId);
+    }
+    const claimExpiresAt = now + claimTtlMs;
+    const next = { ...current, claimExpiresAt, updatedAt: now };
+    this.db.harnessChannelActionReceipts.set(channelActionReceiptKey(next.harnessName, next.id), cloneJson(next));
+    return { claimExpiresAt, storageNow: now };
+  }
+
+  async updateChannelActionReceipt(record: ChannelActionReceipt, opts: { claimId: string }): Promise<void> {
+    const namespace = resolveHarnessName(record.harnessName, this.harnessName);
+    const current = this.db.harnessChannelActionReceipts.get(channelActionReceiptKey(namespace, record.id));
+    const storageNow = Date.now();
+    if (
+      !current ||
+      current.claimId !== opts.claimId ||
+      current.claimExpiresAt === undefined ||
+      current.claimExpiresAt <= storageNow ||
+      isTerminalChannelActionReceiptStatus(current.status)
+    ) {
+      throw new HarnessStorageChannelActionClaimConflictError(record.id, opts.claimId);
+    }
+    const next = { ...record, harnessName: namespace };
+    assertLegalChannelActionReceiptUpdate(current, next);
+    this.db.harnessChannelActionReceipts.set(channelActionReceiptKey(namespace, record.id), cloneJson(next));
+  }
+
   private findChannelInboxByIdempotencyKey({
     harnessName,
     channelId,
@@ -1115,6 +1412,95 @@ export class InMemoryHarness extends HarnessStorage {
     for (const item of this.db.harnessChannelInbox.values()) {
       if (item.harnessName === harnessName && item.channelId === channelId && item.idempotencyKey === idempotencyKey) {
         return cloneJson(item);
+      }
+    }
+    return null;
+  }
+
+  private findChannelActionTokenById({
+    harnessName,
+    channelId,
+    actionTokenId,
+  }: {
+    harnessName: string;
+    channelId: string;
+    actionTokenId: string;
+  }): ChannelActionToken | null {
+    const token = this.db.harnessChannelActionTokens.get(channelActionTokenKey(harnessName, channelId, actionTokenId));
+    return token ? cloneJson(token) : null;
+  }
+
+  private findChannelActionTokenByTransportHash({
+    harnessName,
+    channelId,
+    transportHash,
+  }: {
+    harnessName: string;
+    channelId: string;
+    transportHash: string;
+  }): ChannelActionToken | null {
+    for (const token of this.db.harnessChannelActionTokens.values()) {
+      if (token.harnessName === harnessName && token.channelId === channelId && token.transportHash === transportHash) {
+        return cloneJson(token);
+      }
+    }
+    return null;
+  }
+
+  private findChannelActionTokenForPendingItem(input: {
+    harnessName: string;
+    channelId: string;
+    bindingId: string;
+    bindingGeneration: number;
+    owningSessionId: string;
+    itemId: string;
+    kind: ChannelActionToken['kind'];
+    runId: string;
+    pendingRequestedAt: number;
+    metadataHash: string;
+  }): ChannelActionToken | null {
+    for (const token of this.db.harnessChannelActionTokens.values()) {
+      if (
+        token.harnessName === input.harnessName &&
+        token.channelId === input.channelId &&
+        token.bindingId === input.bindingId &&
+        token.bindingGeneration === input.bindingGeneration &&
+        token.owningSessionId === input.owningSessionId &&
+        token.itemId === input.itemId &&
+        token.kind === input.kind &&
+        token.runId === input.runId &&
+        token.pendingRequestedAt === input.pendingRequestedAt &&
+        token.metadataHash === input.metadataHash
+      ) {
+        return cloneJson(token);
+      }
+    }
+    return null;
+  }
+
+  private findChannelActionReceiptById(receiptId: string): ChannelActionReceipt | null {
+    for (const receipt of this.db.harnessChannelActionReceipts.values()) {
+      if (receipt.id === receiptId) return cloneJson(receipt);
+    }
+    return null;
+  }
+
+  private findChannelActionReceiptByTokenId({
+    harnessName,
+    channelId,
+    actionTokenId,
+  }: {
+    harnessName: string;
+    channelId: string;
+    actionTokenId: string;
+  }): ChannelActionReceipt | null {
+    for (const receipt of this.db.harnessChannelActionReceipts.values()) {
+      if (
+        receipt.harnessName === harnessName &&
+        receipt.channelId === channelId &&
+        receipt.actionTokenId === actionTokenId
+      ) {
+        return cloneJson(receipt);
       }
     }
     return null;
@@ -1167,6 +1553,8 @@ export class InMemoryHarness extends HarnessStorage {
     this.db.harnessMessageResultEvidence.clear();
     this.db.harnessOperationTombstones.clear();
     this.db.harnessChannelInbox.clear();
+    this.db.harnessChannelActionTokens.clear();
+    this.db.harnessChannelActionReceipts.clear();
     this.db.harnessThreadDeleteFences.clear();
   }
 }
@@ -1208,6 +1596,14 @@ function messageEvidenceKey(harnessName: string, sessionId: string, signalId: st
 
 function channelInboxKey(_harnessName: string, inboxItemId: string): string {
   return inboxItemId;
+}
+
+function channelActionTokenKey(harnessName: string, channelId: string, actionTokenId: string): string {
+  return `${harnessName}\u0000${channelId}\u0000${actionTokenId}`;
+}
+
+function channelActionReceiptKey(_harnessName: string, receiptId: string): string {
+  return receiptId;
 }
 
 function resolveHarnessName(input: string | undefined, fallback: string): string {
@@ -1261,10 +1657,20 @@ function isTerminalChannelInboxStatus(status: ChannelInboxItem['status']): boole
   return status === 'accepted' || status === 'queued' || status === 'dead';
 }
 
+function isTerminalChannelActionReceiptStatus(status: ChannelActionReceipt['status']): boolean {
+  return status === 'applied' || status === 'conflict' || status === 'dead';
+}
+
 function isChannelInboxClaimable(item: ChannelInboxItem, now: number): boolean {
   if (isTerminalChannelInboxStatus(item.status)) return false;
   if (item.nextAttemptAt !== undefined && item.nextAttemptAt > now) return false;
   return item.claimId === undefined || item.claimExpiresAt === undefined || item.claimExpiresAt <= now;
+}
+
+function isChannelActionReceiptClaimable(receipt: ChannelActionReceipt, now: number): boolean {
+  if (isTerminalChannelActionReceiptStatus(receipt.status)) return false;
+  if (receipt.nextAttemptAt !== undefined && receipt.nextAttemptAt > now) return false;
+  return receipt.claimId === undefined || receipt.claimExpiresAt === undefined || receipt.claimExpiresAt <= now;
 }
 
 function assertLegalChannelInboxUpdate(current: ChannelInboxItem, next: ChannelInboxItem): void {
@@ -1353,6 +1759,219 @@ function channelInboxItemsEqual(a: ChannelInboxItem, b: ChannelInboxItem): boole
   const aValues = channelInboxComparableValues(a);
   const bValues = channelInboxComparableValues(b);
   return aValues.length === bValues.length && aValues.every((value, index) => Object.is(value, bValues[index]));
+}
+
+function assertLegalChannelActionReceiptUpdate(current: ChannelActionReceipt, next: ChannelActionReceipt): void {
+  const immutableMismatch =
+    current.id !== next.id ||
+    current.harnessName !== next.harnessName ||
+    current.channelId !== next.channelId ||
+    current.providerId !== next.providerId ||
+    current.actionTokenId !== next.actionTokenId ||
+    current.actionId !== next.actionId ||
+    current.bindingId !== next.bindingId ||
+    current.bindingGeneration !== next.bindingGeneration ||
+    current.resourceId !== next.resourceId ||
+    current.owningSessionId !== next.owningSessionId ||
+    current.itemId !== next.itemId ||
+    current.kind !== next.kind ||
+    current.runId !== next.runId ||
+    current.pendingRequestedAt !== next.pendingRequestedAt ||
+    stableJsonString(current.audience) !== stableJsonString(next.audience) ||
+    current.responseHash !== next.responseHash;
+  if (immutableMismatch) {
+    throw new HarnessStorageChannelActionReceiptTransitionError(
+      current.id,
+      current.status,
+      next.status,
+      'immutable token, item, and response identity fields cannot change',
+    );
+  }
+  const allowed =
+    current.status === next.status ||
+    (current.status === 'received' &&
+      (next.status === 'accepted' ||
+        next.status === 'failed' ||
+        next.status === 'conflict' ||
+        next.status === 'dead')) ||
+    (current.status === 'accepted' &&
+      (next.status === 'applied' || next.status === 'failed' || next.status === 'dead')) ||
+    (current.status === 'failed' &&
+      (next.status === 'received' || next.status === 'accepted' || next.status === 'failed' || next.status === 'dead'));
+  if (!allowed || isTerminalChannelActionReceiptStatus(current.status)) {
+    throw new HarnessStorageChannelActionReceiptTransitionError(
+      current.id,
+      current.status,
+      next.status,
+      'transition is not legal for channel action receipt state machine',
+    );
+  }
+  assertValidChannelActionReceiptState(next, current.status);
+}
+
+function assertValidChannelActionReceiptState(
+  record: ChannelActionReceipt,
+  currentStatus?: ChannelActionReceipt['status'],
+): void {
+  const validStatus =
+    record.status === 'received' ||
+    record.status === 'accepted' ||
+    record.status === 'applied' ||
+    record.status === 'conflict' ||
+    record.status === 'failed' ||
+    record.status === 'dead';
+  if (!validStatus) {
+    throw new HarnessStorageChannelActionReceiptTransitionError(
+      record.id,
+      currentStatus,
+      record.status,
+      'status is not a known channel action receipt state',
+    );
+  }
+  if (record.status === 'accepted' && record.acceptedAt == null) {
+    throw new HarnessStorageChannelActionReceiptTransitionError(
+      record.id,
+      currentStatus,
+      record.status,
+      'accepted receipts require acceptedAt',
+    );
+  }
+  if (record.status === 'applied' && (record.appliedAt == null || record.result === undefined)) {
+    throw new HarnessStorageChannelActionReceiptTransitionError(
+      record.id,
+      currentStatus,
+      record.status,
+      'applied receipts require appliedAt and result',
+    );
+  }
+  if (record.status === 'conflict' && record.conflictReason == null) {
+    throw new HarnessStorageChannelActionReceiptTransitionError(
+      record.id,
+      currentStatus,
+      record.status,
+      'conflict receipts require conflictReason',
+    );
+  }
+  if (record.status === 'failed' && (record.failedAt == null || record.lastError == null)) {
+    throw new HarnessStorageChannelActionReceiptTransitionError(
+      record.id,
+      currentStatus,
+      record.status,
+      'failed receipts require failedAt and lastError',
+    );
+  }
+  if (record.status === 'dead' && (record.deadAt == null || record.lastError == null)) {
+    throw new HarnessStorageChannelActionReceiptTransitionError(
+      record.id,
+      currentStatus,
+      record.status,
+      'dead receipts require deadAt and lastError',
+    );
+  }
+  if (
+    record.conflictReason !== undefined &&
+    record.conflictReason !== 'response_mismatch' &&
+    record.conflictReason !== 'stale_item' &&
+    record.conflictReason !== 'kind_mismatch' &&
+    record.conflictReason !== 'run_mismatch' &&
+    record.conflictReason !== 'binding_mismatch' &&
+    record.conflictReason !== 'session_closed' &&
+    record.conflictReason !== 'actor_not_allowed' &&
+    record.conflictReason !== 'token_expired' &&
+    record.conflictReason !== 'token_revoked'
+  ) {
+    throw new HarnessStorageChannelActionReceiptTransitionError(
+      record.id,
+      currentStatus,
+      record.status,
+      'conflictReason is not a known channel action receipt reason',
+    );
+  }
+}
+
+function channelActionTokensEquivalent(a: ChannelActionToken, b: ChannelActionToken): boolean {
+  return (
+    a.actionTokenId === b.actionTokenId &&
+    a.harnessName === b.harnessName &&
+    a.channelId === b.channelId &&
+    a.providerId === b.providerId &&
+    a.resourceId === b.resourceId &&
+    a.owningSessionId === b.owningSessionId &&
+    a.itemId === b.itemId &&
+    a.kind === b.kind &&
+    a.bindingId === b.bindingId &&
+    a.bindingGeneration === b.bindingGeneration &&
+    a.runId === b.runId &&
+    a.pendingRequestedAt === b.pendingRequestedAt &&
+    stableJsonString(a.audience) === stableJsonString(b.audience) &&
+    a.metadataHash === b.metadataHash &&
+    a.transportHash === b.transportHash &&
+    a.keyId === b.keyId &&
+    a.expiresAt === b.expiresAt
+  );
+}
+
+function channelActionReceiptsEquivalentForCreate(a: ChannelActionReceipt, b: ChannelActionReceipt): boolean {
+  return (
+    a.harnessName === b.harnessName &&
+    a.channelId === b.channelId &&
+    a.providerId === b.providerId &&
+    a.actionTokenId === b.actionTokenId &&
+    a.actionId === b.actionId &&
+    a.bindingId === b.bindingId &&
+    a.bindingGeneration === b.bindingGeneration &&
+    a.resourceId === b.resourceId &&
+    a.owningSessionId === b.owningSessionId &&
+    a.itemId === b.itemId &&
+    a.kind === b.kind &&
+    a.runId === b.runId &&
+    a.pendingRequestedAt === b.pendingRequestedAt &&
+    stableJsonString(a.audience) === stableJsonString(b.audience) &&
+    a.responseHash === b.responseHash
+  );
+}
+
+function channelActionReceiptsEqual(a: ChannelActionReceipt, b: ChannelActionReceipt): boolean {
+  const aValues = channelActionReceiptComparableValues(a);
+  const bValues = channelActionReceiptComparableValues(b);
+  return aValues.length === bValues.length && aValues.every((value, index) => Object.is(value, bValues[index]));
+}
+
+function channelActionReceiptComparableValues(record: ChannelActionReceipt): unknown[] {
+  return [
+    record.id,
+    record.harnessName,
+    record.channelId,
+    record.providerId,
+    record.actionTokenId,
+    record.actionId,
+    record.bindingId,
+    record.bindingGeneration,
+    record.resourceId,
+    record.owningSessionId,
+    record.itemId,
+    record.kind,
+    record.runId,
+    record.pendingRequestedAt,
+    stableJsonString(record.audience),
+    stableJsonString(record.verifiedActor),
+    record.responseHash,
+    stableJsonString(record.response),
+    record.status,
+    record.conflictReason,
+    record.attempts,
+    record.claimId,
+    record.claimExpiresAt,
+    record.nextAttemptAt,
+    record.acceptedAt,
+    record.appliedAt,
+    record.failedAt,
+    record.deadAt,
+    stableJsonString(record.result),
+    record.lastError ? stableJsonString(record.lastError) : undefined,
+    record.createdAt,
+    record.updatedAt,
+  ];
 }
 
 function channelInboxComparableValues(record: ChannelInboxItem): unknown[] {

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -534,6 +534,102 @@ export interface CreateOrLoadChannelInboxItemResult {
   claimed: boolean;
 }
 
+export type ChannelActionKind = PendingResume['kind'];
+export type ChannelActionAudience = JsonValue;
+
+export interface ChannelActionActor {
+  platformUserId: string;
+  displayName?: string;
+  metadata?: Record<string, JsonValue>;
+}
+
+export interface ChannelActionToken {
+  actionTokenId: string;
+  harnessName: string;
+  channelId: string;
+  providerId: string;
+  resourceId: string;
+  owningSessionId: string;
+  itemId: string;
+  kind: ChannelActionKind;
+  bindingId: string;
+  bindingGeneration: number;
+  runId: string;
+  pendingRequestedAt: number;
+  audience: ChannelActionAudience;
+  metadataHash: string;
+  transportHash: string;
+  keyId?: string;
+  expiresAt?: number;
+  revokedAt?: number;
+  revokedReason?: Extract<HarnessRowErrorCode, 'session_deleted'>;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ChannelActionReceipt {
+  id: string;
+  harnessName: string;
+  channelId: string;
+  providerId: string;
+  actionTokenId: string;
+  actionId: string;
+  bindingId: string;
+  bindingGeneration: number;
+  resourceId: string;
+  owningSessionId: string;
+  itemId: string;
+  kind: ChannelActionKind;
+  runId: string;
+  pendingRequestedAt: number;
+  audience: ChannelActionAudience;
+  verifiedActor?: ChannelActionActor;
+  responseHash: string;
+  response: JsonValue;
+  status: 'received' | 'accepted' | 'applied' | 'conflict' | 'failed' | 'dead';
+  conflictReason?:
+    | 'response_mismatch'
+    | 'stale_item'
+    | 'kind_mismatch'
+    | 'run_mismatch'
+    | 'binding_mismatch'
+    | 'session_closed'
+    | 'actor_not_allowed'
+    | 'token_expired'
+    | 'token_revoked';
+  attempts: number;
+  claimId?: string;
+  claimExpiresAt?: number;
+  nextAttemptAt?: number;
+  acceptedAt?: number;
+  appliedAt?: number;
+  failedAt?: number;
+  deadAt?: number;
+  result?: JsonValue;
+  lastError?: { code: HarnessRowErrorCode; message: string; retryable?: boolean };
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ChannelActionInitialClaim {
+  claimId: string;
+  now: number;
+  claimTtlMs: number;
+}
+
+export interface CreateOrLoadChannelActionTokenResult {
+  token: ChannelActionToken;
+  duplicate: boolean;
+  conflict: boolean;
+}
+
+export interface CreateOrLoadChannelActionReceiptResult {
+  receipt: ChannelActionReceipt;
+  duplicate: boolean;
+  conflict: boolean;
+  claimed: boolean;
+}
+
 export interface OperationAdmissionTombstone {
   kind: HarnessOperationKind;
   harnessName: string;

--- a/packages/core/src/storage/domains/inmemory-db.ts
+++ b/packages/core/src/storage/domains/inmemory-db.ts
@@ -24,6 +24,8 @@ import type {
   AgentSignalResultEvidence,
   AttachmentRecord,
   AttachmentReference,
+  ChannelActionReceipt,
+  ChannelActionToken,
   ChannelInboxItem,
   OperationAdmissionTombstone,
   SessionRecord,
@@ -100,6 +102,8 @@ export class InMemoryDB {
   readonly harnessMessageResultEvidence = new Map<string, AgentSignalResultEvidence>();
   readonly harnessOperationTombstones = new Map<string, OperationAdmissionTombstone>();
   readonly harnessChannelInbox = new Map<string, ChannelInboxItem>();
+  readonly harnessChannelActionTokens = new Map<string, ChannelActionToken>();
+  readonly harnessChannelActionReceipts = new Map<string, ChannelActionReceipt>();
   readonly harnessThreadDeleteFences = new Map<
     string,
     { threadId: string; ownerId: string; leaseId: string; createdAt: number; expiresAt: number }
@@ -150,6 +154,8 @@ export class InMemoryDB {
     this.harnessMessageResultEvidence.clear();
     this.harnessOperationTombstones.clear();
     this.harnessChannelInbox.clear();
+    this.harnessChannelActionTokens.clear();
+    this.harnessChannelActionReceipts.clear();
     this.harnessThreadDeleteFences.clear();
   }
 }

--- a/packages/core/src/storage/domains/operations/inmemory.ts
+++ b/packages/core/src/storage/domains/operations/inmemory.ts
@@ -52,6 +52,8 @@ export class StoreOperationsInMemory extends StoreOperations {
       mastra_harness_operation_tombstones: new Map(),
       mastra_harness_thread_delete_fences: new Map(),
       mastra_harness_channel_inbox: new Map(),
+      mastra_harness_channel_action_tokens: new Map(),
+      mastra_harness_channel_action_receipts: new Map(),
     };
   }
 

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -8,10 +8,13 @@ import type { Client } from '@libsql/client';
 import {
   TABLE_HARNESS_ATTACHMENT_REFERENCES,
   TABLE_HARNESS_ATTACHMENTS,
+  TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS,
   TABLE_HARNESS_CHANNEL_INBOX,
   TABLE_HARNESS_MESSAGE_RESULTS,
   TABLE_HARNESS_SESSIONS,
   TABLE_HARNESS_THREAD_DELETE_FENCES,
+  HarnessStorageChannelActionClaimConflictError,
+  HarnessStorageChannelActionReceiptTransitionError,
   HarnessStorageChannelInboxClaimConflictError,
   HarnessStorageChannelInboxTransitionError,
   HarnessStorageDeleteGuardConflictError,
@@ -19,6 +22,8 @@ import {
   HarnessStorageVersionConflictError,
 } from '@mastra/core/storage';
 import type {
+  ChannelActionReceipt,
+  ChannelActionToken,
   ChannelInboxItem,
   SessionRecord,
   HarnessStorageParentSessionUnavailableError,
@@ -1333,6 +1338,293 @@ describe('HarnessLibSQL channel inbox ledger', () => {
   });
 });
 
+describe('HarnessLibSQL channel action ledger', () => {
+  let storage: HarnessLibSQL;
+  let client: Client;
+
+  beforeEach(async () => {
+    client = createHarnessTestClient();
+    storage = new HarnessLibSQL({ client });
+    await storage.init();
+  });
+
+  it('dedupes exact action tokens and flags immutable token mismatches', async () => {
+    await expect(storage.createOrLoadChannelActionToken(sampleChannelActionToken())).resolves.toMatchObject({
+      duplicate: false,
+      conflict: false,
+    });
+
+    await expect(storage.createOrLoadChannelActionToken(sampleChannelActionToken())).resolves.toMatchObject({
+      duplicate: true,
+      conflict: false,
+      token: { actionTokenId: 'action-token-1', metadataHash: 'metadata-hash-1' },
+    });
+    await expect(
+      storage.createOrLoadChannelActionToken(sampleChannelActionToken({ metadataHash: 'metadata-hash-2' })),
+    ).resolves.toMatchObject({
+      duplicate: true,
+      conflict: true,
+      token: { actionTokenId: 'action-token-1', metadataHash: 'metadata-hash-1' },
+    });
+    await expect(
+      storage.createOrLoadChannelActionToken(
+        sampleChannelActionToken({ actionTokenId: 'action-token-2', transportHash: 'transport-hash-1' }),
+      ),
+    ).resolves.toMatchObject({
+      duplicate: true,
+      conflict: true,
+      token: { actionTokenId: 'action-token-1', transportHash: 'transport-hash-1' },
+    });
+  });
+
+  it('creates receipt indexes on the lazy ensure path', async () => {
+    const client = createHarnessTestClient();
+    const lazyStorage = new HarnessLibSQL({ client });
+
+    await lazyStorage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt());
+    await lazyStorage.loadChannelActionReceiptByTokenId({
+      harnessName: 'default',
+      channelId: 'support',
+      actionTokenId: 'action-token-1',
+    });
+
+    await expect(indexNames(client, TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS)).resolves.toEqual(
+      expect.arrayContaining([
+        'idx_harness_channel_action_receipts_token',
+        'idx_harness_channel_action_receipts_action',
+        'idx_harness_channel_action_receipts_claim',
+      ]),
+    );
+  });
+
+  it('dedupes exact action receipts and does not steal an active initial claim', async () => {
+    const first = await storage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt(), {
+      initialClaim: { claimId: 'claim-1', now: 1000, claimTtlMs: 5000 },
+    });
+    const duplicate = await storage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt({ id: 'receipt-2' }), {
+      initialClaim: { claimId: 'claim-2', now: 2000, claimTtlMs: 5000 },
+    });
+
+    expect(first).toMatchObject({ duplicate: false, conflict: false, claimed: true });
+    expect(duplicate).toMatchObject({
+      duplicate: true,
+      conflict: false,
+      claimed: false,
+      receipt: { id: 'receipt-1', claimId: 'claim-1', claimExpiresAt: 6000 },
+    });
+  });
+
+  it('flags same action token with a different response hash as a conflict', async () => {
+    await storage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt());
+
+    await expect(
+      storage.createOrLoadChannelActionReceipt(
+        sampleChannelActionReceipt({ id: 'receipt-2', responseHash: 'response-hash-2' }),
+      ),
+    ).resolves.toMatchObject({
+      duplicate: true,
+      conflict: true,
+      claimed: false,
+      receipt: { id: 'receipt-1', responseHash: 'response-hash-1' },
+    });
+  });
+
+  it('treats action receipt provider action ids as immutable identity', async () => {
+    await storage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt());
+
+    await expect(
+      storage.createOrLoadChannelActionReceipt(
+        sampleChannelActionReceipt({ id: 'receipt-2', actionId: 'provider-action-2' }),
+      ),
+    ).resolves.toMatchObject({
+      duplicate: true,
+      conflict: true,
+      claimed: false,
+      receipt: { id: 'receipt-1', actionId: 'provider-action-1' },
+    });
+    await expect(
+      storage.saveChannelActionReceipt(sampleChannelActionReceipt({ actionId: 'provider-action-2', updatedAt: 1200 })),
+    ).rejects.toBeInstanceOf(HarnessStorageChannelActionReceiptTransitionError);
+  });
+
+  it('reclaims crashed action receipts after claim expiry but respects nextAttemptAt backoff', async () => {
+    await storage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt({ nextAttemptAt: 7000 }), {
+      initialClaim: { claimId: 'claim-1', now: 1000, claimTtlMs: 1000 },
+    });
+
+    await expect(
+      storage.claimChannelActionReceipts({
+        harnessName: 'default',
+        statuses: ['received'],
+        claimId: 'early',
+        limit: 10,
+        now: 6500,
+        claimTtlMs: 1000,
+      }),
+    ).resolves.toEqual([]);
+    await expect(
+      storage.claimChannelActionReceipts({
+        harnessName: 'default',
+        statuses: ['received'],
+        claimId: 'recovery',
+        limit: 10,
+        now: 7000,
+        claimTtlMs: 1000,
+      }),
+    ).resolves.toEqual([expect.objectContaining({ id: 'receipt-1', claimId: 'recovery', claimExpiresAt: 8000 })]);
+  });
+
+  it('does not treat non-positive claim limits as unbounded', async () => {
+    await storage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt());
+
+    await expect(
+      storage.claimChannelActionReceipts({
+        harnessName: 'default',
+        statuses: ['received'],
+        claimId: 'claim-1',
+        limit: -1,
+        now: 2000,
+        claimTtlMs: 1000,
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it('guards action receipt renewal and applied updates by owner claim', async () => {
+    const now = 10_000;
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now);
+    try {
+      await storage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt(), {
+        initialClaim: { claimId: 'claim-1', now, claimTtlMs: 5000 },
+      });
+
+      await expect(
+        storage.renewChannelActionReceiptClaim({
+          receiptId: 'receipt-1',
+          claimId: 'other',
+          now: now + 100,
+          claimTtlMs: 5000,
+        }),
+      ).rejects.toBeInstanceOf(HarnessStorageChannelActionClaimConflictError);
+      await expect(
+        storage.renewChannelActionReceiptClaim({
+          receiptId: 'receipt-1',
+          claimId: 'claim-1',
+          now: now + 100,
+          claimTtlMs: 5000,
+        }),
+      ).resolves.toEqual({ claimExpiresAt: now + 5100, storageNow: now + 100 });
+
+      await storage.updateChannelActionReceipt(
+        sampleChannelActionReceipt({
+          status: 'accepted',
+          acceptedAt: now + 200,
+          updatedAt: now + 200,
+          claimId: 'claim-1',
+          claimExpiresAt: now + 5100,
+        }),
+        { claimId: 'claim-1' },
+      );
+      await storage.updateChannelActionReceipt(
+        sampleChannelActionReceipt({
+          status: 'applied',
+          acceptedAt: now + 200,
+          appliedAt: now + 300,
+          result: { ok: true },
+          updatedAt: now + 300,
+          claimId: undefined,
+          claimExpiresAt: undefined,
+        }),
+        { claimId: 'claim-1' },
+      );
+      await expect(
+        storage.renewChannelActionReceiptClaim({
+          receiptId: 'receipt-1',
+          claimId: 'claim-1',
+          now: now + 400,
+          claimTtlMs: 5000,
+        }),
+      ).rejects.toBeInstanceOf(HarnessStorageChannelActionClaimConflictError);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
+  it('rejects stale same-claim action receipt updates after another writer changes the row', async () => {
+    const now = 10_000;
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now + 100);
+    await storage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt(), {
+      initialClaim: { claimId: 'claim-1', now, claimTtlMs: 5000 },
+    });
+    const originalExecute = client.execute.bind(client);
+    let injectConcurrentUpdate = false;
+    try {
+      vi.spyOn(client, 'execute').mockImplementation(async statement => {
+        const result = await originalExecute(statement);
+        const sql = typeof statement === 'string' ? statement : statement.sql;
+        if (
+          injectConcurrentUpdate &&
+          sql.includes(`SELECT * FROM ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}`) &&
+          sql.includes('WHERE harness_name = ? AND id = ?')
+        ) {
+          injectConcurrentUpdate = false;
+          await originalExecute({
+            sql: `UPDATE ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}
+                  SET attempts = ?
+                  WHERE id = ?`,
+            args: [1, 'receipt-1'],
+          });
+        }
+        return result;
+      });
+      injectConcurrentUpdate = true;
+
+      await expect(
+        storage.updateChannelActionReceipt(
+          sampleChannelActionReceipt({
+            status: 'accepted',
+            acceptedAt: now + 100,
+            attempts: 2,
+            updatedAt: now + 100,
+            claimId: 'claim-1',
+            claimExpiresAt: now + 5000,
+          }),
+          { claimId: 'claim-1' },
+        ),
+      ).rejects.toBeInstanceOf(HarnessStorageChannelActionClaimConflictError);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
+  it('validates new action receipt rows before insert and keeps terminal saves idempotent', async () => {
+    await expect(
+      storage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt({ status: 'accepted' })),
+    ).rejects.toBeInstanceOf(HarnessStorageChannelActionReceiptTransitionError);
+    await expect(
+      storage.createOrLoadChannelActionReceipt(sampleChannelActionReceipt({ status: 'mystery' as any })),
+    ).rejects.toBeInstanceOf(HarnessStorageChannelActionReceiptTransitionError);
+    await expect(
+      storage.createOrLoadChannelActionReceipt(
+        sampleChannelActionReceipt({ status: 'conflict', conflictReason: 'mystery' as any }),
+      ),
+    ).rejects.toBeInstanceOf(HarnessStorageChannelActionReceiptTransitionError);
+    const terminal = sampleChannelActionReceipt({
+      status: 'applied',
+      acceptedAt: 1200,
+      appliedAt: 1300,
+      result: { b: 2, a: 1 },
+      updatedAt: 1300,
+    });
+    const replay = { ...terminal, result: { a: 1, b: 2 } };
+
+    await storage.saveChannelActionReceipt(terminal);
+    await expect(storage.saveChannelActionReceipt(replay)).resolves.toBeUndefined();
+    await expect(
+      storage.saveChannelActionReceipt({ ...terminal, result: { changed: true }, updatedAt: 1400 }),
+    ).rejects.toBeInstanceOf(HarnessStorageChannelActionReceiptTransitionError);
+  });
+});
+
 function sampleSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
   return {
     harnessName: 'default',
@@ -1383,6 +1675,59 @@ function sampleChannelInbox(overrides: Partial<ChannelInboxItem> = {}): ChannelI
     },
     content: 'hello',
     attachments: [],
+    ...overrides,
+  };
+}
+
+function sampleChannelActionToken(overrides: Partial<ChannelActionToken> = {}): ChannelActionToken {
+  return {
+    actionTokenId: 'action-token-1',
+    harnessName: 'default',
+    channelId: 'support',
+    providerId: 'slack',
+    resourceId: 'resource-1',
+    owningSessionId: 'session-1',
+    itemId: 'question-1',
+    kind: 'question',
+    bindingId: 'binding-1',
+    bindingGeneration: 1,
+    runId: 'run-1',
+    pendingRequestedAt: 1000,
+    audience: { platformUserIds: ['user-1'] },
+    metadataHash: 'metadata-hash-1',
+    transportHash: 'transport-hash-1',
+    keyId: 'key-1',
+    expiresAt: 10_000,
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  };
+}
+
+function sampleChannelActionReceipt(overrides: Partial<ChannelActionReceipt> = {}): ChannelActionReceipt {
+  return {
+    id: 'receipt-1',
+    harnessName: 'default',
+    channelId: 'support',
+    providerId: 'slack',
+    actionTokenId: 'action-token-1',
+    actionId: 'provider-action-1',
+    bindingId: 'binding-1',
+    bindingGeneration: 1,
+    resourceId: 'resource-1',
+    owningSessionId: 'session-1',
+    itemId: 'question-1',
+    kind: 'question',
+    runId: 'run-1',
+    pendingRequestedAt: 1000,
+    audience: { platformUserIds: ['user-1'] },
+    verifiedActor: { platformUserId: 'user-1', displayName: 'User One' },
+    responseHash: 'response-hash-1',
+    response: { answer: 'approved' },
+    status: 'received',
+    attempts: 0,
+    createdAt: 1100,
+    updatedAt: 1100,
     ...overrides,
   };
 }

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -6,6 +6,9 @@ import {
   HarnessStorageAdmissionConflictError,
   HarnessStorageAttachmentInUseError,
   HarnessStorageAttachmentUnavailableError,
+  HarnessStorageChannelActionClaimConflictError,
+  HarnessStorageChannelActionReceiptTransitionError,
+  HarnessStorageChannelActionTokenConflictError,
   HarnessStorageChannelInboxClaimConflictError,
   HarnessStorageChannelInboxTransitionError,
   HarnessStorageDeleteGuardConflictError,
@@ -17,6 +20,8 @@ import {
   TABLE_CONFIGS,
   TABLE_HARNESS_ATTACHMENT_REFERENCES,
   TABLE_HARNESS_ATTACHMENTS,
+  TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS,
+  TABLE_HARNESS_CHANNEL_ACTION_TOKENS,
   TABLE_HARNESS_CHANNEL_INBOX,
   TABLE_HARNESS_MESSAGE_RESULTS,
   TABLE_HARNESS_OPERATION_TOMBSTONES,
@@ -32,9 +37,13 @@ import type {
   AttachmentReference,
   AttachmentRecord,
   AttachmentSemanticMetadata,
+  ChannelActionReceipt,
+  ChannelActionToken,
   ChannelInboxItem,
   CreateOrLoadActiveSessionOptions,
   CreateOrLoadActiveSessionResult,
+  CreateOrLoadChannelActionReceiptResult,
+  CreateOrLoadChannelActionTokenResult,
   CreateOrLoadChannelInboxItemResult,
   DeleteSessionOptions,
   ListActiveSessionsByThreadInput,
@@ -82,6 +91,7 @@ export class HarnessLibSQL extends HarnessStorage {
   #harnessName: string;
   #compactionLocks = new Map<string, Promise<void>>();
   #channelInboxIndexesReady: Promise<void> | undefined;
+  #channelActionIndexesReady: Promise<void> | undefined;
   #localThreadDeleteFences = new Map<string, { ownerId: string; leaseId: string; ttlMs: number }>();
 
   constructor(config: LibSQLDomainConfig) {
@@ -129,6 +139,7 @@ export class HarnessLibSQL extends HarnessStorage {
       compositePrimaryKey: threadDeleteFencesConfig?.compositePrimaryKey,
     });
     await this.#ensureChannelInboxTable();
+    await this.#ensureChannelActionTables();
     await this.#db.alterTable({
       tableName: TABLE_HARNESS_SESSIONS,
       schema: TABLE_SCHEMAS[TABLE_HARNESS_SESSIONS],
@@ -201,12 +212,15 @@ export class HarnessLibSQL extends HarnessStorage {
     await this.#ensureOperationTombstonesTable();
     await this.#ensureThreadDeleteFencesTable();
     await this.#ensureChannelInboxTable();
+    await this.#ensureChannelActionTables();
     this.#localThreadDeleteFences.clear();
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_ATTACHMENT_REFERENCES}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_ATTACHMENTS}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_MESSAGE_RESULTS}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_OPERATION_TOMBSTONES}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_CHANNEL_INBOX}`);
+    await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}`);
+    await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_CHANNEL_ACTION_TOKENS}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_THREAD_DELETE_FENCES}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_SESSIONS}`);
   }
@@ -1960,6 +1974,534 @@ export class HarnessLibSQL extends HarnessStorage {
     }
   }
 
+  // -------------------------------------------------------------------------
+  // Channel action token and receipt ledger
+  // -------------------------------------------------------------------------
+
+  async createOrLoadChannelActionToken(record: ChannelActionToken): Promise<CreateOrLoadChannelActionTokenResult> {
+    await this.#ensureChannelActionTables();
+    const token = { ...record, harnessName: this.#resolveHarnessName(record.harnessName) };
+    const existing = await this.loadChannelActionTokenById({
+      harnessName: token.harnessName,
+      channelId: token.channelId,
+      actionTokenId: token.actionTokenId,
+    });
+    if (existing) {
+      return { token: existing, duplicate: true, conflict: !channelActionTokensEquivalent(existing, token) };
+    }
+    const existingByTransport = await this.loadChannelActionTokenByTransportHash({
+      harnessName: token.harnessName,
+      channelId: token.channelId,
+      transportHash: token.transportHash,
+    });
+    if (existingByTransport) return { token: existingByTransport, duplicate: true, conflict: true };
+    const existingByPending = await this.loadChannelActionTokenForPendingItem({
+      harnessName: token.harnessName,
+      channelId: token.channelId,
+      bindingId: token.bindingId,
+      bindingGeneration: token.bindingGeneration,
+      owningSessionId: token.owningSessionId,
+      itemId: token.itemId,
+      kind: token.kind,
+      runId: token.runId,
+      pendingRequestedAt: token.pendingRequestedAt,
+      metadataHash: token.metadataHash,
+    });
+    if (existingByPending) return { token: existingByPending, duplicate: true, conflict: true };
+    const cols = channelActionTokenColumnValues(token);
+    try {
+      await this.#client.execute({
+        sql: `INSERT INTO ${TABLE_HARNESS_CHANNEL_ACTION_TOKENS}
+              (${cols.names.join(', ')})
+              VALUES (${cols.names.map(() => '?').join(', ')})`,
+        args: cols.values,
+      });
+    } catch (err) {
+      if (!isUniqueConstraintError(err)) throw err;
+      const raced =
+        (await this.loadChannelActionTokenById({
+          harnessName: token.harnessName,
+          channelId: token.channelId,
+          actionTokenId: token.actionTokenId,
+        })) ??
+        (await this.loadChannelActionTokenByTransportHash({
+          harnessName: token.harnessName,
+          channelId: token.channelId,
+          transportHash: token.transportHash,
+        })) ??
+        (await this.loadChannelActionTokenForPendingItem({
+          harnessName: token.harnessName,
+          channelId: token.channelId,
+          bindingId: token.bindingId,
+          bindingGeneration: token.bindingGeneration,
+          owningSessionId: token.owningSessionId,
+          itemId: token.itemId,
+          kind: token.kind,
+          runId: token.runId,
+          pendingRequestedAt: token.pendingRequestedAt,
+          metadataHash: token.metadataHash,
+        }));
+      if (raced) return { token: raced, duplicate: true, conflict: !channelActionTokensEquivalent(raced, token) };
+      throw err;
+    }
+    return { token, duplicate: false, conflict: false };
+  }
+
+  async loadChannelActionTokenById({
+    harnessName,
+    channelId,
+    actionTokenId,
+  }: {
+    harnessName: string;
+    channelId: string;
+    actionTokenId: string;
+  }): Promise<ChannelActionToken | null> {
+    await this.#ensureChannelActionTables();
+    const namespace = this.#resolveHarnessName(harnessName);
+    const row = await this.#client.execute({
+      sql: `SELECT * FROM ${TABLE_HARNESS_CHANNEL_ACTION_TOKENS}
+            WHERE harness_name = ? AND channel_id = ? AND action_token_id = ?
+            LIMIT 1`,
+      args: [namespace, channelId, actionTokenId],
+    });
+    return row.rows[0] ? rowToChannelActionToken(row.rows[0] as Record<string, unknown>) : null;
+  }
+
+  async loadChannelActionTokenByTransportHash({
+    harnessName,
+    channelId,
+    transportHash,
+  }: {
+    harnessName: string;
+    channelId: string;
+    transportHash: string;
+  }): Promise<ChannelActionToken | null> {
+    await this.#ensureChannelActionTables();
+    const namespace = this.#resolveHarnessName(harnessName);
+    const row = await this.#client.execute({
+      sql: `SELECT * FROM ${TABLE_HARNESS_CHANNEL_ACTION_TOKENS}
+            WHERE harness_name = ? AND channel_id = ? AND transport_hash = ?
+            LIMIT 1`,
+      args: [namespace, channelId, transportHash],
+    });
+    return row.rows[0] ? rowToChannelActionToken(row.rows[0] as Record<string, unknown>) : null;
+  }
+
+  async loadChannelActionTokenForPendingItem(opts: {
+    harnessName: string;
+    channelId: string;
+    bindingId: string;
+    bindingGeneration: number;
+    owningSessionId: string;
+    itemId: string;
+    kind: ChannelActionToken['kind'];
+    runId: string;
+    pendingRequestedAt: number;
+    metadataHash: string;
+  }): Promise<ChannelActionToken | null> {
+    await this.#ensureChannelActionTables();
+    const namespace = this.#resolveHarnessName(opts.harnessName);
+    const row = await this.#client.execute({
+      sql: `SELECT * FROM ${TABLE_HARNESS_CHANNEL_ACTION_TOKENS}
+            WHERE harness_name = ? AND channel_id = ? AND binding_id = ? AND binding_generation = ?
+              AND owning_session_id = ? AND item_id = ? AND kind = ? AND run_id = ?
+              AND pending_requested_at = ? AND metadata_hash = ?
+            LIMIT 1`,
+      args: [
+        namespace,
+        opts.channelId,
+        opts.bindingId,
+        opts.bindingGeneration,
+        opts.owningSessionId,
+        opts.itemId,
+        opts.kind,
+        opts.runId,
+        opts.pendingRequestedAt,
+        opts.metadataHash,
+      ],
+    });
+    return row.rows[0] ? rowToChannelActionToken(row.rows[0] as Record<string, unknown>) : null;
+  }
+
+  async revokeChannelActionToken(opts: {
+    harnessName: string;
+    channelId: string;
+    actionTokenId: string;
+    revokedAt?: number;
+    revokedReason?: ChannelActionToken['revokedReason'];
+  }): Promise<ChannelActionToken> {
+    await this.#ensureChannelActionTables();
+    const namespace = this.#resolveHarnessName(opts.harnessName);
+    const revokedAt = opts.revokedAt ?? Date.now();
+    const result = await this.#client.execute({
+      sql: `UPDATE ${TABLE_HARNESS_CHANNEL_ACTION_TOKENS}
+            SET revoked_at = ?, revoked_reason = ?, updated_at = ?
+            WHERE harness_name = ? AND channel_id = ? AND action_token_id = ?`,
+      args: [revokedAt, opts.revokedReason ?? null, revokedAt, namespace, opts.channelId, opts.actionTokenId],
+    });
+    if (result.rowsAffected === 0) {
+      throw new HarnessStorageChannelActionTokenConflictError(opts.actionTokenId, 'token was not found');
+    }
+    return (await this.loadChannelActionTokenById({
+      harnessName: namespace,
+      channelId: opts.channelId,
+      actionTokenId: opts.actionTokenId,
+    }))!;
+  }
+
+  async saveChannelActionReceipt(record: ChannelActionReceipt): Promise<void> {
+    await this.#ensureChannelActionTables();
+    const receipt = { ...record, harnessName: this.#resolveHarnessName(record.harnessName) };
+    assertValidChannelActionReceiptState(receipt);
+    const existing = await this.#loadChannelActionReceiptById(receipt.id);
+    if (existing) {
+      if (channelActionReceiptsEqual(existing, receipt)) return;
+      assertLegalChannelActionReceiptUpdate(existing, receipt);
+    }
+    const existingByToken = await this.loadChannelActionReceiptByTokenId({
+      harnessName: receipt.harnessName,
+      channelId: receipt.channelId,
+      actionTokenId: receipt.actionTokenId,
+    });
+    if (existingByToken && existingByToken.id !== receipt.id) {
+      throw new HarnessStorageChannelActionReceiptTransitionError(
+        receipt.id,
+        existingByToken.status,
+        receipt.status,
+        'action token is already owned by another receipt',
+      );
+    }
+    const cols = channelActionReceiptColumnValues(receipt);
+    try {
+      const result = await this.#client.execute({
+        sql: `INSERT INTO ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}
+              (${cols.names.join(', ')})
+              VALUES (${cols.names.map(() => '?').join(', ')})
+              ON CONFLICT(id) DO UPDATE SET
+                ${cols.names
+                  .filter(name => name !== 'id')
+                  .map(name => `${name} = excluded.${name}`)
+                  .join(', ')}
+              WHERE ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.harness_name = excluded.harness_name
+                AND ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.channel_id = excluded.channel_id
+                AND ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.provider_id = excluded.provider_id
+                AND ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.action_token_id = excluded.action_token_id
+                AND ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.action_id = excluded.action_id
+                AND ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.binding_id = excluded.binding_id
+                AND ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.binding_generation = excluded.binding_generation
+                AND ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.resource_id = excluded.resource_id
+                AND ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.owning_session_id = excluded.owning_session_id
+                AND ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.item_id = excluded.item_id
+                AND ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.kind = excluded.kind
+                AND ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.run_id = excluded.run_id
+                AND ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.pending_requested_at = excluded.pending_requested_at
+                AND ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.audience = excluded.audience
+                AND ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.response_hash = excluded.response_hash
+                AND (
+                  (
+                    ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.status = excluded.status
+                    AND ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.status NOT IN ('applied', 'conflict', 'dead')
+                  )
+                  OR (
+                    ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.status = 'received'
+                    AND excluded.status IN ('accepted', 'failed', 'conflict', 'dead')
+                  )
+                  OR (
+                    ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.status = 'accepted'
+                    AND excluded.status IN ('applied', 'failed', 'dead')
+                  )
+                  OR (
+                    ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}.status = 'failed'
+                    AND excluded.status IN ('received', 'accepted', 'failed', 'dead')
+                  )
+                )`,
+        args: cols.values,
+      });
+      if (result.rowsAffected === 0) {
+        const conflict = await this.#loadChannelActionReceiptById(receipt.id);
+        if (conflict && channelActionReceiptsEqual(conflict, receipt)) return;
+        if (conflict) assertLegalChannelActionReceiptUpdate(conflict, receipt);
+        throw new HarnessStorageChannelActionReceiptTransitionError(
+          receipt.id,
+          conflict?.status,
+          receipt.status,
+          'receipt upsert did not affect a row',
+        );
+      }
+    } catch (err) {
+      if (!isUniqueConstraintError(err)) throw err;
+      const conflictingByToken = await this.loadChannelActionReceiptByTokenId({
+        harnessName: receipt.harnessName,
+        channelId: receipt.channelId,
+        actionTokenId: receipt.actionTokenId,
+      });
+      if (conflictingByToken && conflictingByToken.id !== receipt.id) {
+        throw new HarnessStorageChannelActionReceiptTransitionError(
+          receipt.id,
+          conflictingByToken.status,
+          receipt.status,
+          'action token is already owned by another receipt',
+        );
+      }
+      throw err;
+    }
+  }
+
+  async createOrLoadChannelActionReceipt(
+    record: ChannelActionReceipt,
+    opts?: { initialClaim?: { claimId: string; now: number; claimTtlMs: number } },
+  ): Promise<CreateOrLoadChannelActionReceiptResult> {
+    await this.#ensureChannelActionTables();
+    const namespace = this.#resolveHarnessName(record.harnessName);
+    const incoming: ChannelActionReceipt = { ...record, harnessName: namespace };
+    assertValidChannelActionReceiptState(incoming);
+    let existing = await this.loadChannelActionReceiptByTokenId({
+      harnessName: namespace,
+      channelId: incoming.channelId,
+      actionTokenId: incoming.actionTokenId,
+    });
+    if (existing) return this.#channelActionReceiptDuplicate(existing, incoming, opts);
+    const insertReceipt =
+      opts?.initialClaim === undefined
+        ? incoming
+        : {
+            ...incoming,
+            claimId: opts.initialClaim.claimId,
+            claimExpiresAt: opts.initialClaim.now + opts.initialClaim.claimTtlMs,
+            updatedAt: opts.initialClaim.now,
+          };
+    const cols = channelActionReceiptColumnValues(insertReceipt);
+    try {
+      await this.#client.execute({
+        sql: `INSERT INTO ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}
+              (${cols.names.join(', ')})
+              VALUES (${cols.names.map(() => '?').join(', ')})`,
+        args: cols.values,
+      });
+      return {
+        receipt: insertReceipt,
+        duplicate: false,
+        conflict: false,
+        claimed: opts?.initialClaim !== undefined,
+      };
+    } catch (err) {
+      if (!isUniqueConstraintError(err)) throw err;
+    }
+    existing = await this.loadChannelActionReceiptByTokenId({
+      harnessName: namespace,
+      channelId: incoming.channelId,
+      actionTokenId: incoming.actionTokenId,
+    });
+    if (existing) return this.#channelActionReceiptDuplicate(existing, incoming, opts);
+    const existingById = await this.#loadChannelActionReceiptById(incoming.id);
+    if (existingById) {
+      throw new HarnessStorageChannelActionReceiptTransitionError(
+        incoming.id,
+        existingById.status,
+        incoming.status,
+        'id is already owned by another action receipt',
+      );
+    }
+    throw new HarnessStorageChannelActionClaimConflictError(incoming.id);
+  }
+
+  async #channelActionReceiptDuplicate(
+    existing: ChannelActionReceipt,
+    incoming: ChannelActionReceipt,
+    opts?: { initialClaim?: { claimId: string; now: number; claimTtlMs: number } },
+  ): Promise<CreateOrLoadChannelActionReceiptResult> {
+    const conflict = !channelActionReceiptsEquivalentForCreate(existing, incoming);
+    let receipt = existing;
+    let claimed = false;
+    if (!conflict && opts?.initialClaim && isChannelActionReceiptClaimable(existing, opts.initialClaim.now)) {
+      const update = await this.#client.execute({
+        sql: `UPDATE ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}
+              SET claim_id = ?, claim_expires_at = ?, updated_at = ?
+              WHERE id = ?
+                AND (claim_id IS NULL OR claim_expires_at IS NULL OR claim_expires_at <= ?)
+                AND (next_attempt_at IS NULL OR next_attempt_at <= ?)
+                AND status NOT IN ('applied', 'conflict', 'dead')`,
+        args: [
+          opts.initialClaim.claimId,
+          opts.initialClaim.now + opts.initialClaim.claimTtlMs,
+          opts.initialClaim.now,
+          existing.id,
+          opts.initialClaim.now,
+          opts.initialClaim.now,
+        ],
+      });
+      if (update.rowsAffected > 0) {
+        claimed = true;
+        receipt = (await this.#loadChannelActionReceiptById(existing.id)) ?? existing;
+      }
+    }
+    return { receipt, duplicate: true, conflict, claimed };
+  }
+
+  async loadChannelActionReceiptByActionId(opts: {
+    harnessName: string;
+    channelId: string;
+    actionId: string;
+  }): Promise<ChannelActionReceipt | null> {
+    await this.#ensureChannelActionTables();
+    const namespace = this.#resolveHarnessName(opts.harnessName);
+    const row = await this.#client.execute({
+      sql: `SELECT * FROM ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}
+            WHERE harness_name = ? AND channel_id = ? AND action_id = ?
+            ORDER BY created_at ASC, id ASC
+            LIMIT 1`,
+      args: [namespace, opts.channelId, opts.actionId],
+    });
+    return row.rows[0] ? rowToChannelActionReceipt(row.rows[0] as Record<string, unknown>) : null;
+  }
+
+  async loadChannelActionReceiptByTokenId(opts: {
+    harnessName: string;
+    channelId: string;
+    actionTokenId: string;
+  }): Promise<ChannelActionReceipt | null> {
+    await this.#ensureChannelActionTables();
+    const namespace = this.#resolveHarnessName(opts.harnessName);
+    const row = await this.#client.execute({
+      sql: `SELECT * FROM ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}
+            WHERE harness_name = ? AND channel_id = ? AND action_token_id = ?
+            LIMIT 1`,
+      args: [namespace, opts.channelId, opts.actionTokenId],
+    });
+    return row.rows[0] ? rowToChannelActionReceipt(row.rows[0] as Record<string, unknown>) : null;
+  }
+
+  async #loadChannelActionReceiptById(id: string, harnessName?: string): Promise<ChannelActionReceipt | null> {
+    const conditions = ['id = ?'];
+    const args: string[] = [id];
+    if (harnessName !== undefined) {
+      conditions.unshift('harness_name = ?');
+      args.unshift(this.#resolveHarnessName(harnessName));
+    }
+    const row = await this.#client.execute({
+      sql: `SELECT * FROM ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}
+            WHERE ${conditions.join(' AND ')}
+            LIMIT 1`,
+      args,
+    });
+    return row.rows[0] ? rowToChannelActionReceipt(row.rows[0] as Record<string, unknown>) : null;
+  }
+
+  async claimChannelActionReceipts(opts: {
+    harnessName: string;
+    channelId?: string;
+    statuses: Array<'received' | 'accepted' | 'failed'>;
+    claimId: string;
+    limit: number;
+    now: number;
+    claimTtlMs: number;
+  }): Promise<ChannelActionReceipt[]> {
+    await this.#ensureChannelActionTables();
+    if (opts.limit <= 0 || opts.statuses.length === 0) return [];
+    const namespace = this.#resolveHarnessName(opts.harnessName);
+    const filters = ['harness_name = ?', `status IN (${opts.statuses.map(() => '?').join(', ')})`];
+    const args: any[] = [namespace, ...opts.statuses];
+    if (opts.channelId !== undefined) {
+      filters.push('channel_id = ?');
+      args.push(opts.channelId);
+    }
+    filters.push('(next_attempt_at IS NULL OR next_attempt_at <= ?)');
+    filters.push('(claim_id IS NULL OR claim_expires_at IS NULL OR claim_expires_at <= ?)');
+    args.push(opts.now, opts.now, opts.limit);
+    const rows = await this.#client.execute({
+      sql: `SELECT id FROM ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}
+            WHERE ${filters.join(' AND ')}
+            ORDER BY created_at ASC, id ASC
+            LIMIT ?`,
+      args,
+    });
+    const claimed: ChannelActionReceipt[] = [];
+    for (const row of rows.rows) {
+      const id = String((row as Record<string, unknown>).id);
+      const result = await this.#client.execute({
+        sql: `UPDATE ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}
+              SET claim_id = ?, claim_expires_at = ?, updated_at = ?
+              WHERE id = ? AND status IN (${opts.statuses.map(() => '?').join(', ')})
+                AND (claim_id IS NULL OR claim_expires_at IS NULL OR claim_expires_at <= ?)
+                AND (next_attempt_at IS NULL OR next_attempt_at <= ?)
+                AND status NOT IN ('applied', 'conflict', 'dead')`,
+        args: [opts.claimId, opts.now + opts.claimTtlMs, opts.now, id, ...opts.statuses, opts.now, opts.now],
+      });
+      if (result.rowsAffected === 0) continue;
+      const receipt = await this.#loadChannelActionReceiptById(id);
+      if (receipt) claimed.push(receipt);
+    }
+    return claimed;
+  }
+
+  async renewChannelActionReceiptClaim(opts: {
+    receiptId: string;
+    claimId: string;
+    now: number;
+    claimTtlMs: number;
+  }): Promise<{ claimExpiresAt: number; storageNow: number }> {
+    await this.#ensureChannelActionTables();
+    const claimExpiresAt = opts.now + opts.claimTtlMs;
+    const result = await this.#client.execute({
+      sql: `UPDATE ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}
+            SET claim_expires_at = ?, updated_at = ?
+            WHERE id = ? AND claim_id = ?
+              AND claim_expires_at IS NOT NULL AND claim_expires_at > ?
+              AND status NOT IN ('applied', 'conflict', 'dead')`,
+      args: [claimExpiresAt, opts.now, opts.receiptId, opts.claimId, opts.now],
+    });
+    if (result.rowsAffected === 0) {
+      throw new HarnessStorageChannelActionClaimConflictError(opts.receiptId, opts.claimId);
+    }
+    return { claimExpiresAt, storageNow: opts.now };
+  }
+
+  async updateChannelActionReceipt(record: ChannelActionReceipt, opts: { claimId: string }): Promise<void> {
+    await this.#ensureChannelActionTables();
+    const namespace = this.#resolveHarnessName(record.harnessName);
+    const current = await this.#loadChannelActionReceiptById(record.id, namespace);
+    const storageNow = Date.now();
+    if (
+      !current ||
+      current.claimId !== opts.claimId ||
+      current.claimExpiresAt === undefined ||
+      current.claimExpiresAt <= storageNow ||
+      isTerminalChannelActionReceiptStatus(current.status)
+    ) {
+      throw new HarnessStorageChannelActionClaimConflictError(record.id, opts.claimId);
+    }
+    const next = { ...record, harnessName: namespace };
+    assertLegalChannelActionReceiptUpdate(current, next);
+    const cols = channelActionReceiptColumnValues(next);
+    const currentCols = channelActionReceiptColumnValues(current);
+    const preservesCurrentClaim = next.claimId === opts.claimId && next.claimExpiresAt !== undefined;
+    const updateNames = cols.names.filter(
+      name => name !== 'id' && (!preservesCurrentClaim || (name !== 'claim_id' && name !== 'claim_expires_at')),
+    );
+    const stateCompareNames = cols.names.filter(
+      name => name !== 'id' && name !== 'claim_id' && name !== 'claim_expires_at' && name !== 'updated_at',
+    );
+    const result = await this.#client.execute({
+      sql: `UPDATE ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}
+            SET ${updateNames.map(name => `${name} = ?`).join(', ')}
+            WHERE harness_name = ? AND id = ? AND claim_id = ?
+              AND claim_expires_at IS NOT NULL AND claim_expires_at > ?
+              AND status NOT IN ('applied', 'conflict', 'dead')
+              AND ${stateCompareNames.map(name => `${name} IS ?`).join(' AND ')}`,
+      args: [
+        ...updateNames.map(name => cols.values[cols.names.indexOf(name)]),
+        namespace,
+        next.id,
+        opts.claimId,
+        storageNow,
+        ...stateCompareNames.map(name => currentCols.values[currentCols.names.indexOf(name)]),
+      ],
+    });
+    if (result.rowsAffected === 0) {
+      throw new HarnessStorageChannelActionClaimConflictError(record.id, opts.claimId);
+    }
+  }
+
   async #loadChannelInboxItemById(id: string, harnessName?: string): Promise<ChannelInboxItem | null> {
     const conditions = ['id = ?'];
     const args: string[] = [id];
@@ -2064,6 +2606,61 @@ export class HarnessLibSQL extends HarnessStorage {
     await this.#client.execute({
       sql: `CREATE INDEX IF NOT EXISTS idx_harness_channel_inbox_claim
             ON "${TABLE_HARNESS_CHANNEL_INBOX}" ("harness_name", "channel_id", "status", "next_attempt_at", "claim_expires_at", "received_at")`,
+      args: [],
+    });
+  }
+
+  async #ensureChannelActionTables(): Promise<void> {
+    const tokenConfig = TABLE_CONFIGS[TABLE_HARNESS_CHANNEL_ACTION_TOKENS];
+    await this.#db.createTable({
+      tableName: TABLE_HARNESS_CHANNEL_ACTION_TOKENS,
+      schema: TABLE_SCHEMAS[TABLE_HARNESS_CHANNEL_ACTION_TOKENS],
+      compositePrimaryKey: tokenConfig?.compositePrimaryKey,
+    });
+    const receiptConfig = TABLE_CONFIGS[TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS];
+    await this.#db.createTable({
+      tableName: TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS,
+      schema: TABLE_SCHEMAS[TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS],
+      compositePrimaryKey: receiptConfig?.compositePrimaryKey,
+    });
+    await this.#ensureChannelActionIndexes();
+  }
+
+  async #ensureChannelActionIndexes(): Promise<void> {
+    if (this.#channelActionIndexesReady !== undefined) {
+      return this.#channelActionIndexesReady;
+    }
+    this.#channelActionIndexesReady = this.#createChannelActionIndexes().catch(error => {
+      this.#channelActionIndexesReady = undefined;
+      throw error;
+    });
+    return this.#channelActionIndexesReady;
+  }
+
+  async #createChannelActionIndexes(): Promise<void> {
+    await this.#client.execute({
+      sql: `CREATE UNIQUE INDEX IF NOT EXISTS idx_harness_channel_action_tokens_transport
+            ON "${TABLE_HARNESS_CHANNEL_ACTION_TOKENS}" ("harness_name", "channel_id", "transport_hash")`,
+      args: [],
+    });
+    await this.#client.execute({
+      sql: `CREATE UNIQUE INDEX IF NOT EXISTS idx_harness_channel_action_tokens_pending
+            ON "${TABLE_HARNESS_CHANNEL_ACTION_TOKENS}" ("harness_name", "channel_id", "binding_id", "binding_generation", "owning_session_id", "item_id", "kind", "run_id", "pending_requested_at", "metadata_hash")`,
+      args: [],
+    });
+    await this.#client.execute({
+      sql: `CREATE UNIQUE INDEX IF NOT EXISTS idx_harness_channel_action_receipts_token
+            ON "${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}" ("harness_name", "channel_id", "action_token_id")`,
+      args: [],
+    });
+    await this.#client.execute({
+      sql: `CREATE INDEX IF NOT EXISTS idx_harness_channel_action_receipts_action
+            ON "${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}" ("harness_name", "channel_id", "action_id", "created_at")`,
+      args: [],
+    });
+    await this.#client.execute({
+      sql: `CREATE INDEX IF NOT EXISTS idx_harness_channel_action_receipts_claim
+            ON "${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}" ("harness_name", "channel_id", "status", "next_attempt_at", "claim_expires_at", "created_at")`,
       args: [],
     });
   }
@@ -2398,6 +2995,195 @@ function rowToChannelInboxItem(row: Record<string, unknown>): ChannelInboxItem {
   };
 }
 
+const CHANNEL_ACTION_TOKEN_COLUMN_NAMES = [
+  'action_token_id',
+  'harness_name',
+  'channel_id',
+  'provider_id',
+  'resource_id',
+  'owning_session_id',
+  'item_id',
+  'kind',
+  'binding_id',
+  'binding_generation',
+  'run_id',
+  'pending_requested_at',
+  'audience',
+  'metadata_hash',
+  'transport_hash',
+  'key_id',
+  'expires_at',
+  'revoked_at',
+  'revoked_reason',
+  'created_at',
+  'updated_at',
+] as const;
+
+function channelActionTokenColumnValues(record: ChannelActionToken): { names: string[]; values: any[] } {
+  const values = [
+    record.actionTokenId,
+    record.harnessName,
+    record.channelId,
+    record.providerId,
+    record.resourceId,
+    record.owningSessionId,
+    record.itemId,
+    record.kind,
+    record.bindingId,
+    record.bindingGeneration,
+    record.runId,
+    record.pendingRequestedAt,
+    JSON.stringify(record.audience),
+    record.metadataHash,
+    record.transportHash,
+    record.keyId ?? null,
+    record.expiresAt ?? null,
+    record.revokedAt ?? null,
+    record.revokedReason ?? null,
+    record.createdAt,
+    record.updatedAt,
+  ];
+  return { names: [...CHANNEL_ACTION_TOKEN_COLUMN_NAMES], values };
+}
+
+function rowToChannelActionToken(row: Record<string, unknown>): ChannelActionToken {
+  return {
+    actionTokenId: String(row.action_token_id),
+    harnessName: String(row.harness_name),
+    channelId: String(row.channel_id),
+    providerId: String(row.provider_id),
+    resourceId: String(row.resource_id),
+    owningSessionId: String(row.owning_session_id),
+    itemId: String(row.item_id),
+    kind: String(row.kind) as ChannelActionToken['kind'],
+    bindingId: String(row.binding_id),
+    bindingGeneration: Number(row.binding_generation),
+    runId: String(row.run_id),
+    pendingRequestedAt: Number(row.pending_requested_at),
+    audience: parseJson(row.audience),
+    metadataHash: String(row.metadata_hash),
+    transportHash: String(row.transport_hash),
+    keyId: row.key_id == null ? undefined : String(row.key_id),
+    expiresAt: row.expires_at == null ? undefined : Number(row.expires_at),
+    revokedAt: row.revoked_at == null ? undefined : Number(row.revoked_at),
+    revokedReason:
+      row.revoked_reason == null ? undefined : (String(row.revoked_reason) as ChannelActionToken['revokedReason']),
+    createdAt: Number(row.created_at),
+    updatedAt: Number(row.updated_at),
+  };
+}
+
+const CHANNEL_ACTION_RECEIPT_COLUMN_NAMES = [
+  'id',
+  'harness_name',
+  'channel_id',
+  'provider_id',
+  'action_token_id',
+  'action_id',
+  'binding_id',
+  'binding_generation',
+  'resource_id',
+  'owning_session_id',
+  'item_id',
+  'kind',
+  'run_id',
+  'pending_requested_at',
+  'audience',
+  'verified_actor',
+  'response_hash',
+  'response',
+  'status',
+  'conflict_reason',
+  'attempts',
+  'claim_id',
+  'claim_expires_at',
+  'next_attempt_at',
+  'accepted_at',
+  'applied_at',
+  'failed_at',
+  'dead_at',
+  'result',
+  'last_error',
+  'created_at',
+  'updated_at',
+] as const;
+
+function channelActionReceiptColumnValues(record: ChannelActionReceipt): { names: string[]; values: any[] } {
+  const values = [
+    record.id,
+    record.harnessName,
+    record.channelId,
+    record.providerId,
+    record.actionTokenId,
+    record.actionId,
+    record.bindingId,
+    record.bindingGeneration,
+    record.resourceId,
+    record.owningSessionId,
+    record.itemId,
+    record.kind,
+    record.runId,
+    record.pendingRequestedAt,
+    JSON.stringify(record.audience),
+    record.verifiedActor ? JSON.stringify(record.verifiedActor) : null,
+    record.responseHash,
+    JSON.stringify(record.response),
+    record.status,
+    record.conflictReason ?? null,
+    record.attempts,
+    record.claimId ?? null,
+    record.claimExpiresAt ?? null,
+    record.nextAttemptAt ?? null,
+    record.acceptedAt ?? null,
+    record.appliedAt ?? null,
+    record.failedAt ?? null,
+    record.deadAt ?? null,
+    record.result === undefined ? null : JSON.stringify(record.result),
+    record.lastError ? JSON.stringify(record.lastError) : null,
+    record.createdAt,
+    record.updatedAt,
+  ];
+  return { names: [...CHANNEL_ACTION_RECEIPT_COLUMN_NAMES], values };
+}
+
+function rowToChannelActionReceipt(row: Record<string, unknown>): ChannelActionReceipt {
+  return {
+    id: String(row.id),
+    harnessName: String(row.harness_name),
+    channelId: String(row.channel_id),
+    providerId: String(row.provider_id),
+    actionTokenId: String(row.action_token_id),
+    actionId: String(row.action_id),
+    bindingId: String(row.binding_id),
+    bindingGeneration: Number(row.binding_generation),
+    resourceId: String(row.resource_id),
+    owningSessionId: String(row.owning_session_id),
+    itemId: String(row.item_id),
+    kind: String(row.kind) as ChannelActionReceipt['kind'],
+    runId: String(row.run_id),
+    pendingRequestedAt: Number(row.pending_requested_at),
+    audience: parseJson(row.audience),
+    verifiedActor: parseJson(row.verified_actor) ?? undefined,
+    responseHash: String(row.response_hash),
+    response: parseJson(row.response),
+    status: String(row.status) as ChannelActionReceipt['status'],
+    conflictReason:
+      row.conflict_reason == null ? undefined : (String(row.conflict_reason) as ChannelActionReceipt['conflictReason']),
+    attempts: Number(row.attempts),
+    claimId: row.claim_id == null ? undefined : String(row.claim_id),
+    claimExpiresAt: row.claim_expires_at == null ? undefined : Number(row.claim_expires_at),
+    nextAttemptAt: row.next_attempt_at == null ? undefined : Number(row.next_attempt_at),
+    acceptedAt: row.accepted_at == null ? undefined : Number(row.accepted_at),
+    appliedAt: row.applied_at == null ? undefined : Number(row.applied_at),
+    failedAt: row.failed_at == null ? undefined : Number(row.failed_at),
+    deadAt: row.dead_at == null ? undefined : Number(row.dead_at),
+    result: row.result == null ? undefined : parseJson(row.result),
+    lastError: parseJson(row.last_error) ?? undefined,
+    createdAt: Number(row.created_at),
+    updatedAt: Number(row.updated_at),
+  };
+}
+
 function rowToSession(row: Record<string, unknown>): SessionRecord {
   return {
     harnessName: String(row.harness_name ?? 'default'),
@@ -2667,10 +3453,20 @@ function isTerminalChannelInboxStatus(status: ChannelInboxItem['status']): boole
   return status === 'accepted' || status === 'queued' || status === 'dead';
 }
 
+function isTerminalChannelActionReceiptStatus(status: ChannelActionReceipt['status']): boolean {
+  return status === 'applied' || status === 'conflict' || status === 'dead';
+}
+
 function isChannelInboxClaimable(item: ChannelInboxItem, now: number): boolean {
   if (isTerminalChannelInboxStatus(item.status)) return false;
   if (item.nextAttemptAt !== undefined && item.nextAttemptAt > now) return false;
   return item.claimId === undefined || item.claimExpiresAt === undefined || item.claimExpiresAt <= now;
+}
+
+function isChannelActionReceiptClaimable(receipt: ChannelActionReceipt, now: number): boolean {
+  if (isTerminalChannelActionReceiptStatus(receipt.status)) return false;
+  if (receipt.nextAttemptAt !== undefined && receipt.nextAttemptAt > now) return false;
+  return receipt.claimId === undefined || receipt.claimExpiresAt === undefined || receipt.claimExpiresAt <= now;
 }
 
 function assertLegalChannelInboxUpdate(current: ChannelInboxItem, next: ChannelInboxItem): void {
@@ -2754,10 +3550,223 @@ function assertValidChannelInboxState(record: ChannelInboxItem, currentStatus?: 
   }
 }
 
+function assertLegalChannelActionReceiptUpdate(current: ChannelActionReceipt, next: ChannelActionReceipt): void {
+  const immutableMismatch =
+    current.id !== next.id ||
+    current.harnessName !== next.harnessName ||
+    current.channelId !== next.channelId ||
+    current.providerId !== next.providerId ||
+    current.actionTokenId !== next.actionTokenId ||
+    current.actionId !== next.actionId ||
+    current.bindingId !== next.bindingId ||
+    current.bindingGeneration !== next.bindingGeneration ||
+    current.resourceId !== next.resourceId ||
+    current.owningSessionId !== next.owningSessionId ||
+    current.itemId !== next.itemId ||
+    current.kind !== next.kind ||
+    current.runId !== next.runId ||
+    current.pendingRequestedAt !== next.pendingRequestedAt ||
+    stableJsonString(current.audience) !== stableJsonString(next.audience) ||
+    current.responseHash !== next.responseHash;
+  if (immutableMismatch) {
+    throw new HarnessStorageChannelActionReceiptTransitionError(
+      current.id,
+      current.status,
+      next.status,
+      'immutable token, item, and response identity fields cannot change',
+    );
+  }
+  const allowed =
+    current.status === next.status ||
+    (current.status === 'received' &&
+      (next.status === 'accepted' ||
+        next.status === 'failed' ||
+        next.status === 'conflict' ||
+        next.status === 'dead')) ||
+    (current.status === 'accepted' &&
+      (next.status === 'applied' || next.status === 'failed' || next.status === 'dead')) ||
+    (current.status === 'failed' &&
+      (next.status === 'received' || next.status === 'accepted' || next.status === 'failed' || next.status === 'dead'));
+  if (!allowed || isTerminalChannelActionReceiptStatus(current.status)) {
+    throw new HarnessStorageChannelActionReceiptTransitionError(
+      current.id,
+      current.status,
+      next.status,
+      'transition is not legal for channel action receipt state machine',
+    );
+  }
+  assertValidChannelActionReceiptState(next, current.status);
+}
+
+function assertValidChannelActionReceiptState(
+  record: ChannelActionReceipt,
+  currentStatus?: ChannelActionReceipt['status'],
+): void {
+  const validStatus =
+    record.status === 'received' ||
+    record.status === 'accepted' ||
+    record.status === 'applied' ||
+    record.status === 'conflict' ||
+    record.status === 'failed' ||
+    record.status === 'dead';
+  if (!validStatus) {
+    throw new HarnessStorageChannelActionReceiptTransitionError(
+      record.id,
+      currentStatus,
+      record.status,
+      'status is not a known channel action receipt state',
+    );
+  }
+  if (record.status === 'accepted' && record.acceptedAt == null) {
+    throw new HarnessStorageChannelActionReceiptTransitionError(
+      record.id,
+      currentStatus,
+      record.status,
+      'accepted receipts require acceptedAt',
+    );
+  }
+  if (record.status === 'applied' && (record.appliedAt == null || record.result === undefined)) {
+    throw new HarnessStorageChannelActionReceiptTransitionError(
+      record.id,
+      currentStatus,
+      record.status,
+      'applied receipts require appliedAt and result',
+    );
+  }
+  if (record.status === 'conflict' && record.conflictReason == null) {
+    throw new HarnessStorageChannelActionReceiptTransitionError(
+      record.id,
+      currentStatus,
+      record.status,
+      'conflict receipts require conflictReason',
+    );
+  }
+  if (record.status === 'failed' && (record.failedAt == null || record.lastError == null)) {
+    throw new HarnessStorageChannelActionReceiptTransitionError(
+      record.id,
+      currentStatus,
+      record.status,
+      'failed receipts require failedAt and lastError',
+    );
+  }
+  if (record.status === 'dead' && (record.deadAt == null || record.lastError == null)) {
+    throw new HarnessStorageChannelActionReceiptTransitionError(
+      record.id,
+      currentStatus,
+      record.status,
+      'dead receipts require deadAt and lastError',
+    );
+  }
+  if (
+    record.conflictReason !== undefined &&
+    record.conflictReason !== 'response_mismatch' &&
+    record.conflictReason !== 'stale_item' &&
+    record.conflictReason !== 'kind_mismatch' &&
+    record.conflictReason !== 'run_mismatch' &&
+    record.conflictReason !== 'binding_mismatch' &&
+    record.conflictReason !== 'session_closed' &&
+    record.conflictReason !== 'actor_not_allowed' &&
+    record.conflictReason !== 'token_expired' &&
+    record.conflictReason !== 'token_revoked'
+  ) {
+    throw new HarnessStorageChannelActionReceiptTransitionError(
+      record.id,
+      currentStatus,
+      record.status,
+      'conflictReason is not a known channel action receipt reason',
+    );
+  }
+}
+
 function channelInboxItemsEqual(a: ChannelInboxItem, b: ChannelInboxItem): boolean {
   const aValues = channelInboxComparableValues(a);
   const bValues = channelInboxComparableValues(b);
   return aValues.length === bValues.length && aValues.every((value, index) => Object.is(value, bValues[index]));
+}
+
+function channelActionTokensEquivalent(a: ChannelActionToken, b: ChannelActionToken): boolean {
+  return (
+    a.actionTokenId === b.actionTokenId &&
+    a.harnessName === b.harnessName &&
+    a.channelId === b.channelId &&
+    a.providerId === b.providerId &&
+    a.resourceId === b.resourceId &&
+    a.owningSessionId === b.owningSessionId &&
+    a.itemId === b.itemId &&
+    a.kind === b.kind &&
+    a.bindingId === b.bindingId &&
+    a.bindingGeneration === b.bindingGeneration &&
+    a.runId === b.runId &&
+    a.pendingRequestedAt === b.pendingRequestedAt &&
+    stableJsonString(a.audience) === stableJsonString(b.audience) &&
+    a.metadataHash === b.metadataHash &&
+    a.transportHash === b.transportHash &&
+    a.keyId === b.keyId &&
+    a.expiresAt === b.expiresAt
+  );
+}
+
+function channelActionReceiptsEquivalentForCreate(a: ChannelActionReceipt, b: ChannelActionReceipt): boolean {
+  return (
+    a.harnessName === b.harnessName &&
+    a.channelId === b.channelId &&
+    a.providerId === b.providerId &&
+    a.actionTokenId === b.actionTokenId &&
+    a.actionId === b.actionId &&
+    a.bindingId === b.bindingId &&
+    a.bindingGeneration === b.bindingGeneration &&
+    a.resourceId === b.resourceId &&
+    a.owningSessionId === b.owningSessionId &&
+    a.itemId === b.itemId &&
+    a.kind === b.kind &&
+    a.runId === b.runId &&
+    a.pendingRequestedAt === b.pendingRequestedAt &&
+    stableJsonString(a.audience) === stableJsonString(b.audience) &&
+    a.responseHash === b.responseHash
+  );
+}
+
+function channelActionReceiptsEqual(a: ChannelActionReceipt, b: ChannelActionReceipt): boolean {
+  const aValues = channelActionReceiptComparableValues(a);
+  const bValues = channelActionReceiptComparableValues(b);
+  return aValues.length === bValues.length && aValues.every((value, index) => Object.is(value, bValues[index]));
+}
+
+function channelActionReceiptComparableValues(record: ChannelActionReceipt): unknown[] {
+  return [
+    record.id,
+    record.harnessName,
+    record.channelId,
+    record.providerId,
+    record.actionTokenId,
+    record.actionId,
+    record.bindingId,
+    record.bindingGeneration,
+    record.resourceId,
+    record.owningSessionId,
+    record.itemId,
+    record.kind,
+    record.runId,
+    record.pendingRequestedAt,
+    stableJsonString(record.audience),
+    stableJsonString(record.verifiedActor),
+    record.responseHash,
+    stableJsonString(record.response),
+    record.status,
+    record.conflictReason,
+    record.attempts,
+    record.claimId,
+    record.claimExpiresAt,
+    record.nextAttemptAt,
+    record.acceptedAt,
+    record.appliedAt,
+    record.failedAt,
+    record.deadAt,
+    stableJsonString(record.result),
+    record.lastError ? stableJsonString(record.lastError) : undefined,
+    record.createdAt,
+    record.updatedAt,
+  ];
 }
 
 function channelInboxComparableValues(record: ChannelInboxItem): unknown[] {


### PR DESCRIPTION
Linear: PF-371

## Scope

Adds the storage-only foundation for Harness v1 channel action tokens and receipts:

- core storage constants, types, base contract, and in-memory adapter support
- LibSQL table creation, indexes, guarded upserts, claim/reclaim/renew/update support
- focused adapter tests and changesets for `@mastra/core` and `@mastra/libsql`

This intentionally does **not** implement the live channel inbox bridge, server route behavior, or the accepted-to-applied recovery worker. Council review found that the live bridge needs ChannelBinding storage plus an action recovery worker before it can be production-safe, so this PR lands only the durable ledger surface PF-371 needs.

## Overlap

Fresh open PR overlap check before opening:

- #58 touches ClickHouse memory storage only; independent.
- #68 touches legacy harness/tool-gate/agent durable execution paths; no PF-371 v1 channel action storage file overlap.
- #69 is a stale broad revert branch; not a dependency and not a base for this work.

## Validation

- `pnpm test packages/core/src/storage/domains/harness/inmemory.test.ts` -> 35 passed
- `pnpm test stores/libsql/src/storage/domains/harness/index.test.ts` -> 45 passed
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./stores/libsql build:lib`
- focused ESLint over touched core files
- focused ESLint over touched LibSQL files
- `git diff --check`
- two local Codex review passes; findings patched
- `coderabbit review --plain`; initial schema finding patched, rerun completed with no findings

## Notes

- Receipt `actionId` is immutable/query identity and covered by regression tests.
- Token table uses only the composite primary key config for `(harness_name, channel_id, action_token_id)`.
- Out-of-scope bridge/recovery work should proceed in the channel binding/action worker issues rather than expanding this storage PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a durable "receipt book" for Harness channel actions: it records action tokens and their outcomes so the system can deduplicate, recover, and safely retry work after restarts. It provides the storage foundations (types, tables, adapters, and tests) but does not enable the live inbox bridge or recovery worker yet.

---

## Overview

Implements durable, storage-only foundations for Harness v1 channel action tokens and receipts across `@mastra/core` and the LibSQL adapter, including:
- Core storage constants, schemas, types, base contract (errors + 13 new abstract methods), and an in-memory adapter implementation.
- LibSQL persistence: table creation with indexes, guarded upserts, claim/reclaim/renew/update operations, row mapping helpers, and readiness/index init.
- Focused tests: in-memory adapter and LibSQL adapter suites exercising idempotency, deduplication, conflict detection, claim lifecycle, and guarded updates.
- Changesets for `@mastra/core` and `@mastra/libsql`.

Deliberately out of scope: live channel inbox bridge, server route behavior, and the accepted-to-applied recovery worker. Council review required for ChannelBinding storage and an action recovery worker before enabling a production live bridge.

---

## Key Changes

- `@mastra/core`
  - New table constants: mastra_harness_channel_action_tokens and mastra_harness_channel_action_receipts; added to TABLE_NAMES, TABLE_SCHEMAS, and TABLE_CONFIGS (tokens use composite PK: harness_name, channel_id, action_token_id).
  - New types/interfaces: ChannelActionKind, ChannelActionAudience, ChannelActionActor, ChannelActionToken, ChannelActionReceipt, ChannelActionInitialClaim, CreateOrLoadChannelActionTokenResult, CreateOrLoadChannelActionReceiptResult.
  - New error classes: HarnessStorageChannelActionClaimConflictError, HarnessStorageChannelActionTokenConflictError, HarnessStorageChannelActionReceiptTransitionError.
  - Extended HarnessStorage base with 13 methods for token/receipt create/load, revoke, claim, renew, and claim-gated updates.
  - InMemoryHarness: full in-memory implementation with Maps, state-machine enforcement (immutable identity, allowed transitions), duplicate/conflict detection, claim-based locking, and helpers; InMemoryDB updated to include the new maps; test helpers and extensive in-memory tests added.

- `@mastra/libsql` (HarnessLibSQL)
  - Init now creates token and receipt tables and required indexes for efficient lookups and claim recovery.
  - Added a readiness promise for channel action indexes and truncation in dangerouslyClearAll().
  - Implements the same 13 persistence APIs as the core contract, using idempotent upserts, secondary lookups for dedupe/conflict detection, guarded SQL updates that enforce claim ownership and transition legality, batch claim acquisition with backoff, and claim renewal TTL handling.
  - Row ↔ domain mapping helpers, status/claim predicates, and legality/equivalence helpers implemented.
  - Comprehensive LibSQL tests added mirroring in-memory behavior and validating index-backed semantics.

---

## Testing & Validation

- Unit tests: In-memory adapter tests (35 passing) and LibSQL harness index/tests (45 passing).
- CI/quality: pnpm builds/checks for affected packages, focused ESLint on touched files, git diff --check passed.
- Reviews: two local Codex passes with fixes; CodeRabbit rerun with no findings.
- Regression coverage: receipt.actionId treated as immutable and used as query identity (tests cover this).
- Changesets: entries added for `@mastra/core` and `@mastra/libsql` (minor bumps).

---

## Implementation Notes / Constraints

- receipt.actionId is immutable and used as query identity.
- Token table enforces composite primary key (harness_name, channel_id, action_token_id).
- Claim-based locking prevents concurrent acceptance→applied transitions; renew/update are gated by claim ownership.
- Avoids expanding to bridge/recovery logic here — further work should live in channel binding and action worker issues.
- No file overlap with unrelated PRs (`#58`, `#68`); `#69` is stale.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->