### PR TITLE
[PF-525] Harden stream admission evidence failures

### DIFF
--- a/.changeset/spotty-roses-drive.md
+++ b/.changeset/spotty-roses-drive.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed streaming messages to fail cleanly after evidence write errors.

--- a/packages/core/src/harness/v1/session.message.test.ts
+++ b/packages/core/src/harness/v1/session.message.test.ts
@@ -789,6 +789,39 @@ describe('Session.message() — default path', () => {
     expect(waitForRunOutput).not.toHaveBeenCalled();
   });
 
+  it('keeps the original startup failure when a later run watcher failure arrives', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const startupError = new Error('post-dispatch pending evidence unavailable');
+    const watcherError = new Error('Agent thread run id "startup-failed-run" has been aborted');
+
+    (session as any)._rememberCompletedRun('startup-failed-run', { ok: false, err: startupError });
+    (session as any)._rememberCompletedRun('startup-failed-run', { ok: false, err: watcherError });
+
+    await expect(
+      (session as any)._returnDuplicateMessageResult(
+        { status: 'pending', signalId: 'startup-failed-signal', runId: 'startup-failed-run' },
+        { content: 'hi' },
+      ),
+    ).rejects.toBe(startupError);
+  });
+
+  it('keeps the completed result when a later run watcher failure arrives', async () => {
+    const { harness, agent } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const watcherError = new Error('Agent thread run id "completed-run" has been aborted');
+
+    (session as any)._rememberCompletedRun('completed-run', { ok: true, full: agent.fullOutput });
+    (session as any)._rememberCompletedRun('completed-run', { ok: false, err: watcherError });
+
+    await expect(
+      (session as any)._returnDuplicateMessageResult(
+        { status: 'pending', signalId: 'completed-signal', runId: 'completed-run' },
+        { content: 'hi' },
+      ),
+    ).resolves.toBe(agent.fullOutput);
+  });
+
   it('does not return retained completed output for duplicate stream retries', async () => {
     const { harness, agent } = setup();
     const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });

--- a/packages/core/src/harness/v1/session.message.test.ts
+++ b/packages/core/src/harness/v1/session.message.test.ts
@@ -484,6 +484,80 @@ describe('Session.message() — default path', () => {
     expect(storage.writes).not.toContain('failed');
   });
 
+  it('fails stream admission startup when post-dispatch pending evidence cannot be persisted', async () => {
+    class PostDispatchPendingEvidenceFailingStorage extends InMemoryHarness {
+      readonly writes: any[] = [];
+      pendingAttempts = 0;
+
+      override async writeMessageResultEvidence(record: any): Promise<{ created: boolean }> {
+        this.writes.push(record);
+        if (record.admissionId === 'stream-pending-failure' && record.status === 'pending') {
+          this.pendingAttempts++;
+          if (this.pendingAttempts === 2) {
+            throw new Error('post-dispatch pending evidence unavailable');
+          }
+        }
+        return super.writeMessageResultEvidence(record);
+      }
+    }
+    const agent = new LiveStreamFakeAgent('default');
+    const storage = new PostDispatchPendingEvidenceFailingStorage({ db: new InMemoryDB() });
+    const harness = new Harness({
+      agents: { default: agent } as any,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      sessions: { storage },
+    });
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    await expect(
+      session.message({ content: 'go', admissionId: 'stream-pending-failure', stream: true }),
+    ).rejects.toThrow('post-dispatch pending evidence unavailable');
+
+    expect(agent.calls[0]!.options.abortSignal.aborted).toBe(true);
+    const failedWrite = storage.writes.find(record => record.status === 'failed');
+    expect(failedWrite).toMatchObject({
+      admissionId: 'stream-pending-failure',
+      status: 'failed',
+    });
+    await expect(
+      storage.loadMessageResultEvidence({
+        harnessName: (session as any)._record.harnessName,
+        sessionId: session.id,
+        resourceId: session.resourceId,
+        threadId: session.threadId,
+        signalId: failedWrite.signalId,
+      }),
+    ).resolves.toMatchObject({
+      admissionId: 'stream-pending-failure',
+      status: 'failed',
+    });
+
+    agent.releaseStream?.();
+    await nextTick();
+    await nextTick();
+
+    await expect(
+      storage.loadMessageResultEvidence({
+        harnessName: (session as any)._record.harnessName,
+        sessionId: session.id,
+        resourceId: session.resourceId,
+        threadId: session.threadId,
+        signalId: failedWrite.signalId,
+      }),
+    ).resolves.toMatchObject({
+      admissionId: 'stream-pending-failure',
+      status: 'failed',
+    });
+    await expect(
+      session.message({ content: 'go', admissionId: 'stream-pending-failure', stream: true }),
+    ).rejects.toMatchObject({
+      name: 'HarnessValidationError',
+      message: expect.stringContaining('duplicate stream is no longer live'),
+    });
+    expect(agent.calls).toHaveLength(1);
+  });
+
   it('deduplicates concurrent exact admissionId retries before dispatching a second signal', async () => {
     const { harness, agent } = setup();
     const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });

