### PR TITLE
[PF-546] Fail closed legacy agent FGA execution

### DIFF
--- a/.changeset/fine-garlics-shine.md
+++ b/.changeset/fine-garlics-shine.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed authorization and request-context checks in legacy agent execution methods.
+
+`generateLegacy()` and `streamLegacy()` now enforce the same authorization and request-context rules as `generate()` and `stream()`. When Fine-Grained Authorization (FGA) is enabled, these legacy methods require an authorized user in the request context and throw `FGADeniedError` when authorization fails. Agents with a request context schema now validate that schema before legacy execution. Behavior is unchanged for legacy calls that use neither FGA nor a request context schema.

--- a/packages/core/src/agent/__tests__/agent-fga.test.ts
+++ b/packages/core/src/agent/__tests__/agent-fga.test.ts
@@ -1,6 +1,7 @@
 /**
  * @license Mastra Enterprise License - see ee/LICENSE
  */
+import { simulateReadableStream, MockLanguageModelV1 } from '@internal/ai-sdk-v4/test';
 import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { z } from 'zod';
@@ -51,6 +52,39 @@ function createMockModel() {
       content: [{ type: 'text', text: 'ok' }],
     }),
   });
+}
+
+function createMockLegacyModel() {
+  const doGenerate = vi.fn(async () => ({
+    rawCall: { rawPrompt: null, rawSettings: {} },
+    finishReason: 'stop' as const,
+    usage: { promptTokens: 5, completionTokens: 10 },
+    text: 'ok',
+  }));
+  const doStream = vi.fn(async () => ({
+    stream: simulateReadableStream({
+      chunks: [
+        { type: 'text-delta' as const, textDelta: 'ok' },
+        {
+          type: 'finish' as const,
+          finishReason: 'stop' as const,
+          usage: { promptTokens: 5, completionTokens: 10 },
+        },
+      ],
+    }),
+    rawCall: { rawPrompt: null, rawSettings: {} },
+  }));
+
+  return Object.assign(
+    new MockLanguageModelV1({
+      doGenerate,
+      doStream,
+    }),
+    {
+      doGenerateMock: doGenerate,
+      doStreamMock: doStream,
+    },
+  );
 }
 
 function createWorkflowRunStorage({
@@ -390,6 +424,332 @@ describe('Agent FGA checks', () => {
 
       await expect(agent.stream('test')).rejects.toThrow(FGADeniedError);
       expect(fgaProvider.require).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('generateLegacy()', () => {
+    it('should call FGA provider check when FGA provider is configured', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: createMockLegacyModel(),
+      });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1', organizationMembershipId: 'om-1' });
+
+      await agent.generateLegacy('test', { requestContext: requestContext as any });
+
+      expect(fgaProvider.require).toHaveBeenCalledWith(
+        { id: 'user-1', organizationMembershipId: 'om-1' },
+        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+      );
+    });
+
+    it('should fail closed when FGA is configured and no user is present in requestContext', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const model = createMockLegacyModel();
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.generateLegacy('test')).rejects.toThrow(FGADeniedError);
+      expect(fgaProvider.require).not.toHaveBeenCalled();
+      expect(model.doGenerateMock).not.toHaveBeenCalled();
+    });
+
+    it('should fail closed before legacy structured output option validation', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const model = createMockLegacyModel();
+      const defaultGenerateOptionsLegacy = vi.fn(() => {
+        throw new Error('default options should not run');
+      });
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model,
+        defaultGenerateOptionsLegacy,
+      });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.generateLegacy('test', { structuredOutput: { schema: z.object({}) } } as any)).rejects.toThrow(
+        FGADeniedError,
+      );
+      expect(fgaProvider.require).not.toHaveBeenCalled();
+      expect(defaultGenerateOptionsLegacy).not.toHaveBeenCalled();
+      expect(model.doGenerateMock).not.toHaveBeenCalled();
+    });
+
+    it('should reject unsupported structured output before resolving legacy defaults when no preflight is configured', async () => {
+      const mastra = createMockMastra();
+      const model = createMockLegacyModel();
+      const defaultGenerateOptionsLegacy = vi.fn(() => {
+        throw new Error('default options should not run');
+      });
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model,
+        defaultGenerateOptionsLegacy,
+      });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(
+        agent.generateLegacy('test', { structuredOutput: { schema: z.object({}) } } as any),
+      ).rejects.toMatchObject({
+        id: 'AGENT_GENERATE_LEGACY_STRUCTURED_OUTPUT_NOT_SUPPORTED',
+      });
+      expect(defaultGenerateOptionsLegacy).not.toHaveBeenCalled();
+      expect(model.doGenerateMock).not.toHaveBeenCalled();
+    });
+
+    it('should throw FGADeniedError when FGA check fails', async () => {
+      const fgaProvider = createMockFGAProvider(false);
+      const mastra = createMockMastra(fgaProvider);
+      const model = createMockLegacyModel();
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+
+      await expect(agent.generateLegacy('test', { requestContext: requestContext as any })).rejects.toThrow(
+        FGADeniedError,
+      );
+      expect(model.doGenerateMock).not.toHaveBeenCalled();
+    });
+
+    it('should authorize the explicit request context over default legacy options', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const defaultRequestContext = new RequestContext();
+      defaultRequestContext.set('user', { id: 'default-user', organizationMembershipId: 'default-om' });
+      const explicitRequestContext = new RequestContext();
+      explicitRequestContext.set('user', { id: 'explicit-user', organizationMembershipId: 'explicit-om' });
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: createMockLegacyModel(),
+        defaultGenerateOptionsLegacy: { requestContext: defaultRequestContext as any },
+      });
+      (agent as any).__registerMastra(mastra);
+
+      await agent.generateLegacy('test', { requestContext: explicitRequestContext as any });
+
+      expect(fgaProvider.require).toHaveBeenCalledWith(
+        { id: 'explicit-user', organizationMembershipId: 'explicit-om' },
+        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+      );
+      expect(fgaProvider.require).toHaveBeenCalledTimes(1);
+    });
+
+    it('should authorize the effective request context from default legacy options', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'default-user', organizationMembershipId: 'default-om' });
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: createMockLegacyModel(),
+        defaultGenerateOptionsLegacy: { requestContext: requestContext as any },
+      });
+      (agent as any).__registerMastra(mastra);
+
+      await agent.generateLegacy('test');
+
+      expect(fgaProvider.require).toHaveBeenCalledWith(
+        { id: 'default-user', organizationMembershipId: 'default-om' },
+        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+      );
+      expect(fgaProvider.require).toHaveBeenCalledTimes(1);
+    });
+
+    it('should still run local legacy calls without a user when no FGA provider is configured', async () => {
+      const mastra = createMockMastra();
+      const model = createMockLegacyModel();
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model });
+      (agent as any).__registerMastra(mastra);
+
+      await agent.generateLegacy('test');
+
+      expect(model.doGenerateMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should validate request context schema before local legacy calls without FGA', async () => {
+      const mastra = createMockMastra();
+      const model = createMockLegacyModel();
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model,
+        requestContextSchema: z.object({ allowed: z.literal(true) }),
+      });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.generateLegacy('test')).rejects.toMatchObject({
+        id: 'AGENT_REQUEST_CONTEXT_VALIDATION_FAILED',
+      });
+      expect(model.doGenerateMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('streamLegacy()', () => {
+    it('should call FGA provider check when FGA provider is configured', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: createMockLegacyModel(),
+      });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1', organizationMembershipId: 'om-1' });
+
+      const stream = await agent.streamLegacy('test', { requestContext: requestContext as any });
+      await stream.consumeStream();
+
+      expect(fgaProvider.require).toHaveBeenCalledWith(
+        { id: 'user-1', organizationMembershipId: 'om-1' },
+        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+      );
+    });
+
+    it('should fail closed when FGA is configured and no user is present in requestContext', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const model = createMockLegacyModel();
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.streamLegacy('test')).rejects.toThrow(FGADeniedError);
+      expect(fgaProvider.require).not.toHaveBeenCalled();
+      expect(model.doStreamMock).not.toHaveBeenCalled();
+    });
+
+    it('should throw FGADeniedError when FGA check fails', async () => {
+      const fgaProvider = createMockFGAProvider(false);
+      const mastra = createMockMastra(fgaProvider);
+      const model = createMockLegacyModel();
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+
+      await expect(agent.streamLegacy('test', { requestContext: requestContext as any })).rejects.toThrow(
+        FGADeniedError,
+      );
+      expect(model.doStreamMock).not.toHaveBeenCalled();
+    });
+
+    it('should authorize the explicit request context over default legacy options', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const defaultRequestContext = new RequestContext();
+      defaultRequestContext.set('user', { id: 'default-user', organizationMembershipId: 'default-om' });
+      const explicitRequestContext = new RequestContext();
+      explicitRequestContext.set('user', { id: 'explicit-user', organizationMembershipId: 'explicit-om' });
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: createMockLegacyModel(),
+        defaultStreamOptionsLegacy: { requestContext: defaultRequestContext as any },
+      });
+      (agent as any).__registerMastra(mastra);
+
+      const stream = await agent.streamLegacy('test', { requestContext: explicitRequestContext as any });
+      await stream.consumeStream();
+
+      expect(fgaProvider.require).toHaveBeenCalledWith(
+        { id: 'explicit-user', organizationMembershipId: 'explicit-om' },
+        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+      );
+      expect(fgaProvider.require).toHaveBeenCalledTimes(1);
+    });
+
+    it('should authorize the effective request context from default legacy options', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'default-user', organizationMembershipId: 'default-om' });
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: createMockLegacyModel(),
+        defaultStreamOptionsLegacy: { requestContext: requestContext as any },
+      });
+      (agent as any).__registerMastra(mastra);
+
+      const stream = await agent.streamLegacy('test');
+      await stream.consumeStream();
+
+      expect(fgaProvider.require).toHaveBeenCalledWith(
+        { id: 'default-user', organizationMembershipId: 'default-om' },
+        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+      );
+      expect(fgaProvider.require).toHaveBeenCalledTimes(1);
+    });
+
+    it('should still run local legacy streams without a user when no FGA provider is configured', async () => {
+      const mastra = createMockMastra();
+      const model = createMockLegacyModel();
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model });
+      (agent as any).__registerMastra(mastra);
+
+      const stream = await agent.streamLegacy('test');
+      await stream.consumeStream();
+
+      expect(model.doStreamMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should validate request context schema before local legacy streams without FGA', async () => {
+      const mastra = createMockMastra();
+      const model = createMockLegacyModel();
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model,
+        requestContextSchema: z.object({ allowed: z.literal(true) }),
+      });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.streamLegacy('test')).rejects.toMatchObject({
+        id: 'AGENT_REQUEST_CONTEXT_VALIDATION_FAILED',
+      });
+      expect(model.doStreamMock).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/agent/agent-legacy.ts
+++ b/packages/core/src/agent/agent-legacy.ts
@@ -75,6 +75,13 @@ export interface AgentLegacyCapabilities {
   getDefaultStreamOptionsLegacy(options: {
     requestContext?: RequestContext;
   }): AgentStreamOptions | Promise<AgentStreamOptions>;
+  /**
+   * Enforce request-context schema validation and FGA before legacy execution.
+   * Throws when FGA is configured and requestContext has no user.
+   */
+  assertAgentExecutionPreflight(requestContext?: RequestContext): Promise<void>;
+  /** Whether legacy execution needs request-context schema or FGA preflight. */
+  needsAgentExecutionPreflight(): boolean;
   /** Check if agent has own memory */
   hasOwnMemory(): boolean;
   /** Get instructions */
@@ -919,18 +926,32 @@ export class AgentLegacyHandler {
     messages: MessageListInput,
     generateOptions: AgentGenerateOptions<OUTPUT, EXPERIMENTAL_OUTPUT> = {},
   ): Promise<OUTPUT extends undefined ? GenerateTextResult<any, EXPERIMENTAL_OUTPUT> : GenerateObjectResult<OUTPUT>> {
-    if ('structuredOutput' in generateOptions && generateOptions.structuredOutput) {
+    const requestContextToUse = generateOptions.requestContext;
+    if (requestContextToUse) {
+      await this.capabilities.assertAgentExecutionPreflight(requestContextToUse);
+    }
+
+    const needsExecutionPreflight = this.capabilities.needsAgentExecutionPreflight();
+    const hasStructuredOutput = 'structuredOutput' in generateOptions && generateOptions.structuredOutput;
+    const rejectLegacyStructuredOutput = () => {
       throw new MastraError({
         id: 'AGENT_GENERATE_LEGACY_STRUCTURED_OUTPUT_NOT_SUPPORTED',
         domain: ErrorDomain.AGENT,
         category: ErrorCategory.USER,
         text: 'This method does not support structured output. Please use generate() instead.',
       });
+    };
+
+    if (hasStructuredOutput) {
+      if (!requestContextToUse && needsExecutionPreflight) {
+        await this.capabilities.assertAgentExecutionPreflight(undefined);
+      }
+      rejectLegacyStructuredOutput();
     }
 
     const defaultGenerateOptionsLegacy = await Promise.resolve(
       this.capabilities.getDefaultGenerateOptionsLegacy({
-        requestContext: generateOptions.requestContext,
+        requestContext: requestContextToUse,
       }),
     );
 
@@ -941,6 +962,12 @@ export class AgentLegacyHandler {
         defaultGenerateOptionsLegacy.experimental_generateMessageId ||
         this.capabilities.mastra?.generateId?.bind(this.capabilities.mastra),
     };
+
+    if (requestContextToUse) {
+      mergedGenerateOptions.requestContext = requestContextToUse;
+    } else {
+      await this.capabilities.assertAgentExecutionPreflight(mergedGenerateOptions.requestContext);
+    }
 
     const { llm, before, after } = await this.prepareLLMOptions(messages, mergedGenerateOptions as any, 'generate');
 
@@ -1269,9 +1296,14 @@ export class AgentLegacyHandler {
     | StreamTextResult<any, EXPERIMENTAL_OUTPUT>
     | (StreamObjectResult<OUTPUT extends ZodSchema | JSONSchema7 ? OUTPUT : never> & TracingProperties)
   > {
+    const requestContextToUse = streamOptions.requestContext;
+    if (requestContextToUse) {
+      await this.capabilities.assertAgentExecutionPreflight(requestContextToUse);
+    }
+
     const defaultStreamOptionsLegacy = await Promise.resolve(
       this.capabilities.getDefaultStreamOptionsLegacy({
-        requestContext: streamOptions.requestContext,
+        requestContext: requestContextToUse,
       }),
     );
 
@@ -1282,6 +1314,12 @@ export class AgentLegacyHandler {
         defaultStreamOptionsLegacy.experimental_generateMessageId ||
         this.capabilities.mastra?.generateId?.bind(this.capabilities.mastra),
     };
+
+    if (requestContextToUse) {
+      mergedStreamOptions.requestContext = requestContextToUse;
+    } else {
+      await this.capabilities.assertAgentExecutionPreflight(mergedStreamOptions.requestContext);
+    }
 
     const { llm, before, after } = await this.prepareLLMOptions(messages, mergedStreamOptions as any, 'stream');
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1833,6 +1833,9 @@ export class Agent<
         mastra: this.#mastra,
         getDefaultGenerateOptionsLegacy: this.getDefaultGenerateOptionsLegacy.bind(this),
         getDefaultStreamOptionsLegacy: this.getDefaultStreamOptionsLegacy.bind(this),
+        assertAgentExecutionPreflight: this.#assertAgentExecutionPreflight.bind(this),
+        needsAgentExecutionPreflight: () =>
+          Boolean(this.#requestContextSchema) || Boolean(this.#mastra?.getServer()?.fga),
         hasOwnMemory: this.hasOwnMemory.bind(this),
         getInstructions: async (options: { requestContext: RequestContext }) => {
           const result = await this.getInstructions(options);
@@ -6668,7 +6671,7 @@ export class Agent<
     }
     let preparedOptionsWithPubSub: (AgentExecutionOptionsBase<any> & { runId?: string; _pubsub: PubSub }) | undefined;
     let preflightedRequestContext: RequestContext | undefined = skipExecutionPreflight
-      ? preflightedDefaultOptions?.requestContext ?? requestContextToUse
+      ? (preflightedDefaultOptions?.requestContext ?? requestContextToUse)
       : undefined;
     let hasPreflightedRequestContext = skipExecutionPreflight;
     const reserveAdmittedRun = () => {


### PR DESCRIPTION
## Linear

PF-546: https://linear.app/papersflow/issue/PF-546/harness-v1-decide-legacy-agent-execution-fga-fail-closed-semantics

## Summary

- Route generateLegacy() and streamLegacy() through the same agent execution preflight used by current generate()/stream() paths.
- Preserve explicit requestContext precedence over legacy default options before authorization.
- Keep legacy structuredOutput unsupported while ensuring FGA/schema preflight is not masked where relevant.
- Add focused legacy FGA, schema-validation, default-context, provider-denial, and structuredOutput ordering coverage.

## Coordination

- Related follow-up from PF-531; adjacent issue PF-545 remains separate.
- Open PR overlap check before implementation found mbenhamd/mastra#136 / PF-365 only. It touches server attachment routes, not these agent legacy files, so PF-546 proceeds independently.
- Branch is based on origin/main 4d9a5907be4b2186e181cd2c653ba226ba17ea56.

## Validation

- pnpm exec prettier --write packages/core/src/agent/agent.ts packages/core/src/agent/agent-legacy.ts packages/core/src/agent/__tests__/agent-fga.test.ts .changeset/fine-garlics-shine.md
- pnpm test packages/core/src/agent/__tests__/agent-fga.test.ts --project unit:packages/core: 55 tests passed
- pnpm --filter ./packages/core exec eslint src/agent/agent.ts src/agent/agent-legacy.ts src/agent/__tests__/agent-fga.test.ts
- git diff --check
- pnpm --filter ./packages/core check: fails on existing current-base errors outside this PR in src/agent/__tests__/mock-model.ts, src/harness/v1/harness.ts, and src/test-utils/llm-mock.ts
- Local Codex review pass 1: no findings after fixes
- Local Codex review pass 2: no findings after fixes
- CodeRabbit CLI local review: no findings

## Notes

Earlier local CodeRabbit/Codex review findings around structuredOutput ordering were verified against source and resolved before opening this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->