### PR TITLE
[PF-375] Harden background task recovery and shutdown

### DIFF
--- a/.changeset/curly-wasps-call.md
+++ b/.changeset/curly-wasps-call.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Hardened background task recovery so crashed or shutdown workers do not incorrectly time out durable work.
+Fixed background task recovery so crashed or shutdown workers do not incorrectly mark durable work as timed out.

--- a/.changeset/curly-wasps-call.md
+++ b/.changeset/curly-wasps-call.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Hardened background task recovery so crashed or shutdown workers do not incorrectly time out durable work.

--- a/packages/core/src/background-tasks/manager.test.ts
+++ b/packages/core/src/background-tasks/manager.test.ts
@@ -1213,6 +1213,42 @@ describe('BackgroundTaskManager', () => {
       }
     });
 
+    it('retries recovery after a transient storage failure', async () => {
+      vi.useFakeTimers();
+      const seedStorage = new MockStore();
+      const bgStore = await seedStorage.getStore('backgroundTasks');
+      await bgStore!.createTask({
+        id: 'recovery-after-error',
+        status: 'running',
+        toolName: 'missing-tool',
+        toolCallId: 'c',
+        args: {},
+        agentId: 'a',
+        runId: 'r',
+        retryCount: 0,
+        maxRetries: 0,
+        timeoutMs: 5,
+        createdAt: new Date(),
+        startedAt: new Date(Date.now() - 60_000),
+      });
+      const listTasks = vi.spyOn(bgStore!, 'listTasks').mockRejectedValueOnce(new Error('temporary storage failure'));
+
+      try {
+        await withRecoveringManager(seedStorage, async () => {
+          expect((await bgStore!.getTask('recovery-after-error'))?.status).toBe('running');
+
+          await vi.advanceTimersByTimeAsync(60_000);
+
+          const failed = await bgStore!.getTask('recovery-after-error');
+          expect(failed?.status).toBe('failed');
+          expect(failed?.error?.message).toContain('could not be recovered after restart');
+        });
+      } finally {
+        listTasks.mockRestore();
+        vi.useRealTimers();
+      }
+    });
+
     it('re-dispatches stale pending tasks on init', async () => {
       const seedStorage = new MockStore();
       const local = new Mastra({

--- a/packages/core/src/background-tasks/manager.test.ts
+++ b/packages/core/src/background-tasks/manager.test.ts
@@ -50,6 +50,27 @@ async function makeLocalManager(config: BackgroundTaskManagerConfig) {
   };
 }
 
+async function withRecoveringManager<T>(
+  seedStorage: MockStore,
+  fn: (args: { mgr: BackgroundTaskManager; bgStore: NonNullable<Awaited<ReturnType<MockStore['getStore']>>> }) => T,
+): Promise<Awaited<T>> {
+  const bgStore = await seedStorage.getStore('backgroundTasks');
+  const localMastra = new Mastra({ logger: false, storage: seedStorage });
+  await localMastra.startWorkers();
+  const isolatedPubsub = new EventEmitterPubSub();
+  const mgr = new BackgroundTaskManager({ enabled: true });
+  mgr.__registerMastra(localMastra);
+
+  try {
+    await mgr.init(isolatedPubsub);
+    return await fn({ mgr, bgStore: bgStore! });
+  } finally {
+    await mgr.shutdown();
+    await isolatedPubsub.close();
+    await localMastra.stopWorkers();
+  }
+}
+
 describe('BackgroundTaskManager', () => {
   let pubsub: EventEmitterPubSub;
   let manager: BackgroundTaskManager;
@@ -1043,9 +1064,152 @@ describe('BackgroundTaskManager', () => {
         const completed = await mgr.getTask('stale-1');
         expect(completed?.status).toBe('completed');
         expect(completed?.result).toBe('recovered');
+        expect(completed?.retryCount).toBe(1);
       } finally {
         await local.backgroundTaskManager?.shutdown();
         await local.stopWorkers();
+      }
+    });
+
+    it('fails expired running tasks when no executor can be reconstructed', async () => {
+      const seedStorage = new MockStore();
+      const bgStore = await seedStorage.getStore('backgroundTasks');
+      await bgStore!.createTask({
+        id: 'expired-no-executor',
+        status: 'running',
+        toolName: 'missing-tool',
+        toolCallId: 'c',
+        args: {},
+        agentId: 'a',
+        runId: 'r',
+        retryCount: 0,
+        maxRetries: 1,
+        timeoutMs: 5,
+        createdAt: new Date(),
+        startedAt: new Date(Date.now() - 60_000),
+      });
+
+      await withRecoveringManager(seedStorage, async () => {
+        const failed = await bgStore!.getTask('expired-no-executor');
+        expect(failed?.status).toBe('failed');
+        expect(failed?.error?.message).toContain('could not be recovered after restart');
+      });
+    });
+
+    it('leaves unexpired running tasks without an executor untouched', async () => {
+      const seedStorage = new MockStore();
+      const bgStore = await seedStorage.getStore('backgroundTasks');
+      await bgStore!.createTask({
+        id: 'active-elsewhere',
+        status: 'running',
+        toolName: 'missing-tool',
+        toolCallId: 'c',
+        args: {},
+        agentId: 'a',
+        runId: 'r',
+        retryCount: 0,
+        maxRetries: 1,
+        timeoutMs: 60_000,
+        createdAt: new Date(),
+        startedAt: new Date(),
+      });
+
+      await withRecoveringManager(seedStorage, async () => {
+        const stillRunning = await bgStore!.getTask('active-elsewhere');
+        expect(stillRunning?.status).toBe('running');
+        expect(stillRunning?.error).toBeUndefined();
+      });
+    });
+
+    it('rechecks unexpired running tasks after their timeout window expires', async () => {
+      vi.useFakeTimers();
+      const seedStorage = new MockStore();
+      const bgStore = await seedStorage.getStore('backgroundTasks');
+      await bgStore!.createTask({
+        id: 'active-then-expired',
+        status: 'running',
+        toolName: 'missing-tool',
+        toolCallId: 'c',
+        args: {},
+        agentId: 'a',
+        runId: 'r',
+        retryCount: 0,
+        maxRetries: 1,
+        timeoutMs: 20,
+        createdAt: new Date(),
+        startedAt: new Date(),
+      });
+
+      try {
+        await withRecoveringManager(seedStorage, async () => {
+          expect((await bgStore!.getTask('active-then-expired'))?.status).toBe('running');
+
+          await vi.advanceTimersByTimeAsync(21);
+
+          const failed = await bgStore!.getTask('active-then-expired');
+          expect(failed?.status).toBe('failed');
+          expect(failed?.error?.message).toContain('could not be recovered after restart');
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not fail pending tasks when no executor is available on this process', async () => {
+      const seedStorage = new MockStore();
+      const bgStore = await seedStorage.getStore('backgroundTasks');
+      await bgStore!.createTask({
+        id: 'pending-no-executor',
+        status: 'pending',
+        toolName: 'missing-tool',
+        toolCallId: 'c',
+        args: {},
+        agentId: 'a',
+        runId: 'r',
+        retryCount: 0,
+        maxRetries: 1,
+        timeoutMs: 5000,
+        createdAt: new Date(),
+      });
+
+      await withRecoveringManager(seedStorage, async () => {
+        const stillPending = await bgStore!.getTask('pending-no-executor');
+        expect(stillPending?.status).toBe('pending');
+        expect(stillPending?.error).toBeUndefined();
+      });
+    });
+
+    it('leaves stale running tasks untouched when recovery CAS loses', async () => {
+      const seedStorage = new MockStore();
+      const bgStore = await seedStorage.getStore('backgroundTasks');
+      await bgStore!.createTask({
+        id: 'recovery-cas-race',
+        status: 'running',
+        toolName: 'missing-tool',
+        toolCallId: 'c',
+        args: {},
+        agentId: 'a',
+        runId: 'r',
+        retryCount: 0,
+        maxRetries: 0,
+        timeoutMs: 5,
+        createdAt: new Date(),
+        startedAt: new Date(Date.now() - 60_000),
+      });
+      const update = vi.spyOn(bgStore!, 'updateTaskIfStatus').mockResolvedValueOnce(false);
+
+      try {
+        await withRecoveringManager(seedStorage, async () => {
+          expect(update).toHaveBeenCalledWith(
+            'recovery-cas-race',
+            'running',
+            expect.objectContaining({ status: 'failed' }),
+          );
+          const stillRunning = await bgStore!.getTask('recovery-cas-race');
+          expect(stillRunning?.status).toBe('running');
+        });
+      } finally {
+        update.mockRestore();
       }
     });
 
@@ -1513,6 +1677,43 @@ describe('BackgroundTaskManager', () => {
       await expect(
         manager.enqueue({ toolName: 'tool', toolCallId: 'c1', args: {}, agentId: 'a1', runId: 'run-1' }),
       ).rejects.toThrow('shutting down');
+    });
+
+    it('aborts active task controllers during shutdown', async () => {
+      let taskSignal: AbortSignal | undefined;
+      let sawAbort!: () => void;
+      const abortSeen = new Promise<void>(resolve => {
+        sawAbort = resolve;
+      });
+      const executeFn = vi.fn(
+        (_args: any, opts: { abortSignal: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            taskSignal = opts.abortSignal;
+            opts.abortSignal.addEventListener(
+              'abort',
+              () => {
+                sawAbort();
+                reject(new Error('aborted-by-shutdown'));
+              },
+              { once: true },
+            );
+          }),
+      );
+
+      const { task } = await manager.enqueue(
+        { toolName: 'slow-shutdown-tool', toolCallId: 'c1', args: {}, agentId: 'a1', runId: 'run-1' },
+        ctx(executeFn),
+      );
+      await tick();
+      expect((await manager.getTask(task.id))?.status).toBe('running');
+
+      await manager.shutdown();
+      await abortSeen;
+      await tick(100);
+
+      expect(taskSignal?.aborted).toBe(true);
+      expect(manager.activeAbortControllers.size).toBe(0);
+      expect((await manager.getTask(task.id))?.status).toBe('running');
     });
   });
 });

--- a/packages/core/src/background-tasks/manager.test.ts
+++ b/packages/core/src/background-tasks/manager.test.ts
@@ -1751,5 +1751,80 @@ describe('BackgroundTaskManager', () => {
       expect(manager.activeAbortControllers.size).toBe(0);
       expect((await manager.getTask(task.id))?.status).toBe('running');
     });
+
+    it('does not complete a task when the executor resolves after shutdown abort', async () => {
+      let taskSignal: AbortSignal | undefined;
+      let sawAbort!: () => void;
+      const abortSeen = new Promise<void>(resolve => {
+        sawAbort = resolve;
+      });
+      const executeFn = vi.fn(
+        (_args: any, opts: { abortSignal: AbortSignal }) =>
+          new Promise(resolve => {
+            taskSignal = opts.abortSignal;
+            opts.abortSignal.addEventListener(
+              'abort',
+              () => {
+                sawAbort();
+                resolve('resolved-after-shutdown');
+              },
+              { once: true },
+            );
+          }),
+      );
+
+      const { task } = await manager.enqueue(
+        { toolName: 'shutdown-resolve-tool', toolCallId: 'c1', args: {}, agentId: 'a1', runId: 'run-1' },
+        ctx(executeFn),
+      );
+      await tick();
+      expect((await manager.getTask(task.id))?.status).toBe('running');
+
+      await manager.shutdown();
+      await abortSeen;
+      await tick(100);
+
+      expect(taskSignal?.aborted).toBe(true);
+      expect((await manager.getTask(task.id))?.status).toBe('running');
+    });
+
+    it('does not suspend a task when the executor reacts to shutdown abort by suspending', async () => {
+      let taskSignal: AbortSignal | undefined;
+      let sawAbort!: () => void;
+      const abortSeen = new Promise<void>(resolve => {
+        sawAbort = resolve;
+      });
+      const executeFn = vi.fn(
+        (_args: any, opts: { abortSignal: AbortSignal; suspend: (data?: unknown) => Promise<void> }) =>
+          new Promise(resolve => {
+            taskSignal = opts.abortSignal;
+            opts.abortSignal.addEventListener(
+              'abort',
+              async () => {
+                await opts.suspend({ after: 'shutdown' });
+                sawAbort();
+                resolve('resolved-after-shutdown-suspend');
+              },
+              { once: true },
+            );
+          }),
+      );
+
+      const { task } = await manager.enqueue(
+        { toolName: 'shutdown-suspend-tool', toolCallId: 'c1', args: {}, agentId: 'a1', runId: 'run-1' },
+        ctx(executeFn),
+      );
+      await tick();
+      expect((await manager.getTask(task.id))?.status).toBe('running');
+
+      await manager.shutdown();
+      await abortSeen;
+      await tick(100);
+
+      const current = await manager.getTask(task.id);
+      expect(taskSignal?.aborted).toBe(true);
+      expect(current?.status).toBe('running');
+      expect(current?.suspendPayload).toBeUndefined();
+    });
   });
 });

