### PR TITLE
[PF-548] Add default harness sugar and shutdown

### DIFF
--- a/.changeset/pf-548-default-harness-sugar-shutdown.md
+++ b/.changeset/pf-548-default-harness-sugar-shutdown.md
@@ -1,0 +1,19 @@
+---
+'@mastra/core': minor
+---
+
+Added support for registering a single Harness with `harness`, available as the `default` harness.
+
+```ts
+const mastra = new Mastra({ agents, storage, harness });
+const defaultHarness = mastra.getHarness();
+```
+
+Registered Harness instances now shut down as part of `mastra.shutdown()`. Mastra attempts every
+registered harness shutdown, logs individual harness failures, and throws the first harness shutdown
+failure after the remaining cleanup steps have been attempted. Apps that use the existing
+`harnesses` map can keep calling `mastra.getHarness('name')`.
+
+`stopWorkers()` also now attempts every owned cleanup step before returning: worker stops, workflow
+push subscription cleanup, user event listener cleanup, and pubsub flushing. If cleanup fails, Mastra
+logs each failure and throws the first error after the remaining cleanup steps have been attempted.

--- a/docs/src/content/en/reference/configuration.mdx
+++ b/docs/src/content/en/reference/configuration.mdx
@@ -269,6 +269,87 @@ export const mastra = new Mastra({
 })
 ```
 
+### harness
+
+**Type:** `Harness`
+
+Registers a single Harness v1 instance on the Mastra instance as the `default`
+harness. The harness uses the parent Mastra instance's agents and storage, and
+can be retrieved with `mastra.getHarness()`.
+
+Use `harnesses` instead when you need multiple named harnesses. The `harness`
+option cannot be combined with `harnesses.default`.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { Agent } from '@mastra/core/agent'
+import { Harness } from '@mastra/core/harness/v1'
+import { LibSQLStore } from '@mastra/libsql'
+
+const assistant = new Agent({
+  id: 'assistant',
+  name: 'Assistant',
+  instructions: 'You help users',
+  model: 'openai/gpt-5.4',
+})
+
+const storage = new LibSQLStore({
+  id: 'mastra-storage',
+  url: 'file:./mastra.db',
+})
+
+const harness = new Harness({
+  modes: [{ id: 'default', agentId: 'assistant' }],
+  defaultModeId: 'default',
+})
+
+export const mastra = new Mastra({
+  agents: { assistant },
+  storage,
+  harness,
+})
+```
+
+### harnesses
+
+**Type:** `Record<string, Harness>`
+
+Registers named Harness v1 instances on the Mastra instance. Each harness uses
+the parent Mastra instance's agents and storage, and can be retrieved with
+`mastra.getHarness(name)`.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { Agent } from '@mastra/core/agent'
+import { Harness } from '@mastra/core/harness/v1'
+import { LibSQLStore } from '@mastra/libsql'
+
+const assistant = new Agent({
+  id: 'assistant',
+  name: 'Assistant',
+  instructions: 'You help users',
+  model: 'openai/gpt-5.4',
+})
+
+const storage = new LibSQLStore({
+  id: 'mastra-storage',
+  url: 'file:./mastra.db',
+})
+
+const supportHarness = new Harness({
+  modes: [{ id: 'default', agentId: 'assistant' }],
+  defaultModeId: 'default',
+})
+
+export const mastra = new Mastra({
+  agents: { assistant },
+  storage,
+  harnesses: {
+    support: supportHarness,
+  },
+})
+```
+
 ### idGenerator
 
 **Type:** `(context?: IdGeneratorContext) => string`\

--- a/docs/src/content/en/reference/core/mastra-class.mdx
+++ b/docs/src/content/en/reference/core/mastra-class.mdx
@@ -112,6 +112,20 @@ Visit the [Configuration reference](/reference/configuration) for detailed docum
       'Deployment environment name (e.g. `production`, `staging`, `development`). When set, automatically attached to all observability signals so they can be filtered by environment without passing `tracingOptions.metadata.environment` on each call. Falls back to `process.env.NODE_ENV` when unset; left undefined if neither is set. Per-call `tracingOptions.metadata.environment` always takes precedence.',
   },
   {
+    name: 'harness',
+    type: 'Harness',
+    isOptional: true,
+    description:
+      'Harness v1 instance to register as the default harness. It can be retrieved with `mastra.getHarness()`.',
+  },
+  {
+    name: 'harnesses',
+    type: 'Record<string, Harness>',
+    isOptional: true,
+    description:
+      'Named Harness v1 instances to register on this Mastra. Use `mastra.getHarness(name)` to retrieve a named harness.',
+  },
+  {
     name: 'deployer',
     type: 'MastraDeployer',
     isOptional: true,

--- a/docs/src/content/en/reference/harness/harness-class.mdx
+++ b/docs/src/content/en/reference/harness/harness-class.mdx
@@ -49,6 +49,47 @@ await harness.selectOrCreateThread()
 await harness.sendMessage({ content: 'Hello!' })
 ```
 
+## Mastra registration
+
+Harness v1 instances can be registered on a `Mastra` instance so they use the
+parent's agents and storage. Use `harness` for the common single-harness case;
+Mastra registers it as the `default` harness and `mastra.getHarness()` returns
+that instance.
+
+```typescript
+import { Harness } from '@mastra/core/harness/v1'
+import { Mastra } from '@mastra/core/mastra'
+
+const harness = new Harness({
+  modes: [{ id: 'default', agentId: 'assistant' }],
+  defaultModeId: 'default',
+})
+
+const mastra = new Mastra({
+  agents: { assistant },
+  storage,
+  harness,
+})
+
+const defaultHarness = mastra.getHarness()
+```
+
+Use `harnesses` when an app needs multiple named harnesses. The `harness`
+shortcut and `harnesses.default` are mutually exclusive.
+
+```typescript
+const mastra = new Mastra({
+  agents: { assistant },
+  storage,
+  harnesses: {
+    support: supportHarness,
+    research: researchHarness,
+  },
+})
+
+const support = mastra.getHarness('support')
+```
+
 ## Constructor parameters
 
 <PropertiesTable