--- a/packages/core/src/harness/v1/session.message.test.ts
+++ b/packages/core/src/harness/v1/session.message.test.ts
@@ -510,55 +510,60 @@ describe('Session.message() — default path', () => {
     });
     const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
 
-    await expect(
-      session.message({ content: 'go', admissionId: 'stream-pending-failure', stream: true }),
-    ).rejects.toThrow('post-dispatch pending evidence unavailable');
+    try {
+      await expect(
+        session.message({ content: 'go', admissionId: 'stream-pending-failure', stream: true }),
+      ).rejects.toThrow('post-dispatch pending evidence unavailable');
 
-    expect(agent.calls[0]!.options.abortSignal.aborted).toBe(true);
-    await nextTick();
-    const failedWrite = storage.writes.find(record => record.status === 'failed');
-    expect(failedWrite).toBeDefined();
-    expect(failedWrite).toMatchObject({
-      admissionId: 'stream-pending-failure',
-      status: 'failed',
-    });
-    await expect(
-      storage.loadMessageResultEvidence({
-        harnessName: (session as any)._record.harnessName,
-        sessionId: session.id,
-        resourceId: session.resourceId,
-        threadId: session.threadId,
-        signalId: failedWrite.signalId,
-      }),
-    ).resolves.toMatchObject({
-      admissionId: 'stream-pending-failure',
-      status: 'failed',
-    });
+      expect(agent.calls[0]!.options.abortSignal.aborted).toBe(true);
+      await nextTick();
+      const failedWrite = storage.writes.find(record => record.status === 'failed');
+      expect(failedWrite).toBeDefined();
+      expect(failedWrite).toMatchObject({
+        admissionId: 'stream-pending-failure',
+        status: 'failed',
+      });
+      await expect(
+        storage.loadMessageResultEvidence({
+          harnessName: (session as any)._record.harnessName,
+          sessionId: session.id,
+          resourceId: session.resourceId,
+          threadId: session.threadId,
+          signalId: failedWrite.signalId,
+        }),
+      ).resolves.toMatchObject({
+        admissionId: 'stream-pending-failure',
+        status: 'failed',
+      });
 
-    agent.releaseStream?.();
-    await nextTick();
-    await nextTick();
+      agent.releaseStream?.();
+      await nextTick();
+      await nextTick();
 
-    expect(failedWrite).toBeDefined();
-    await expect(
-      storage.loadMessageResultEvidence({
-        harnessName: (session as any)._record.harnessName,
-        sessionId: session.id,
-        resourceId: session.resourceId,
-        threadId: session.threadId,
-        signalId: failedWrite.signalId,
-      }),
-    ).resolves.toMatchObject({
-      admissionId: 'stream-pending-failure',
-      status: 'failed',
-    });
-    await expect(
-      session.message({ content: 'go', admissionId: 'stream-pending-failure', stream: true }),
-    ).rejects.toMatchObject({
-      name: 'HarnessValidationError',
-      message: expect.stringContaining('duplicate stream is no longer live'),
-    });
-    expect(agent.calls).toHaveLength(1);
+      expect(failedWrite).toBeDefined();
+      await expect(
+        storage.loadMessageResultEvidence({
+          harnessName: (session as any)._record.harnessName,
+          sessionId: session.id,
+          resourceId: session.resourceId,
+          threadId: session.threadId,
+          signalId: failedWrite.signalId,
+        }),
+      ).resolves.toMatchObject({
+        admissionId: 'stream-pending-failure',
+        status: 'failed',
+      });
+      await expect(
+        session.message({ content: 'go', admissionId: 'stream-pending-failure', stream: true }),
+      ).rejects.toMatchObject({
+        name: 'HarnessValidationError',
+        message: expect.stringContaining('duplicate stream is no longer live'),
+      });
+      expect(agent.calls).toHaveLength(1);
+    } finally {
+      agent.releaseStream?.();
+      await nextTick();
+    }
   });
 
   it('does not wait for failed evidence persistence before rejecting stream admission startup', async () => {
@@ -615,45 +620,51 @@ describe('Session.message() — default path', () => {
       outcome = value;
     });
 
-    await failedWriteStarted;
-    await nextTick();
+    try {
+      await failedWriteStarted;
+      await nextTick();
 
-    expect(outcome).toBeDefined();
-    expect(outcome!.ok).toBe(false);
-    if (!outcome!.ok) {
-      expect(outcome!.err).toMatchObject({ message: 'post-dispatch pending evidence unavailable' });
+      expect(outcome).toBeDefined();
+      expect(outcome!.ok).toBe(false);
+      if (!outcome!.ok) {
+        expect(outcome!.err).toMatchObject({ message: 'post-dispatch pending evidence unavailable' });
+      }
+      expect(agent.calls[0]!.options.abortSignal.aborted).toBe(true);
+
+      await expect(
+        session.message({ content: 'go', admissionId: 'stream-pending-stalled-failure', stream: true }),
+      ).rejects.toMatchObject({
+        name: 'HarnessValidationError',
+        message: expect.stringContaining('duplicate stream is no longer live'),
+      });
+      expect(agent.calls).toHaveLength(1);
+
+      releaseFailedWrite();
+      await failedWriteFinished;
+      await expect(
+        storage.loadMessageResultEvidence({
+          harnessName: (session as any)._record.harnessName,
+          sessionId: session.id,
+          resourceId: session.resourceId,
+          threadId: session.threadId,
+          signalId: failedSignalId,
+        }),
+      ).resolves.toMatchObject({
+        admissionId: 'stream-pending-stalled-failure',
+        status: 'failed',
+      });
+      await expect(
+        session.message({ content: 'go', admissionId: 'stream-pending-stalled-failure', stream: true }),
+      ).rejects.toMatchObject({
+        name: 'HarnessValidationError',
+        message: expect.stringContaining('duplicate stream is no longer live'),
+      });
+      expect(agent.calls).toHaveLength(1);
+    } finally {
+      agent.releaseStream?.();
+      if (typeof releaseFailedWrite === 'function') releaseFailedWrite();
+      await nextTick();
     }
-    expect(agent.calls[0]!.options.abortSignal.aborted).toBe(true);
-
-    await expect(
-      session.message({ content: 'go', admissionId: 'stream-pending-stalled-failure', stream: true }),
-    ).rejects.toMatchObject({
-      name: 'HarnessValidationError',
-      message: expect.stringContaining('duplicate stream is no longer live'),
-    });
-    expect(agent.calls).toHaveLength(1);
-
-    releaseFailedWrite();
-    await failedWriteFinished;
-    await expect(
-      storage.loadMessageResultEvidence({
-        harnessName: (session as any)._record.harnessName,
-        sessionId: session.id,
-        resourceId: session.resourceId,
-        threadId: session.threadId,
-        signalId: failedSignalId,
-      }),
-    ).resolves.toMatchObject({
-      admissionId: 'stream-pending-stalled-failure',
-      status: 'failed',
-    });
-    await expect(
-      session.message({ content: 'go', admissionId: 'stream-pending-stalled-failure', stream: true }),
-    ).rejects.toMatchObject({
-      name: 'HarnessValidationError',
-      message: expect.stringContaining('duplicate stream is no longer live'),
-    });
-    expect(agent.calls).toHaveLength(1);
   });
 
   it('deduplicates concurrent exact admissionId retries before dispatching a second signal', async () => {

--- a/packages/core/src/harness/v1/session.message.test.ts
+++ b/packages/core/src/harness/v1/session.message.test.ts
@@ -515,7 +515,9 @@ describe('Session.message() — default path', () => {
     ).rejects.toThrow('post-dispatch pending evidence unavailable');
 
     expect(agent.calls[0]!.options.abortSignal.aborted).toBe(true);
+    await nextTick();
     const failedWrite = storage.writes.find(record => record.status === 'failed');
+    expect(failedWrite).toBeDefined();
     expect(failedWrite).toMatchObject({
       admissionId: 'stream-pending-failure',
       status: 'failed',
@@ -537,6 +539,7 @@ describe('Session.message() — default path', () => {
     await nextTick();
     await nextTick();
 
+    expect(failedWrite).toBeDefined();
     await expect(
       storage.loadMessageResultEvidence({
         harnessName: (session as any)._record.harnessName,
@@ -551,6 +554,101 @@ describe('Session.message() — default path', () => {
     });
     await expect(
       session.message({ content: 'go', admissionId: 'stream-pending-failure', stream: true }),
+    ).rejects.toMatchObject({
+      name: 'HarnessValidationError',
+      message: expect.stringContaining('duplicate stream is no longer live'),
+    });
+    expect(agent.calls).toHaveLength(1);
+  });
+
+  it('does not wait for failed evidence persistence before rejecting stream admission startup', async () => {
+    let releaseFailedWrite!: () => void;
+    let resolveFailedWriteStarted!: () => void;
+    let resolveFailedWriteFinished!: () => void;
+    let failedSignalId!: string;
+    const failedWriteStarted = new Promise<void>(resolve => {
+      resolveFailedWriteStarted = resolve;
+    });
+    const failedWriteFinished = new Promise<void>(resolve => {
+      resolveFailedWriteFinished = resolve;
+    });
+    const failedWriteCanFinish = new Promise<void>(resolve => {
+      releaseFailedWrite = resolve;
+    });
+    class StallingFailedEvidenceStorage extends InMemoryHarness {
+      pendingAttempts = 0;
+
+      override async writeMessageResultEvidence(record: any): Promise<{ created: boolean }> {
+        if (record.admissionId === 'stream-pending-stalled-failure' && record.status === 'pending') {
+          this.pendingAttempts++;
+          if (this.pendingAttempts === 2) {
+            throw new Error('post-dispatch pending evidence unavailable');
+          }
+        }
+        if (record.admissionId === 'stream-pending-stalled-failure' && record.status === 'failed') {
+          failedSignalId = record.signalId;
+          resolveFailedWriteStarted();
+          await failedWriteCanFinish;
+          const result = await super.writeMessageResultEvidence(record);
+          resolveFailedWriteFinished();
+          return result;
+        }
+        return super.writeMessageResultEvidence(record);
+      }
+    }
+    const agent = new LiveStreamFakeAgent('default');
+    const storage = new StallingFailedEvidenceStorage({ db: new InMemoryDB() });
+    const harness = new Harness({
+      agents: { default: agent } as any,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      sessions: { storage },
+    });
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    let outcome: { ok: true } | { ok: false; err: unknown } | undefined;
+    const outcomePromise = session
+      .message({ content: 'go', admissionId: 'stream-pending-stalled-failure', stream: true })
+      .then(() => ({ ok: true as const }))
+      .catch(err => ({ ok: false as const, err }));
+    void outcomePromise.then(value => {
+      outcome = value;
+    });
+
+    await failedWriteStarted;
+    await nextTick();
+
+    expect(outcome).toBeDefined();
+    expect(outcome!.ok).toBe(false);
+    if (!outcome!.ok) {
+      expect(outcome!.err).toMatchObject({ message: 'post-dispatch pending evidence unavailable' });
+    }
+    expect(agent.calls[0]!.options.abortSignal.aborted).toBe(true);
+
+    await expect(
+      session.message({ content: 'go', admissionId: 'stream-pending-stalled-failure', stream: true }),
+    ).rejects.toMatchObject({
+      name: 'HarnessValidationError',
+      message: expect.stringContaining('duplicate stream is no longer live'),
+    });
+    expect(agent.calls).toHaveLength(1);
+
+    releaseFailedWrite();
+    await failedWriteFinished;
+    await expect(
+      storage.loadMessageResultEvidence({
+        harnessName: (session as any)._record.harnessName,
+        sessionId: session.id,
+        resourceId: session.resourceId,
+        threadId: session.threadId,
+        signalId: failedSignalId,
+      }),
+    ).resolves.toMatchObject({
+      admissionId: 'stream-pending-stalled-failure',
+      status: 'failed',
+    });
+    await expect(
+      session.message({ content: 'go', admissionId: 'stream-pending-stalled-failure', stream: true }),
     ).rejects.toMatchObject({
       name: 'HarnessValidationError',
       message: expect.stringContaining('duplicate stream is no longer live'),

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -1837,6 +1837,7 @@ export class Session {
     runId: string,
     entry: { ok: true; full: FullOutput<unknown> } | { ok: false; err: unknown },
   ): void {
+    if (this._completedRuns.has(runId)) return;
     this._completedRuns.set(runId, entry);
     while (this._completedRuns.size > 64) {
       const oldest = this._completedRuns.keys().next().value;

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -1817,6 +1817,11 @@ export class Session {
   private async _handleRunTerminal(runId: string, out: MastraModelOutput<unknown>): Promise<void> {
     const waiter = this._runCompletionPromises.get(runId);
     this._runCompletionPromises.delete(runId);
+    const cached = this._completedRuns.get(runId);
+    if (cached && !cached.ok) {
+      if (waiter) waiter.reject(cached.err);
+      return;
+    }
     try {
       const full = (await out.getFullOutput()) as FullOutput<unknown>;
       this._rememberCompletedRun(runId, { ok: true, full });
@@ -2272,7 +2277,17 @@ export class Session {
     // the wake path).
     const completion = this._awaitRunCompletion(signal.runId);
     void completion.catch(() => {});
-    if (admissionStart && admissionIdentity !== undefined && admissionHash !== undefined) {
+    let admissionStartSettled = false;
+    const resolveMessageAdmissionStart = () => {
+      if (
+        admissionStartSettled ||
+        admissionStart === undefined ||
+        admissionIdentity === undefined ||
+        admissionHash === undefined
+      ) {
+        return;
+      }
+      admissionStartSettled = true;
       const now = Date.now();
       admissionStart.resolve({
         status: 'pending',
@@ -2287,7 +2302,12 @@ export class Session {
         createdAt: now,
         updatedAt: now,
       });
-    }
+    };
+    const rejectMessageAdmissionStart = (err: unknown) => {
+      if (admissionStartSettled || admissionStart === undefined) return;
+      admissionStartSettled = true;
+      admissionStart.reject(err);
+    };
 
     const pendingEvidenceWrite =
       admissionIdentity !== undefined
@@ -2302,6 +2322,41 @@ export class Session {
             { compatibleAdmissionHashes },
           )
         : Promise.resolve();
+    void pendingEvidenceWrite.catch(() => {});
+
+    const failDispatchedMessageTurn = async (err: unknown) => {
+      turnAbortController.abort(err);
+      finishOwnedMessageTurn();
+      rejectMessageAdmissionStart(err);
+      void completion.catch(() => {});
+      const waiter = this._runCompletionPromises.get(signal.runId);
+      this._runCompletionPromises.delete(signal.runId);
+      this._rememberCompletedRun(signal.runId, { ok: false, err });
+      waiter?.reject(err);
+      try {
+        if (admissionIdentity !== undefined && this._shouldWriteTurnFailureEvidence(err)) {
+          await this._writeMessageResultEvidenceBestEffort(
+            {
+              status: 'failed',
+              signalId: signal.signal.id,
+              runId: signal.runId,
+              error: projectHarnessPublicError(err),
+              admissionId: opts.admissionId!,
+              admissionHash: admissionHash!,
+            },
+            { compatibleAdmissionHashes },
+          ).catch(() => {});
+        }
+      } finally {
+        if (opts.admissionId !== undefined) this._messageAdmissionStarts.delete(opts.admissionId);
+        void this._maybeDrainQueue();
+      }
+    };
+
+    const awaitPendingMessageEvidence = async () => {
+      await Promise.race([pendingEvidenceWrite, activeTurnWaiter.promise]);
+      resolveMessageAdmissionStart();
+    };
 
     // Streaming path: hand the live `MastraModelOutput` back. The drain
     // loop is responsible for harness events; we still keep the turn
@@ -2309,7 +2364,12 @@ export class Session {
     if (opts.stream === true) {
       let out = agent.getRunOutput(signal.runId) as MastraModelOutput<unknown> | undefined;
       if (!out && (signal.output || admissionIdentity !== undefined)) {
-        await Promise.race([pendingEvidenceWrite.catch(() => {}), activeTurnWaiter.promise]);
+        try {
+          await awaitPendingMessageEvidence();
+        } catch (err) {
+          await failDispatchedMessageTurn(err);
+          throw err;
+        }
         try {
           out = signal.output
             ? ((await Promise.race([signal.output, activeTurnWaiter.promise])) as MastraModelOutput<unknown>)
@@ -2348,32 +2408,18 @@ export class Session {
         }
       }
       if (!out) {
-        finishOwnedMessageTurn();
-        void pendingEvidenceWrite.catch(() => {});
         const err = new HarnessConfigError('message()', 'agent did not register a run for the dispatched signal');
         // Drop the completion waiter so duplicate retries do not treat an
         // unregistered run as live forever.
-        void completion.catch(() => {});
-        const waiter = this._runCompletionPromises.get(signal.runId);
-        this._runCompletionPromises.delete(signal.runId);
-        this._rememberCompletedRun(signal.runId, { ok: false, err });
-        waiter?.reject(err);
-        if (admissionIdentity !== undefined) {
-          await this._writeMessageResultEvidenceBestEffort(
-            {
-              status: 'failed',
-              signalId: signal.signal.id,
-              runId: signal.runId,
-              error: projectHarnessPublicError(err),
-              admissionId: opts.admissionId!,
-              admissionHash: admissionHash!,
-            },
-            { compatibleAdmissionHashes },
-          );
-        }
+        await failDispatchedMessageTurn(err);
         throw err;
       }
-      await Promise.race([pendingEvidenceWrite.catch(() => {}), activeTurnWaiter.promise]);
+      try {
+        await awaitPendingMessageEvidence();
+      } catch (err) {
+        await failDispatchedMessageTurn(err);
+        throw err;
+      }
       let streamCompletedEvidenceWriteFailed = false;
       void Promise.race([completion, activeTurnWaiter.promise])
         .then(async full => {
@@ -2440,7 +2486,11 @@ export class Session {
     let streamStarted = signal.output === undefined;
     let completedEvidenceWriteFailed = false;
     try {
+      // The pre-dispatch reservation is the durable admission barrier here.
+      // Keep the post-dispatch pending refresh best-effort so completion
+      // evidence remains the authoritative default-path result.
       await Promise.race([pendingEvidenceWrite.catch(() => {}), activeTurnWaiter.promise]);
+      resolveMessageAdmissionStart();
       if (signal.output) {
         await Promise.race([signal.output, activeTurnWaiter.promise]);
         streamStarted = true;

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -162,6 +162,7 @@ const ASK_USER_TOOL_NAME = ASK_USER_TOOL_ID;
 const SUBMIT_PLAN_TOOL_NAME = SUBMIT_PLAN_TOOL_ID;
 const MESSAGE_ADMISSION_DURABLE_WAIT_TIMEOUT_MS = 30_000;
 const MESSAGE_ADMISSION_DURABLE_WAIT_INTERVAL_MS = 100;
+const MESSAGE_RESULT_EVIDENCE_BACKGROUND_OBSERVE_TIMEOUT_MS = 5_000;
 const QUEUE_ACCEPTED_RECOVERY_STALE_MS = 30_000;
 const QUEUE_POST_RUN_FINALIZATION_RETRY_MS = 1_000;
 const SUPPORTED_SKILL_ARG_SCHEMA_KEYS = new Set([
@@ -2333,24 +2334,21 @@ export class Session {
       this._runCompletionPromises.delete(signal.runId);
       this._rememberCompletedRun(signal.runId, { ok: false, err });
       waiter?.reject(err);
-      try {
-        if (admissionIdentity !== undefined && this._shouldWriteTurnFailureEvidence(err)) {
-          await this._writeMessageResultEvidenceBestEffort(
-            {
-              status: 'failed',
-              signalId: signal.signal.id,
-              runId: signal.runId,
-              error: projectHarnessPublicError(err),
-              admissionId: opts.admissionId!,
-              admissionHash: admissionHash!,
-            },
-            { compatibleAdmissionHashes },
-          ).catch(() => {});
-        }
-      } finally {
-        if (opts.admissionId !== undefined) this._messageAdmissionStarts.delete(opts.admissionId);
-        void this._maybeDrainQueue();
+      if (admissionIdentity !== undefined && this._shouldWriteTurnFailureEvidence(err)) {
+        this._writeMessageResultEvidenceBestEffortInBackground(
+          {
+            status: 'failed',
+            signalId: signal.signal.id,
+            runId: signal.runId,
+            error: projectHarnessPublicError(err),
+            admissionId: opts.admissionId!,
+            admissionHash: admissionHash!,
+          },
+          { compatibleAdmissionHashes },
+        );
       }
+      if (opts.admissionId !== undefined) this._messageAdmissionStarts.delete(opts.admissionId);
+      void this._maybeDrainQueue();
     };
 
     const awaitPendingMessageEvidence = async () => {
@@ -2390,7 +2388,7 @@ export class Session {
           this._rememberCompletedRun(signal.runId, { ok: false, err });
           waiter?.reject(err);
           if (admissionIdentity !== undefined && this._shouldWriteTurnFailureEvidence(err)) {
-            await this._writeMessageResultEvidenceBestEffort(
+            this._writeMessageResultEvidenceBestEffortInBackground(
               {
                 status: 'failed',
                 signalId: signal.signal.id,
@@ -2816,6 +2814,23 @@ export class Session {
       // Non-idempotent callers have no durable replay contract, so storage
       // evidence is only best-effort for them.
     }
+  }
+
+  private _writeMessageResultEvidenceBestEffortInBackground(
+    status: AgentSignalResultStatus & { admissionId?: string; admissionHash?: string },
+    options?: { compatibleAdmissionHashes?: readonly string[] },
+  ): void {
+    const write = this._writeMessageResultEvidenceBestEffort(status, options);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<void>(resolve => {
+      timer = setTimeout(resolve, MESSAGE_RESULT_EVIDENCE_BACKGROUND_OBSERVE_TIMEOUT_MS);
+      timer.unref?.();
+    });
+    void Promise.race([write, timeout])
+      .catch(() => {})
+      .finally(() => {
+        if (timer !== undefined) clearTimeout(timer);
+      });
   }
 
   private _computeMessageAdmissionHashes(


### PR DESCRIPTION
## Summary
- Gate streaming Session.message with stream true and admissionId on the post-dispatch pending evidence write.
- Fail and abort the dispatched stream startup when that evidence write fails, persist failed evidence when possible, and keep later completion caching from overwriting the failed startup state.
- Add regression coverage for duplicate stream retry behavior after the failed evidence-write race.

## Validation
- git diff --check
- pnpm --dir /tmp/mastra-fork-pf-525 exec vitest run packages/core/src/harness/v1/session.message.test.ts --project unit:packages/core
- pnpm --dir /tmp/mastra-fork-pf-525 --filter @mastra/core check
- local Codex review pass 1: found cleanup/abort issues; fixed
- local Codex review pass 2: found accidental non-stream broadening; narrowed default path back to prior best-effort behavior
- coderabbit review --plain initially requested changeset wording and questioned default-path behavior; changeset fixed, default-path decision documented in source; final rerun reported no findings

## Notes
- Gemini council review was attempted but unavailable due model capacity.
- opencode council review was attempted but the configured model was unavailable.
- Claude council review was attempted but did not return output and was stopped.

Linear: PF-525


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

If starting a live AI stream fails because the system can't save the "I started" record, the stream now stops immediately, records that failure (when possible), and prevents future retries or later completion caching from pretending the stream succeeded.

---

## Changes

### Test Coverage
- Added Vitest tests validating streaming admission startup failure behavior and duplicate-retry semantics:
  - Test: failing post-dispatch pending-evidence write — verifies session.message(stream: true) startup rejects with the write error, the per-turn abortSignal is aborted, failed evidence is persisted/reloadable, and a later duplicate-stream retry is rejected as not live (single agent invocation).
  - Test: stalled failed-evidence persistence during rejection — verifies startup rejects without waiting for the stalled write, still aborts the per-turn abortSignal, rejects duplicate streaming retries while persistence is in-flight, and confirms failed evidence becomes persisted/reloadable after the stall resolves.
  - Additional tests for _returnDuplicateMessageResult: preserve the original startup error if later watcher failures arrive, and preserve a completed result against later watcher failures.

### Core Session Handling
- Admission startup gating and settlement:
  - For streaming admissions (stream: true + admissionId), admission resolution is gated to await the post-dispatch pending-evidence write (best-effort) so write failures can abort startup.
  - Introduced one-time admission-settlement helpers resolveMessageAdmissionStart() and rejectMessageAdmissionStart() guarded by admissionStartSettled to ensure single settlement.
- Robust failure flow:
  - Added failDispatchedMessageTurn() to abort the owned turn, finalize owned-turn state, reject the admission-start promise, cache a failed terminal outcome for the runId, and reject any completion waiters — preventing later completion caching from overwriting the failed startup state.
  - Streaming paths that detect "agent never registered a run" or pending-evidence write failures route through failDispatchedMessageTurn() and rethrow as appropriate.
  - On pending-evidence write failure during streaming startup: the dispatched stream startup fails and aborts, failed evidence is emitted when possible, and subsequent completion caching is prevented from masking the failed startup.
- Background evidence writes:
  - Introduced MESSAGE_RESULT_EVIDENCE_BACKGROUND_OBSERVE_TIMEOUT_MS (5_000 ms) and _writeMessageResultEvidenceBestEffortInBackground() to run best-effort evidence writes in the background with a short observe-timeout (timer is unref'd) so background persistence doesn't block admission failure handling.
- Completion cache idempotency and terminal handling:
  - _rememberCompletedRun is now idempotent and will not overwrite an existing cached completed result for the same runId.
  - _handleRunTerminal short-circuits when a non-OK terminal result is already cached for runId: it rejects any registered completion waiter and avoids redundant getFullOutput() work.

### Changelog
- Added a patch changeset for `@mastra/core` noting that streaming messages now fail cleanly after evidence write errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->