### PR TITLE
[PF-548] Guard background restore status updates

### DIFF
--- a/.changeset/little-worlds-look.md
+++ b/.changeset/little-worlds-look.md
@@ -1,0 +1,6 @@
+---
+'@mastra/dynamodb': patch
+'@mastra/core': patch
+---
+
+Fixed background task dispatch races so competing workers keep producer contexts until terminal fan-out events arrive.

--- a/.changeset/tiny-ghosts-scream.md
+++ b/.changeset/tiny-ghosts-scream.md
@@ -1,0 +1,16 @@
+---
+'@mastra/cloudflare-d1': patch
+'@mastra/clickhouse': patch
+'@mastra/cloudflare': patch
+'@mastra/dynamodb': patch
+'@mastra/mongodb': patch
+'@mastra/upstash': patch
+'@mastra/core': patch
+'@mastra/convex': patch
+'@mastra/libsql': patch
+'@mastra/lance': patch
+'@mastra/mssql': patch
+'@mastra/pg': patch
+---
+
+Fixed background task dispatch to claim and restore tasks with storage-level conditional status updates so concurrent workers do not overwrite completed, failed, or suspended task state.

--- a/packages/core/src/background-tasks/manager.test.ts
+++ b/packages/core/src/background-tasks/manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitterPubSub } from '../events/event-emitter';
+import type { Event } from '../events/types';
 import { Mastra } from '../mastra';
 import { MockStore } from '../storage';
 import { createBackgroundTask } from './create';
@@ -15,6 +16,10 @@ const testStorage = new MockStore();
 
 /** Wait for async microtasks/timers to settle */
 const tick = (ms = 50) => new Promise(resolve => setTimeout(resolve, ms));
+
+async function dispatchWithPrivateHandler(manager: BackgroundTaskManager, event: Event): Promise<boolean> {
+  return (manager as unknown as { handleDispatch(event: Event): Promise<boolean> }).handleDispatch(event);
+}
 
 /**
  * Spin up a private Mastra + bg-task manager scoped to a single test. Tests
@@ -144,6 +149,123 @@ describe('BackgroundTaskManager', () => {
       const result = await manager.getTask(task.id);
       expect(result?.status).toBe('failed');
       expect(result?.error?.message).toContain('No executor');
+    });
+
+    it('keeps task context when dispatch claim loses to another worker', async () => {
+      const backgroundTasksStore = await testStorage.getStore('backgroundTasks');
+      const taskId = 'claim-race';
+      await backgroundTasksStore!.createTask({
+        id: taskId,
+        status: 'pending',
+        toolName: 'tool',
+        toolCallId: 'call-claim-race',
+        args: {},
+        agentId: 'agent-1',
+        runId: 'run-claim-race',
+        retryCount: 0,
+        maxRetries: 0,
+        timeoutMs: 5000,
+        createdAt: new Date(),
+      });
+      manager.registerTaskContext(taskId, ctx(vi.fn().mockResolvedValue('ok')));
+      const claim = vi.spyOn(backgroundTasksStore!, 'updateTaskIfStatus').mockResolvedValueOnce(false);
+
+      const nacked = await dispatchWithPrivateHandler(manager, {
+        id: 'event-claim-race',
+        type: 'task.dispatch',
+        data: { taskId },
+        runId: taskId,
+        createdAt: new Date(),
+      });
+
+      expect(nacked).toBe(false);
+      expect(manager.taskContexts.has(taskId)).toBe(true);
+      expect(claim).toHaveBeenCalledWith(taskId, 'pending', expect.objectContaining({ status: 'running' }));
+      claim.mockRestore();
+    });
+
+    it('keeps task context until fan-out cleanup when dispatch claim loses to a terminal transition', async () => {
+      const backgroundTasksStore = await testStorage.getStore('backgroundTasks');
+      const taskId = 'claim-cancel-race';
+      await backgroundTasksStore!.createTask({
+        id: taskId,
+        status: 'pending',
+        toolName: 'tool',
+        toolCallId: 'call-claim-cancel-race',
+        args: {},
+        agentId: 'agent-1',
+        runId: 'run-claim-cancel-race',
+        retryCount: 0,
+        maxRetries: 0,
+        timeoutMs: 5000,
+        createdAt: new Date(),
+      });
+      manager.registerTaskContext(taskId, ctx(vi.fn().mockResolvedValue('ok')));
+      const claim = vi.spyOn(backgroundTasksStore!, 'updateTaskIfStatus').mockImplementationOnce(async () => {
+        await backgroundTasksStore!.updateTask(taskId, { status: 'cancelled', completedAt: new Date() });
+        return false;
+      });
+
+      const nacked = await dispatchWithPrivateHandler(manager, {
+        id: 'event-claim-cancel-race',
+        type: 'task.dispatch',
+        data: { taskId },
+        runId: taskId,
+        createdAt: new Date(),
+      });
+
+      expect(nacked).toBe(false);
+      expect(manager.taskContexts.has(taskId)).toBe(true);
+      expect(claim).toHaveBeenCalledWith(taskId, 'pending', expect.objectContaining({ status: 'running' }));
+      claim.mockRestore();
+
+      const cancelledTask = await backgroundTasksStore!.getTask(taskId);
+      await manager.publishLifecycleEvent('task.cancelled', cancelledTask!);
+      await tick();
+
+      expect(manager.taskContexts.has(taskId)).toBe(false);
+    });
+
+    it('clears retained task context on fan-out cancellation after claim contention', async () => {
+      const backgroundTasksStore = await testStorage.getStore('backgroundTasks');
+      const taskId = 'claim-running-cancel-race';
+      await backgroundTasksStore!.createTask({
+        id: taskId,
+        status: 'pending',
+        toolName: 'tool',
+        toolCallId: 'call-claim-running-cancel-race',
+        args: {},
+        agentId: 'agent-1',
+        runId: 'run-claim-running-cancel-race',
+        retryCount: 0,
+        maxRetries: 0,
+        timeoutMs: 5000,
+        createdAt: new Date(),
+      });
+      manager.registerTaskContext(taskId, ctx(vi.fn().mockResolvedValue('ok')));
+      const claim = vi.spyOn(backgroundTasksStore!, 'updateTaskIfStatus').mockImplementationOnce(async () => {
+        await backgroundTasksStore!.updateTask(taskId, { status: 'running', startedAt: new Date() });
+        return false;
+      });
+
+      const nacked = await dispatchWithPrivateHandler(manager, {
+        id: 'event-claim-running-cancel-race',
+        type: 'task.dispatch',
+        data: { taskId },
+        runId: taskId,
+        createdAt: new Date(),
+      });
+      claim.mockRestore();
+
+      expect(nacked).toBe(false);
+      expect(manager.taskContexts.has(taskId)).toBe(true);
+
+      await backgroundTasksStore!.updateTask(taskId, { status: 'cancelled', completedAt: new Date() });
+      const cancelledTask = await backgroundTasksStore!.getTask(taskId);
+      await manager.publishLifecycleEvent('task.cancelled', cancelledTask!);
+      await tick();
+
+      expect(manager.taskContexts.has(taskId)).toBe(false);
     });
   });
 

--- a/packages/core/src/background-tasks/manager.ts
+++ b/packages/core/src/background-tasks/manager.ts
@@ -20,6 +20,9 @@ const TOPIC_DISPATCH = 'background-tasks';
 const TOPIC_RESULT = 'background-tasks-result';
 const WORKER_GROUP = 'background-task-workers';
 
+const isTerminalBackgroundTaskStatus = (status: BackgroundTaskStatus) =>
+  status === 'completed' || status === 'failed' || status === 'cancelled' || status === 'timed_out';
+
 export class BackgroundTaskManager {
   private pubsub!: PubSub;
   config: Required<
@@ -112,6 +115,8 @@ export class BackgroundTaskManager {
     this.resultCallback = async (event: Event, ack?: () => Promise<void>) => {
       if (event.type === 'task.completed' || event.type === 'task.failed') {
         await this.handleResult(event);
+      } else if (event.type === 'task.cancelled') {
+        this.handleCancel(event);
       }
       await ack?.();
     };
@@ -489,12 +494,9 @@ export class BackgroundTaskManager {
   ): Promise<BackgroundTask> {
     const storage = await this.getStorage();
 
-    const isTerminal = (status: string) =>
-      status === 'completed' || status === 'failed' || status === 'cancelled' || status === 'timed_out';
-
     for (const id of taskIds) {
       const task = await storage.getTask(id);
-      if (task && isTerminal(task.status)) {
+      if (task && isTerminalBackgroundTaskStatus(task.status)) {
         return task;
       }
     }
@@ -519,7 +521,7 @@ export class BackgroundTaskManager {
       const pollInterval = setInterval(async () => {
         for (const id of taskIds) {
           const task = await storage.getTask(id);
-          if (task && isTerminal(task.status)) {
+          if (task && isTerminalBackgroundTaskStatus(task.status)) {
             clearInterval(pollInterval);
             if (timeout) clearTimeout(timeout);
             if (progressInterval) clearInterval(progressInterval);
@@ -785,8 +787,15 @@ export class BackgroundTaskManager {
       this.deregisterTaskContext(taskId);
       return false;
     }
-    if (!task || task.status !== 'pending') {
+    if (!task) {
       this.deregisterTaskContext(taskId);
+      return false;
+    }
+    if (task.status !== 'pending') {
+      // Keep taskContexts registered on claim contention so local hooks can
+      // still observe the worker that owns the final completion. Terminal
+      // statuses are also consumed through fan-out result/cancel events; do
+      // not race those handlers by deregistering here.
       return false;
     }
 
@@ -801,7 +810,13 @@ export class BackgroundTaskManager {
       retryCount: deliveryAttempt - 1,
     });
     if (!claimed) {
-      this.deregisterTaskContext(taskId);
+      const latestTask = await storage.getTask(taskId);
+      if (!latestTask) {
+        this.deregisterTaskContext(taskId);
+      }
+      // Keep taskContexts registered only on active claim contention so local
+      // hooks can still observe the worker that owns the final completion.
+      // Terminal statuses are cleaned up by the fan-out result/cancel handlers.
       return false;
     }
 

--- a/packages/core/src/background-tasks/manager.ts
+++ b/packages/core/src/background-tasks/manager.ts
@@ -785,17 +785,25 @@ export class BackgroundTaskManager {
       this.deregisterTaskContext(taskId);
       return false;
     }
-    if (!task || task.status === 'cancelled') {
+    if (!task || task.status !== 'pending') {
       this.deregisterTaskContext(taskId);
       return false;
     }
 
     const restorePending = async () => {
-      await storage.updateTask(taskId, { status: 'pending', startedAt: undefined });
-      this.deregisterTaskContext(taskId);
+      const restored = await storage.updateTaskIfStatus(taskId, 'running', { status: 'pending', startedAt: undefined });
+      if (restored) this.deregisterTaskContext(taskId);
     };
 
-    await storage.updateTask(taskId, { status: 'running', startedAt: new Date(), retryCount: deliveryAttempt - 1 });
+    const claimed = await storage.updateTaskIfStatus(taskId, 'pending', {
+      status: 'running',
+      startedAt: new Date(),
+      retryCount: deliveryAttempt - 1,
+    });
+    if (!claimed) {
+      this.deregisterTaskContext(taskId);
+      return false;
+    }
 
     // Publish running lifecycle event (fan-out, for stream consumers)
     const runningTask = await storage.getTask(taskId);
@@ -864,7 +872,7 @@ export class BackgroundTaskManager {
     }
 
     const restoreSuspended = async () => {
-      await storage.updateTask(taskId, {
+      await storage.updateTaskIfStatus(taskId, 'running', {
         status: 'suspended',
         startedAt: task.startedAt,
         suspendPayload: task.suspendPayload,
@@ -872,12 +880,13 @@ export class BackgroundTaskManager {
       });
     };
 
-    await storage.updateTask(taskId, {
+    const claimed = await storage.updateTaskIfStatus(taskId, 'suspended', {
       status: 'running',
       startedAt: new Date(),
       suspendPayload: undefined,
       suspendedAt: undefined,
     });
+    if (!claimed) return;
     const resumedTask = await storage.getTask(taskId);
     if (this.shuttingDown) {
       await restoreSuspended();

--- a/packages/core/src/storage/domains/background-tasks/__tests__/inmemory.test.ts
+++ b/packages/core/src/storage/domains/background-tasks/__tests__/inmemory.test.ts
@@ -73,6 +73,21 @@ describe('BackgroundTasksInMemory', () => {
     });
   });
 
+  describe('updateTaskIfStatus', () => {
+    it('updates only when the current status matches', async () => {
+      const task = makeTask({ status: 'running' });
+      await storage.createTask(task);
+
+      await expect(
+        storage.updateTaskIfStatus(task.id, 'running', { status: 'pending', startedAt: undefined }),
+      ).resolves.toBe(true);
+      await expect(storage.getTask(task.id)).resolves.toMatchObject({ status: 'pending' });
+
+      await expect(storage.updateTaskIfStatus(task.id, 'running', { status: 'failed' })).resolves.toBe(false);
+      await expect(storage.getTask(task.id)).resolves.toMatchObject({ status: 'pending' });
+    });
+  });
+
   describe('getTask', () => {
     it('returns null for non-existent task', async () => {
       const result = await storage.getTask('non-existent');

--- a/packages/core/src/storage/domains/background-tasks/base.ts
+++ b/packages/core/src/storage/domains/background-tasks/base.ts
@@ -1,4 +1,12 @@
-import type { BackgroundTask, TaskFilter, TaskListResult, UpdateBackgroundTask } from '../../../background-tasks/types';
+import type {
+  BackgroundTask,
+  BackgroundTaskStatus,
+  TaskFilter,
+  TaskListResult,
+  UpdateBackgroundTask,
+} from '../../../background-tasks/types';
+import { ErrorCategory, ErrorDomain, MastraError } from '../../../error';
+import { createStorageErrorId } from '../../utils';
 import { StorageDomain } from '../base';
 
 /**
@@ -25,6 +33,33 @@ export abstract class BackgroundTasksStorage extends StorageDomain {
    * Only the provided fields are updated; others are left unchanged.
    */
   abstract updateTask(taskId: string, update: UpdateBackgroundTask): Promise<void>;