--- a/packages/core/src/background-tasks/manager.ts
+++ b/packages/core/src/background-tasks/manager.ts
@@ -145,8 +145,12 @@ export class BackgroundTaskManager {
     await this.pubsub.subscribe(TOPIC_DISPATCH, this.workerCallback, { group: WORKER_GROUP });
     await this.pubsub.subscribe(TOPIC_RESULT, this.resultCallback);
 
+    if (this.shuttingDown) return;
+
     // Recover stale tasks from a previous process
     await this.recoverStaleTasks();
+
+    if (this.shuttingDown) return;
 
     // Start periodic cleanup if configured
     const cleanupConfig = this.config.cleanup;
@@ -222,6 +226,9 @@ export class BackgroundTaskManager {
     // whose Mastra hasn't yet registered the bg-task workflow → "Workflow
     // with id __background-task not found"). Await readiness up front.
     if (this.initPromise) await this.initPromise;
+    if (this.shuttingDown) {
+      throw new Error('BackgroundTaskManager is shutting down, cannot enqueue new tasks');
+    }
 
     const task: BackgroundTask = {
       id: this.#mastra?.generateId() ?? randomUUID(),
@@ -245,12 +252,32 @@ export class BackgroundTaskManager {
     }
 
     const storage = await this.getStorage();
+    if (this.shuttingDown) {
+      this.deregisterTaskContext(task.id);
+      throw new Error('BackgroundTaskManager is shutting down, cannot enqueue new tasks');
+    }
+
     await storage.createTask(task);
+    if (this.shuttingDown) {
+      this.deregisterTaskContext(task.id);
+      await storage.deleteTask(task.id);
+      throw new Error('BackgroundTaskManager is shutting down, cannot enqueue new tasks');
+    }
 
     const canRun = await this.checkConcurrency(task.agentId);
+    if (this.shuttingDown) {
+      this.deregisterTaskContext(task.id);
+      await storage.deleteTask(task.id);
+      throw new Error('BackgroundTaskManager is shutting down, cannot enqueue new tasks');
+    }
 
     if (canRun) {
-      await this.dispatch(task);
+      const dispatched = await this.dispatch(task);
+      if (!dispatched) {
+        this.deregisterTaskContext(task.id);
+        await storage.deleteTask(task.id);
+        throw new Error('BackgroundTaskManager is shutting down, cannot enqueue new tasks');
+      }
       return { task };
     }
 
@@ -371,9 +398,19 @@ export class BackgroundTaskManager {
     }
 
     if (this.initPromise) await this.initPromise;
+    if (this.shuttingDown) {
+      throw new Error('BackgroundTaskManager is shutting down, cannot resume tasks');
+    }
 
     const storage = await this.getStorage();
+    if (this.shuttingDown) {
+      throw new Error('BackgroundTaskManager is shutting down, cannot resume tasks');
+    }
+
     const task = await storage.getTask(taskId);
+    if (this.shuttingDown) {
+      throw new Error('BackgroundTaskManager is shutting down, cannot resume tasks');
+    }
     if (!task) {
       throw new Error(`Task not found: ${taskId}`);
     }
@@ -382,6 +419,9 @@ export class BackgroundTaskManager {
     }
 
     const canRun = await this.checkConcurrency(task.agentId);
+    if (this.shuttingDown) {
+      throw new Error('BackgroundTaskManager is shutting down, cannot resume tasks');
+    }
     if (!canRun) {
       // Resume sits outside the queue/fallback-sync paths — there's no
       // synchronous caller to fall back to, and silently leaving the task
@@ -672,6 +712,15 @@ export class BackgroundTaskManager {
   async shutdown(): Promise<void> {
     this.shuttingDown = true;
 
+    if (this.initPromise) {
+      try {
+        await this.initPromise;
+      } catch {
+        // Constructor-started init logs its own failure. Continue best-effort
+        // cleanup for any subscriptions or timers that were already created.
+      }
+    }
+
     if (this.cleanupInterval) {
       clearInterval(this.cleanupInterval);
       this.cleanupInterval = undefined;
@@ -690,7 +739,9 @@ export class BackgroundTaskManager {
 
   // --- Internal ---
 
-  private async dispatch(task: BackgroundTask): Promise<void> {
+  private async dispatch(task: BackgroundTask): Promise<boolean> {
+    if (this.shuttingDown) return false;
+
     // Publish `task.dispatch` on `TOPIC_DISPATCH` with `WORKER_GROUP`, so
     // exactly one worker handles the task. `handleDispatch` flips the
     // task to running and starts the per-task workflow run.
@@ -710,28 +761,53 @@ export class BackgroundTaskManager {
       },
       runId: task.id,
     });
+    return true;
   }
 
   /**
    * Handles a task.dispatch event. Returns true if the message was nacked (for retry).
    */
   private async handleDispatch(event: Event): Promise<boolean> {
+    if (this.shuttingDown) return false;
+
     const { taskId } = event.data;
     const deliveryAttempt = event.deliveryAttempt ?? 1;
     let nacked = false;
 
     const storage = await this.getStorage();
+    if (this.shuttingDown) {
+      this.deregisterTaskContext(taskId);
+      return false;
+    }
+
     const task = await storage.getTask(taskId);
+    if (this.shuttingDown) {
+      this.deregisterTaskContext(taskId);
+      return false;
+    }
     if (!task || task.status === 'cancelled') {
       this.deregisterTaskContext(taskId);
       return false;
     }
 
+    const restorePending = async () => {
+      await storage.updateTask(taskId, { status: 'pending', startedAt: undefined });
+      this.deregisterTaskContext(taskId);
+    };
+
     await storage.updateTask(taskId, { status: 'running', startedAt: new Date(), retryCount: deliveryAttempt - 1 });
 
     // Publish running lifecycle event (fan-out, for stream consumers)
     const runningTask = await storage.getTask(taskId);
+    if (this.shuttingDown) {
+      await restorePending();
+      return false;
+    }
     if (runningTask) await this.publishLifecycleEvent('task.running', runningTask);
+    if (this.shuttingDown) {
+      await restorePending();
+      return false;
+    }
 
     // Fire-and-forget the workflow run; the workflow step body owns
     // executor invocation, retries, and suspend/resume. The local
@@ -740,6 +816,10 @@ export class BackgroundTaskManager {
       if (runningTask) void this.runLocalExecutionHook(runningTask);
       const workflow = this.#mastra.__getInternalWorkflow(BACKGROUND_TASK_WORKFLOW_ID);
       const run = await workflow.createRun({ runId: taskId });
+      if (this.shuttingDown) {
+        await restorePending();
+        return false;
+      }
       void run
         .start({ inputData: { taskId } })
         .then(result => {
@@ -767,16 +847,30 @@ export class BackgroundTaskManager {
    * than the one that suspended the task can drive the resume.
    */
   private async handleResume(event: Event): Promise<void> {
+    if (this.shuttingDown) return;
+
     const { taskId, resumeData } = event.data;
 
     const storage = await this.getStorage();
+    if (this.shuttingDown) return;
+
     const task = await storage.getTask(taskId);
+    if (this.shuttingDown) return;
     if (!task || task.status !== 'suspended') {
       // Either gone or already resumed/cancelled by another worker. Drop the
       // event silently — the worker group ensures exactly-once delivery, but
       // the task may have moved on between publish and pickup.
       return;
     }
+
+    const restoreSuspended = async () => {
+      await storage.updateTask(taskId, {
+        status: 'suspended',
+        startedAt: task.startedAt,
+        suspendPayload: task.suspendPayload,
+        suspendedAt: task.suspendedAt,
+      });
+    };
 
     await storage.updateTask(taskId, {
       status: 'running',
@@ -785,8 +879,16 @@ export class BackgroundTaskManager {
       suspendedAt: undefined,
     });
     const resumedTask = await storage.getTask(taskId);
+    if (this.shuttingDown) {
+      await restoreSuspended();
+      return;
+    }
     if (resumedTask) {
       await this.publishLifecycleEvent('task.resumed', resumedTask);
+    }
+    if (this.shuttingDown) {
+      await restoreSuspended();
+      return;
     }
 
     if (!this.#mastra) return;
@@ -794,6 +896,10 @@ export class BackgroundTaskManager {
     // `createRun({ runId })` reattaches to the existing snapshot when given a
     // stable runId — we don't want a fresh run.
     const run = await workflow.createRun({ runId: taskId });
+    if (this.shuttingDown) {
+      await restoreSuspended();
+      return;
+    }
     void run
       .resume({ resumeData })
       .then(result => {
@@ -1035,6 +1141,8 @@ export class BackgroundTaskManager {
   }
 
   private handleCancel(event: Event): void {
+    if (this.shuttingDown) return;
+
     const { taskId } = event.data;
     const controller = this.activeAbortControllers.get(taskId);
     if (controller) {
@@ -1095,6 +1203,8 @@ export class BackgroundTaskManager {
   }
 
   private async drainPending(): Promise<void> {
+    if (this.shuttingDown) return;
+
     const storage = await this.getStorage();
     const { tasks: pending } = await storage.listTasks({
       status: 'pending',
@@ -1103,6 +1213,7 @@ export class BackgroundTaskManager {
     });
 
     for (const task of pending) {
+      if (this.shuttingDown) return;
       if (await this.checkConcurrency(task.agentId)) {
         await this.dispatch(task);
       }
@@ -1114,9 +1225,12 @@ export class BackgroundTaskManager {
    */
   private async recoverStaleTasks(): Promise<void> {
     try {
+      if (this.shuttingDown) return;
+
       const storage = await this.getStorage();
       const { tasks: staleTasks } = await storage.listTasks({ status: 'running' });
       for (const task of staleTasks) {
+        if (this.shuttingDown) return;
         if (task.maxRetries > 0) {
           await storage.updateTask(task.id, {
             status: 'pending',
@@ -1137,6 +1251,7 @@ export class BackgroundTaskManager {
         orderDirection: 'asc',
       });
       for (const task of pendingTasks) {
+        if (this.shuttingDown) return;
         if (await this.checkConcurrency(task.agentId)) {
           await this.dispatch(task);
         }

--- a/packages/core/src/harness/v1/harness.test.ts
+++ b/packages/core/src/harness/v1/harness.test.ts
@@ -14,6 +14,8 @@ import { z } from 'zod';
 
 import { Agent } from '../../agent';
 import type { ChannelProvider } from '../../channels';
+import { PubSub } from '../../events';
+import type { Event, EventCallback, SubscribeOptions } from '../../events';
 import { Mastra } from '../../mastra';
 import type { ChannelOutboxEnqueueOptions } from '../../storage/domains/harness';
 import {
@@ -24,6 +26,7 @@ import {
 import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
 import { InMemoryDB } from '../../storage/domains/inmemory-db';
 import { InMemoryStore } from '../../storage/mock';
+import { MastraWorker } from '../../worker';
 
 import { extractSignalContents, MockAgent } from './__test-utils__';
 import type { HarnessSessionDeleteBlockedError } from './errors';
@@ -156,6 +159,111 @@ class BlockingGenerateMockAgent extends MockAgent {
   }
 }
 
+class RecordingStopWorker extends MastraWorker {
+  readonly name: string;
+  registerCalls = 0;
+  stopCalls = 0;
+
+  constructor(
+    name: string,
+    private readonly failure?: Error,
+  ) {
+    super();
+    this.name = name;
+  }
+
+  override __registerMastra(mastra: Mastra): void {
+    this.registerCalls += 1;
+    super.__registerMastra(mastra);
+  }
+
+  async start(): Promise<void> {}
+
+  async stop(): Promise<void> {
+    this.stopCalls += 1;
+    if (this.failure) throw this.failure;
+  }
+
+  get isRunning(): boolean {
+    return true;
+  }
+}
+
+class FailingCleanupPubSub extends PubSub {
+  readonly unsubscribeCalls: string[] = [];
+  flushCalls = 0;
+
+  constructor(
+    private readonly unsubscribeFailures: Record<string, unknown>,
+    private readonly flushFailure?: unknown,
+  ) {
+    super();
+  }
+
+  override get supportedModes(): ReadonlyArray<'push'> {
+    return ['push'];
+  }
+
+  async publish(_topic: string, _event: Omit<Event, 'id' | 'createdAt'>): Promise<void> {}
+
+  async subscribe(_topic: string, _cb: EventCallback, _options?: SubscribeOptions): Promise<void> {}
+
+  async unsubscribe(topic: string, _cb: EventCallback): Promise<void> {
+    this.unsubscribeCalls.push(topic);
+    if (Object.prototype.hasOwnProperty.call(this.unsubscribeFailures, topic)) {
+      throw this.unsubscribeFailures[topic];
+    }
+  }
+
+  async flush(): Promise<void> {
+    this.flushCalls += 1;
+    if (this.flushFailure) throw this.flushFailure;
+  }
+}
+
+class DeferredSubscribePubSub extends PubSub {
+  readonly publishCalls: string[] = [];
+  readonly subscribeCalls: string[] = [];
+  readonly unsubscribeCalls: string[] = [];
+
+  private resolveFirstSubscribeStarted!: () => void;
+  private resolveSubscribeGate!: () => void;
+  private readonly firstSubscribeStarted = new Promise<void>(resolve => {
+    this.resolveFirstSubscribeStarted = resolve;
+  });
+  private readonly subscribeGate = new Promise<void>(resolve => {
+    this.resolveSubscribeGate = resolve;
+  });
+
+  override get supportedModes(): ReadonlyArray<'pull' | 'push'> {
+    return ['pull', 'push'];
+  }
+
+  async publish(topic: string, _event: Omit<Event, 'id' | 'createdAt'>): Promise<void> {
+    this.publishCalls.push(topic);
+  }
+
+  async subscribe(topic: string, _cb: EventCallback, _options?: SubscribeOptions): Promise<void> {
+    this.subscribeCalls.push(topic);
+    this.resolveFirstSubscribeStarted();
+    await this.subscribeGate;
+  }
+
+  async unsubscribe(topic: string, _cb: EventCallback): Promise<void> {
+    this.unsubscribeCalls.push(topic);
+  }
+
+  async flush(): Promise<void> {}
+
+  waitForFirstSubscribe(): Promise<void> {
+    return this.firstSubscribeStarted;
+  }
+
+  releaseSubscribes(): void {
+    this.resolveSubscribeGate();
+  }
+}
+
 function makeHarness(overrides?: Partial<ConstructorParameters<typeof Harness>[0]>) {
   const { sessions: overrideSessions, ...restOverrides } = overrides ?? {};
   const storage = overrideSessions?.storage ?? makeStorage();
@@ -175,6 +283,354 @@ function makeHarness(overrides?: Partial<ConstructorParameters<typeof Harness>[0
 describe('Harness v1 — construction', () => {
   it('accepts a valid config', () => {
     expect(() => makeHarness()).not.toThrow();
+  });
+
+  it('registers single-harness Mastra sugar under the default key', async () => {
+    const storage = new InMemoryStore();
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+
+    const mastra = new Mastra({
+      agents: { default: makeAgent() },
+      storage,
+      harness,
+    });
+
+    expect(mastra.getHarness()).toBe(harness);
+    expect(mastra.getHarness('default')).toBe(harness);
+    expect(mastra.getHarnesses()).toEqual({ default: harness });
+
+    const session = await harness.session({ threadId: 'default-thread', resourceId: 'r1' });
+    expect(session.getRecord().harnessName).toBe('default');
+  });
+
+  it('rejects duplicate default harness registration between sugar and explicit map', () => {
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+    const worker = new RecordingStopWorker('side-effect-check');
+    const logger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      trackException: vi.fn(),
+      warn: vi.fn(),
+    };
+
+    expect(
+      () =>
+        new Mastra({
+          agents: { default: makeAgent() },
+          storage: new InMemoryStore(),
+          logger: logger as any,
+          workers: [worker],
+          harness,
+          harnesses: { default: harness },
+        }),
+    ).toThrow(/config\.harnesses\.default/);
+    expect(worker.registerCalls).toBe(0);
+    expect(logger.trackException).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores nullish explicit default harness entries when using single-harness sugar', () => {
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+
+    const mastra = new Mastra({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+      harness,
+      harnesses: { default: undefined },
+    });
+
+    expect(mastra.getHarness()).toBe(harness);
+  });
+
+  it('shuts down registered harnesses during Mastra shutdown', async () => {
+    const alpha = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+    const beta = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+    const alphaShutdown = vi.spyOn(alpha, 'shutdown');
+    const betaShutdown = vi.spyOn(beta, 'shutdown');
+
+    const mastra = new Mastra({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+      harnesses: { alpha, beta },
+    });
+
+    await mastra.shutdown();
+
+    expect(alphaShutdown).toHaveBeenCalledTimes(1);
+    expect(betaShutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs harness shutdown failures, continues shutting down other harnesses, and throws the first failure', async () => {
+    const failure = new Error('shutdown failed');
+    const logger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      trackException: vi.fn(),
+      warn: vi.fn(),
+    };
+    const alpha = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+    const beta = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+    const alphaShutdown = vi.spyOn(alpha, 'shutdown').mockRejectedValueOnce(failure);
+    const betaShutdown = vi.spyOn(beta, 'shutdown');
+
+    const mastra = new Mastra({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+      logger: logger as any,
+      harnesses: { alpha, beta },
+    });
+
+    await expect(mastra.shutdown()).rejects.toBe(failure);
+
+    expect(alphaShutdown).toHaveBeenCalledTimes(1);
+    expect(betaShutdown).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith('Failed to shutdown harness "alpha"', failure);
+  });
+
+  it('propagates falsy cleanup rejection reasons after best-effort shutdown', async () => {
+    const logger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      trackException: vi.fn(),
+      warn: vi.fn(),
+    };
+    const pubsub = new FailingCleanupPubSub({
+      workflows: undefined,
+    });
+
+    const mastra = new Mastra({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+      logger: logger as any,
+      pubsub,
+      workers: false,
+    });
+
+    await mastra.startWorkers();
+    await expect(mastra.stopWorkers()).rejects.toBeUndefined();
+
+    expect(pubsub.unsubscribeCalls).toEqual(['workflows']);
+    expect(logger.error).toHaveBeenCalledWith('Failed to unsubscribe workflow push subscription', undefined);
+  });
+
+  it('keeps stopping workers and shuts down harnesses when one worker fails', async () => {
+    const failure = new Error('worker stop failed');
+    const logger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      trackException: vi.fn(),
+      warn: vi.fn(),
+    };
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+    const harnessShutdown = vi.spyOn(harness, 'shutdown');
+    const first = new RecordingStopWorker('first');
+    const failing = new RecordingStopWorker('failing', failure);
+
+    const mastra = new Mastra({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+      logger: logger as any,
+      workers: [first, failing],
+      harness,
+    });
+
+    await expect(mastra.shutdown()).rejects.toBe(failure);
+
+    expect(failing.stopCalls).toBe(1);
+    expect(first.stopCalls).toBe(1);
+    expect(harnessShutdown).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith('Failed to stop worker "failing"', failure);
+    expect(logger.error).toHaveBeenCalledWith('Failed to stop workers', failure);
+  });
+
+  it('does not mask worker stop failures when observability shutdown also fails', async () => {
+    const workerFailure = new Error('worker stop failed');
+    const observabilityFailure = new Error('observability shutdown failed');
+    const logger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      trackException: vi.fn(),
+      warn: vi.fn(),
+    };
+    const worker = new RecordingStopWorker('failing', workerFailure);
+    const observability = {
+      shutdown: vi.fn().mockRejectedValue(observabilityFailure),
+      setMastraContext: vi.fn(),
+      setLogger: vi.fn(),
+      getSelectedInstance: vi.fn(),
+      registerInstance: vi.fn(),
+      getInstance: vi.fn(),
+      getDefaultInstance: vi.fn(),
+      listInstances: vi.fn(() => new Map()),
+      unregisterInstance: vi.fn(),
+      hasInstance: vi.fn(),
+      setConfigSelector: vi.fn(),
+      clear: vi.fn(),
+    };
+
+    const mastra = new Mastra({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+      logger: logger as any,
+      workers: [worker],
+      observability: observability as any,
+    });
+
+    await expect(mastra.shutdown()).rejects.toBe(workerFailure);
+
+    expect(worker.stopCalls).toBe(1);
+    expect(observability.shutdown).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith('Failed to stop workers', workerFailure);
+    expect(logger.error).toHaveBeenCalledWith('Failed to shutdown observability', observabilityFailure);
+  });
+
+  it('shuts down Mastra-owned background task manager and still shuts down harnesses after failure', async () => {
+    const backgroundFailure = new Error('background task shutdown failed');
+    const logger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      trackException: vi.fn(),
+      warn: vi.fn(),
+    };
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+    const harnessShutdown = vi.spyOn(harness, 'shutdown');
+
+    const mastra = new Mastra({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+      logger: logger as any,
+      backgroundTasks: { enabled: true },
+      workers: [],
+      harness,
+    });
+    const backgroundTaskManager = mastra.backgroundTaskManager!;
+    const backgroundShutdown = vi.spyOn(backgroundTaskManager, 'shutdown').mockRejectedValueOnce(backgroundFailure);
+
+    await expect(mastra.shutdown()).rejects.toBe(backgroundFailure);
+
+    expect(backgroundShutdown).toHaveBeenCalledTimes(1);
+    expect(harnessShutdown).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith('Failed to shutdown background task manager', backgroundFailure);
+
+    backgroundShutdown.mockRestore();
+    await backgroundTaskManager.shutdown();
+  });
+
+  it('waits for Mastra-owned background task init before shutdown cleanup', async () => {
+    const pubsub = new DeferredSubscribePubSub();
+    const storage = new InMemoryStore();
+    const bgStore = await storage.getStore('backgroundTasks');
+    await bgStore!.createTask({
+      id: 'pending-during-shutdown',
+      status: 'pending',
+      toolName: 'test-tool',
+      toolCallId: 'tool-call-1',
+      args: {},
+      agentId: 'default',
+      runId: 'run-1',
+      retryCount: 0,
+      maxRetries: 0,
+      timeoutMs: 5000,
+      createdAt: new Date(),
+    });
+    const mastra = new Mastra({
+      agents: { default: makeAgent() },
+      storage,
+      logger: false,
+      pubsub,
+      backgroundTasks: { enabled: true },
+      workers: [],
+    });
+
+    await pubsub.waitForFirstSubscribe();
+    const shutdown = mastra.shutdown();
+    await Promise.resolve();
+
+    expect(pubsub.unsubscribeCalls).toEqual([]);
+
+    pubsub.releaseSubscribes();
+    await shutdown;
+
+    expect(pubsub.subscribeCalls).toEqual(['background-tasks', 'background-tasks-result']);
+    expect(pubsub.unsubscribeCalls).toEqual(['background-tasks', 'background-tasks-result']);
+    expect(pubsub.publishCalls).toEqual([]);
+  });
+
+  it('keeps cleanup subscriptions that fail during worker stop', async () => {
+    const pushFailure = new Error('push unsubscribe failed');
+    const eventFailure = new Error('event unsubscribe failed');
+    const flushFailure = new Error('flush failed');
+    const logger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      trackException: vi.fn(),
+      warn: vi.fn(),
+    };
+    const pubsub = new FailingCleanupPubSub(
+      {
+        workflows: pushFailure,
+        updates: eventFailure,
+      },
+      flushFailure,
+    );
+
+    const mastra = new Mastra({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+      logger: logger as any,
+      pubsub,
+      events: {
+        updates: async () => {},
+      },
+      workers: false,
+    });
+
+    await mastra.startWorkers();
+    await expect(mastra.stopWorkers()).rejects.toBe(pushFailure);
+
+    expect(pubsub.unsubscribeCalls).toEqual(['workflows', 'updates']);
+    expect(pubsub.flushCalls).toBe(1);
+    expect(logger.error).toHaveBeenCalledWith('Failed to unsubscribe workflow push subscription', pushFailure);
+    expect(logger.error).toHaveBeenCalledWith('Failed to unsubscribe event listener for topic "updates"', eventFailure);
+    expect(logger.error).toHaveBeenCalledWith('Failed to flush pubsub during worker shutdown', flushFailure);
+
+    await expect(mastra.stopWorkers()).rejects.toBe(pushFailure);
+
+    expect(pubsub.unsubscribeCalls).toEqual(['workflows', 'updates', 'workflows', 'updates']);
+    expect(pubsub.flushCalls).toBe(2);
   });
 
   it('registers harness channel bindings with stable durable identity', () => {
@@ -530,28 +986,30 @@ describe('Harness v1 — construction', () => {
 
     await harness.channels.enqueueOutbox(channelOutboxInput({ deliverySemantics: 'lookup-reconcile' }));
 
-    await expect(harness.channels.dispatchOutbox({ channelId: 'support', claimId: 'claim-lookup-1' })).resolves.toEqual({
-      claimed: 1,
-      sent: 0,
-      failed: 1,
-      dead: 0,
-      items: [
-        {
-          outboxItemId: expect.any(String),
-          status: 'failed',
-          error: { code: 'unknown', message: 'delivery outcome unknown' },
-        },
-      ],
-    });
-    await expect(harness.channels.dispatchOutbox({ channelId: 'support', claimId: 'claim-lookup-2' })).resolves.toEqual({
-      claimed: 1,
-      sent: 1,
-      failed: 0,
-      dead: 0,
-      items: [
-        { outboxItemId: expect.any(String), status: 'sent', providerMessageId: 'provider-message-recovered' },
-      ],
-    });
+    await expect(harness.channels.dispatchOutbox({ channelId: 'support', claimId: 'claim-lookup-1' })).resolves.toEqual(
+      {
+        claimed: 1,
+        sent: 0,
+        failed: 1,
+        dead: 0,
+        items: [
+          {
+            outboxItemId: expect.any(String),
+            status: 'failed',
+            error: { code: 'unknown', message: 'delivery outcome unknown' },
+          },
+        ],
+      },
+    );
+    await expect(harness.channels.dispatchOutbox({ channelId: 'support', claimId: 'claim-lookup-2' })).resolves.toEqual(
+      {
+        claimed: 1,
+        sent: 1,
+        failed: 0,
+        dead: 0,
+        items: [{ outboxItemId: expect.any(String), status: 'sent', providerMessageId: 'provider-message-recovered' }],
+      },
+    );
     expect(deliverCalls).toBe(1);
   });
 

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -264,7 +264,10 @@ export interface HarnessChannelAdapter {
     request: HarnessChannelTransportRequest,
     ctx: HarnessChannelRouteContext,
   ): Promise<ChannelIngressEnvelope>;
-  verifyAction?(request: HarnessChannelTransportRequest, ctx: HarnessChannelRouteContext): Promise<ChannelActionEnvelope>;
+  verifyAction?(
+    request: HarnessChannelTransportRequest,
+    ctx: HarnessChannelRouteContext,
+  ): Promise<ChannelActionEnvelope>;
   deliverySemantics?: ChannelDeliverySemantics;
   deliverySemanticsByOperation?: Partial<Record<ChannelOutboxOperationKind, ChannelDeliverySemantics>>;
   resolveDeliveryPlan?(
@@ -434,7 +437,9 @@ export interface UseSkillOptions {
  *
  *   1. **Registered on a Mastra instance.** The Harness is created with no
  *      `mastra` / `agents` / `storage` of its own and is then registered as
- *      a child of a `Mastra` instance (`new Mastra({ harnesses: { ... } })`).
+ *      a child of a `Mastra` instance (`new Mastra({ harness })` for a
+ *      default harness, or `new Mastra({ harnesses: { ... } })` for named
+ *      harnesses).
  *      The parent calls `harness.__registerMastra(mastra, name)` and the
  *      harness reads agents and storage from there.
  *
@@ -459,9 +464,9 @@ export type HarnessConfig = HarnessConfigCommon &
          * exclusive with top-level `agents` / `storage`.
          *
          * Prefer omitting this field when you want the parent `Mastra` to own
-         * registration (`new Mastra({ harnesses })`). A harness that is already
-         * bound to the same `Mastra` may still be registered there under a
-         * configured harness name.
+         * registration (`new Mastra({ harness })` or `new Mastra({ harnesses })`).
+         * A harness that is already bound to the same `Mastra` may still be
+         * registered there under a configured harness name.
          */
         mastra: Mastra;
         agents?: never;
@@ -664,7 +669,8 @@ export interface HarnessConfigCommon {
    * Harness channel bridge configuration (§9.3 / §14). Each record binds a
    * harness-local `channelId` to a registered Mastra `ChannelProvider`.
    * When set, construct with a parent `mastra` or register the harness through
-   * `new Mastra({ channels, harnesses })` so provider bindings exist.
+   * `new Mastra({ channels, harness })` / `new Mastra({ channels, harnesses })`
+   * so provider bindings exist.
    *
    * PF-369 validates identity only. Later channel PRs consume these bindings
    * to mount ingress/action routes and durable inbox/outbox workers.

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -467,6 +467,16 @@ export interface Config<
   environment?: string;
 
   /**
+   * Harness v1 instance registered on this Mastra. The harness is bound
+   * to this Mastra during construction so its modes can resolve agents and
+   * its sessions persist via the harness-storage domain.
+   *
+   * Use `harness` for the common single-harness case. It is registered under
+   * the `default` key and can be retrieved with `mastra.getHarness()`.
+   */
+  harness?: HarnessV1;
+
+  /**
    * Harness v1 instances registered on this Mastra. Each harness is bound
    * to this Mastra during construction so its modes can resolve agents and
    * its sessions persist via the harness-storage domain.
@@ -927,6 +937,24 @@ export class Mastra<
       TChannels
     >,
   ) {
+    const configuredHarnesses = config?.harnesses ? { ...config.harnesses } : {};
+    if (config?.harness != null) {
+      if (configuredHarnesses.default != null) {
+        const error = new MastraError({
+          id: 'MASTRA_HARNESS_DEFAULT_DUPLICATE',
+          domain: ErrorDomain.MASTRA,
+          category: ErrorCategory.USER,
+          text: 'Cannot register config.harness when config.harnesses.default is also set',
+          details: { status: 400, name: 'default' },
+        });
+        if (config.logger !== false && config.logger != null) {
+          config.logger.trackException(error);
+        }
+        throw error;
+      }
+      configuredHarnesses.default = config.harness;
+    }
+
     // Register AsyncLocalStorage-backed context resolvers so that DualLogger
     // can correlate logs to the active span. Must happen before any agent runs.
     initContextStorage();
@@ -1240,8 +1268,8 @@ export class Mastra<
     // Harnesses bind to this Mastra after agents are registered so that
     // mode->agent validation succeeds. Each harness is single-bound; calling
     // __registerMastra a second time with a different parent throws.
-    if (config?.harnesses) {
-      for (const [key, harness] of Object.entries(config.harnesses)) {
+    if (Object.keys(configuredHarnesses).length > 0) {
+      for (const [key, harness] of Object.entries(configuredHarnesses)) {
         if (harness == null) continue;
         harness.__registerMastra(this, key);
         this.#harnesses[key] = harness;
@@ -2337,7 +2365,8 @@ export class Mastra<
    * Look up a Harness v1 instance registered on this Mastra.
    *
    * @param name - The key the harness was registered under in the
-   *   `harnesses` config map.
+   *   `harnesses` config map. Defaults to `default` for `config.harness`
+   *   single-harness sugar.
    * @returns The harness instance.
    * @throws If no harness is registered under the given name.
    *
@@ -2347,7 +2376,7 @@ export class Mastra<
    * const session = await code.session({ threadId, resourceId });
    * ```
    */
-  public getHarness(name: string): HarnessV1 {
+  public getHarness(name = 'default'): HarnessV1 {
     const harness = this.#harnesses[name];
     if (!harness) {
       const error = new MastraError({
@@ -4132,28 +4161,62 @@ export class Mastra<
    * Stop all running workers and unsubscribe event listeners.
    */
   public async stopWorkers(): Promise<void> {
+    let stopError: unknown;
+    let hasStopError = false;
+    const recordStopError = (message: string, error: unknown) => {
+      if (!hasStopError) {
+        stopError = error;
+        hasStopError = true;
+      }
+      this.#logger?.error(message, error);
+    };
+
     // Stop registered workers in reverse order
     for (const worker of [...this.#workers].reverse()) {
       if (worker.isRunning) {
-        await worker.stop();
+        try {
+          await worker.stop();
+        } catch (error) {
+          recordStopError(`Failed to stop worker "${worker.name}"`, error);
+        }
       }
     }
 
     // Tear down the in-process push subscription wired during startWorkers().
     if (this.#pushSubscription) {
-      await this.#pubsub.unsubscribe(this.#pushSubscription.topic, this.#pushSubscription.cb);
-      this.#pushSubscription = undefined;
+      try {
+        await this.#pubsub.unsubscribe(this.#pushSubscription.topic, this.#pushSubscription.cb);
+        this.#pushSubscription = undefined;
+      } catch (error) {
+        recordStopError('Failed to unsubscribe workflow push subscription', error);
+      }
     }
 
     // Unsubscribe only the (topic, listener) pairs we actually registered in
     // startWorkers() — keeps stopWorkers() symmetric with startWorkers() and
     // avoids unsubscribing listeners that startWorkers never owned.
+    const remainingUserEventSubscriptions: Array<{
+      topic: string;
+      cb: (event: Event, ack?: () => Promise<void>) => Promise<void>;
+    }> = [];
     for (const { topic, cb } of this.#userEventSubscriptions) {
-      await this.#pubsub.unsubscribe(topic, cb);
+      try {
+        await this.#pubsub.unsubscribe(topic, cb);
+      } catch (error) {
+        remainingUserEventSubscriptions.push({ topic, cb });
+        recordStopError(`Failed to unsubscribe event listener for topic "${topic}"`, error);
+      }
     }
-    this.#userEventSubscriptions = [];
+    this.#userEventSubscriptions = remainingUserEventSubscriptions;
 
-    await this.#pubsub.flush();
+    try {
+      await this.#pubsub.flush();
+    } catch (error) {
+      recordStopError('Failed to flush pubsub during worker shutdown', error);
+    }
+    if (hasStopError) {
+      throw stopError;
+    }
   }
 
   /**
@@ -4428,9 +4491,62 @@ export class Mastra<
         this.#logger?.error('Failed to stop workflow scheduler', error);
       }
     }
-    await this.stopWorkers();
+    let stopWorkersError: unknown;
+    let hasStopWorkersError = false;
+    try {
+      await this.stopWorkers();
+    } catch (error) {
+      stopWorkersError = error;
+      hasStopWorkersError = true;
+      this.#logger?.error('Failed to stop workers', error);
+    }
+    let backgroundTaskShutdownError: unknown;
+    let hasBackgroundTaskShutdownError = false;
+    if (this.#backgroundTaskManager) {
+      try {
+        await this.#backgroundTaskManager.shutdown();
+      } catch (error) {
+        backgroundTaskShutdownError = error;
+        hasBackgroundTaskShutdownError = true;
+        this.#logger?.error('Failed to shutdown background task manager', error);
+      }
+    }
+    let harnessShutdownError: unknown;
+    let hasHarnessShutdownError = false;
+    const harnessShutdowns = Object.entries(this.#harnesses).map(async ([key, harness]) => {
+      try {
+        await harness.shutdown();
+      } catch (error) {
+        if (!hasHarnessShutdownError) {
+          harnessShutdownError = error;
+          hasHarnessShutdownError = true;
+        }
+        this.#logger?.error(`Failed to shutdown harness "${key}"`, error);
+      }
+    });
+    await Promise.all(harnessShutdowns);
     // Shutdown observability registry, exporters, etc...
-    await this.#observability.shutdown();
+    let observabilityShutdownError: unknown;
+    let hasObservabilityShutdownError = false;
+    try {
+      await this.#observability.shutdown();
+    } catch (error) {
+      observabilityShutdownError = error;
+      hasObservabilityShutdownError = true;
+      this.#logger?.error('Failed to shutdown observability', error);
+    }
+    if (hasStopWorkersError) {
+      throw stopWorkersError;
+    }
+    if (hasBackgroundTaskShutdownError) {
+      throw backgroundTaskShutdownError;
+    }
+    if (hasHarnessShutdownError) {
+      throw harnessShutdownError;
+    }
+    if (hasObservabilityShutdownError) {
+      throw observabilityShutdownError;
+    }
 
     this.#logger?.info('Mastra shutdown completed');
   }


### PR DESCRIPTION
[PF-548] adds Mastra default Harness registration and shutdown integration.

## Summary

- Add `new Mastra({ harness })` for the common single-Harness case, registered as `default`.
- Keep named registration with `harnesses`, reject non-null duplicate `harnesses.default`, and allow nullish spread entries.
- Make `mastra.getHarness()` default to the `default` Harness.
- Shut down registered Harness instances from `mastra.shutdown()` after worker cleanup and before observability cleanup.
- Make worker shutdown cleanup best-effort across worker stop, push unsubscribe, user event unsubscribe, pubsub flush, and Mastra-owned background-task manager shutdown while preserving the first failure including falsy rejection reasons.
- Guard background-task manager init, recovery, enqueue, dispatch, and resume paths against shutdown races.
- Document the new config in the Harness reference, Mastra class reference, configuration reference, and changeset.

## Verification

- Base: `c097848dee9b3764db5c586b1fe0731442c8ddcd`
- Head: `ff412ed9ffcd92e98af41c6c7fe02dd7039aecc8`
- `pnpm --dir /tmp/mastra-fork-pf-548 exec vitest run packages/core/src/harness/v1/harness.test.ts --project unit:packages/core`
- `pnpm --filter ./packages/core exec vitest run src/harness/v1/harness.test.ts src/background-tasks/manager.test.ts`
- `pnpm --dir /tmp/mastra-fork-pf-548 exec vitest run packages/core/src/mastra/workers-filter.test.ts --project unit:packages/core`
- `pnpm --dir /tmp/mastra-fork-pf-548 exec eslint packages/core/src/mastra/index.ts packages/core/src/harness/v1/harness.test.ts packages/core/src/harness/v1/types.ts packages/core/src/background-tasks/manager.ts`
- `pnpm --dir /tmp/mastra-fork-pf-548 --filter @mastra/core typecheck`
- `pnpm --filter ./packages/core check`
- `pnpm --dir /tmp/mastra-fork-pf-548 exec prettier --check .changeset/pf-548-default-harness-sugar-shutdown.md docs/src/content/en/reference/harness/harness-class.mdx docs/src/content/en/reference/core/mastra-class.mdx docs/src/content/en/reference/configuration.mdx packages/core/src/harness/v1/types.ts packages/core/src/harness/v1/harness.test.ts packages/core/src/mastra/index.ts packages/core/src/background-tasks/manager.ts`
- `git -C /tmp/mastra-fork-pf-548 diff --check origin/main`
- Local Codex review pass 1: no findings.
- Local Codex review pass 2: no findings.
- Local CodeRabbit CLI: no findings.

Note: one read-only review pass accidentally invoked the package-wide `@mastra/core test:unit` script while trying to run a single file; that broad run failed on unrelated existing suites and package build prerequisites. The targeted PF-548 Vitest commands above passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

You can now pass a single Harness directly when creating Mastra (so it becomes the "default"), and Mastra will shut down any registered Harnesses cleanly during application shutdown while trying all cleanup steps and surfacing the first error.

## Overview

Adds constructor sugar for single-harness apps, a default lookup for mastra.getHarness(), and robust, best-effort shutdown sequencing that includes registered Harness instances. Improves worker cleanup semantics to attempt all teardown steps (stop, unsubscribe, flush) while preserving and rethrowing the first failure. Updates background-task shutdown guards, docs, and tests.

## Key Changes

Configuration & Registration
- New Config.harness?: HarnessV1 single-harness shorthand; mapped to configuredHarnesses.default during construction.
- new Mastra({ harness }) registers that Harness under the "default" key.
- Rejects duplicate default registration when both config.harness and config.harnesses.default are provided; allows nullish spread entries in harnesses.

API
- Mastra.getHarness(name = 'default'): default no-arg lookup returns the "default" Harness; named lookup remains supported.

Shutdown & Cleanup
- mastra.shutdown() now:
  - runs stopWorkers() (best-effort across worker.stop, push unsubscribe, user event unsubscribe, pubsub.flush),
  - then shuts down the background task manager (if present),
  - then shuts down all registered Harness instances (concurrently, preserving the first harness error),
  - finally shuts down observability — errors are captured and rethrown in the order: workers → background task manager → harnesses → observability, while still attempting later cleanup steps.
- stopWorkers() records the first failure (including falsy rejection reasons), logs individual failures, and attempts remaining teardown steps before rethrowing the first.

Background Task Manager
- Added shuttingDown guards across init, recovery, enqueue, dispatch, resume, and handler paths to prevent dispatch/recovery during shutdown.
- shutdown() attempts to await in-progress init (best-effort) before cleaning up timers and subscriptions; dispatch short-circuits when shutting down.

Tests & Mocks
- Expanded harness tests (new fakes: RecordingStopWorker, FailingCleanupPubSub, DeferredSubscribePubSub) covering:
  - single-harness sugar behavior and duplicate-default validation,
  - harness shutdown sequencing and error preservation,
  - worker/unsubscribe/flush failure scenarios,
  - shutdown ordering with background-task init timing.
- Tests targeted to harness and workers-filter suites passed.

Documentation & Types
- Docs updated: configuration reference, Mastra class reference, Harness class reference, and changeset with examples for new single-harness sugar.
- JSDoc extended with examples for new Mastra({ harness }) usage.
- Public type surface changes: Config now includes optional harness?: HarnessV1; Mastra.getHarness signature defaults name = 'default'.

Validation
- Targeted Vitest runs for relevant suites passed.
- ESLint, TypeScript typecheck for `@mastra/core`, and Prettier checks on changed files/changeset passed.
- Local reviews (Codex, CodeRabbit) reported no blocking findings; noted one unrelated broader test run failure outside targeted commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->