### PR TITLE
[PF-547] Require PubSub for MastraCode cross-process mode

### DIFF
--- a/.changeset/social-snails-know.md
+++ b/.changeset/social-snails-know.md
@@ -1,0 +1,12 @@
+---
+'mastracode': patch
+---
+
+Fixed MastraCode to require a configured PubSub when cross-process mode is enabled. Existing cross-process setups that previously passed `crossProcessPubSub: true` without shared signal routing now fail at startup with a clear configuration error.
+
+```ts
+createMastraCode({
+  pubsub,
+  crossProcessPubSub: true,
+});
+```

--- a/mastracode/src/__tests__/thread-lock-startup.test.ts
+++ b/mastracode/src/__tests__/thread-lock-startup.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const harnessConstructorMock = vi.fn();
+const createStorageMock = vi.fn((): { storage: unknown; backend?: string } => ({ storage: {} }));
+const createVectorStoreMock = vi.fn(() => ({}));
+const acquireThreadLockMock = vi.fn();
+const releaseThreadLockMock = vi.fn();
+const syncGatewaysMock = vi.fn();
+
+vi.mock('@mastra/core/agent', () => ({
+  Agent: class {},
+}));
+
+vi.mock('@mastra/core/harness', () => ({
+  Harness: class {
+    constructor(config: unknown) {
+      harnessConstructorMock(config);
+    }
+    subscribe() {}
+  },
+}));
+
+vi.mock('@mastra/core/llm', () => ({
+  GatewayRegistry: {
+    getInstance: vi.fn(() => ({
+      syncGateways: syncGatewaysMock,
+      getProviders: vi.fn(() => ({})),
+    })),
+  },
+  PROVIDER_REGISTRY: {},
+}));
+
+vi.mock('@mastra/core/processors', () => ({
+  AgentsMDInjector: class {},
+  PrefillErrorHandler: class {},
+  ProviderHistoryCompat: class {},
+  StreamErrorRetryProcessor: class {},
+}));
+
+vi.mock('@mastra/core/storage', () => ({
+  MastraCompositeStore: class {
+    constructor(readonly config: unknown) {}
+  },
+}));
+
+vi.mock('@mastra/duckdb', () => ({
+  DuckDBStore: class {},
+}));
+
+vi.mock('@mastra/observability', () => ({
+  Observability: class {
+    constructor(readonly config: unknown) {}
+  },
+  MastraStorageExporter: class {
+    constructor(readonly config: unknown) {}
+  },
+  MastraPlatformExporter: class {
+    constructor(readonly config: unknown) {}
+  },
+  SensitiveDataFilter: class {},
+}));
+
+vi.mock('../agents/instructions.js', () => ({ getDynamicInstructions: vi.fn() }));
+vi.mock('../agents/memory.js', () => ({ getDynamicMemory: vi.fn(() => vi.fn()) }));
+vi.mock('../agents/model.js', () => ({ getDynamicModel: vi.fn(), resolveModel: vi.fn() }));
+vi.mock('../agents/prompts/agent-instructions.js', () => ({ getStaticallyLoadedInstructionPaths: vi.fn(() => []) }));
+vi.mock('../agents/subagents/execute.js', () => ({ executeSubagent: { id: 'execute' } }));
+vi.mock('../agents/subagents/explore.js', () => ({ exploreSubagent: { id: 'explore' } }));
+vi.mock('../agents/subagents/plan.js', () => ({ planSubagent: { id: 'plan' } }));
+vi.mock('../agents/thread-caveman-state.js', () => ({
+  attachCavemanThreadStatePersistence: vi.fn(),
+  restoreCavemanForCurrentThread: vi.fn(() => Promise.resolve()),
+}));
+vi.mock('../agents/tools.js', () => ({ createDynamicTools: vi.fn(() => ({})) }));
+vi.mock('../agents/workspace.js', () => ({ getDynamicWorkspace: vi.fn() }));
+vi.mock('../auth/storage.js', () => ({
+  AuthStorage: class {
+    get() {
+      return undefined;
+    }
+    getStoredApiKey() {
+      return undefined;
+    }
+    hasStoredApiKey() {
+      return false;
+    }
+    isLoggedIn() {
+      return false;
+    }
+    loadStoredApiKeysIntoEnv() {}
+  },
+}));
+vi.mock('../evals/scorers/index.js', () => ({
+  createOutcomeScorer: vi.fn(() => ({})),
+  createEfficiencyScorer: vi.fn(() => ({})),
+}));
+vi.mock('../hooks/index.js', () => ({
+  HookManager: class {
+    setSessionId() {}
+  },
+}));
+vi.mock('../mcp/index.js', () => ({ createMcpManager: vi.fn() }));
+vi.mock('../onboarding/packs.js', () => ({
+  getAvailableModePacks: vi.fn(() => []),
+  getAvailableOmPacks: vi.fn(() => []),
+}));
+vi.mock('../onboarding/settings.js', () => ({
+  getCustomProviderId: vi.fn(),
+  loadSettings: vi.fn(() => ({
+    models: {
+      modeDefaults: {},
+      omObservationThreshold: null,
+      omReflectionThreshold: null,
+      omCavemanObservations: null,
+      subagentModels: {},
+    },
+    preferences: { yolo: null, thinkingLevel: 'off' },
+    storage: { backend: 'libsql', libsql: {}, pg: {} },
+    customProviders: [],
+    modelUseCounts: {},
+    memoryGateway: {},
+    observability: { resources: {}, localTracing: false },
+  })),
+  MEMORY_GATEWAY_PROVIDER: 'mastra',
+  OBSERVABILITY_AUTH_PREFIX: 'observability:',
+  resolveModelDefaults: vi.fn(() => ({})),
+  resolveOmRoleModel: vi.fn(() => undefined),
+  saveSettings: vi.fn(),
+  toCustomProviderModelId: vi.fn(),
+}));
+vi.mock('../permissions.js', () => ({ getToolCategory: vi.fn() }));
+vi.mock('../providers/claude-max.js', () => ({ setAuthStorage: vi.fn() }));
+vi.mock('../providers/github-copilot.js', () => ({
+  getCopilotModelCatalog: vi.fn(() => Promise.resolve([])),
+  setAuthStorage: vi.fn(),
+}));
+vi.mock('../providers/openai-codex.js', () => ({ setAuthStorage: vi.fn() }));
+vi.mock('../schema.js', () => ({ stateSchema: {} }));
+vi.mock('../tui/theme.js', () => ({ mastra: { green: 'green', purple: 'purple', orange: 'orange' } }));
+vi.mock('../utils/gateway-sync.js', () => ({ syncGateways: syncGatewaysMock }));
+vi.mock('../utils/project.js', () => ({
+  detectProject: vi.fn(() => ({
+    rootPath: process.cwd(),
+    resourceId: 'resource-1',
+    name: 'project',
+    gitBranch: 'main',
+  })),
+  getObservabilityDatabasePath: vi.fn(() => ':memory:'),
+  getStorageConfig: vi.fn(() => ({ type: 'memory' })),
+  getResourceIdOverride: vi.fn(() => undefined),
+}));
+vi.mock('../utils/storage-factory.js', () => ({
+  createStorage: createStorageMock,
+  createVectorStore: createVectorStoreMock,
+}));
+vi.mock('../utils/thread-lock.js', () => ({
+  acquireThreadLock: acquireThreadLockMock,
+  releaseThreadLock: releaseThreadLockMock,
+}));
+
+describe('createMastraCode thread lock startup config', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    harnessConstructorMock.mockReset();
+    createStorageMock.mockClear();
+    createVectorStoreMock.mockClear();
+    acquireThreadLockMock.mockClear();
+    releaseThreadLockMock.mockClear();
+    syncGatewaysMock.mockClear();
+  });
+
+  it('keeps file thread locks when cross-process PubSub mode is disabled', async () => {
+    const { createMastraCode } = await import('../index.js');
+
+    await createMastraCode();
+
+    expect(harnessConstructorMock).toHaveBeenCalled();
+    const harnessConfig = harnessConstructorMock.mock.calls[0]?.[0] as
+      | { pubsub?: unknown; threadLock?: unknown }
+      | undefined;
+    expect(harnessConfig?.pubsub).toBeUndefined();
+    expect(harnessConfig?.threadLock).toEqual({
+      acquire: acquireThreadLockMock,
+      release: releaseThreadLockMock,
+    });
+  });
+
+  it('rejects cross-process PubSub mode before storage or Harness setup when PubSub is missing', async () => {
+    const { createMastraCode } = await import('../index.js');
+
+    await expect(createMastraCode({ crossProcessPubSub: true })).rejects.toThrow(
+      'crossProcessPubSub requires config.pubsub',
+    );
+
+    expect(createStorageMock).not.toHaveBeenCalled();
+    expect(harnessConstructorMock).not.toHaveBeenCalled();
+  });
+
+  it('uses configured PubSub instead of file thread locks for cross-process PubSub mode', async () => {
+    const pubsub = { id: 'shared-pubsub' };
+    const { createMastraCode } = await import('../index.js');
+
+    await createMastraCode({ pubsub: pubsub as never, crossProcessPubSub: true });
+
+    expect(harnessConstructorMock).toHaveBeenCalled();
+    const harnessConfig = harnessConstructorMock.mock.calls[0]?.[0] as
+      | { pubsub?: unknown; threadLock?: unknown }
+      | undefined;
+    expect(harnessConfig?.pubsub).toBe(pubsub);
+    expect(harnessConfig?.threadLock).toBeUndefined();
+  });
+});

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -74,6 +74,7 @@ import {
 } from './utils/project.js';
 import type { StorageConfig } from './utils/project.js';
 import { createStorage, createVectorStore } from './utils/storage-factory.js';
