### PR TITLE
[PF-531] Fail closed agent FGA without user

### DIFF
--- a/.changeset/pf-531-agent-fga-missing-user.md
+++ b/.changeset/pf-531-agent-fga-missing-user.md
@@ -2,7 +2,7 @@
 '@mastra/core': patch
 ---
 
-Tightened agent execution authorization when a Mastra server FGA provider is configured. Fresh `agent.generate(...)` and `agent.stream(...)` calls now fail closed unless the effective `requestContext` includes a `user`, matching the existing resume API boundary. Existing callers that execute agents against an FGA-enabled server without a request-context user now receive an authorization error before the model runs.
+Fixed agent execution authorization when using a server-side fine-grained access control provider. New `agent.generate(...)` and `agent.stream(...)` calls now require a `user` in `requestContext`; calls without a user are denied with an authorization error before the model runs.
 
 ```ts
 const requestContext = new RequestContext();

--- a/.changeset/pf-531-agent-fga-missing-user.md
+++ b/.changeset/pf-531-agent-fga-missing-user.md
@@ -1,0 +1,13 @@
+---
+'@mastra/core': patch
+---
+
+Tightened agent execution authorization when a Mastra server FGA provider is configured. Fresh `agent.generate(...)` and `agent.stream(...)` calls now fail closed unless the effective `requestContext` includes a `user`, matching the existing resume API boundary. Existing callers that execute agents against an FGA-enabled server without a request-context user now receive an authorization error before the model runs.
+
+```ts
+const requestContext = new RequestContext();
+requestContext.set('user', { id: 'user-1' });
+await agent.generate('Summarize this', { requestContext });
+```
+
+Local agent calls without a configured FGA provider continue to run without requiring a `user` in request context.

--- a/docs/src/content/en/docs/server/auth/fga.mdx
+++ b/docs/src/content/en/docs/server/auth/fga.mdx
@@ -101,7 +101,7 @@ When an FGA provider is configured, Mastra automatically checks authorization at
 
 | Lifecycle point | Permission checked | Resource |
 | - | - | - |
-| Agent execution (`generate`, `stream`) | `agents:execute` | `{ type: 'agent', id: agentId }` |
+| Agent execution (`generate`, `stream`, `streamUntilIdle`, `resumeGenerate`, `resumeStream`, `resumeStreamUntilIdle`) | `agents:execute` | `{ type: 'agent', id: agentId }` |
 | Workflow execution | `workflows:execute` | `{ type: 'workflow', id: workflowId }` |
 | Tool execution | `tools:execute` | `{ type: 'tool', id: toolName }` |
 | Thread/memory access | `memory:read`, `memory:write`, `memory:delete` | `{ type: 'thread', id: threadId }` |
@@ -109,6 +109,8 @@ When an FGA provider is configured, Mastra automatically checks authorization at
 | HTTP routes (opt-in) | Configured per route | Configured per route |
 
 All checks are **no-ops when FGA is not configured**, maintaining backward compatibility.
+
+When FGA is configured, agent execution fails closed unless the effective `requestContext` contains a `user`. For direct SDK calls, pass the authenticated user in `requestContext`. For server routes, ensure your auth middleware populates the request context before calling `generate()`, `stream()`, `streamUntilIdle()`, or resume APIs. Calls without a user throw before the model is invoked or a persisted resume snapshot is loaded.
 
 ## Custom FGA provider
 

--- a/packages/core/src/agent/__tests__/agent-fga.test.ts
+++ b/packages/core/src/agent/__tests__/agent-fga.test.ts
@@ -127,6 +127,19 @@ describe('Agent FGA checks', () => {
       await expect(agent.generate('test', { requestContext: requestContext as any })).rejects.toThrow(FGADeniedError);
     });
 
+    it('should reject missing users when FGA is configured', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const model = createMockModel();
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.generate('test')).rejects.toThrow(FGADeniedError);
+      expect(fgaProvider.require).not.toHaveBeenCalled();
+      expect(model.doGenerateCalls).toHaveLength(0);
+    });
+
     it('should not call FGA check when no FGA provider configured', async () => {
       const mastra = createMockMastra();
       const model = createMockModel();
@@ -138,6 +151,18 @@ describe('Agent FGA checks', () => {
       requestContext.set('user', { id: 'user-1' });
 
       await agent.generate('test', { requestContext: requestContext as any });
+
+      expect(model.doGenerateCalls).toHaveLength(1);
+    });
+
+    it('should still run local calls without a user when no FGA provider is configured', async () => {
+      const mastra = createMockMastra();
+      const model = createMockModel();
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model });
+      (agent as any).__registerMastra(mastra);
+
+      await agent.generate('test');
 
       expect(model.doGenerateCalls).toHaveLength(1);
     });
@@ -167,6 +192,41 @@ describe('Agent FGA checks', () => {
         { id: 'default-user', organizationMembershipId: 'default-om' },
         { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
       );
+      expect(fgaProvider.require).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reject default request contexts without users when FGA is configured', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: createMockModel(),
+        defaultOptions: { requestContext: new RequestContext() as any },
+      });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.generate('test')).rejects.toThrow(FGADeniedError);
+      expect(fgaProvider.require).not.toHaveBeenCalled();
+    });
+
+    it('should reject function default options without users when FGA is configured', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: createMockModel(),
+        defaultOptions: () => ({ requestContext: new RequestContext() as any }),
+      });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.generate('test')).rejects.toThrow(FGADeniedError);
+      expect(fgaProvider.require).not.toHaveBeenCalled();
     });
   });
 
@@ -206,6 +266,31 @@ describe('Agent FGA checks', () => {
       await expect(agent.stream('test', { requestContext: requestContext as any })).rejects.toThrow(FGADeniedError);
     });
 
+    it('should reject missing users when FGA is configured', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: createMockModel() });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.stream('test')).rejects.toThrow(FGADeniedError);
+      expect(fgaProvider.require).not.toHaveBeenCalled();
+    });
+
+    it('should still run local calls without a user when no FGA provider is configured', async () => {
+      const mastra = createMockMastra();
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: createMockModel(),
+      });
+      (agent as any).__registerMastra(mastra);
+
+      await agent.stream('test');
+    });
+
     it('should authorize the effective request context from default options', async () => {
       const fgaProvider = createMockFGAProvider(true);
       const mastra = createMockMastra(fgaProvider);
@@ -231,6 +316,40 @@ describe('Agent FGA checks', () => {
         { id: 'default-user', organizationMembershipId: 'default-om' },
         { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
       );
+    });
+
+    it('should reject default request contexts without users when FGA is configured', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: createMockModel(),
+        defaultOptions: { requestContext: new RequestContext() as any },
+      });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.stream('test')).rejects.toThrow(FGADeniedError);
+      expect(fgaProvider.require).not.toHaveBeenCalled();
+    });
+
+    it('should reject function default options without users when FGA is configured', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: createMockModel(),
+        defaultOptions: () => ({}),
+      });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.stream('test')).rejects.toThrow(FGADeniedError);
+      expect(fgaProvider.require).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/agent/__tests__/agent-fga.test.ts
+++ b/packages/core/src/agent/__tests__/agent-fga.test.ts
@@ -3,6 +3,7 @@
  */
 import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod';
 
 import { FGADeniedError } from '../../auth/ee/fga-check';
 import type { IFGAProvider } from '../../auth/ee/interfaces/fga';
@@ -140,6 +141,27 @@ describe('Agent FGA checks', () => {
       expect(model.doGenerateCalls).toHaveLength(0);
     });
 
+    it('should reject missing users before request context schema validation when FGA is configured', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const model = createMockModel();
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model,
+        requestContextSchema: z.object({ user: z.object({ id: z.string() }) }),
+      });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.generate('test', { requestContext: new RequestContext() as any })).rejects.toThrow(
+        FGADeniedError,
+      );
+      expect(fgaProvider.require).not.toHaveBeenCalled();
+      expect(model.doGenerateCalls).toHaveLength(0);
+    });
+
     it('should not call FGA check when no FGA provider configured', async () => {
       const mastra = createMockMastra();
       const model = createMockModel();
@@ -226,6 +248,24 @@ describe('Agent FGA checks', () => {
       (agent as any).__registerMastra(mastra);
 
       await expect(agent.generate('test')).rejects.toThrow(FGADeniedError);
+      expect(fgaProvider.require).not.toHaveBeenCalled();
+    });
+
+    it('should reject streamUntilIdle before resolving memory when FGA is configured without a user', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const getMemory = vi.fn();
+      const mastra = createMockMastra(fgaProvider, () => undefined, getMemory);
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: createMockModel(),
+      });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.streamUntilIdle('test')).rejects.toThrow(FGADeniedError);
+      expect(getMemory).not.toHaveBeenCalled();
       expect(fgaProvider.require).not.toHaveBeenCalled();
     });
   });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -918,18 +918,13 @@ export class Agent<
   /**
    * Enforces the request-context and FGA boundary shared by fresh and resumed agent execution.
    */
-  async #assertAgentExecutionPreflight(
-    requestContext?: RequestContext,
-    { requireFgaUser = false }: { requireFgaUser?: boolean } = {},
-  ) {
+  async #assertAgentExecutionPreflight(requestContext?: RequestContext) {
     await this.#validateRequestContext(requestContext);
 
     const fgaProvider = this.#mastra?.getServer()?.fga;
     if (!fgaProvider) return;
 
     const user = requestContext?.get('user');
-    if (!user && !requireFgaUser) return;
-
     const { checkFGA, FGADeniedError } = await import(/* @vite-ignore */ '../auth/ee/fga-check');
     if (!user) {
       throw new FGADeniedError({ id: 'unknown' }, { type: 'agent', id: this.id }, MastraFGAPermissions.AGENTS_EXECUTE);
@@ -6655,6 +6650,7 @@ export class Agent<
     }
     let preparedOptionsWithPubSub: (AgentExecutionOptionsBase<any> & { runId?: string; _pubsub: PubSub }) | undefined;
     let preflightedRequestContext: RequestContext | undefined;
+    let hasPreflightedRequestContext = false;
     const reserveAdmittedRun = () => {
       if (ownsReservation || !canReserveBeforeDefaults) return;
       releaseReservedRun = agentThreadStreamRuntime.reserveRun(
@@ -6677,10 +6673,12 @@ export class Agent<
       if (requestContextToUse) {
         await this.#assertAgentExecutionPreflight(requestContextToUse);
         preflightedRequestContext = requestContextToUse;
+        hasPreflightedRequestContext = true;
         reserveAdmittedRun();
       } else if (staticDefaultOptions) {
         await this.#assertAgentExecutionPreflight(staticDefaultOptions.requestContext);
         preflightedRequestContext = staticDefaultOptions.requestContext;
+        hasPreflightedRequestContext = true;
         reserveAdmittedRun();
       }
       const defaultOptions =
@@ -6694,7 +6692,10 @@ export class Agent<
       ) as AgentExecutionOptions<OUTPUT> & { model?: DynamicArgument<MastraModelConfig> };
       if (requestContextToUse) {
         mergedOptions.requestContext = requestContextToUse;
-      } else if (mergedOptions.requestContext !== preflightedRequestContext) {
+      } else if (
+        hasExecutionPreflight &&
+        (!hasPreflightedRequestContext || mergedOptions.requestContext !== preflightedRequestContext)
+      ) {
         await this.#assertAgentExecutionPreflight(mergedOptions.requestContext);
       }
 
@@ -7094,12 +7095,12 @@ export class Agent<
     };
     if (streamOptionsWithPubSub.requestContext) {
       // Preflight before idle-wrapper setup, which can resolve defaults and memory before delegating to resumeStream().
-      await this.#assertAgentExecutionPreflight(streamOptionsWithPubSub.requestContext, { requireFgaUser: true });
+      await this.#assertAgentExecutionPreflight(streamOptionsWithPubSub.requestContext);
     } else {
       const defaultOptions = await this.getDefaultOptions({
         requestContext: streamOptionsWithPubSub.requestContext,
       });
-      await this.#assertAgentExecutionPreflight(defaultOptions.requestContext, { requireFgaUser: true });
+      await this.#assertAgentExecutionPreflight(defaultOptions.requestContext);
       streamOptionsWithPubSub = {
         ...streamOptionsWithPubSub,
         _pubsub: pubsub,
@@ -7174,12 +7175,12 @@ export class Agent<
     if (!streamOptionsWithPubSub?.[SKIP_AGENT_EXECUTION_PREFLIGHT]) {
       if (requestContextToUse) {
         // Keep explicit-context resume preflight before snapshot loading/reservation so denied callers cannot touch persisted runs.
-        await this.#assertAgentExecutionPreflight(requestContextToUse, { requireFgaUser: true });
+        await this.#assertAgentExecutionPreflight(requestContextToUse);
       } else if (this.#requestContextSchema || this.#mastra?.getServer()?.fga) {
         defaultOptions = (await this.getDefaultOptions({
           requestContext: requestContextToUse,
         })) as AgentExecutionOptions<TOutput>;
-        await this.#assertAgentExecutionPreflight(defaultOptions.requestContext, { requireFgaUser: true });
+        await this.#assertAgentExecutionPreflight(defaultOptions.requestContext);
       }
     }
     const { resourceId: runResourceId, snapshot: existingSnapshot } = await this.#loadAgenticLoopSnapshotOrThrow({
@@ -7202,7 +7203,7 @@ export class Agent<
       !preflightedDefaultOptions &&
       (this.#requestContextSchema || this.#mastra?.getServer()?.fga)
     ) {
-      await this.#assertAgentExecutionPreflight(ownershipOptions.requestContext, { requireFgaUser: true });
+      await this.#assertAgentExecutionPreflight(ownershipOptions.requestContext);
     }
     this.#assertAgenticLoopResumeOwnership({
       method: 'resumeStream',
@@ -7531,12 +7532,12 @@ export class Agent<
     let defaultOptions: AgentExecutionOptions<TOutput> | undefined;
     if (requestContextToUse) {
       // Keep explicit-context resume preflight before snapshot loading/model resolution so denied callers cannot touch persisted runs.
-      await this.#assertAgentExecutionPreflight(requestContextToUse, { requireFgaUser: true });
+      await this.#assertAgentExecutionPreflight(requestContextToUse);
     } else if (this.#requestContextSchema || this.#mastra?.getServer()?.fga) {
       defaultOptions = (await this.getDefaultOptions({
         requestContext: requestContextToUse,
       })) as AgentExecutionOptions<TOutput>;
-      await this.#assertAgentExecutionPreflight(defaultOptions.requestContext, { requireFgaUser: true });
+      await this.#assertAgentExecutionPreflight(defaultOptions.requestContext);
     }
 
     const runId = options?.runId ?? '';

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -137,14 +137,18 @@ export type MastraLLM = MastraLLMV1 | MastraLLMVNext;
 
 const SKIP_AGENT_EXECUTION_PREFLIGHT = Symbol('skipAgentExecutionPreflight');
 
-type ResumeStreamInternalOptions = AgentExecutionOptionsBase<any> & {
-  structuredOutput?: PublicStructuredOutputOptions<any>;
-  toolCallId?: string;
-  model?: DynamicArgument<MastraModelConfig>;
-  _pubsub: PubSub;
+type AgentExecutionPreflightOptions = {
   [SKIP_AGENT_EXECUTION_PREFLIGHT]?: true;
   [STREAM_UNTIL_IDLE_DEFAULT_OPTIONS]?: AgentExecutionOptions<any>;
 };
+
+type ResumeStreamInternalOptions = AgentExecutionOptionsBase<any> &
+  AgentExecutionPreflightOptions & {
+    structuredOutput?: PublicStructuredOutputOptions<any>;
+    toolCallId?: string;
+    model?: DynamicArgument<MastraModelConfig>;
+    _pubsub: PubSub;
+  };
 
 type ModelFallbacks = {
   id: string;
@@ -919,22 +923,30 @@ export class Agent<
    * Enforces the request-context and FGA boundary shared by fresh and resumed agent execution.
    */
   async #assertAgentExecutionPreflight(requestContext?: RequestContext) {
-    await this.#validateRequestContext(requestContext);
-
     const fgaProvider = this.#mastra?.getServer()?.fga;
-    if (!fgaProvider) return;
+    if (fgaProvider) {
+      const user = requestContext?.get('user');
+      const { checkFGA, FGADeniedError } = await import(/* @vite-ignore */ '../auth/ee/fga-check');
+      if (!user) {
+        throw new FGADeniedError(
+          { id: 'unknown' },
+          { type: 'agent', id: this.id },
+          MastraFGAPermissions.AGENTS_EXECUTE,
+        );
+      }
 
-    const user = requestContext?.get('user');
-    const { checkFGA, FGADeniedError } = await import(/* @vite-ignore */ '../auth/ee/fga-check');
-    if (!user) {
-      throw new FGADeniedError({ id: 'unknown' }, { type: 'agent', id: this.id }, MastraFGAPermissions.AGENTS_EXECUTE);
+      await this.#validateRequestContext(requestContext);
+
+      await checkFGA({
+        fgaProvider,
+        user,
+        resource: { type: 'agent', id: this.id },
+        permission: MastraFGAPermissions.AGENTS_EXECUTE,
+      });
+      return;
     }
-    await checkFGA({
-      fgaProvider,
-      user,
-      resource: { type: 'agent', id: this.id },
-      permission: MastraFGAPermissions.AGENTS_EXECUTE,
-    });
+
+    await this.#validateRequestContext(requestContext);
   }
 
   /**
@@ -6617,9 +6629,15 @@ export class Agent<
     const callerProvidedRunId = Boolean(streamOptionsBase.runId);
     const requestContextToUse = streamOptionsBase.requestContext;
     const hasExecutionPreflight = Boolean(this.#requestContextSchema) || Boolean(this.#mastra?.getServer()?.fga);
+    const skipExecutionPreflight = Boolean(
+      (streamOptionsBase as AgentExecutionPreflightOptions)[SKIP_AGENT_EXECUTION_PREFLIGHT],
+    );
+    const preflightedDefaultOptions = (streamOptionsBase as AgentExecutionPreflightOptions)[
+      STREAM_UNTIL_IDLE_DEFAULT_OPTIONS
+    ] as AgentExecutionOptions<OUTPUT> | undefined;
     const needsDefaultRequestContextPreflight = !requestContextToUse && hasExecutionPreflight;
     const staticDefaultOptions =
-      needsDefaultRequestContextPreflight && typeof this.#defaultOptions !== 'function'
+      !skipExecutionPreflight && needsDefaultRequestContextPreflight && typeof this.#defaultOptions !== 'function'
         ? (this.#defaultOptions as unknown as AgentExecutionOptions<OUTPUT>)
         : undefined;
     const streamOptionsWithRunId = {
@@ -6649,8 +6667,10 @@ export class Agent<
       trackedThreadStreamPubSubTarget = { runId: streamOptionsWithRunId.runId };
     }
     let preparedOptionsWithPubSub: (AgentExecutionOptionsBase<any> & { runId?: string; _pubsub: PubSub }) | undefined;
-    let preflightedRequestContext: RequestContext | undefined;
-    let hasPreflightedRequestContext = false;
+    let preflightedRequestContext: RequestContext | undefined = skipExecutionPreflight
+      ? preflightedDefaultOptions?.requestContext ?? requestContextToUse
+      : undefined;
+    let hasPreflightedRequestContext = skipExecutionPreflight;
     const reserveAdmittedRun = () => {
       if (ownsReservation || !canReserveBeforeDefaults) return;
       releaseReservedRun = agentThreadStreamRuntime.reserveRun(
@@ -6670,18 +6690,19 @@ export class Agent<
     };
 
     try {
-      if (requestContextToUse) {
+      if (!skipExecutionPreflight && requestContextToUse) {
         await this.#assertAgentExecutionPreflight(requestContextToUse);
         preflightedRequestContext = requestContextToUse;
         hasPreflightedRequestContext = true;
         reserveAdmittedRun();
-      } else if (staticDefaultOptions) {
+      } else if (!skipExecutionPreflight && staticDefaultOptions) {
         await this.#assertAgentExecutionPreflight(staticDefaultOptions.requestContext);
         preflightedRequestContext = staticDefaultOptions.requestContext;
         hasPreflightedRequestContext = true;
         reserveAdmittedRun();
       }
       const defaultOptions =
+        preflightedDefaultOptions ??
         staticDefaultOptions ??
         (await this.getDefaultOptions({
           requestContext: requestContextToUse,
@@ -7013,7 +7034,27 @@ export class Agent<
   ): Promise<MastraModelOutput<OUTPUT>> {
     const pubsub =
       (streamOptions as { _pubsub?: PubSub } | undefined)?._pubsub ?? this.getPubSub() ?? defaultAgentThreadPubSub;
-    const streamOptionsWithPubSub = { ...(streamOptions ?? {}), _pubsub: pubsub };
+    let streamOptionsWithPubSub: Record<string | symbol, any> & { maxIdleMs?: number; _pubsub: PubSub } = {
+      ...(streamOptions ?? {}),
+      _pubsub: pubsub,
+    };
+    if (streamOptionsWithPubSub.requestContext) {
+      await this.#assertAgentExecutionPreflight(streamOptionsWithPubSub.requestContext);
+      streamOptionsWithPubSub = {
+        ...streamOptionsWithPubSub,
+        [SKIP_AGENT_EXECUTION_PREFLIGHT]: true,
+      };
+    } else if (this.#requestContextSchema || this.#mastra?.getServer()?.fga) {
+      const defaultOptions = await this.getDefaultOptions({
+        requestContext: streamOptionsWithPubSub.requestContext,
+      });
+      await this.#assertAgentExecutionPreflight(defaultOptions.requestContext);
+      streamOptionsWithPubSub = {
+        ...streamOptionsWithPubSub,
+        [STREAM_UNTIL_IDLE_DEFAULT_OPTIONS]: defaultOptions,
+        [SKIP_AGENT_EXECUTION_PREFLIGHT]: true,
+      };
+    }
     return runStreamUntilIdle<OUTPUT>(this, messages, streamOptionsWithPubSub, {
       activeStreams: this.#activeStreamUntilIdle,
       bgManager: this.#mastra?.backgroundTaskManager,


### PR DESCRIPTION
## Summary
- Fail closed fresh agent generate/stream execution when a Mastra server FGA provider is configured and the effective requestContext has no user.
- Preserve no-FGA local execution behavior.
- Document the agent execution FGA boundary and add a patch changeset for @mastra/core.

## Linear
- PF-531
- Follow-ups recorded: PF-545 for network FGA semantics, PF-546 for legacy execution FGA semantics.

## Coordination
- Based on origin/main 7ab2af2a397e5aed86ae7a905aad6aba2e5d4851.
- Open PR overlap scan before work: #124 and #125 had no PF-531 path overlap; stale #69 touches agent.ts and remains a dirty coordination risk, not a blocker for this branch.

## Validation
- pnpm --filter ./packages/core test -- src/agent/__tests__/agent-fga.test.ts
- pnpm --filter ./packages/core exec eslint src/agent/agent.ts src/agent/__tests__/agent-fga.test.ts
- pnpm --filter ./packages/core check
- pnpm --filter mastra-docs validate:frontmatter
- pnpm --filter mastra-docs lint:remark -- src/content/en/docs/server/auth/fga.mdx
- git diff --check
- Local Codex review pass 1: fixed duplicate stream FGA check finding.
- Local Codex review pass 2: fixed duplicate stream FGA check and docs wording/coverage findings.
- CodeRabbit CLI: no findings.

## Notes
- Gemini council review was attempted but failed in the local CLI environment; Claude council review produced the dynamic-default fail-closed finding, which this branch handles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Summary

If your Mastra server has Fine-Grained Authorization (FGA) turned on, agents now require you to say who is making the request—calls with no user are denied immediately to keep things safe. If FGA isn't configured, behavior is unchanged and agents run as before.

## Overview

Implements "fail closed" agent execution when a Mastra server FGA provider is configured: agent execution entry points (generate, stream, streamUntilIdle, resumeGenerate, resumeStream, resumeStreamUntilIdle) require a `user` in the effective `requestContext`. If no user is present, the call throws `FGADeniedError` before any model invocation or resume snapshot loading. Local execution remains a no-op when FGA is not configured.

## Changes

- Documentation (docs/src/content/en/docs/server/auth/fga.mdx)
  - Expanded enforcement points to include agent/resume lifecycle methods (generate, stream, streamUntilIdle, resumeGenerate, resumeStream, resumeStreamUntilIdle)
  - Added note that agent execution fails closed when FGA is configured unless `requestContext` contains a `user`; failures occur before model invocation or resume snapshot load
  - Changeset added to `@mastra/core` documenting the behavior and example usage

- Tests (packages/core/src/agent/__tests__/agent-fga.test.ts)
  - Added tests asserting missing-user rejection with `FGADeniedError` for generate/stream/streamUntilIdle when FGA is configured
  - Verified `fgaProvider.require` is not called and no model execution occurs in missing-user cases
  - Added tests ensuring defaultOptions (RequestContext or function) without a user are rejected when FGA is present
  - Confirmed behavior is unchanged (local execution allowed without a user) when no FGA provider is configured

- Implementation (packages/core/src/agent/agent.ts)
  - Refactored `#assertAgentExecutionPreflight` to accept only `requestContext` and enforce user presence when FGA is configured (removed `requireFgaUser` flag usage)
  - Adjusted stream() to track and reuse a preflighted requestContext to avoid redundant checks
  - Updated streamUntilIdle() to perform preflight up-front and mark skip for the idle-wrapper path
  - Aligned resume paths (resumeStreamUntilIdle, resumeStream, resumeGenerate) with the unified "require user when FGA present" behavior by removing prior `requireFgaUser` parameter usage

- Changeset (.changeset/pf-531-agent-fga-missing-user.md)
  - Patch bump for `@mastra/core` and documented the new behavior and example of setting `requestContext.set('user', ...)`

## Validation

- Unit tests for FGA behavior run (pnpm test for the changed tests)
- ESLint/type checks and docs linting passed
- git diff --check passed
- Local code reviews and static tools ran; noted follow-ups PF-545 (network FGA semantics) and PF-546 (legacy execution FGA semantics)

## Notes

- No exported/public API signatures were changed.
- The change ensures authorization checks fail fast for missing user context when a server-side FGA provider is configured, preserving backward compatibility when FGA is absent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->