--- a/packages/core/src/background-tasks/manager.ts
+++ b/packages/core/src/background-tasks/manager.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import type { Mastra } from '..';
 import type { PubSub } from '../events/pubsub';
 import type { Event, EventCallback } from '../events/types';
+import { BACKGROUND_TASK_SHUTDOWN_ABORT_MESSAGE } from './shutdown';
 import type {
   BackgroundTask,
   BackgroundTaskManagerConfig,
@@ -22,6 +23,13 @@ const WORKER_GROUP = 'background-task-workers';
 
 const isTerminalBackgroundTaskStatus = (status: BackgroundTaskStatus) =>
   status === 'completed' || status === 'failed' || status === 'cancelled' || status === 'timed_out';
+
+const createUnrecoverableTaskError = (task: BackgroundTask): { message: string } => ({
+  message:
+    `Background task "${task.id}" for tool "${task.toolName}" could not be recovered after restart because ` +
+    `no local task context or registered static executor is available. Closure-backed tasks must stay behind ` +
+    `an owning durable Harness row that can retry or repair the work.`,
+});
 
 export class BackgroundTaskManager {
   private pubsub!: PubSub;
@@ -55,6 +63,7 @@ export class BackgroundTaskManager {
 
   // Cleanup interval handle
   private cleanupInterval?: ReturnType<typeof setInterval>;
+  private recoveryTimer?: ReturnType<typeof setTimeout>;
 
   // Tracks the in-flight `init(pubsub)` so consumers can await readiness.
   // Mastra fires init as fire-and-forget in `#ensureBackgroundTaskManager`,
@@ -212,6 +221,21 @@ export class BackgroundTaskManager {
    */
   getStaticExecutor(toolName: string): ToolExecutor | undefined {
     return this.staticExecutors.get(toolName);
+  }
+
+  /** @internal — read by workflow step bodies before starting local execution. */
+  isShuttingDown(): boolean {
+    return this.shuttingDown;
+  }
+
+  private canResolveTaskExecutor(task: BackgroundTask): boolean {
+    return this.taskContexts.has(task.id) || this.staticExecutors.has(task.toolName);
+  }
+
+  private isRunningTaskExpired(task: BackgroundTask, now: Date): boolean {
+    if (!task.startedAt) return true;
+    const expiresAt = task.startedAt.getTime() + task.timeoutMs;
+    return Number.isFinite(expiresAt) && expiresAt <= now.getTime();
   }
 
   // --- Core operations ---
@@ -727,6 +751,10 @@ export class BackgroundTaskManager {
       clearInterval(this.cleanupInterval);
       this.cleanupInterval = undefined;
     }
+    if (this.recoveryTimer) {
+      clearTimeout(this.recoveryTimer);
+      this.recoveryTimer = undefined;
+    }
 
     if (this.workerCallback) {
       await this.pubsub.unsubscribe(TOPIC_DISPATCH, this.workerCallback);
@@ -734,6 +762,14 @@ export class BackgroundTaskManager {
     if (this.resultCallback) {
       await this.pubsub.unsubscribe(TOPIC_RESULT, this.resultCallback);
     }
+
+    const shutdownError = new Error(BACKGROUND_TASK_SHUTDOWN_ABORT_MESSAGE);
+    for (const controller of this.activeAbortControllers.values()) {
+      if (!controller.signal.aborted) {
+        controller.abort(shutdownError);
+      }
+    }
+    this.activeAbortControllers.clear();
 
     this.taskContexts.clear();
     await this.pubsub.flush();
@@ -807,7 +843,7 @@ export class BackgroundTaskManager {
     const claimed = await storage.updateTaskIfStatus(taskId, 'pending', {
       status: 'running',
       startedAt: new Date(),
-      retryCount: deliveryAttempt - 1,
+      retryCount: Math.max(task.retryCount, deliveryAttempt - 1),
     });
     if (!claimed) {
       const latestTask = await storage.getTask(taskId);
@@ -1250,20 +1286,35 @@ export class BackgroundTaskManager {
   private async recoverStaleTasks(): Promise<void> {
     try {
       if (this.shuttingDown) return;
+      if (this.recoveryTimer) {
+        clearTimeout(this.recoveryTimer);
+        this.recoveryTimer = undefined;
+      }
 
       const storage = await this.getStorage();
       const { tasks: staleTasks } = await storage.listTasks({ status: 'running' });
+      const now = new Date();
+      let nextRecoveryAt: number | undefined;
       for (const task of staleTasks) {
         if (this.shuttingDown) return;
-        if (task.maxRetries > 0) {
-          await storage.updateTask(task.id, {
+        if (!this.isRunningTaskExpired(task, now)) {
+          const retryAt = task.startedAt ? task.startedAt.getTime() + task.timeoutMs : now.getTime();
+          nextRecoveryAt = Math.min(nextRecoveryAt ?? retryAt, retryAt);
+          continue;
+        }
+
+        if (task.retryCount < task.maxRetries && this.canResolveTaskExecutor(task)) {
+          await storage.updateTaskIfStatus(task.id, 'running', {
             status: 'pending',
             startedAt: undefined,
+            retryCount: task.retryCount + 1,
           });
         } else {
-          await storage.updateTask(task.id, {
+          await storage.updateTaskIfStatus(task.id, 'running', {
             status: 'failed',
-            error: { message: 'Worker process terminated before task completed' },
+            error: this.canResolveTaskExecutor(task)
+              ? { message: 'Worker process terminated before task completed' }
+              : createUnrecoverableTaskError(task),
             completedAt: new Date(),
           });
         }
@@ -1276,15 +1327,26 @@ export class BackgroundTaskManager {
       });
       for (const task of pendingTasks) {
         if (this.shuttingDown) return;
+        if (!this.canResolveTaskExecutor(task)) continue;
         if (await this.checkConcurrency(task.agentId)) {
           await this.dispatch(task);
         }
       }
+      this.scheduleRecovery(nextRecoveryAt, now.getTime());
     } catch (error) {
       const logger = this.#mastra?.getLogger();
       if (logger) {
         logger.error('Failed to recover stale background tasks', error);
       }
     }
+  }
+
+  private scheduleRecovery(retryAt: number | undefined, nowMs: number): void {
+    if (this.shuttingDown || retryAt === undefined) return;
+    const delayMs = Math.min(Math.max(retryAt - nowMs, 0), 2_147_483_647);
+    this.recoveryTimer = setTimeout(() => {
+      this.recoveryTimer = undefined;
+      void this.recoverStaleTasks();
+    }, delayMs);
   }
 }

--- a/packages/core/src/background-tasks/manager.ts
+++ b/packages/core/src/background-tasks/manager.ts
@@ -20,6 +20,7 @@ import { BACKGROUND_TASK_WORKFLOW_ID } from './workflow-id';
 const TOPIC_DISPATCH = 'background-tasks';
 const TOPIC_RESULT = 'background-tasks-result';
 const WORKER_GROUP = 'background-task-workers';
+const RECOVERY_ERROR_RETRY_MS = 60_000;
 
 const isTerminalBackgroundTaskStatus = (status: BackgroundTaskStatus) =>
   status === 'completed' || status === 'failed' || status === 'cancelled' || status === 'timed_out';
@@ -1284,6 +1285,7 @@ export class BackgroundTaskManager {
    * Recovers tasks left in 'running' or 'pending' state from a previous process.
    */
   private async recoverStaleTasks(): Promise<void> {
+    let nextRecoveryAt: number | undefined;
     try {
       if (this.shuttingDown) return;
       if (this.recoveryTimer) {
@@ -1294,7 +1296,6 @@ export class BackgroundTaskManager {
       const storage = await this.getStorage();
       const { tasks: staleTasks } = await storage.listTasks({ status: 'running' });
       const now = new Date();
-      let nextRecoveryAt: number | undefined;
       for (const task of staleTasks) {
         if (this.shuttingDown) return;
         if (!this.isRunningTaskExpired(task, now)) {
@@ -1332,11 +1333,15 @@ export class BackgroundTaskManager {
           await this.dispatch(task);
         }
       }
-      this.scheduleRecovery(nextRecoveryAt, now.getTime());
     } catch (error) {
       const logger = this.#mastra?.getLogger();
       if (logger) {
         logger.error('Failed to recover stale background tasks', error);
+      }
+      nextRecoveryAt = Date.now() + RECOVERY_ERROR_RETRY_MS;
+    } finally {
+      if (!this.recoveryTimer) {
+        this.scheduleRecovery(nextRecoveryAt, Date.now());
       }
     }
   }

--- a/packages/core/src/background-tasks/shutdown.ts
+++ b/packages/core/src/background-tasks/shutdown.ts
@@ -1,0 +1,1 @@
+export const BACKGROUND_TASK_SHUTDOWN_ABORT_MESSAGE = 'BackgroundTaskManager shutting down';

--- a/packages/core/src/background-tasks/workflow.ts
+++ b/packages/core/src/background-tasks/workflow.ts
@@ -110,6 +110,12 @@ export function buildBackgroundTaskWorkflow(manager: BackgroundTaskManager) {
 
       const abortController = new AbortController();
       manager.activeAbortControllers.set(taskId, abortController);
+      if (manager.isShuttingDown()) {
+        abortController.abort(new Error(BACKGROUND_TASK_SHUTDOWN_ABORT_MESSAGE));
+        manager.activeAbortControllers.delete(taskId);
+        manager.deregisterTaskContext(taskId);
+        return { taskId, outcome: 'cancelled' as const };
+      }
       // Wire the workflow's run-level abort signal into our local controller
       // so `workflow.getRun(taskId).cancel()` propagates to the executor.
       const onWorkflowAbort = () => abortController.abort(new Error('Task cancelled'));

--- a/packages/core/src/background-tasks/workflow.ts
+++ b/packages/core/src/background-tasks/workflow.ts
@@ -127,6 +127,10 @@ export function buildBackgroundTaskWorkflow(manager: BackgroundTaskManager) {
       const timeoutHandle = setTimeout(() => {
         abortController.abort(new Error(`Task timed out after ${task.timeoutMs}ms`));
       }, task.timeoutMs);
+      const wasShutdownAbort = () =>
+        abortController.signal.aborted &&
+        abortController.signal.reason instanceof Error &&
+        abortController.signal.reason.message === BACKGROUND_TASK_SHUTDOWN_ABORT_MESSAGE;
 
       // Wrap the workflow runtime's `suspend` so we persist
       // `status: 'suspended'` + `suspendPayload`, fire the per-task
@@ -140,6 +144,7 @@ export function buildBackgroundTaskWorkflow(manager: BackgroundTaskManager) {
       // tool's call.
       let pendingSuspend: { data?: unknown; suspendOptions?: SuspendOptions } | undefined;
       const wrappedSuspend = async (data?: unknown, suspendOptions?: SuspendOptions) => {
+        if (wasShutdownAbort()) return;
         await storage.updateTask(taskId, {
           status: 'suspended',
           suspendPayload: data,
@@ -171,6 +176,11 @@ export function buildBackgroundTaskWorkflow(manager: BackgroundTaskManager) {
           return suspend(pendingSuspend.data, pendingSuspend.suspendOptions as SuspendOptions);
         }
 
+        if (wasShutdownAbort()) {
+          manager.deregisterTaskContext(taskId);
+          return { taskId, outcome: 'cancelled' as const };
+        }
+
         return { taskId, outcome: 'success' as const, result };
       } catch (error: any) {
         const currentTask = await storage.getTask(taskId);
@@ -182,11 +192,7 @@ export function buildBackgroundTaskWorkflow(manager: BackgroundTaskManager) {
         // Shutdown aborts are local process teardown, not task timeouts. Other
         // aborted-signal exits are treated as timeouts; explicit cancellation is
         // already handled by the storage-status check above.
-        if (
-          abortController.signal.aborted &&
-          abortController.signal.reason instanceof Error &&
-          abortController.signal.reason.message === BACKGROUND_TASK_SHUTDOWN_ABORT_MESSAGE
-        ) {
+        if (wasShutdownAbort()) {
           manager.deregisterTaskContext(taskId);
           return { taskId, outcome: 'cancelled' as const };
         }

--- a/packages/core/src/background-tasks/workflow.ts
+++ b/packages/core/src/background-tasks/workflow.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import type { SuspendOptions } from '../workflows';
 import { createStep, createWorkflow } from '../workflows/evented';
 import type { BackgroundTaskManager } from './manager';
+import { BACKGROUND_TASK_SHUTDOWN_ABORT_MESSAGE } from './shutdown';
 import type { BackgroundTaskStatus } from './types';
 import { BACKGROUND_TASK_WORKFLOW_ID } from './workflow-id';
 
@@ -59,6 +60,10 @@ export function buildBackgroundTaskWorkflow(manager: BackgroundTaskManager) {
       const storage = await manager.getStorage();
       const task = await storage.getTask(taskId);
       if (!task || task.status === 'cancelled') {
+        manager.deregisterTaskContext(taskId);
+        return { taskId, outcome: 'cancelled' as const };
+      }
+      if (manager.isShuttingDown()) {
         manager.deregisterTaskContext(taskId);
         return { taskId, outcome: 'cancelled' as const };
       }
@@ -168,11 +173,18 @@ export function buildBackgroundTaskWorkflow(manager: BackgroundTaskManager) {
           return { taskId, outcome: 'cancelled' as const };
         }
 
-        // Treat any aborted-signal exit as a timeout. The cancel path is
-        // already handled by the storage-status check above, so if we reach
-        // here with `signal.aborted`, it's the timeout abort. The
-        // `AbortError` / message checks are belt-and-braces for executors
-        // that throw their own abort error instead of propagating ours.
+        // Shutdown aborts are local process teardown, not task timeouts. Other
+        // aborted-signal exits are treated as timeouts; explicit cancellation is
+        // already handled by the storage-status check above.
+        if (
+          abortController.signal.aborted &&
+          abortController.signal.reason instanceof Error &&
+          abortController.signal.reason.message === BACKGROUND_TASK_SHUTDOWN_ABORT_MESSAGE
+        ) {
+          manager.deregisterTaskContext(taskId);
+          return { taskId, outcome: 'cancelled' as const };
+        }
+
         if (
           abortController.signal.aborted ||
           error?.name === 'AbortError' ||


### PR DESCRIPTION
## Summary
- expire and recover only timed-out running background tasks, leaving active rows for the owning process
- use CAS for running-task recovery, preserve retry budget, and skip pending tasks without a local/static executor
- abort active task controllers during shutdown without rewriting durable rows as timeouts
- add focused recovery/shutdown coverage and an @mastra/core patch changeset

## Linear
PF-375

## Overlap
Fresh `gh pr list --repo mbenhamd/mastra --state open` returned no open PRs before this PR was created.

## Validation
- `pnpm --filter ./packages/core exec vitest run src/background-tasks/manager.test.ts`
- `pnpm --filter ./packages/core exec eslint src/background-tasks/manager.ts src/background-tasks/workflow.ts src/background-tasks/types.ts src/background-tasks/shutdown.ts src/background-tasks/manager.test.ts`
- `pnpm --filter @internal/external-types build:lib` then `pnpm --filter ./packages/core check`
- `git diff --check`
- local Codex correctness/concurrency review: no findings
- local Codex tests/maintainability review: findings fixed, post-fix sanity review found no BLOCKER/REVIEW issues
- `coderabbit review --plain`: no findings

## Notes
Claude council CLI stalled without output and was killed; Gemini council review completed earlier and its valid findings are reflected in this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes background jobs safer: when a worker crashes or the manager stops, only truly timed-out work is retried or failed, in-progress work is aborted cleanly without being misclassified, and recovery is more race-resistant so tasks aren't lost or double-run.

## Summary

Hardens background task recovery and shutdown behavior in `@mastra/core` by:
- Only expiring/recovering running tasks that have actually timed out; leaving unexpired tasks owned by live processes alone.
- Using CAS-style (compare-and-swap) updates during recovery to avoid races, preserve retry budgets, and handle transient storage failures.
- Skipping recovery of pending tasks when no local/static executor can be reconstructed.
- Aborting in-flight task AbortControllers during manager shutdown and treating shutdown-initiated aborts as cancellation (without rewriting durable rows as timeouts). Introduces a distinct BACKGROUND_TASK_SHUTDOWN_ABORT_MESSAGE constant and a wasShutdownAbort helper.
- Adding recovery scheduling/cleanup via a recoveryTimer/nextRecoveryAt mechanism and exposing isShuttingDown().
- Refining retry accounting (retryCount = Math.max(task.retryCount, deliveryAttempt - 1)) so retries are preserved across recovery.
- Expanding tests to cover focused recovery and shutdown scenarios (CAS races, timer-driven rechecks, executor-unavailable cases, retry-on-transient-failure, and shutdown abort behaviors including executor responses to aborts).
- Bumping `@mastra/core` via a patch changeset.

## Changes by File

- .changeset/curly-wasps-call.md
  - Patch changeset for `@mastra/core` noting hardened background task recovery.

- packages/core/src/background-tasks/shutdown.ts
  - Added exported constant BACKGROUND_TASK_SHUTDOWN_ABORT_MESSAGE ('BackgroundTaskManager shutting down').

- packages/core/src/background-tasks/workflow.ts
  - Added initial and post-controller shutdown checks; registers per-task AbortControllers; treats shutdown aborts as 'cancelled' and uses wasShutdownAbort to classify shutdown vs. timeout/abort; ensures proper deregistration and cleanup on shutdown.

- packages/core/src/background-tasks/manager.ts
  - Added public isShuttingDown() method.
  - On shutdown(), aborts all active AbortControllers and clears the controller map; clears any scheduled recovery timer.
  - Introduced recoveryTimer/nextRecoveryAt scheduling and helper predicates (canResolveTaskExecutor, isRunningTaskExpired) and createUnrecoverableTaskError().
  - Refined retry accounting to preserve retry budgets.
  - Refactored recoverStaleTasks() to:
    - schedule/clear recovery passes,
    - only recover tasks when an executor can be resolved,
    - use CAS-safe transitions to move eligible tasks back to pending (clearing startedAt and incrementing retryCount) or mark truly expired tasks as failed with distinct errors,
    - dispatch eligible pending tasks after recovery gating.

- packages/core/src/background-tasks/manager.test.ts
  - Added withRecoveringManager test helper.
  - Reworked/expanded recovery-on-startup tests to cover:
    - expired running → failed with unrecoverable error,
    - unexpired running → remains running,
    - fake-timer-driven rechecks causing later expiry,
    - pending tasks remain pending when no executor is available,
    - CAS race where recovery loses leaves task running,
    - transient storage failures retried before eventual failure.
  - Extended shutdown tests with additional cases:
    - executor that resolves only after shutdown abort leaves task running (not completed),
    - executor that responds to shutdown by suspending leaves task running with suspendPayload cleared/undefined.
  - Existing abort-controller assertions retained and ensured active controllers are cleared after shutdown.

## Validation

- Unit tests: vitest run src/background-tasks/manager.test.ts
- Linting: ESLint on modified background-task files
- Build/type-check: pnpm --filter `@internal/external-types` build:lib and pnpm --filter ./packages/core check
- git diff --check passed
- Local reviews: Codex/Gemini council reviews addressed; coderabbit review returned no findings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->