+import { resolveMastraCodeThreadLockConfig } from './utils/thread-lock-config.js';
 import { acquireThreadLock, releaseThreadLock } from './utils/thread-lock.js';
 
 const PROVIDER_TO_OAUTH_ID: Record<string, string> = {
@@ -133,7 +134,7 @@ export interface MastraCodeConfig {
   memory?: HarnessConfig['memory'];
   /** Browser provider for browser automation tools. When set, the agent gains access to browser tools. */
   browser?: HarnessConfig['browser'];
-  /** PubSub for signal routing. When crossProcessPubSub is true, thread locks are disabled. */
+  /** PubSub for signal routing. Required before crossProcessPubSub can disable file thread locks. */
   pubsub?: PubSub;
   /** Marks the configured PubSub as cross-process-safe, allowing Mastra Code to skip file thread locks. */
   crossProcessPubSub?: boolean;
@@ -234,6 +235,12 @@ export async function createMastraCode(config?: MastraCodeConfig) {
 
   const signalsPubSub = config?.pubsub;
   const crossProcessPubSub = config?.crossProcessPubSub ?? false;
+  const threadLockConfig = resolveMastraCodeThreadLockConfig({
+    pubsub: signalsPubSub,
+    crossProcessPubSub,
+    acquireThreadLock,
+    releaseThreadLock,
+  });
 
   // Storage
   const storageConfig = config?.storage ?? getStorageConfig(project.rootPath, globalSettings.storage);
@@ -532,7 +539,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     storage,
     observability,
     memory,
-    pubsub: signalsPubSub,
+    pubsub: threadLockConfig.pubsub,
     stateSchema,
     subagents,
     resolveModel: modelId => resolveModel(modelId) as LanguageModel,
@@ -637,12 +644,7 @@ export async function createMastraCode(config?: MastraCodeConfig) {
 
       return customModels;
     },
-    threadLock: crossProcessPubSub
-      ? undefined
-      : {
-          acquire: acquireThreadLock,
-          release: releaseThreadLock,
-        },
+    threadLock: threadLockConfig.threadLock,
   });
 
   // Sync hookManager session ID on thread changes

--- a/mastracode/src/utils/__tests__/thread-lock-config.test.ts
+++ b/mastracode/src/utils/__tests__/thread-lock-config.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { resolveMastraCodeThreadLockConfig } from '../thread-lock-config.js';
+
+describe('resolveMastraCodeThreadLockConfig', () => {
+  it('uses file thread locks by default', () => {
+    const acquireThreadLock = vi.fn();
+    const releaseThreadLock = vi.fn();
+
+    const config = resolveMastraCodeThreadLockConfig({
+      crossProcessPubSub: false,
+      acquireThreadLock,
+      releaseThreadLock,
+    });
+
+    expect(config.pubsub).toBeUndefined();
+    expect(config.threadLock).toEqual({
+      acquire: acquireThreadLock,
+      release: releaseThreadLock,
+    });
+  });
+
+  it('rejects cross-process PubSub mode without a configured PubSub', () => {
+    expect(() =>
+      resolveMastraCodeThreadLockConfig({
+        crossProcessPubSub: true,
+        acquireThreadLock: vi.fn(),
+        releaseThreadLock: vi.fn(),
+      }),
+    ).toThrow('crossProcessPubSub requires config.pubsub');
+  });
+
+  it('uses configured PubSub instead of file thread locks for cross-process PubSub mode', () => {
+    const pubsub = { id: 'shared-pubsub' };
+
+    const config = resolveMastraCodeThreadLockConfig({
+      pubsub,
+      crossProcessPubSub: true,
+      acquireThreadLock: vi.fn(),
+      releaseThreadLock: vi.fn(),
+    });
+
+    expect(config.pubsub).toBe(pubsub);
+    expect(config.threadLock).toBeUndefined();
+  });
+});

--- a/mastracode/src/utils/thread-lock-config.ts
+++ b/mastracode/src/utils/thread-lock-config.ts
@@ -1,0 +1,40 @@
+export type MastraCodeThreadLock = {
+  acquire: (threadId: string) => Promise<void> | void;
+  release: (threadId: string) => Promise<void> | void;
+};
+
+type ResolveMastraCodeThreadLockConfigOptions<TPubSub> = {
+  pubsub?: TPubSub;
+  crossProcessPubSub: boolean;
+  acquireThreadLock: MastraCodeThreadLock['acquire'];
+  releaseThreadLock: MastraCodeThreadLock['release'];
+};
+
+type MastraCodeThreadLockConfig<TPubSub> = {
+  pubsub?: TPubSub;
+  threadLock?: MastraCodeThreadLock;
+};
+
+export function resolveMastraCodeThreadLockConfig<TPubSub>({
+  pubsub,
+  crossProcessPubSub,
+  acquireThreadLock,
+  releaseThreadLock,
+}: ResolveMastraCodeThreadLockConfigOptions<TPubSub>): MastraCodeThreadLockConfig<TPubSub> {
+  if (crossProcessPubSub) {
+    if (!pubsub) {
+      throw new Error(
+        'Invalid MastraCode configuration: crossProcessPubSub requires config.pubsub so thread locks are not disabled without shared signal routing.',
+      );
+    }
+    return { pubsub, threadLock: undefined };
+  }
+
+  return {
+    pubsub,
+    threadLock: {
+      acquire: acquireThreadLock,
+      release: releaseThreadLock,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Add a MastraCode startup config resolver that keeps file thread locks enabled by default.
- Fail closed when `crossProcessPubSub: true` is provided without `config.pubsub`, before storage or Harness construction.
- Pass the configured PubSub through and omit file thread locks only when cross-process mode has a PubSub.

## Linear
PF-547

## Validation
- `pnpm --dir mastracode exec vitest run src/utils/__tests__/thread-lock-config.test.ts src/__tests__/thread-lock-startup.test.ts --project unit:mastracode` -> passed, 6 tests.
- `pnpm --filter mastracode lint -- src/index.ts src/utils/thread-lock-config.ts src/utils/__tests__/thread-lock-config.test.ts src/__tests__/thread-lock-startup.test.ts` -> passed.
- `git diff --check` -> passed.
- Gemini council review -> agreed fail-closed startup validation is the correct contract and requested focused coverage.
- Local Codex review pass 1 -> no runtime regression found.
- Local Codex review pass 2 -> requested startup-level coverage and JSDoc tightening; both fixed.
- CodeRabbit CLI -> initial changeset wording finding fixed; rerun reported no findings.

## Known Local Check Limitation
- `pnpm --filter mastracode check` currently fails in this fresh worktree on pre-existing or unrelated workspace package/type issues after building only the narrow dependency set. Examples include missing or unbuilt `@mastra/fastembed`, `@mastra/stagehand`, `@mastra/agent-browser`, `@mastra/pg`, plus existing `storage-factory.ts` LibSQL type incompatibilities.
- The PF-547 touched files pass focused unit tests, lint, whitespace check, and direct `tsc --ignoreConfig` checking for the new helper/test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes MastraCode safer when running across multiple processes by requiring you to set up a shared messaging system (PubSub) when you enable cross-process mode. If you forget to provide it, the application fails immediately with a clear error instead of silently breaking later.

---

## Changes

### New Infrastructure
- **`mastracode/src/utils/thread-lock-config.ts`** – Introduces a configuration resolver that determines whether to use file-based thread locks or rely on shared PubSub for synchronization. It exports `resolveMastraCodeThreadLockConfig`, which validates that `crossProcessPubSub: true` requires a `config.pubsub` and throws a startup error if missing. It also exports the `MastraCodeThreadLock` type defining `acquire`/`release` callbacks.

### Integration Updates
- **`mastracode/src/index.ts`** – Refactored to use the new resolver instead of inline branching logic. The `createMastraCode` function now calls `resolveMastraCodeThreadLockConfig` and passes the resolved config to the Harness, ensuring thread locks are omitted only when cross-process mode has a PubSub. Updated JSDoc to clarify that `config.pubsub` is required for cross-process-safe disabling of file thread locks.

### Test Coverage
- **`mastracode/src/utils/__tests__/thread-lock-config.test.ts`** – Unit tests for the resolver, validating three scenarios: default mode (file locks enabled, no pubsub), cross-process without pubsub (throws error), and cross-process with pubsub (file locks omitted).
- **`mastracode/src/__tests__/thread-lock-startup.test.ts`** – Integration tests for `createMastraCode` startup behavior, mocking all Mastra components to verify the resolver's output is correctly wired into Harness configuration.

### Changelog
- **`.changeset/social-snails-know.md`** – Patch release note documenting the requirement and providing a code example.

---

## Validation

✅ Unit tests: 6 tests across 2 files passed  
✅ ESLint: specified files passed  
✅ Whitespace check (`git diff --check`): passed  
✅ Code review: Gemini council approved the fail-closed validation approach; Codex reviewers approved startup-level test coverage and JSDoc updates  
✅ CodeRabbit CLI: no findings on rerun

---

## Technical Details

The resolver implements a fail-closed contract: when `crossProcessPubSub: true` is provided, it immediately validates the presence of `config.pubsub` before any storage or Harness setup occurs. This prevents silent failures in distributed scenarios where multiple processes would otherwise contend on file locks without a shared signal routing mechanism.

Thread-lock handling:
- **Default (single-process)**: file-based locks are enabled via `threadLock: { acquire, release }`
- **Cross-process with PubSub**: file-based locks are disabled (`threadLock: undefined`), relying on shared event coordination
- **Cross-process without PubSub**: startup error thrown before Harness initialization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->