+
+  /**
+   * Update a task only when its current status still matches the expected state.
+   * Implementations should use the strongest conditional write primitive the
+   * backend supports and return false when the expected status no longer
+   * matches. The default fails closed for external adapters that have not yet
+   * implemented the conditional claim contract.
+   */
+  async updateTaskIfStatus(
+    taskId: string,
+    expectedStatus: BackgroundTaskStatus,
+    update: UpdateBackgroundTask,
+  ): Promise<boolean> {
+    throw new MastraError(
+      {
+        id: createStorageErrorId('MASTRA', 'UPDATE_BACKGROUND_TASK_IF_STATUS', 'NOT_SUPPORTED'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: {
+          taskId,
+          expectedStatus,
+          updateStatus: update.status ?? null,
+        },
+      },
+      'Background task dispatch requires storage support for atomic conditional status updates.',
+    );
+  }
 
   /** Get a single task by ID. Returns null if not found. */
   abstract getTask(taskId: string): Promise<BackgroundTask | null>;

--- a/packages/core/src/storage/domains/background-tasks/inmemory.ts
+++ b/packages/core/src/storage/domains/background-tasks/inmemory.ts
@@ -24,6 +24,17 @@ export class BackgroundTasksInMemory extends BackgroundTasksStorage {
     this.db.backgroundTasks.set(taskId, { ...existing, ...update });
   }
 
+  async updateTaskIfStatus(
+    taskId: string,
+    expectedStatus: BackgroundTask['status'],
+    update: UpdateBackgroundTask,
+  ): Promise<boolean> {
+    const existing = this.db.backgroundTasks.get(taskId);
+    if (!existing || existing.status !== expectedStatus) return false;
+    this.db.backgroundTasks.set(taskId, { ...existing, ...update });
+    return true;
+  }
+
   async getTask(taskId: string): Promise<BackgroundTask | null> {
     const task = this.db.backgroundTasks.get(taskId);
     return task ? { ...task } : null;

--- a/stores/_test-utils/src/domains/background-tasks/index.ts
+++ b/stores/_test-utils/src/domains/background-tasks/index.ts
@@ -5,9 +5,12 @@ import { createSampleTask } from './data';
 
 export interface BackgroundTasksTestOptions {
   storage: MastraStorage;
+  capabilities?: {
+    backgroundTasksUpdateIfStatus?: boolean;
+  };
 }
 
-export function createBackgroundTasksTests({ storage }: BackgroundTasksTestOptions) {
+export function createBackgroundTasksTests({ storage, capabilities = {} }: BackgroundTasksTestOptions) {
   let bgStorage: BackgroundTasksStorage;
 
   beforeAll(async () => {
@@ -173,6 +176,96 @@ export function createBackgroundTasksTests({ storage }: BackgroundTasksTestOptio
         expect(resumed!.status).toBe('running');
         expect(resumed!.suspendPayload).toBeUndefined();
         expect(resumed!.suspendedAt).toBeUndefined();
+      });
+    });
+
+    describe('updateTaskIfStatus', () => {
+      const supportsUpdateIfStatus = capabilities.backgroundTasksUpdateIfStatus !== false;
+
+      it.runIf(supportsUpdateIfStatus)('updates task when status matches', async () => {
+        if (!bgStorage) return;
+        const task = createSampleTask({ id: 'update-if-status-match' });
+        await bgStorage.createTask(task);
+
+        const updated = await bgStorage.updateTaskIfStatus(task.id, 'pending', {
+          status: 'running',
+          startedAt: new Date(),
+          retryCount: 1,
+        });
+
+        const result = await bgStorage.getTask(task.id);
+        expect(updated).toBe(true);
+        expect(result!.status).toBe('running');
+        expect(result!.startedAt).toBeInstanceOf(Date);
+        expect(result!.retryCount).toBe(1);
+      });
+
+      it.runIf(supportsUpdateIfStatus)('does not update task when status mismatches', async () => {
+        if (!bgStorage) return;
+        const task = createSampleTask({ id: 'update-if-status-mismatch', status: 'running', startedAt: new Date() });
+        await bgStorage.createTask(task);
+
+        const updated = await bgStorage.updateTaskIfStatus(task.id, 'pending', {
+          status: 'completed',
+          result: { data: 'should-not-write' },
+          completedAt: new Date(),
+        });
+
+        const result = await bgStorage.getTask(task.id);
+        expect(updated).toBe(false);
+        expect(result!.status).toBe('running');
+        expect(result!.result).toBeUndefined();
+        expect(result!.completedAt).toBeUndefined();
+      });
+
+      it.runIf(supportsUpdateIfStatus)('returns false for missing task', async () => {
+        if (!bgStorage) return;
+
+        await expect(
+          bgStorage.updateTaskIfStatus('missing-task', 'pending', {
+            status: 'running',
+            startedAt: new Date(),
+          }),
+        ).resolves.toBe(false);
+      });
+
+      it.runIf(supportsUpdateIfStatus)('clears nullable fields when status matches', async () => {
+        if (!bgStorage) return;
+        const task = createSampleTask({
+          id: 'update-if-status-clear',
+          status: 'suspended',
+          startedAt: new Date(),
+          suspendedAt: new Date(),
+          suspendPayload: { checkpoint: 'approval' },
+        });
+        await bgStorage.createTask(task);
+
+        const updated = await bgStorage.updateTaskIfStatus(task.id, 'suspended', {
+          status: 'running',
+          startedAt: undefined,
+          suspendedAt: undefined,
+          suspendPayload: undefined,
+        });
+
+        const result = await bgStorage.getTask(task.id);
+        expect(updated).toBe(true);
+        expect(result!.status).toBe('running');
+        expect(result!.startedAt).toBeUndefined();
+        expect(result!.suspendedAt).toBeUndefined();
+        expect(result!.suspendPayload).toBeUndefined();
+      });
+
+      it.runIf(!supportsUpdateIfStatus)('fails closed when conditional updates are unsupported', async () => {
+        if (!bgStorage) return;
+        const task = createSampleTask({ id: 'update-if-status-unsupported' });
+        await bgStorage.createTask(task);
+
+        await expect(
+          bgStorage.updateTaskIfStatus(task.id, 'pending', {
+            status: 'running',
+            startedAt: new Date(),
+          }),
+        ).rejects.toThrow(/not supported|NOT_SUPPORTED/i);
       });
     });
 

--- a/stores/_test-utils/src/domains/harness/index.ts
+++ b/stores/_test-utils/src/domains/harness/index.ts
@@ -595,17 +595,18 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
 
       it('blocks active-session admission while a thread delete fence is held', async () => {
         if (!harness) return;
+        const harnessStorage = harness;
 
-        await harness.withThreadDeleteFence(
+        await harnessStorage.withThreadDeleteFence(
           { threadId: 'thread-1', ownerId: 'deleter', ttlMs: 30_000 },
           async fence => {
             await expect(
-              harness.createOrLoadActiveSession(createSampleSessionRecord(), {
+              harnessStorage.createOrLoadActiveSession(createSampleSessionRecord(), {
                 initialLease: { ownerId: 'h', ttlMs: 30_000 },
               }),
             ).rejects.toBeInstanceOf(HarnessStorageThreadDeleteFenceConflictError);
             await expect(
-              harness.saveSession(createSampleSessionRecord({ id: 'direct-blocked' }), {
+              harnessStorage.saveSession(createSampleSessionRecord({ id: 'direct-blocked' }), {
                 ownerId: 'h',
                 ifVersion: 0,
               }),
@@ -1668,14 +1669,15 @@ export function createHarnessTest({ storage }: HarnessTestOptions) {
 
       it('clears active thread delete fences', async () => {
         if (!harness) return;
+        const harnessStorage = harness;
 
-        await harness.withThreadDeleteFence(
+        await harnessStorage.withThreadDeleteFence(
           { threadId: 'reset-thread', ownerId: 'deleter', ttlMs: 30_000 },
           async () => {
-            await harness.dangerouslyClearAll();
+            await harnessStorage.dangerouslyClearAll();
 
             await expect(
-              harness.createOrLoadActiveSession(
+              harnessStorage.createOrLoadActiveSession(
                 createSampleSessionRecord({ id: 'after-reset', threadId: 'reset-thread' }),
                 {
                   initialLease: { ownerId: 'h', ttlMs: 30_000 },

--- a/stores/_test-utils/src/factory.ts
+++ b/stores/_test-utils/src/factory.ts
@@ -29,6 +29,8 @@ export * from './domains/schedules/data';
 export type TestCapabilities = {
   /** Whether the adapter supports listing scores by span (defaults to true) */
   listScoresBySpan?: boolean;
+  /** Whether background task storage supports atomic status-conditional updates (defaults to true) */
+  backgroundTasksUpdateIfStatus?: boolean;
 };
 
 export function createTestSuite(storage: MastraStorage, capabilities: TestCapabilities = {}) {
@@ -104,7 +106,7 @@ export function createTestSuite(storage: MastraStorage, capabilities: TestCapabi
     createAgentsTests({ storage });
     createDatasetsTests({ storage });
     createExperimentsTests({ storage });
-    createBackgroundTasksTests({ storage });
+    createBackgroundTasksTests({ storage, capabilities });
     createSchedulesTests({ storage });
     createHarnessTest({ storage });
   });

--- a/stores/clickhouse/src/storage/domains/background-tasks/index.ts
+++ b/stores/clickhouse/src/storage/domains/background-tasks/index.ts
@@ -6,7 +6,13 @@ import type {
   TaskListResult,
   UpdateBackgroundTask,
 } from '@mastra/core/background-tasks';
-import { BackgroundTasksStorage, TABLE_BACKGROUND_TASKS, TABLE_SCHEMAS } from '@mastra/core/storage';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import {
+  BackgroundTasksStorage,
+  createStorageErrorId,
+  TABLE_BACKGROUND_TASKS,
+  TABLE_SCHEMAS,
+} from '@mastra/core/storage';
 import { ClickhouseDB, resolveClickhouseConfig } from '../../db';
 import type { ClickhouseDomainConfig } from '../../db';
 
@@ -133,6 +139,26 @@ export class BackgroundTasksStorageClickhouse extends BackgroundTasksStorage {
 
     // ClickHouse ReplacingMergeTree — insert replaces by primary key
     await this.createTask(merged);
+  }
+
+  async updateTaskIfStatus(
+    taskId: string,
+    expectedStatus: BackgroundTaskStatus,
+    update: UpdateBackgroundTask,
+  ): Promise<boolean> {
+    throw new MastraError(
+      {
+        id: createStorageErrorId('CLICKHOUSE', 'UPDATE_BACKGROUND_TASK_IF_STATUS', 'NOT_SUPPORTED'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: {
+          taskId,
+          expectedStatus,
+          updateStatus: update.status ?? null,
+        },
+      },
+      'ClickHouse background task storage uses ReplacingMergeTree rows and cannot safely provide the atomic conditional writes required by background task dispatch. Use a transactional storage adapter for background tasks.',
+    );
   }
 
   async getTask(taskId: string): Promise<BackgroundTask | null> {

--- a/stores/clickhouse/src/storage/index.test.ts
+++ b/stores/clickhouse/src/storage/index.test.ts
@@ -32,7 +32,7 @@ const createTestClient = () =>
 
 const storage = new ClickhouseStore(TEST_CONFIG);
 
-createTestSuite(storage);
+createTestSuite(storage, { backgroundTasksUpdateIfStatus: false });
 
 // Configuration validation tests
 createConfigValidationTests({

--- a/stores/cloudflare-d1/src/storage/domains/background-tasks/index.ts
+++ b/stores/cloudflare-d1/src/storage/domains/background-tasks/index.ts
@@ -168,6 +168,55 @@ export class BackgroundTasksStorageD1 extends BackgroundTasksStorage {
     });
   }
 
+  async updateTaskIfStatus(
+    taskId: string,
+    expectedStatus: BackgroundTaskStatus,
+    update: UpdateBackgroundTask,
+  ): Promise<boolean> {
+    const sets: string[] = [];
+    const params: any[] = [];
+    if ('status' in update) {
+      sets.push('status = ?');
+      params.push(update.status);
+    }
+    if ('result' in update) {
+      sets.push('result = ?');
+      params.push(serializeJson(update.result));
+    }
+    if ('error' in update) {
+      sets.push('error = ?');
+      params.push(serializeJson(update.error));
+    }
+    if ('suspendPayload' in update) {
+      sets.push('suspend_payload = ?');
+      params.push(serializeJson(update.suspendPayload));
+    }
+    if ('retryCount' in update) {
+      sets.push('retry_count = ?');
+      params.push(update.retryCount);
+    }
+    if ('startedAt' in update) {
+      sets.push('startedAt = ?');
+      params.push(update.startedAt?.toISOString() ?? null);
+    }
+    if ('suspendedAt' in update) {
+      sets.push('suspendedAt = ?');
+      params.push(update.suspendedAt?.toISOString() ?? null);
+    }
+    if ('completedAt' in update) {
+      sets.push('completedAt = ?');
+      params.push(update.completedAt?.toISOString() ?? null);
+    }
+    if (sets.length === 0) return false;
+    params.push(taskId, expectedStatus);
+    const fullTableName = this.#db.getTableName(TABLE_BACKGROUND_TASKS);
+    const rows = await this.#db.executeQuery({
+      sql: `UPDATE ${fullTableName} SET ${sets.join(', ')} WHERE id = ? AND status = ? RETURNING id`,
+      params,
+    });
+    return Array.isArray(rows) && rows.length > 0;
+  }
+
   async getTask(taskId: string): Promise<BackgroundTask | null> {
     const fullTableName = this.#db.getTableName(TABLE_BACKGROUND_TASKS);
     const { sql, params } = createSqlBuilder().select('*').from(fullTableName).where('id = ?', taskId).build();

--- a/stores/cloudflare/src/do/storage/domains/background-tasks/index.ts
+++ b/stores/cloudflare/src/do/storage/domains/background-tasks/index.ts
@@ -182,6 +182,69 @@ export class BackgroundTasksStorageDO extends BackgroundTasksStorage {
     }
   }
 
+  async updateTaskIfStatus(
+    taskId: string,
+    expectedStatus: BackgroundTaskStatus,
+    update: UpdateBackgroundTask,
+  ): Promise<boolean> {
+    const columns: string[] = [];
+    const values: SqlParam[] = [];
+
+    if ('status' in update) {
+      columns.push('status');
+      values.push(update.status as string);
+    }
+    if ('result' in update) {
+      columns.push('result');
+      values.push(serializeJson(update.result));
+    }
+    if ('error' in update) {
+      columns.push('error');
+      values.push(serializeJson(update.error));
+    }
+    if ('suspendPayload' in update) {
+      columns.push('suspend_payload');
+      values.push(serializeJson(update.suspendPayload));
+    }
+    if ('retryCount' in update) {
+      columns.push('retry_count');
+      values.push(update.retryCount as number);
+    }
+    if ('startedAt' in update) {
+      columns.push('startedAt');
+      values.push(update.startedAt?.toISOString() ?? null);
+    }
+    if ('suspendedAt' in update) {
+      columns.push('suspendedAt');
+      values.push(update.suspendedAt?.toISOString() ?? null);
+    }
+    if ('completedAt' in update) {
+      columns.push('completedAt');
+      values.push(update.completedAt?.toISOString() ?? null);
+    }
+
+    if (columns.length === 0) return false;
+
+    try {
+      const fullTableName = this.#db.getTableName(TABLE_BACKGROUND_TASKS);
+      const setClauses = columns.map(column => `${column} = ?`).join(', ');
+      const rows = await this.#db.executeQuery({
+        sql: `UPDATE ${fullTableName} SET ${setClauses} WHERE id = ? AND status = ? RETURNING id`,
+        params: [...values, taskId, expectedStatus],
+      });
+      return Array.isArray(rows) && rows.length > 0;
+    } catch (error) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('CLOUDFLARE_DO', 'BACKGROUND_TASKS_UPDATE_IF_STATUS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+        },
+        error,
+      );
+    }
+  }
+
   async getTask(taskId: string): Promise<BackgroundTask | null> {
     try {
       const fullTableName = this.#db.getTableName(TABLE_BACKGROUND_TASKS);

--- a/stores/cloudflare/src/kv/storage/binding-api.test.ts
+++ b/stores/cloudflare/src/kv/storage/binding-api.test.ts
@@ -90,12 +90,10 @@ const requiredBindingTables = [
 
 const bindingsWithout = (missingTable: (typeof requiredBindingTables)[number]) =>
   Object.fromEntries(
-    requiredBindingTables
-      .filter(table => table !== missingTable)
-      .map(table => [table, kvBindings[table]]),
+    requiredBindingTables.filter(table => table !== missingTable).map(table => [table, kvBindings[table]]),
   );
 
-createTestSuite(new CloudflareStore(TEST_CONFIG));
+createTestSuite(new CloudflareStore(TEST_CONFIG), { backgroundTasksUpdateIfStatus: false });
 
 // Pre-configured client acceptance tests (using bindings)
 createClientAcceptanceTests({

--- a/stores/cloudflare/src/kv/storage/domains/background-tasks/index.ts
+++ b/stores/cloudflare/src/kv/storage/domains/background-tasks/index.ts
@@ -5,7 +5,8 @@ import type {
   TaskListResult,
   UpdateBackgroundTask,
 } from '@mastra/core/background-tasks';
-import { BackgroundTasksStorage, TABLE_BACKGROUND_TASKS } from '@mastra/core/storage';
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import { BackgroundTasksStorage, createStorageErrorId, TABLE_BACKGROUND_TASKS } from '@mastra/core/storage';
 import { CloudflareKVDB, resolveCloudflareConfig } from '../../db';
 import type { CloudflareDomainConfig } from '../../types';
 
@@ -86,6 +87,26 @@ export class BackgroundTasksStorageCloudflare extends BackgroundTasksStorage {
     if ('suspendedAt' in update) merged.suspendedAt = update.suspendedAt;
     if ('completedAt' in update) merged.completedAt = update.completedAt;
     await this.#db.putKV({ tableName: TABLE_BACKGROUND_TASKS, key: taskId, value: toRecord(merged) });
+  }
+
+  async updateTaskIfStatus(
+    taskId: string,
+    expectedStatus: BackgroundTaskStatus,
+    update: UpdateBackgroundTask,
+  ): Promise<boolean> {
+    throw new MastraError(
+      {
+        id: createStorageErrorId('CLOUDFLARE', 'UPDATE_BACKGROUND_TASK_IF_STATUS', 'NOT_SUPPORTED'),
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: {
+          taskId,
+          expectedStatus,
+          updateStatus: update.status ?? null,
+        },
+      },
+      'Cloudflare KV does not support the atomic conditional writes required by background task dispatch. Use Cloudflare Durable Objects or D1 storage for background tasks.',
+    );
   }
 
   async getTask(taskId: string): Promise<BackgroundTask | null> {

--- a/stores/convex/src/server/storage.ts
+++ b/stores/convex/src/server/storage.ts
@@ -311,6 +311,22 @@ export async function handleTypedOperation(
       return { ok: true };
     }
 
+    case 'updateIfFieldEquals': {
+      // The check and patch stay inside this single Convex mutation transaction.
+      const existing = await ctx.db
+        .query(convexTable)
+        .withIndex('by_record_id', (q: any) => q.eq('id', request.id))
+        .unique();
+
+      if (!existing || existing[request.field] !== request.expectedValue) {
+        return { ok: true, result: false };
+      }
+
+      const { id: _, ...patch } = request.patch;
+      await ctx.db.patch(existing._id, patch);
+      return { ok: true, result: true };
+    }
+
     case 'mergeWorkflowStepResult': {
       if (convexTable !== CONVEX_TABLE_WORKFLOW_SNAPSHOTS) {
         return { ok: false, error: `Unsupported operation ${request.op} for table ${request.tableName}` };
@@ -535,6 +551,9 @@ async function handleVectorOperation(ctx: MutationCtx<any>, request: StorageRequ
       return { ok: true };
     }
 
+    case 'updateIfFieldEquals':
+      return { ok: true, result: false };
+
     default:
       return { ok: false, error: `Unsupported operation ${(request as any).op}` };
   }
@@ -661,6 +680,22 @@ async function handleGenericOperation(ctx: MutationCtx<any>, request: StorageReq
       );
       await deleteDocs(ctx, docsToDelete);
       return { ok: true };
+    }
+
+    case 'updateIfFieldEquals': {
+      // The check and patch stay inside this single Convex mutation transaction.
+      const existing = await ctx.db
+        .query(convexTable)
+        .withIndex('by_table_primary', (q: any) => q.eq('table', tableName).eq('primaryKey', String(request.id)))
+        .unique();
+
+      if (!existing || existing.record?.[request.field] !== request.expectedValue) {
+        return { ok: true, result: false };
+      }
+
+      const { id: _, ...patch } = request.patch;
+      await ctx.db.patch(existing._id, { record: { ...existing.record, ...patch } });
+      return { ok: true, result: true };
     }
 
     default:

--- a/stores/convex/src/storage/db/index.ts
+++ b/stores/convex/src/storage/db/index.ts
@@ -151,6 +151,29 @@ export class ConvexDB extends MastraBase {
     });
   }
 
+  public async updateIfFieldEquals({
+    tableName,
+    id,
+    field,
+    expectedValue,
+    patch,
+  }: {
+    tableName: TABLE_NAMES;
+    id: string;
+    field: string;
+    expectedValue: string | number | boolean | null;
+    patch: Record<string, any>;
+  }): Promise<boolean> {
+    return this.client.callStorage<boolean>({
+      op: 'updateIfFieldEquals',
+      tableName,
+      id,
+      field,
+      expectedValue,
+      patch: this.normalizeRecord(tableName, patch),
+    });
+  }
+
   public async mergeWorkflowStepResult({
     workflowName,
     runId,

--- a/stores/convex/src/storage/domains/background-tasks/index.ts
+++ b/stores/convex/src/storage/domains/background-tasks/index.ts
@@ -1,4 +1,10 @@
-import type { BackgroundTask, TaskFilter, TaskListResult, UpdateBackgroundTask } from '@mastra/core/background-tasks';
+import type {
+  BackgroundTask,
+  BackgroundTaskStatus,
+  TaskFilter,
+  TaskListResult,
+  UpdateBackgroundTask,
+} from '@mastra/core/background-tasks';
 import { BackgroundTasksStorage, TABLE_BACKGROUND_TASKS } from '@mastra/core/storage';
 import { ConvexDB, resolveConvexConfig } from '../../db';
 import type { ConvexDomainConfig } from '../../db';
@@ -22,6 +28,11 @@ function serializeJson(v: unknown): any {
   return v ?? undefined;
 }
 
+function serializeJsonUpdate(v: unknown): any {
+  if (typeof v === 'object' && v != null) return JSON.stringify(v);
+  return v ?? null;
+}
+
 function toStored(task: BackgroundTask): StoredTask {
   return {
     ...task,
@@ -36,9 +47,23 @@ function toStored(task: BackgroundTask): StoredTask {
   };
 }
 
+function toStoredUpdate(update: UpdateBackgroundTask): Record<string, any> {
+  const stored: Record<string, any> = {};
+  if ('status' in update) stored.status = update.status!;
+  if ('result' in update) stored.result = serializeJsonUpdate(update.result);
+  if ('error' in update) stored.error = serializeJsonUpdate(update.error);
+  if ('suspendPayload' in update) stored.suspendPayload = serializeJsonUpdate(update.suspendPayload);
+  if ('retryCount' in update) stored.retryCount = update.retryCount!;
+  if ('startedAt' in update) stored.startedAt = update.startedAt?.toISOString() ?? null;
+  if ('suspendedAt' in update) stored.suspendedAt = update.suspendedAt?.toISOString() ?? null;
+  if ('completedAt' in update) stored.completedAt = update.completedAt?.toISOString() ?? null;
+  return stored;
+}
+
 function fromStored(stored: StoredTask): BackgroundTask {
-  const parseJson = (val?: string): any => {
-    if (!val) return undefined;
+  const parseJson = (val?: unknown): any => {
+    if (val == null || val === '') return undefined;
+    if (typeof val !== 'string') return val;
     try {
       return JSON.parse(val);
     } catch {
@@ -103,6 +128,20 @@ export class BackgroundTasksConvex extends BackgroundTasksStorage {
     // Convex has no update — delete and re-insert
     await this.#db.deleteMany(TABLE_BACKGROUND_TASKS, [taskId]);
     await this.#db.insert({ tableName: TABLE_BACKGROUND_TASKS, record: toStored(merged) });
+  }
+
+  async updateTaskIfStatus(
+    taskId: string,
+    expectedStatus: BackgroundTaskStatus,
+    update: UpdateBackgroundTask,
+  ): Promise<boolean> {
+    return this.#db.updateIfFieldEquals({
+      tableName: TABLE_BACKGROUND_TASKS,
+      id: taskId,
+      field: 'status',
+      expectedValue: expectedStatus,
+      patch: toStoredUpdate(update),
+    });
   }
 
   async getTask(taskId: string): Promise<BackgroundTask | null> {

--- a/stores/convex/src/storage/types.ts
+++ b/stores/convex/src/storage/types.ts
@@ -42,6 +42,14 @@ export type StorageRequest =
       ids: string[];
     }
   | {
+      op: 'updateIfFieldEquals';
+      tableName: TABLE_NAMES | string;
+      id: string;
+      field: string;
+      expectedValue: string | number | boolean | null;
+      patch: Record<string, any>;
+    }
+  | {
       op: 'mergeWorkflowStepResult';
       tableName: TABLE_NAMES | string;
       workflowName: string;

--- a/stores/dynamodb/src/storage/domains/background-tasks/index.ts
+++ b/stores/dynamodb/src/storage/domains/background-tasks/index.ts
@@ -81,6 +81,67 @@ function fromElectroRecord(data: Record<string, any>): BackgroundTask {
   };
 }
 
+function buildBackgroundTaskUpdateFields(update: UpdateBackgroundTask): {
+  setFields: Record<string, unknown>;
+  removeFields: string[];
+} {
+  const setFields: Record<string, unknown> = {};
+  // ElectroDB's .set() ignores undefined values, so any field explicitly set
+  // to undefined must be cleared via .remove() instead.
+  const removeFields: string[] = [];
+
+  if ('status' in update && update.status !== undefined) {
+    setFields.status = update.status;
+  }
+  if ('retryCount' in update && update.retryCount !== undefined) {
+    setFields.retryCount = update.retryCount;
+  }
+  if ('result' in update) {
+    if (update.result === undefined || update.result === null) {
+      removeFields.push('result');
+    } else {
+      setFields.result = serializeJson(update.result);
+    }
+  }
+  if ('error' in update) {
+    if (update.error === undefined || update.error === null) {
+      removeFields.push('error');
+    } else {
+      setFields.error = serializeJson(update.error);
+    }
+  }
+  if ('suspendPayload' in update) {
+    if (update.suspendPayload === undefined || update.suspendPayload === null) {
+      removeFields.push('suspendPayload');
+    } else {
+      setFields.suspendPayload = serializeJson(update.suspendPayload);
+    }
+  }
+  if ('startedAt' in update) {
+    if (update.startedAt === undefined || update.startedAt === null) {
+      removeFields.push('startedAtIso');
+    } else {
+      setFields.startedAtIso = update.startedAt.toISOString();
+    }
+  }
+  if ('suspendedAt' in update) {
+    if (update.suspendedAt === undefined || update.suspendedAt === null) {
+      removeFields.push('suspendedAtIso');
+    } else {
+      setFields.suspendedAtIso = update.suspendedAt.toISOString();
+    }
+  }
+  if ('completedAt' in update) {
+    if (update.completedAt === undefined || update.completedAt === null) {
+      removeFields.push('completedAtIso');
+    } else {
+      setFields.completedAtIso = update.completedAt.toISOString();
+    }
+  }
+
+  return { setFields, removeFields };
+}
+
 export class BackgroundTasksStorageDynamoDB extends BackgroundTasksStorage {
   private service: Service<Record<string, any>>;
 
@@ -131,59 +192,7 @@ export class BackgroundTasksStorageDynamoDB extends BackgroundTasksStorage {
 
   async updateTask(taskId: string, update: UpdateBackgroundTask): Promise<void> {
     try {
-      const setFields: Record<string, unknown> = {};
-      // ElectroDB's .set() ignores undefined values, so any field explicitly set
-      // to undefined must be cleared via .remove() instead.
-      const removeFields: string[] = [];
-
-      if ('status' in update && update.status !== undefined) {
-        setFields.status = update.status;
-      }
-      if ('retryCount' in update && update.retryCount !== undefined) {
-        setFields.retryCount = update.retryCount;
-      }
-      if ('result' in update) {
-        if (update.result === undefined || update.result === null) {
-          removeFields.push('result');
-        } else {
-          setFields.result = serializeJson(update.result);
-        }
-      }
-      if ('error' in update) {
-        if (update.error === undefined || update.error === null) {
-          removeFields.push('error');
-        } else {
-          setFields.error = serializeJson(update.error);
-        }
-      }
-      if ('suspendPayload' in update) {
-        if (update.suspendPayload === undefined || update.suspendPayload === null) {
-          removeFields.push('suspendPayload');
-        } else {
-          setFields.suspendPayload = serializeJson(update.suspendPayload);
-        }
-      }
-      if ('startedAt' in update) {
-        if (update.startedAt === undefined || update.startedAt === null) {
-          removeFields.push('startedAtIso');
-        } else {
-          setFields.startedAtIso = update.startedAt.toISOString();
-        }
-      }
-      if ('suspendedAt' in update) {
-        if (update.suspendedAt === undefined || update.suspendedAt === null) {
-          removeFields.push('suspendedAtIso');
-        } else {
-          setFields.suspendedAtIso = update.suspendedAt.toISOString();
-        }
-      }
-      if ('completedAt' in update) {
-        if (update.completedAt === undefined || update.completedAt === null) {
-          removeFields.push('completedAtIso');
-        } else {
-          setFields.completedAtIso = update.completedAt.toISOString();
-        }
-      }
+      const { setFields, removeFields } = buildBackgroundTaskUpdateFields(update);
 
       if (Object.keys(setFields).length === 0 && removeFields.length === 0) return;
 
@@ -210,35 +219,7 @@ export class BackgroundTasksStorageDynamoDB extends BackgroundTasksStorage {
     update: UpdateBackgroundTask,
   ): Promise<boolean> {
     try {
-      const setFields: Record<string, unknown> = {};
-      const removeFields: string[] = [];
-
-      if ('status' in update && update.status !== undefined) setFields.status = update.status;
-      if ('retryCount' in update && update.retryCount !== undefined) setFields.retryCount = update.retryCount;
-      if ('result' in update) {
-        if (update.result === undefined || update.result === null) removeFields.push('result');
-        else setFields.result = serializeJson(update.result);
-      }
-      if ('error' in update) {
-        if (update.error === undefined || update.error === null) removeFields.push('error');
-        else setFields.error = serializeJson(update.error);
-      }
-      if ('suspendPayload' in update) {
-        if (update.suspendPayload === undefined || update.suspendPayload === null) removeFields.push('suspendPayload');
-        else setFields.suspendPayload = serializeJson(update.suspendPayload);
-      }
-      if ('startedAt' in update) {
-        if (update.startedAt === undefined || update.startedAt === null) removeFields.push('startedAtIso');
-        else setFields.startedAtIso = update.startedAt.toISOString();
-      }
-      if ('suspendedAt' in update) {
-        if (update.suspendedAt === undefined || update.suspendedAt === null) removeFields.push('suspendedAtIso');
-        else setFields.suspendedAtIso = update.suspendedAt.toISOString();
-      }
-      if ('completedAt' in update) {
-        if (update.completedAt === undefined || update.completedAt === null) removeFields.push('completedAtIso');
-        else setFields.completedAtIso = update.completedAt.toISOString();
-      }
+      const { setFields, removeFields } = buildBackgroundTaskUpdateFields(update);
 
       if (Object.keys(setFields).length === 0 && removeFields.length === 0) return false;
 

--- a/stores/dynamodb/src/storage/domains/background-tasks/index.ts
+++ b/stores/dynamodb/src/storage/domains/background-tasks/index.ts
@@ -94,6 +94,25 @@ export class BackgroundTasksStorageDynamoDB extends BackgroundTasksStorage {
     await deleteTableData(this.service, TABLE_BACKGROUND_TASKS);
   }
 
+  private isConditionalCheckFailed(error: unknown): boolean {
+    if (error && typeof error === 'object') {
+      const err = error as { name?: string; code?: string; __type?: string; message?: string; cause?: unknown };
+      if (
+        err.name === 'ConditionalCheckFailedException' ||
+        err.code === 'ConditionalCheckFailedException' ||
+        (err.__type?.includes('ConditionalCheckFailedException') ?? false)
+      ) {
+        return true;
+      }
+      if (err.message?.includes('conditional request failed')) return true;
+      if (err.cause && typeof err.cause === 'object') {
+        const cause = err.cause as { name?: string; code?: string };
+        return cause.name === 'ConditionalCheckFailedException' || cause.code === 'ConditionalCheckFailedException';
+      }
+    }
+    return false;
+  }
+
   async createTask(task: BackgroundTask): Promise<void> {
     try {
       await this.service.entities.background_task.create(toElectroRecord(task)).go();
@@ -179,6 +198,65 @@ export class BackgroundTasksStorageDynamoDB extends BackgroundTasksStorage {
           domain: ErrorDomain.STORAGE,
           category: ErrorCategory.THIRD_PARTY,
           details: { taskId },
+        },
+        error,
+      );
+    }
+  }
+
+  async updateTaskIfStatus(
+    taskId: string,
+    expectedStatus: BackgroundTaskStatus,
+    update: UpdateBackgroundTask,
+  ): Promise<boolean> {
+    try {
+      const setFields: Record<string, unknown> = {};
+      const removeFields: string[] = [];
+
+      if ('status' in update && update.status !== undefined) setFields.status = update.status;
+      if ('retryCount' in update && update.retryCount !== undefined) setFields.retryCount = update.retryCount;
+      if ('result' in update) {
+        if (update.result === undefined || update.result === null) removeFields.push('result');
+        else setFields.result = serializeJson(update.result);
+      }
+      if ('error' in update) {
+        if (update.error === undefined || update.error === null) removeFields.push('error');
+        else setFields.error = serializeJson(update.error);
+      }
+      if ('suspendPayload' in update) {
+        if (update.suspendPayload === undefined || update.suspendPayload === null) removeFields.push('suspendPayload');
+        else setFields.suspendPayload = serializeJson(update.suspendPayload);
+      }
+      if ('startedAt' in update) {
+        if (update.startedAt === undefined || update.startedAt === null) removeFields.push('startedAtIso');
+        else setFields.startedAtIso = update.startedAt.toISOString();
+      }
+      if ('suspendedAt' in update) {
+        if (update.suspendedAt === undefined || update.suspendedAt === null) removeFields.push('suspendedAtIso');
+        else setFields.suspendedAtIso = update.suspendedAt.toISOString();
+      }
+      if ('completedAt' in update) {
+        if (update.completedAt === undefined || update.completedAt === null) removeFields.push('completedAtIso');
+        else setFields.completedAtIso = update.completedAt.toISOString();
+      }
+
+      if (Object.keys(setFields).length === 0 && removeFields.length === 0) return false;
+
+      let op = this.service.entities.background_task
+        .patch({ entity: ENTITY, id: taskId })
+        .where((attr: any, op: any) => op.eq(attr.status, expectedStatus)) as any;
+      if (Object.keys(setFields).length > 0) op = op.set(setFields);
+      if (removeFields.length > 0) op = op.remove(removeFields);
+      await op.go();
+      return true;
+    } catch (error) {
+      if (this.isConditionalCheckFailed(error)) return false;
+      throw new MastraError(
+        {
+          id: createStorageErrorId('DYNAMODB', 'BACKGROUND_TASKS_UPDATE_IF_STATUS', 'FAILED'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.THIRD_PARTY,
+          details: { taskId, expectedStatus },
         },
         error,
       );

--- a/stores/lance/src/storage/domains/background-tasks/index.ts
+++ b/stores/lance/src/storage/domains/background-tasks/index.ts
@@ -39,6 +39,19 @@ function toRecord(task: BackgroundTask): Record<string, any> {
   };
 }
 
+function toUpdateValues(update: UpdateBackgroundTask): Record<string, any> {
+  const values: Record<string, any> = {};
+  if ('status' in update) values.status = update.status!;
+  if ('result' in update) values.result = serializeJson(update.result);
+  if ('error' in update) values.error = serializeJson(update.error);
+  if ('suspendPayload' in update) values.suspend_payload = serializeJson(update.suspendPayload);
+  if ('retryCount' in update) values.retry_count = update.retryCount!;
+  if ('startedAt' in update) values.startedAt = update.startedAt ?? new Date(0);
+  if ('suspendedAt' in update) values.suspendedAt = update.suspendedAt ?? new Date(0);
+  if ('completedAt' in update) values.completedAt = update.completedAt ?? new Date(0);
+  return values;
+}
+
 function fromRecord(row: Record<string, any>): BackgroundTask {
   const parseJson = (val: unknown): any => {
     if (val == null || val === '') return undefined;
@@ -138,6 +151,21 @@ export class StoreBackgroundTasksLance extends BackgroundTasksStorage {
     const table = await this.client.openTable(TABLE_BACKGROUND_TASKS);
     await table.delete(`id = '${escapeStr(taskId)}'`);
     await table.add([toRecord(merged)], { mode: 'append' });
+  }
+
+  async updateTaskIfStatus(
+    taskId: string,
+    expectedStatus: BackgroundTaskStatus,
+    update: UpdateBackgroundTask,
+  ): Promise<boolean> {
+    const values = toUpdateValues(update);
+    if (Object.keys(values).length === 0) return false;
+    const table = await this.client.openTable(TABLE_BACKGROUND_TASKS);
+    const result = await table.update({
+      where: `id = '${escapeStr(taskId)}' AND status = '${escapeStr(expectedStatus)}'`,
+      values,
+    });
+    return result.rowsUpdated > 0;
   }
 
   async getTask(taskId: string): Promise<BackgroundTask | null> {

--- a/stores/libsql/src/storage/domains/background-tasks/index.ts
+++ b/stores/libsql/src/storage/domains/background-tasks/index.ts
@@ -154,6 +154,57 @@ export class BackgroundTasksLibSQL extends BackgroundTasksStorage {
     });
   }
 
+  async updateTaskIfStatus(
+    taskId: string,
+    expectedStatus: BackgroundTaskStatus,
+    update: UpdateBackgroundTask,
+  ): Promise<boolean> {
+    const setClauses: string[] = [];
+    const params: InValue[] = [];
+
+    if ('status' in update) {
+      setClauses.push('status = ?');
+      params.push(update.status as string);
+    }
+    if ('result' in update) {
+      setClauses.push('result = jsonb(?)');
+      params.push(serializeJson(update.result));
+    }
+    if ('error' in update) {
+      setClauses.push('error = jsonb(?)');
+      params.push(serializeJson(update.error));
+    }
+    if ('suspendPayload' in update) {
+      setClauses.push('suspend_payload = jsonb(?)');
+      params.push(serializeJson(update.suspendPayload));
+    }
+    if ('retryCount' in update) {
+      setClauses.push('retry_count = ?');
+      params.push(update.retryCount as number);
+    }
+    if ('startedAt' in update) {
+      setClauses.push('startedAt = ?');
+      params.push(update.startedAt?.toISOString() ?? null);
+    }
+    if ('suspendedAt' in update) {
+      setClauses.push('suspendedAt = ?');
+      params.push(update.suspendedAt?.toISOString() ?? null);
+    }
+    if ('completedAt' in update) {
+      setClauses.push('completedAt = ?');
+      params.push(update.completedAt?.toISOString() ?? null);
+    }
+
+    if (setClauses.length === 0) return false;
+
+    params.push(taskId, expectedStatus);
+    const result = await this.#client.execute({
+      sql: `UPDATE ${TABLE_BACKGROUND_TASKS} SET ${setClauses.join(', ')} WHERE id = ? AND status = ?`,
+      args: params,
+    });
+    return Number(result.rowsAffected ?? 0) > 0;
+  }
+
   async getTask(taskId: string): Promise<BackgroundTask | null> {
     const result = await this.#client.execute({
       sql: `SELECT ${buildSelectColumns(TABLE_BACKGROUND_TASKS)} FROM ${TABLE_BACKGROUND_TASKS} WHERE id = ?`,

--- a/stores/mongodb/src/storage/domains/background-tasks/index.ts
+++ b/stores/mongodb/src/storage/domains/background-tasks/index.ts
@@ -145,6 +145,29 @@ export class BackgroundTasksStorageMongoDB extends BackgroundTasksStorage {
     await collection.updateOne({ id: taskId }, { $set });
   }
 
+  async updateTaskIfStatus(
+    taskId: string,
+    expectedStatus: BackgroundTaskStatus,
+    update: UpdateBackgroundTask,
+  ): Promise<boolean> {
+    const $set: Record<string, any> = {};
+
+    if ('status' in update) $set.status = update.status;
+    if ('result' in update) $set.result = update.result ?? null;
+    if ('error' in update) $set.error = update.error ?? null;
+    if ('suspendPayload' in update) $set.suspend_payload = update.suspendPayload ?? null;
+    if ('retryCount' in update) $set.retry_count = update.retryCount;
+    if ('startedAt' in update) $set.startedAt = update.startedAt?.toISOString() ?? null;
+    if ('suspendedAt' in update) $set.suspendedAt = update.suspendedAt?.toISOString() ?? null;
+    if ('completedAt' in update) $set.completedAt = update.completedAt?.toISOString() ?? null;
+
+    if (Object.keys($set).length === 0) return false;
+
+    const collection = await this.getCollection();
+    const result = await collection.updateOne({ id: taskId, status: expectedStatus }, { $set });
+    return result.modifiedCount > 0;
+  }
+
   async getTask(taskId: string): Promise<BackgroundTask | null> {
     const collection = await this.getCollection();
     const doc = await collection.findOne({ id: taskId });

--- a/stores/mssql/src/storage/domains/background-tasks/index.ts
+++ b/stores/mssql/src/storage/domains/background-tasks/index.ts
@@ -237,6 +237,66 @@ export class BackgroundTasksMSSQL extends BackgroundTasksStorage {
     await request.query(`UPDATE ${this.tableName()} SET ${setClauses.join(', ')} WHERE [id] = @p${idx}`);
   }
 
+  async updateTaskIfStatus(
+    taskId: string,
+    expectedStatus: BackgroundTaskStatus,
+    update: UpdateBackgroundTask,
+  ): Promise<boolean> {
+    const setClauses: string[] = [];
+    const params: Record<string, any> = {};
+    let idx = 1;
+
+    if ('status' in update) {
+      setClauses.push(`[status] = @p${idx}`);
+      params[`p${idx++}`] = update.status;
+    }
+    if ('result' in update) {
+      setClauses.push(`[result] = @p${idx}`);
+      params[`p${idx++}`] = serializeJson(update.result);
+    }
+    if ('error' in update) {
+      setClauses.push(`[error] = @p${idx}`);
+      params[`p${idx++}`] = serializeJson(update.error);
+    }
+    if ('suspendPayload' in update) {
+      setClauses.push(`[suspend_payload] = @p${idx}`);
+      params[`p${idx++}`] = serializeJson(update.suspendPayload);
+    }
+    if ('retryCount' in update) {
+      setClauses.push(`[retry_count] = @p${idx}`);
+      params[`p${idx++}`] = update.retryCount;
+    }
+    if ('startedAt' in update) {
+      setClauses.push(`[startedAt] = @p${idx}`);
+      params[`p${idx++}`] = update.startedAt?.toISOString() ?? null;
+    }
+    if ('suspendedAt' in update) {
+      setClauses.push(`[suspendedAt] = @p${idx}`);
+      params[`p${idx++}`] = update.suspendedAt?.toISOString() ?? null;
+    }
+    if ('completedAt' in update) {
+      setClauses.push(`[completedAt] = @p${idx}`);
+      params[`p${idx++}`] = update.completedAt?.toISOString() ?? null;
+    }
+
+    if (setClauses.length === 0) return false;
+
+    const taskIdParam = `p${idx++}`;
+    const statusParam = `p${idx}`;
+    params[taskIdParam] = taskId;
+    params[statusParam] = expectedStatus;
+
+    const request = this.pool.request();
+    for (const [name, value] of Object.entries(params)) {
+      request.input(name, value);
+    }
+
+    const result = await request.query(
+      `UPDATE ${this.tableName()} SET ${setClauses.join(', ')} WHERE [id] = @${taskIdParam} AND [status] = @${statusParam}`,
+    );
+    return (result.rowsAffected?.[0] ?? 0) > 0;
+  }
+
   async getTask(taskId: string): Promise<BackgroundTask | null> {
     const request = this.pool.request();
     request.input('p1', taskId);

--- a/stores/pg/src/storage/domains/background-tasks/index.ts
+++ b/stores/pg/src/storage/domains/background-tasks/index.ts
@@ -250,6 +250,59 @@ export class BackgroundTasksPG extends BackgroundTasksStorage {
     await this.#db.client.none(`UPDATE ${table} SET ${setClauses.join(', ')} WHERE "id" = $${paramIdx}`, params);
   }
 
+  async updateTaskIfStatus(
+    taskId: string,
+    expectedStatus: BackgroundTaskStatus,
+    update: UpdateBackgroundTask,
+  ): Promise<boolean> {
+    const setClauses: string[] = [];
+    const params: any[] = [];
+    let paramIdx = 1;
+
+    if ('status' in update) {
+      setClauses.push(`"status" = $${paramIdx++}`);
+      params.push(update.status);
+    }
+    if ('result' in update) {
+      setClauses.push(`"result" = $${paramIdx++}`);
+      params.push(serializeJson(update.result));
+    }
+    if ('error' in update) {
+      setClauses.push(`"error" = $${paramIdx++}`);
+      params.push(serializeJson(update.error));
+    }
+    if ('suspendPayload' in update) {
+      setClauses.push(`"suspend_payload" = $${paramIdx++}`);
+      params.push(serializeJson(update.suspendPayload));
+    }
+    if ('retryCount' in update) {
+      setClauses.push(`"retry_count" = $${paramIdx++}`);
+      params.push(update.retryCount);
+    }
+    if ('startedAt' in update) {
+      setClauses.push(`"startedAt" = $${paramIdx++}`);
+      params.push(update.startedAt?.toISOString() ?? null);
+    }
+    if ('suspendedAt' in update) {
+      setClauses.push(`"suspendedAt" = $${paramIdx++}`);
+      params.push(update.suspendedAt?.toISOString() ?? null);
+    }
+    if ('completedAt' in update) {
+      setClauses.push(`"completedAt" = $${paramIdx++}`);
+      params.push(update.completedAt?.toISOString() ?? null);
+    }
+
+    if (setClauses.length === 0) return false;
+
+    const table = getTableName(getSchemaName(this.#schema));
+    params.push(taskId, expectedStatus);
+    const result = await this.#db.client.query(
+      `UPDATE ${table} SET ${setClauses.join(', ')} WHERE "id" = $${paramIdx++} AND "status" = $${paramIdx}`,
+      params,
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
   async getTask(taskId: string): Promise<BackgroundTask | null> {
     const table = getTableName(getSchemaName(this.#schema));
     const row = await this.#db.client.oneOrNone(`SELECT * FROM ${table} WHERE "id" = $1`, [taskId]);

--- a/stores/upstash/src/storage/domains/background-tasks/index.ts
+++ b/stores/upstash/src/storage/domains/background-tasks/index.ts
@@ -1,4 +1,10 @@
-import type { BackgroundTask, BackgroundTaskStatus, TaskFilter, TaskListResult } from '@mastra/core/background-tasks';
+import type {
+  BackgroundTask,
+  BackgroundTaskStatus,
+  TaskFilter,
+  TaskListResult,
+  UpdateBackgroundTask,
+} from '@mastra/core/background-tasks';
 import { BackgroundTasksStorage, TABLE_BACKGROUND_TASKS } from '@mastra/core/storage';
 import type { Redis } from '@upstash/redis';
 import { UpstashDB, resolveUpstashConfig } from '../../db';
@@ -92,6 +98,44 @@ export class BackgroundTasksUpstash extends BackgroundTasksStorage {
     const record = toStorageRecord(merged);
     const { key, processedRecord } = processRecord(TABLE_BACKGROUND_TASKS, record);
     await this.client.set(key, processedRecord);
+  }
+
+  async updateTaskIfStatus(
+    taskId: string,
+    expectedStatus: BackgroundTaskStatus,
+    update: UpdateBackgroundTask,
+  ): Promise<boolean> {
+    const patch: Record<string, any> = {};
+
+    if ('status' in update) patch.status = update.status;
+    if ('result' in update) patch.result = update.result ?? null;
+    if ('error' in update) patch.error = update.error ?? null;
+    if ('suspendPayload' in update) patch.suspend_payload = update.suspendPayload ?? null;
+    if ('retryCount' in update) patch.retry_count = update.retryCount;
+    if ('startedAt' in update) patch.startedAt = update.startedAt?.toISOString() ?? null;
+    if ('suspendedAt' in update) patch.suspendedAt = update.suspendedAt?.toISOString() ?? null;
+    if ('completedAt' in update) patch.completedAt = update.completedAt?.toISOString() ?? null;
+
+    if (Object.keys(patch).length === 0) return false;
+
+    const key = getKey(TABLE_BACKGROUND_TASKS, { id: taskId });
+    const result = await this.client.eval(
+      `
+local raw = redis.call("GET", KEYS[1])
+if not raw then return 0 end
+local record = cjson.decode(raw)
+if record["status"] ~= ARGV[1] then return 0 end
+local patch = cjson.decode(ARGV[2])
+for key, value in pairs(patch) do
+  record[key] = value
+end
+redis.call("SET", KEYS[1], cjson.encode(record))
+return 1
+`,
+      [key],
+      [expectedStatus, JSON.stringify(patch)],
+    );
+    return Number(result) === 1;
   }
 
   async getTask(taskId: string): Promise<BackgroundTask | null> {


### PR DESCRIPTION
## Summary

Follows up merged PR #129 and the late CodeRabbit finding on `restorePending` / `restoreSuspended`.

- Adds `BackgroundTasksStorage.updateTaskIfStatus` as a fail-closed default and uses it for background-task dispatch, resume, and restore transitions.
- Implements conditional status updates for transactional/conditional storage adapters.
- Fails closed for ClickHouse and Cloudflare KV background-task claims because those adapters cannot safely provide the atomic claim contract.
- Fixes Convex conditional updates to preserve clears over JSON transport and documents that check+patch stays inside one Convex mutation transaction.
- Adds a patch changeset for the touched packages.

## Review Evidence

- Local Codex blocker review pass 1: no blocker findings after ClickHouse/Cloudflare KV fail-closed fixes.
- Local Codex final review pass: no blocker findings after Convex null-serialization fix.
- CodeRabbit CLI final pass: no findings.
- CodeRabbit CLI earlier noted a minor Lance empty-patch consistency issue; production callers always send non-empty claim/restore patches, so this is not a PF-548 merge blocker.

## Validation

- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/core exec vitest run src/background-tasks/manager.test.ts src/storage/domains/background-tasks/__tests__/inmemory.test.ts`
- `pnpm --filter ./packages/core exec vitest run src/storage/domains/background-tasks/__tests__/inmemory.test.ts`
- `pnpm --filter @mastra/libsql --filter @mastra/pg --filter @mastra/mongodb --filter @mastra/dynamodb --filter @mastra/cloudflare-d1 --filter @mastra/cloudflare --filter @mastra/redis --filter @mastra/upstash --filter @mastra/clickhouse --filter @mastra/mssql --filter @mastra/convex --filter @mastra/lance build:lib`
- Individual affected-store `build:lib` checks rerun during final review for `@mastra/libsql`, `@mastra/pg`, `@mastra/mongodb`, `@mastra/upstash`, `@mastra/convex`, `@mastra/dynamodb`, `@mastra/cloudflare-d1`, `@mastra/cloudflare`, `@mastra/mssql`, `@mastra/lance`, and `@mastra/clickhouse`
- `pnpm --dir stores/convex exec eslint src/server/storage.ts src/storage/db/index.ts src/storage/domains/background-tasks/index.ts src/storage/types.ts`
- `pnpm --dir packages/core exec eslint src/background-tasks/manager.ts src/storage/domains/background-tasks/base.ts src/storage/domains/background-tasks/inmemory.ts src/storage/domains/background-tasks/__tests__/inmemory.test.ts`
- `pnpm exec prettier --check ...`
- `git diff --check origin/main`

## Notes

This PR intentionally does not try to emulate CAS for Cloudflare KV or ClickHouse. Those adapters now fail closed for background-task conditional claims instead of risking duplicate execution or stale status resurrection. Cloudflare Durable Objects/D1 and transactional stores are the safe production paths for background-task dispatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Multiple workers could stomp on the same task by updating it at the wrong time. This PR makes workers check the task's current state before changing it, and only apply updates if the task is still in the expected state—so no accidental overwrites or races.

---

## Overview

Adds atomic, conditional background-task updates across the storage layer to prevent concurrent workers from overwriting task state transitions (completed, failed, suspended, etc.). Introduces BackgroundTasksStorage.updateTaskIfStatus (fail-closed by default) and plumbs it into BackgroundTaskManager dispatch, resume, and restore flows so claims and restores occur only when the stored status matches the expected value.

## Changes to Core Task Manager

- Dispatch now uses storage.updateTaskIfStatus to atomically claim pending → running and to conditionally restore running → pending on shutdown (only if still running). If claim fails, dispatch returns early and local per-task context is retained until the task is truly gone or terminal.
- Resume uses storage.updateTaskIfStatus to conditionally restore running → suspended and to claim suspended → running; if the claim fails, resume aborts without publishing lifecycle events.
- Uses a shared isTerminalBackgroundTaskStatus helper and routes task.cancelled events to handleCancel.

## Storage Layer

- Base: Adds BackgroundTasksStorage.updateTaskIfStatus(taskId, expectedStatus, update) as a concrete method that by default throws a NOT_SUPPORTED MastraError (fail-closed).
- Implementations that provide safe atomic conditionals:
  - InMemory, PostgreSQL (PG), LibSQL, MSSQL, MongoDB, DynamoDB, Lance, Upstash (Redis via eval/Lua), Cloudflare D1, Cloudflare Durable Objects, Convex — each implements updateTaskIfStatus using database/adapter-specific atomic conditional update logic (dynamic SET/patch construction, JSON serialization, ISO timestamps, and proper null handling).
- Fail-closed adapters:
  - Cloudflare KV and ClickHouse explicitly fail/throw for updateTaskIfStatus because they cannot safely provide the required atomic claim contract.

## Convex-specific work

- Adds a storage operation updateIfFieldEquals and ConvexDB.updateIfFieldEquals.
- Implements Convex background-tasks serialization helpers (serializeJsonUpdate, toStoredUpdate) and updateTaskIfStatus using updateIfFieldEquals; documents that check+patch occurs inside a single Convex mutation transaction and preserves clears over JSON transport.

## Tests and Test Harness

- Adds unit tests for updateTaskIfStatus (in-memory) and extends background-task manager tests to ensure contexts are retained on claim contention and cleared only when appropriate.
- Test harness gained a capability flag backgroundTasksUpdateIfStatus to run conditional-update tests only for adapters that support it. ClickHouse and Cloudflare KV test suites are configured with this capability set to false.

## Validation & CI

- Local Codex/CodeRabbit runs and final reviews passed after fixes; multiple build/test commands across core and adapter packages were executed; ESLint/Prettier and git diff --check against origin/main were run.
- Adds changesets to publish patch releases for affected packages.

## Notes & Compatibility

- The PR intentionally does not emulate CAS for adapters that lack atomic conditionals; such adapters now fail closed for conditional background-task claims. Durable/transactional stores (e.g., Cloudflare Durable Objects/D1, Convex, transactional DBs) are recommended production paths for background-task dispatch requiring atomic claims.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->