### PR TITLE
[PF-366] Add client-js RemoteHarness and RemoteSession

### DIFF
--- a/.changeset/pf-366-client-js-remote-harness.md
+++ b/.changeset/pf-366-client-js-remote-harness.md
@@ -4,7 +4,13 @@
 
 Added first-party client-js RemoteHarness and RemoteSession resources for Harness v1 server routes.
 
-`MastraClient#getHarness(name)` now exposes remote session listing, creation/loading, snapshots, state/mode/model updates, permissions, inbox responses, goals, close, durable message admission, queued work admission, SSE subscription with Last-Event-ID replay, and result lookup settlement for interrupted message/queue operations. Remote skill APIs fail explicitly until matching server routes exist.
+`MastraClient#getHarness(name)` now exposes remote Harness sessions:
+
+- Added remote session management: list, create, load, and close sessions.
+- Added snapshot, state, mode, model, permissions, inbox, and goal APIs.
+- Added durable message admission and queued work admission.
+- Added event subscription with Last-Event-ID replay and result lookup for interrupted operations.
+- Improved remote skill APIs so they fail clearly until matching server routes exist.
 
 **Usage**
 

--- a/.changeset/pf-366-client-js-remote-harness.md
+++ b/.changeset/pf-366-client-js-remote-harness.md
@@ -1,0 +1,27 @@
+---
+"@mastra/client-js": minor
+---
+
+Added first-party client-js RemoteHarness and RemoteSession resources for Harness v1 server routes.
+
+`MastraClient#getHarness(name)` now exposes remote session listing, creation/loading, snapshots, state/mode/model updates, permissions, inbox responses, goals, close, durable message admission, queued work admission, SSE subscription with Last-Event-ID replay, and result lookup settlement for interrupted message/queue operations. Remote skill APIs fail explicitly until matching server routes exist.
+
+**Usage**
+
+```ts
+import { MastraClient } from '@mastra/client-js';
+
+const client = new MastraClient({ baseUrl: 'http://localhost:4111' });
+const session = await client.getHarness('default').session({ threadId: { fresh: true } });
+
+const unsubscribe = session.subscribe(event => {
+  console.log(event.type);
+});
+
+const result = await session.message({
+  content: 'Summarize the workspace status',
+  admissionId: 'workspace-summary-1',
+});
+
+unsubscribe();
+```

--- a/client-sdks/client-js/src/client.ts
+++ b/client-sdks/client-js/src/client.ts
@@ -89,6 +89,7 @@ import {
   Workspace,
   Responses,
   Channels,
+  RemoteHarness,
 } from './resources';
 import type {
   ListScoresBySpanParams,
@@ -237,6 +238,13 @@ export class MastraClient extends BaseResource {
    */
   public getAgent(agentId: string, version?: AgentVersionIdentifier) {
     return new Agent(this.options, agentId, version);
+  }
+
+  /**
+   * Gets a Harness resource by registration name. Single-harness servers use "default".
+   */
+  public getHarness(name = 'default') {
+    return new RemoteHarness(this.options, name);
   }
 
   /**

--- a/client-sdks/client-js/src/index.ts
+++ b/client-sdks/client-js/src/index.ts
@@ -2,6 +2,43 @@ export * from './client';
 export * from './types';
 export * from './tools';
 export type {
+  AttachmentRef,
+  CreateHarnessSessionBody,
+  CreateHarnessSessionResponse,
+  Goal,
+  GoalBody,
+  GoalResponse,
+  HarnessSessionSnapshot,
+  HarnessSessionSummary,
+  InboxResponseBody,
+  InboxResponseResult,
+  MessageAdmissionBody,
+  MessageAdmissionResponse,
+  MessageOperationResult,
+  PermissionsBody,
+  PermissionsResponse,
+  QueueAdmissionBody,
+  QueueAdmissionResponse,
+  QueueOperationResult,
+  RemoteHarnessAgentResult,
+  RemoteHarnessEventListener,
+  RemoteHarnessEventUnsubscribe,
+  RemoteHarnessListSessionsOptions,
+  RemoteHarnessSessionOptions,
+  RemoteHarnessStatePatchOptions,
+  RemoteHarnessSubscriptionOptions,
+  RemoteSessionMessageOptions,
+  RemoteSessionOperationOptions,
+  RemoteSessionQueueOptions,
+} from './resources/harness';
+export {
+  RemoteHarness,
+  RemoteHarnessOperationError,
+  RemoteHarnessStateVersionError,
+  RemoteHarnessUnsupportedError,
+  RemoteSession,
+} from './resources/harness';
+export type {
   ChannelPlatformInfo,
   ChannelInstallationInfo,
   ChannelConnectOAuth,

--- a/client-sdks/client-js/src/resources/harness.test.ts
+++ b/client-sdks/client-js/src/resources/harness.test.ts
@@ -1,0 +1,554 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MastraClient } from '../client';
+import { RemoteHarnessOperationError, RemoteHarnessUnsupportedError } from './harness';
+
+global.fetch = vi.fn();
+
+const clientOptions = {
+  baseUrl: 'http://localhost:4111',
+  headers: {
+    Authorization: 'Bearer test-key',
+  },
+};
+
+function makeSnapshot(overrides: Partial<any> = {}) {
+  return {
+    summary: {
+      sessionId: 'session-1',
+      harnessName: 'default',
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      lifecycle: 'active',
+      createdAt: 1,
+      lastActivityAt: 2,
+      modeId: 'ask',
+      modelId: 'openai/gpt-5',
+      busy: false,
+      queueDepth: 0,
+      pendingInbox: { count: 0, kinds: [], sessionOwnedOnly: true },
+      durableWork: {
+        activeCount: 0,
+        waitingCount: 0,
+        retryingCount: 0,
+        failedCount: 0,
+        sessionOwnedOnly: true,
+      },
+      ...overrides.summary,
+    },
+    state: overrides.state ?? { draft: true },
+    queue: { depth: 0, queuedItemIds: [] },
+    pendingInbox: [],
+    durableWork: { active: [], recentTerminal: [], truncated: false, sessionOwnedOnly: true },
+    channelBindings: [],
+    tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    messages: { cursor: { threadId: 'thread-1', route: 'thread-messages' } },
+    ...overrides,
+  };
+}
+
+function mockJson(data: unknown, init: ResponseInit = {}) {
+  (global.fetch as any).mockResolvedValueOnce(
+    new Response(JSON.stringify(data), {
+      status: init.status ?? 200,
+      statusText: init.statusText ?? 'OK',
+      headers: new Headers({ 'content-type': 'application/json', ...Object.fromEntries(new Headers(init.headers)) }),
+    }),
+  );
+}
+
+function mockSse(events: unknown[]) {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const event of events as Array<{ id: string; type: string }>) {
+        controller.enqueue(encoder.encode(`id: ${event.id}\nevent: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`));
+      }
+      controller.close();
+    },
+  });
+  (global.fetch as any).mockResolvedValueOnce(
+    new Response(body, {
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({ 'content-type': 'text/event-stream' }),
+    }),
+  );
+}
+
+describe('Harness Resource', () => {
+  let client: MastraClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new MastraClient(clientOptions);
+  });
+
+  it('creates a remote session through MastraClient.getHarness()', async () => {
+    mockJson({ session: makeSnapshot() });
+
+    const session = await client.getHarness().session({ threadId: { fresh: true }, modeId: 'ask' });
+
+    expect(session.id).toBe('session-1');
+    expect(session.threadId).toBe('thread-1');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:4111/api/harness/default/sessions',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining(clientOptions.headers),
+        body: JSON.stringify({ threadId: { fresh: true }, modeId: 'ask' }),
+      }),
+    );
+  });
+
+  it('opens an existing session by GET when sessionId is the only option', async () => {
+    mockJson(makeSnapshot());
+
+    const session = await client.getHarness().session({ sessionId: 'session-1' });
+
+    expect(session.id).toBe('session-1');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:4111/api/harness/default/sessions/session-1',
+      expect.objectContaining({
+        headers: expect.objectContaining(clientOptions.headers),
+      }),
+    );
+  });
+
+  it('does not retry non-idempotent session creation after a failed response', async () => {
+    mockJson(
+      { code: 'harness.create_failed', message: 'failed' },
+      { status: 500, statusText: 'Internal Server Error' },
+    );
+
+    await expect(client.getHarness().session({ threadId: { fresh: true } })).rejects.toThrow('HTTP error! status: 500');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('settles message promises through event stream plus result lookup without readmitting work', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockJson({ accepted: true, signalId: 'signal-1', runId: 'run-1', duplicate: false });
+    mockJson({ status: 'pending', source: 'message', runId: 'run-1' });
+    mockSse([
+      {
+        id: 'harness-v1:epoch-1:1',
+        type: 'agent_end',
+        sessionId: 'session-1',
+        signalId: 'signal-1',
+        runId: 'run-1',
+        reason: 'complete',
+        timestamp: 3,
+      },
+    ]);
+    mockJson({ status: 'completed', source: 'message', runId: 'run-1', result: { text: 'done' } });
+
+    const session = await client.getHarness().session();
+    await expect(session.message({ content: 'hello', admissionId: 'admission-1' })).resolves.toEqual({ text: 'done' });
+
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      'http://localhost:4111/api/harness/default/sessions/session-1/messages',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ content: 'hello', admissionId: 'admission-1' }),
+      }),
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:4111/api/harness/default/sessions/session-1/events',
+      expect.objectContaining({
+        headers: expect.objectContaining(clientOptions.headers),
+      }),
+    );
+  });
+
+  it('does not retry message admission after a failed response', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockJson(
+      { code: 'harness.message_failed', message: 'failed' },
+      { status: 500, statusText: 'Internal Server Error' },
+    );
+
+    const session = await client.getHarness().session();
+    await expect(session.message({ content: 'hello', admissionId: 'admission-1' })).rejects.toThrow(
+      'HTTP error! status: 500',
+    );
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('settles queued work through queue result lookup', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockJson({ accepted: true, queuedItemId: 'queue-1', duplicate: false });
+    mockJson({ status: 'pending', source: 'queue' });
+    mockSse([
+      {
+        id: 'harness-v1:epoch-1:1',
+        type: 'agent_end',
+        sessionId: 'session-1',
+        queuedItemId: 'queue-1',
+        reason: 'complete',
+        timestamp: 3,
+      },
+    ]);
+    mockJson({ status: 'completed', source: 'queue', result: { text: 'queued' } });
+
+    const session = await client.getHarness().session();
+    await expect(session.queue({ content: 'later', admissionId: 'queue-admission-1' })).resolves.toEqual({
+      text: 'queued',
+    });
+
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      'http://localhost:4111/api/harness/default/sessions/session-1/queue',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ content: 'later', admissionId: 'queue-admission-1' }),
+      }),
+    );
+  });
+
+  it('throws failed operation evidence as RemoteHarnessOperationError', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockJson({ accepted: true, signalId: 'signal-1', runId: 'run-1', duplicate: false });
+    mockJson({
+      status: 'failed',
+      source: 'message',
+      runId: 'run-1',
+      error: { code: 'harness.message_failed', message: 'model failed' },
+    });
+
+    const session = await client.getHarness().session();
+    await expect(session.message({ content: 'hello', admissionId: 'admission-1' })).rejects.toBeInstanceOf(
+      RemoteHarnessOperationError,
+    );
+  });
+
+  it('refreshes snapshot ETag before patching state when needed', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockJson(makeSnapshot(), { headers: { etag: '"7"' } });
+    mockJson({ draft: false }, { headers: { etag: '"8"' } });
+
+    const session = await client.getHarness().session();
+    await expect(session.setState({ draft: false })).resolves.toEqual({ draft: false });
+
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      3,
+      'http://localhost:4111/api/harness/default/sessions/session-1/state',
+      expect.objectContaining({
+        method: 'PATCH',
+        headers: expect.objectContaining({ 'if-match': '"7"' }),
+        body: JSON.stringify({ draft: false }),
+      }),
+    );
+  });
+
+  it('does not retry conditional state patches after a failed response', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockJson(
+      { code: 'harness.state_conflict', message: 'conflict' },
+      { status: 409, statusText: 'Conflict', headers: { etag: '"8"' } },
+    );
+
+    const session = await client.getHarness().session();
+    await expect(session.setState({ draft: false }, { ifVersion: 7 })).rejects.toThrow('HTTP error! status: 409');
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry goal kickoff requests after a failed response', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockJson({ code: 'harness.goal_failed', message: 'failed' }, { status: 500, statusText: 'Internal Server Error' });
+
+    const session = await client.getHarness().session();
+    await expect(session.setGoal({ objective: 'ship it' })).rejects.toThrow('HTTP error! status: 500');
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry goal replacement without kickoff after a failed response', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockJson({ code: 'harness.goal_failed', message: 'failed' }, { status: 500, statusText: 'Internal Server Error' });
+
+    const session = await client.getHarness().session();
+    await expect(session.setGoal({ objective: 'ship it', kickoff: false })).rejects.toThrow('HTTP error! status: 500');
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('recovers message settlement through result lookup after an event stream failure', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockJson({ accepted: true, signalId: 'signal-1', runId: 'run-1', duplicate: false });
+    mockJson({ status: 'pending', source: 'message', runId: 'run-1' });
+    mockJson({ code: 'harness.stream_failed', message: 'stream failed' }, { status: 500, statusText: 'Server Error' });
+    mockJson({ status: 'completed', source: 'message', runId: 'run-1', result: { text: 'done after reconnect' } });
+
+    const session = await client.getHarness().session();
+    await expect(session.message({ content: 'hello', admissionId: 'admission-1' })).resolves.toEqual({
+      text: 'done after reconnect',
+    });
+  });
+
+  it('rejects failed operation evidence after pending settlement', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockJson({ accepted: true, signalId: 'signal-1', runId: 'run-1', duplicate: false });
+    mockJson({ status: 'pending', source: 'message', runId: 'run-1' });
+    mockSse([
+      {
+        id: 'harness-v1:epoch-1:1',
+        type: 'agent_end',
+        sessionId: 'session-1',
+        signalId: 'signal-1',
+        runId: 'run-1',
+        reason: 'error',
+        timestamp: 3,
+      },
+    ]);
+    mockJson({
+      status: 'failed',
+      source: 'message',
+      runId: 'run-1',
+      error: { code: 'tool.failed', message: 'tool failed' },
+    });
+
+    const session = await client.getHarness().session();
+    await expect(session.message({ content: 'hello', admissionId: 'admission-1' })).rejects.toBeInstanceOf(
+      RemoteHarnessOperationError,
+    );
+  });
+
+  it('rejects expired operation evidence after pending settlement', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockJson({ accepted: true, signalId: 'signal-1', runId: 'run-1', duplicate: false });
+    mockJson({ status: 'pending', source: 'message', runId: 'run-1' });
+    mockSse([
+      {
+        id: 'harness-v1:epoch-1:1',
+        type: 'agent_end',
+        sessionId: 'session-1',
+        signalId: 'signal-1',
+        runId: 'run-1',
+        reason: 'error',
+        timestamp: 3,
+      },
+    ]);
+    mockJson({ status: 'expired', source: 'message', runId: 'run-1', expiredAt: 4 });
+
+    const session = await client.getHarness().session();
+    await expect(session.message({ content: 'hello', admissionId: 'admission-1' })).rejects.toBeInstanceOf(
+      RemoteHarnessOperationError,
+    );
+  });
+
+  it('rejects missing operation evidence after pending settlement', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockJson({ accepted: true, signalId: 'signal-1', runId: 'run-1', duplicate: false });
+    mockJson({ status: 'pending', source: 'message', runId: 'run-1' });
+    mockSse([
+      {
+        id: 'harness-v1:epoch-1:1',
+        type: 'agent_end',
+        sessionId: 'session-1',
+        signalId: 'signal-1',
+        runId: 'run-1',
+        reason: 'error',
+        timestamp: 3,
+      },
+    ]);
+    mockJson({ status: 'not_found', source: 'message' });
+
+    const session = await client.getHarness().session();
+    await expect(session.message({ content: 'hello', admissionId: 'admission-1' })).rejects.toBeInstanceOf(
+      RemoteHarnessOperationError,
+    );
+  });
+
+  it('rejects aborted operation settlement instead of polling forever', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockJson({ accepted: true, signalId: 'signal-1', runId: 'run-1', duplicate: false });
+    mockJson({ status: 'pending', source: 'message', runId: 'run-1' });
+    mockSse([
+      {
+        id: 'harness-v1:epoch-1:1',
+        type: 'agent_end',
+        sessionId: 'session-1',
+        signalId: 'signal-1',
+        runId: 'run-1',
+        reason: 'error',
+        timestamp: 3,
+      },
+    ]);
+    (global.fetch as any).mockRejectedValueOnce(new DOMException('aborted', 'AbortError'));
+
+    const session = await new MastraClient({ ...clientOptions, retries: 0 }).getHarness().session();
+    await expect(session.message({ content: 'hello', admissionId: 'admission-1' })).rejects.toThrow('aborted');
+  });
+
+  it('keeps polling after a transient result lookup failure', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockJson({ accepted: true, signalId: 'signal-1', runId: 'run-1', duplicate: false });
+    mockJson({ status: 'pending', source: 'message', runId: 'run-1' });
+    mockSse([
+      {
+        id: 'harness-v1:epoch-1:1',
+        type: 'agent_end',
+        sessionId: 'session-1',
+        signalId: 'signal-1',
+        runId: 'run-1',
+        reason: 'complete',
+        timestamp: 3,
+      },
+    ]);
+    mockJson(
+      { code: 'harness.lookup_failed', message: 'try again' },
+      { status: 503, statusText: 'Service Unavailable' },
+    );
+    mockJson({ status: 'completed', source: 'message', runId: 'run-1', result: { text: 'done after retry' } });
+
+    const session = await client.getHarness().session();
+    const result = session.message({ content: 'hello', admissionId: 'admission-1' });
+    await vi.waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(5));
+    await new Promise(resolve => setTimeout(resolve, 1100));
+
+    await expect(result).resolves.toEqual({ text: 'done after retry' });
+  });
+
+  it('does not advance the public replay cursor from internal settlement streams', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockJson({ accepted: true, signalId: 'signal-1', runId: 'run-1', duplicate: false });
+    mockJson({ status: 'pending', source: 'message', runId: 'run-1' });
+    mockSse([
+      {
+        id: 'harness-v1:epoch-1:7',
+        type: 'agent_end',
+        sessionId: 'session-1',
+        signalId: 'signal-1',
+        runId: 'run-1',
+        reason: 'complete',
+        timestamp: 3,
+      },
+    ]);
+    mockJson({ status: 'completed', source: 'message', runId: 'run-1', result: { text: 'done' } });
+    mockSse([]);
+
+    const session = await client.getHarness().session();
+    await expect(session.message({ content: 'hello', admissionId: 'admission-1' })).resolves.toEqual({ text: 'done' });
+
+    const unsubscribe = session.subscribe(() => {});
+    await vi.waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(6));
+    expect((global.fetch as any).mock.calls[5][1].headers).not.toHaveProperty('Last-Event-ID');
+    unsubscribe();
+  });
+
+  it('uses Last-Event-ID as a header when reconnecting from a cursor', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockSse([]);
+
+    const session = await client.getHarness().session();
+    const unsubscribe = session.subscribe(() => {}, { lastEventId: 'harness-v1:epoch-1:7' });
+    await vi.waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost:4111/api/harness/default/sessions/session-1/events',
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'Last-Event-ID': 'harness-v1:epoch-1:7' }),
+        }),
+      );
+    });
+    unsubscribe();
+  });
+
+  it('keeps an explicit Last-Event-ID as the public cursor when no events arrive', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockSse([]);
+
+    const session = await client.getHarness().session();
+    const firstUnsubscribe = session.subscribe(() => {}, { lastEventId: 'harness-v1:epoch-1:7' });
+    await vi.waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+    firstUnsubscribe();
+
+    mockSse([]);
+    const secondUnsubscribe = session.subscribe(() => {});
+    await vi.waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3));
+    expect((global.fetch as any).mock.calls[2][1].headers).toMatchObject({
+      'Last-Event-ID': 'harness-v1:epoch-1:7',
+    });
+    secondUnsubscribe();
+  });
+
+  it('stops reconnecting on non-replay 4xx event stream failures', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockJson({ code: 'harness.permission_denied', message: 'denied' }, { status: 403, statusText: 'Forbidden' });
+    const onError = vi.fn();
+
+    const session = await client.getHarness().session();
+    session.subscribe(() => {}, { reconnect: true, onError });
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('advances the replay cursor only after the listener succeeds', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockSse([
+      {
+        id: 'harness-v1:epoch-1:7',
+        type: 'agent_end',
+        sessionId: 'session-1',
+        signalId: 'signal-1',
+        runId: 'run-1',
+        reason: 'complete',
+        timestamp: 3,
+      },
+    ]);
+    const onError = vi.fn();
+
+    const session = await client.getHarness().session();
+    session.subscribe(
+      () => {
+        throw new Error('listener failed');
+      },
+      { onError },
+    );
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+
+    mockSse([]);
+    const unsubscribe = session.subscribe(() => {});
+    await vi.waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3));
+    expect((global.fetch as any).mock.calls[2][1].headers).not.toHaveProperty('Last-Event-ID');
+    unsubscribe();
+  });
+
+  it('aborts the event stream request on unsubscribe', async () => {
+    mockJson({ session: makeSnapshot() });
+    let eventSignal: AbortSignal | undefined;
+    const pull = vi.fn();
+    const body = new ReadableStream<Uint8Array>({
+      pull,
+    });
+    (global.fetch as any).mockImplementationOnce((_url: string, init: RequestInit) => {
+      eventSignal = init.signal as AbortSignal;
+      return Promise.resolve(
+        new Response(body, {
+          status: 200,
+          statusText: 'OK',
+          headers: new Headers({ 'content-type': 'text/event-stream' }),
+        }),
+      );
+    });
+
+    const session = await client.getHarness().session();
+    const unsubscribe = session.subscribe(() => {});
+    await vi.waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost:4111/api/harness/default/sessions/session-1/events',
+        expect.any(Object),
+      );
+    });
+    await vi.waitFor(() => expect(pull).toHaveBeenCalled());
+    unsubscribe();
+
+    expect(eventSignal?.aborted).toBe(true);
+  });
+
+  it('keeps skill APIs explicit until matching server routes exist', async () => {
+    mockJson({ session: makeSnapshot() });
+
+    const session = await client.getHarness().session();
+    await expect(session.useSkill()).rejects.toBeInstanceOf(RemoteHarnessUnsupportedError);
+  });
+});

--- a/client-sdks/client-js/src/resources/harness.test.ts
+++ b/client-sdks/client-js/src/resources/harness.test.ts
@@ -56,12 +56,16 @@ function mockJson(data: unknown, init: ResponseInit = {}) {
   );
 }
 
-function mockSse(events: unknown[]) {
+function mockSse(events: unknown[], newline = '\n') {
   const encoder = new TextEncoder();
   const body = new ReadableStream<Uint8Array>({
     start(controller) {
       for (const event of events as Array<{ id: string; type: string }>) {
-        controller.enqueue(encoder.encode(`id: ${event.id}\nevent: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`));
+        controller.enqueue(
+          encoder.encode(
+            `id: ${event.id}${newline}event: ${event.type}${newline}data: ${JSON.stringify(event)}${newline}${newline}`,
+          ),
+        );
       }
       controller.close();
     },
@@ -123,6 +127,25 @@ describe('Harness Resource', () => {
 
     await expect(client.getHarness().session({ threadId: { fresh: true } })).rejects.toThrow('HTTP error! status: 500');
     expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry aborted requests', async () => {
+    const abortError = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(makeSnapshot()), {
+          status: 200,
+          statusText: 'OK',
+          headers: new Headers({ 'content-type': 'application/json' }),
+        }),
+      )
+      .mockRejectedValueOnce(abortError);
+    const abortingClient = new MastraClient({ ...clientOptions, fetch });
+
+    const session = await abortingClient.getHarness().session({ sessionId: 'session-1' });
+    await expect(session.refresh()).rejects.toThrow('aborted');
+    expect(fetch).toHaveBeenCalledTimes(2);
   });
 
   it('settles message promises through event stream plus result lookup without readmitting work', async () => {
@@ -449,6 +472,30 @@ describe('Harness Resource', () => {
         }),
       );
     });
+    unsubscribe();
+  });
+
+  it('parses CRLF-delimited event stream frames', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockSse(
+      [
+        {
+          id: 'harness-v1:epoch-1:7',
+          type: 'agent_end',
+          sessionId: 'session-1',
+          signalId: 'signal-1',
+          runId: 'run-1',
+          reason: 'complete',
+          timestamp: 3,
+        },
+      ],
+      '\r\n',
+    );
+    const listener = vi.fn();
+
+    const session = await client.getHarness().session();
+    const unsubscribe = session.subscribe(listener);
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledTimes(1));
     unsubscribe();
   });
 

--- a/client-sdks/client-js/src/resources/harness.test.ts
+++ b/client-sdks/client-js/src/resources/harness.test.ts
@@ -426,7 +426,6 @@ describe('Harness Resource', () => {
     const session = await client.getHarness().session();
     const result = session.message({ content: 'hello', admissionId: 'admission-1' });
     await vi.waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(5));
-    await new Promise(resolve => setTimeout(resolve, 1100));
 
     await expect(result).resolves.toEqual({ text: 'done after retry' });
   });

--- a/client-sdks/client-js/src/resources/harness.ts
+++ b/client-sdks/client-js/src/resources/harness.ts
@@ -1,0 +1,888 @@
+import { v4 as uuid } from '@lukeed/uuid';
+import type { HarnessEvent } from '@mastra/core/harness/v1';
+
+import type {
+  GetHarnessNameSessions_Response,
+  GetHarnessNameSessions_QueryParams,
+  GetHarnessNameSessionsSessionId_Response,
+  PostHarnessNameSessions_Body,
+  PostHarnessNameSessions_Response,
+} from '../route-types.generated.js';
+import type { ClientOptions, RequestOptions } from '../types';
+import { MastraClientError } from '../types.js';
+import { BaseResource } from './base';
+
+type JsonObject = Record<string, unknown>;
+export type HarnessSessionSnapshot = GetHarnessNameSessionsSessionId_Response;
+export type HarnessSessionSummary = GetHarnessNameSessions_Response['items'][number];
+export type CreateHarnessSessionBody = PostHarnessNameSessions_Body;
+export type CreateHarnessSessionResponse = PostHarnessNameSessions_Response;
+export type AttachmentRef = {
+  attachmentId: string;
+  resourceId: string;
+  ownerSessionId?: string;
+  bytes?: number;
+  sha256?: string;
+  source?: 'inline' | 'preupload' | 'url' | 'provider';
+  kind?: 'file' | 'primitive' | 'element';
+  name?: string;
+  mimeType?: string;
+  primitiveType?: string;
+  elementType?: string;
+  renderer?: JsonObject;
+  schemaId?: string;
+  metadata?: JsonObject;
+  object?: JsonObject;
+};
+export type MessageAdmissionBody = {
+  content: string;
+  admissionId: string;
+  mode?: string;
+  model?: string;
+  attachments?: AttachmentRef[];
+};
+export type MessageAdmissionResponse = { accepted: true; signalId: string; runId?: string; duplicate: boolean };
+export type QueueAdmissionBody = MessageAdmissionBody & { yolo?: boolean };
+export type QueueAdmissionResponse = { accepted: true; queuedItemId: string; duplicate: boolean };
+export type MessageOperationResult =
+  | { status: 'pending'; source: 'message'; runId?: string }
+  | { status: 'completed'; source: 'message'; runId?: string; result: unknown }
+  | { status: 'failed'; source: 'message'; runId?: string; error: { code: string; message: string } }
+  | { status: 'expired'; source: 'message'; runId?: string; expiredAt?: number }
+  | { status: 'not_found'; source: 'message' };
+export type QueueOperationResult =
+  | { status: 'pending'; source: 'queue'; runId?: string }
+  | { status: 'completed'; source: 'queue'; runId?: string; result: unknown }
+  | { status: 'failed'; source: 'queue'; runId?: string; error: { code: string; message: string } }
+  | { status: 'expired'; source: 'queue'; runId?: string; expiredAt?: number }
+  | { status: 'not_found'; source: 'queue' };
+type OperationResult = MessageOperationResult | QueueOperationResult;
+export type InboxResponseBody =
+  | { kind: 'tool-approval'; approved: boolean; reason?: string; responseId: string }
+  | { kind: 'tool-suspension'; resumeData: unknown; responseId: string }
+  | { kind: 'question'; answer: unknown; responseId: string }
+  | { kind: 'plan-approval'; approved: boolean; revision?: string; responseId: string; transitionToMode?: string };
+export type InboxResponseResult = {
+  itemId: string;
+  kind: 'tool-approval' | 'tool-suspension' | 'question' | 'plan-approval';
+  status: 'accepted' | 'applied';
+  responseId: string;
+  duplicate: boolean;
+};
+export type GoalBody = { objective: string; judgeModel?: string; maxTurns?: number; kickoff?: boolean };
+export type Goal = {
+  id: string;
+  objective: string;
+  status: 'active' | 'paused' | 'done';
+  turnsUsed: number;
+  maxTurns: number;
+  judgeModelId: string;
+  createdAt: number;
+  lastDecision?: { decision: 'done' | 'continue' | 'waiting'; reason: string; judgedAt: number };
+};
+export type GoalResponse = { goal: Goal | null };
+export type PermissionsBody =
+  | { action: 'grantCategory'; category: string }
+  | { action: 'grantTool'; toolName: string }
+  | { action: 'revokeCategory'; category: string }
+  | { action: 'revokeTool'; toolName: string }
+  | { action: 'setPolicy'; category?: string; toolName?: string; policy: 'allow' | 'ask' | 'deny' };
+export type PermissionsResponse = {
+  grants: unknown;
+  rules: unknown;
+};
+type HarnessRequestOptions = RequestOptions & { signal?: AbortSignal; retries?: number };
+
+export interface RemoteHarnessListSessionsOptions extends GetHarnessNameSessions_QueryParams {}
+export interface RemoteHarnessSessionOptions extends CreateHarnessSessionBody {}
+
+export interface RemoteSessionOperationOptions {
+  /**
+   * Stable client admission id. Pass this when the caller needs durable recovery
+   * from ambiguous admission failures; otherwise the convenience helpers mint one
+   * for the current call only.
+   */
+  admissionId?: string;
+  mode?: string;
+  model?: string;
+  attachments?: MessageAdmissionBody['attachments'];
+}
+
+export interface RemoteSessionMessageOptions extends RemoteSessionOperationOptions {
+  content: string;
+  stream?: never;
+  sync?: never;
+  output?: never;
+}
+
+export interface RemoteSessionQueueOptions extends RemoteSessionOperationOptions {
+  content: string;
+  yolo?: boolean;
+}
+
+export interface RemoteHarnessSubscriptionOptions {
+  lastEventId?: string;
+  signal?: AbortSignal;
+  reconnect?: boolean;
+  onReplayGap?: () => void | Promise<void>;
+  onError?: (error: unknown) => void | Promise<void>;
+}
+
+export interface RemoteHarnessStatePatchOptions {
+  ifVersion?: number;
+}
+
+export type RemoteHarnessEventListener = (event: HarnessEvent) => void | Promise<void>;
+export type RemoteHarnessEventUnsubscribe = () => void;
+export type RemoteHarnessAgentResult = unknown;
+
+export class RemoteHarnessUnsupportedError extends Error {
+  readonly name = 'RemoteHarnessUnsupportedError';
+}
+
+export class RemoteHarnessOperationError extends Error {
+  readonly name = 'RemoteHarnessOperationError';
+  readonly code: string;
+  readonly status: OperationResult['status'];
+
+  constructor(result: Extract<OperationResult, { status: 'failed' | 'expired' | 'not_found' }>) {
+    const code = result.status === 'failed' ? result.error.code : `harness.operation_${result.status}`;
+    const message =
+      result.status === 'failed'
+        ? result.error.message
+        : result.status === 'expired'
+          ? 'Harness operation result evidence expired'
+          : 'Harness operation result was not found';
+    super(message);
+    this.code = code;
+    this.status = result.status;
+  }
+}
+
+export class RemoteHarnessStateVersionError extends Error {
+  readonly name = 'RemoteHarnessStateVersionError';
+
+  constructor() {
+    super('RemoteSession.setState() requires a session ETag; refresh the session snapshot and retry');
+  }
+}
+
+export class RemoteHarness extends BaseResource {
+  constructor(
+    options: ClientOptions,
+    private readonly name = 'default',
+  ) {
+    super(options);
+  }
+
+  listSessions(options: RemoteHarnessListSessionsOptions = {}): Promise<GetHarnessNameSessions_Response> {
+    const searchParams = new URLSearchParams();
+    if (options.cursor) searchParams.set('cursor', options.cursor);
+    if (options.limit !== undefined) searchParams.set('limit', String(options.limit));
+    if (options.includeClosed !== undefined) searchParams.set('includeClosed', String(options.includeClosed));
+    const query = searchParams.toString();
+    return this.request(`/harness/${encodeURIComponent(this.name)}/sessions${query ? `?${query}` : ''}`);
+  }
+
+  async session(options: RemoteHarnessSessionOptions = {}): Promise<RemoteSession> {
+    if (options.sessionId !== undefined && Object.keys(options).every(key => key === 'sessionId')) {
+      return this.getSession(options.sessionId);
+    }
+
+    const response = (await requestJson<CreateHarnessSessionResponse>(
+      this.options,
+      this.apiPrefix,
+      `/harness/${encodeURIComponent(this.name)}/sessions`,
+      {
+        method: 'POST',
+        body: options,
+        retries: 0,
+      },
+    )) as CreateHarnessSessionResponse;
+    return new RemoteSession(this.options, this.name, response.session);
+  }
+
+  async getSession(sessionId: string): Promise<RemoteSession> {
+    return new RemoteSession(this.options, this.name, await this.getSnapshot(sessionId));
+  }
+
+  getSnapshot(sessionId: string): Promise<HarnessSessionSnapshot> {
+    return this.request(`/harness/${encodeURIComponent(this.name)}/sessions/${encodeURIComponent(sessionId)}`);
+  }
+}
+
+export class RemoteSession extends BaseResource {
+  readonly id: string;
+  readonly resourceId: string;
+  readonly threadId: string;
+  readonly parentSessionId?: string;
+  readonly createdAt: number;
+
+  private snapshot: HarnessSessionSnapshot;
+  private lastEventId: string | undefined;
+  private stateVersion: number | undefined;
+
+  constructor(
+    options: ClientOptions,
+    private readonly harnessName: string,
+    snapshot: HarnessSessionSnapshot,
+  ) {
+    super(options);
+    this.snapshot = snapshot;
+    this.id = snapshot.summary.sessionId;
+    this.resourceId = snapshot.summary.resourceId;
+    this.threadId = snapshot.summary.threadId;
+    this.parentSessionId = snapshot.summary.parentSessionId;
+    this.createdAt = snapshot.summary.createdAt;
+  }
+
+  get lastActivityAt(): number {
+    return this.snapshot.summary.lastActivityAt;
+  }
+
+  get summary(): HarnessSessionSummary {
+    return this.snapshot.summary;
+  }
+
+  getDisplayState(): unknown {
+    return this.snapshot.displayState;
+  }
+
+  getTokenUsage(): HarnessSessionSnapshot['tokenUsage'] {
+    return this.snapshot.tokenUsage;
+  }
+
+  getQueueDepth(): number {
+    return this.snapshot.queue.depth;
+  }
+
+  isBusy(): boolean {
+    return this.snapshot.summary.busy;
+  }
+
+  async refresh(): Promise<HarnessSessionSnapshot> {
+    this.snapshot = await this.getSnapshot();
+    return this.snapshot;
+  }
+
+  async getSnapshot(): Promise<HarnessSessionSnapshot> {
+    const { data, response } = await this.requestJsonWithResponse<HarnessSessionSnapshot>(this.sessionPath());
+    this.stateVersion = parseSessionVersionFromEtag(response.headers.get('etag')) ?? this.stateVersion;
+    return data;
+  }
+
+  getState<TState = Record<string, unknown>>(): TState {
+    return this.snapshot.state as TState;
+  }
+
+  async setState<TState extends Record<string, unknown>>(
+    updates: Partial<TState>,
+    options: RemoteHarnessStatePatchOptions = {},
+  ): Promise<TState> {
+    const expectedVersion = options.ifVersion ?? this.stateVersion;
+    if (expectedVersion === undefined) {
+      await this.refresh();
+    }
+    const version = options.ifVersion ?? this.stateVersion;
+    if (version === undefined) {
+      throw new RemoteHarnessStateVersionError();
+    }
+    const { data: state, response } = await this.requestJsonWithResponse<TState>(`${this.sessionPath()}/state`, {
+      method: 'PATCH',
+      body: updates,
+      headers: { 'if-match': `"${version}"` },
+      retries: 0,
+    });
+    this.stateVersion = parseSessionVersionFromEtag(response.headers.get('etag')) ?? version + 1;
+    this.snapshot = { ...this.snapshot, state: state as HarnessSessionSnapshot['state'] };
+    return state;
+  }
+
+  async switchMode(options: { mode: string }): Promise<{ modeId: string }> {
+    const response = await this.request<{ modeId: string }>(`${this.sessionPath()}/mode`, {
+      method: 'PATCH',
+      body: options,
+    });
+    this.snapshot = { ...this.snapshot, summary: { ...this.snapshot.summary, modeId: response.modeId } };
+    return response;
+  }
+
+  async switchModel(options: { model: string }): Promise<{ modelId: string }> {
+    const response = await this.request<{ modelId: string }>(`${this.sessionPath()}/model`, {
+      method: 'PATCH',
+      body: options,
+    });
+    this.snapshot = { ...this.snapshot, summary: { ...this.snapshot.summary, modelId: response.modelId } };
+    return response;
+  }
+
+  async patchPermissions(body: PermissionsBody): Promise<PermissionsResponse> {
+    return this.request(`${this.sessionPath()}/permissions`, { method: 'PATCH', body });
+  }
+
+  readonly permissions = Object.freeze({
+    grantCategory: (options: { category: string }) =>
+      this.patchPermissions({ action: 'grantCategory', category: options.category }),
+    grantTool: (options: { toolName: string }) =>
+      this.patchPermissions({ action: 'grantTool', toolName: options.toolName }),
+    revokeCategory: (options: { category: string }) =>
+      this.patchPermissions({ action: 'revokeCategory', category: options.category }),
+    revokeTool: (options: { toolName: string }) =>
+      this.patchPermissions({ action: 'revokeTool', toolName: options.toolName }),
+    setPolicy: (
+      options:
+        | { category: string; toolName?: never; policy: 'allow' | 'ask' | 'deny' }
+        | { toolName: string; category?: never; policy: 'allow' | 'ask' | 'deny' },
+    ) => this.patchPermissions({ action: 'setPolicy', ...options }),
+  });
+
+  async respondToInboxItem(itemId: string, body: InboxResponseBody): Promise<InboxResponseResult> {
+    return this.request(`${this.sessionPath()}/inbox/${encodeURIComponent(itemId)}`, { method: 'POST', body });
+  }
+
+  respondToToolApproval(options: { itemId: string; responseId: string; approved: boolean; reason?: string }) {
+    const { itemId, ...body } = options;
+    return this.respondToInboxItem(itemId, { kind: 'tool-approval', ...body });
+  }
+
+  respondToToolSuspension(options: { itemId: string; responseId: string; resumeData: unknown }) {
+    const { itemId, ...body } = options;
+    return this.respondToInboxItem(itemId, { kind: 'tool-suspension', ...body });
+  }
+
+  respondToQuestion(options: { itemId: string; responseId: string; answer: unknown }) {
+    const { itemId, ...body } = options;
+    return this.respondToInboxItem(itemId, { kind: 'question', ...body });
+  }
+
+  respondToPlanApproval(options: {
+    itemId: string;
+    responseId: string;
+    approved: boolean;
+    revision?: string;
+    transitionToMode?: string;
+  }) {
+    const { itemId, ...body } = options;
+    return this.respondToInboxItem(itemId, { kind: 'plan-approval', ...body });
+  }
+
+  async setGoal(options: GoalBody): Promise<GoalResponse> {
+    return (
+      await this.requestJsonWithResponse<GoalResponse>(`${this.sessionPath()}/goal`, {
+        method: 'PUT',
+        body: options,
+        retries: 0,
+      })
+    ).data;
+  }
+
+  getGoal(): Promise<GoalResponse> {
+    return this.request(`${this.sessionPath()}/goal`);
+  }
+
+  pauseGoal(): Promise<GoalResponse> {
+    return this.request(`${this.sessionPath()}/goal/pause`, { method: 'POST' });
+  }
+
+  async resumeGoal(): Promise<GoalResponse> {
+    return (
+      await this.requestJsonWithResponse<GoalResponse>(`${this.sessionPath()}/goal/resume`, {
+        method: 'POST',
+        retries: 0,
+      })
+    ).data;
+  }
+
+  async clearGoal(): Promise<void> {
+    await this.request(`${this.sessionPath()}/goal`, { method: 'DELETE', stream: true });
+  }
+
+  async close(): Promise<void> {
+    await this.request<unknown>(this.sessionPath(), { method: 'DELETE', stream: true });
+  }
+
+  /**
+   * Admit a message and resolve with its durable result evidence. For ambiguous
+   * admission failures, pass a stable `admissionId` or use `admitMessage()` plus
+   * `settleMessage()` directly.
+   */
+  async message(options: RemoteSessionMessageOptions): Promise<RemoteHarnessAgentResult> {
+    const admission = await this.admitMessage(options);
+    return this.settleMessage(admission.signalId, { runId: admission.runId });
+  }
+
+  admitMessage(options: RemoteSessionMessageOptions): Promise<MessageAdmissionResponse> {
+    const body: MessageAdmissionBody = {
+      content: options.content,
+      admissionId: options.admissionId ?? uuid(),
+      ...(options.mode !== undefined ? { mode: options.mode } : {}),
+      ...(options.model !== undefined ? { model: options.model } : {}),
+      ...(options.attachments !== undefined ? { attachments: options.attachments } : {}),
+    };
+    return this.requestJson(`${this.sessionPath()}/messages`, { method: 'POST', body, retries: 0 });
+  }
+
+  /**
+   * Admit queued work and resolve with its durable result evidence. For ambiguous
+   * admission failures, pass a stable `admissionId` or use `admitQueue()` plus
+   * `settleQueue()` directly.
+   */
+  async queue(options: RemoteSessionQueueOptions): Promise<RemoteHarnessAgentResult> {
+    const admission = await this.admitQueue(options);
+    return this.settleQueue(admission.queuedItemId);
+  }
+
+  admitQueue(options: RemoteSessionQueueOptions): Promise<QueueAdmissionResponse> {
+    const body: QueueAdmissionBody = {
+      content: options.content,
+      admissionId: options.admissionId ?? uuid(),
+      ...(options.mode !== undefined ? { mode: options.mode } : {}),
+      ...(options.model !== undefined ? { model: options.model } : {}),
+      ...(options.yolo !== undefined ? { yolo: options.yolo } : {}),
+      ...(options.attachments !== undefined ? { attachments: options.attachments } : {}),
+    };
+    return this.requestJson(`${this.sessionPath()}/queue`, { method: 'POST', body, retries: 0 });
+  }
+
+  async settleMessage(signalId: string, options: { runId?: string } = {}): Promise<RemoteHarnessAgentResult> {
+    return this.settleOperation('message', signalId, options);
+  }
+
+  async settleQueue(queuedItemId: string): Promise<RemoteHarnessAgentResult> {
+    return this.settleOperation('queue', queuedItemId);
+  }
+
+  lookupMessageResult(signalId: string): Promise<MessageOperationResult> {
+    return this.request(`${this.sessionPath()}/message-results/${encodeURIComponent(signalId)}`);
+  }
+
+  lookupQueueResult(queuedItemId: string): Promise<QueueOperationResult> {
+    return this.request(`${this.sessionPath()}/queue/${encodeURIComponent(queuedItemId)}/result`);
+  }
+
+  subscribe(
+    listener: RemoteHarnessEventListener,
+    options: RemoteHarnessSubscriptionOptions = {},
+  ): RemoteHarnessEventUnsubscribe {
+    return this.subscribeToEvents(listener, options, true);
+  }
+
+  private subscribeToEvents(
+    listener: RemoteHarnessEventListener,
+    options: RemoteHarnessSubscriptionOptions,
+    trackSessionCursor: boolean,
+  ): RemoteHarnessEventUnsubscribe {
+    if (trackSessionCursor && options.lastEventId !== undefined) {
+      this.lastEventId = options.lastEventId;
+    }
+    const subscription = new RemoteHarnessEventSubscription(this.options, this.sessionPath(), listener, {
+      ...options,
+      lastEventId: options.lastEventId ?? this.lastEventId,
+      onEventId: trackSessionCursor
+        ? eventId => {
+            this.lastEventId = eventId;
+          }
+        : undefined,
+      onReplayGap: async () => {
+        if (trackSessionCursor) {
+          this.lastEventId = undefined;
+          await this.refresh();
+        }
+        await options.onReplayGap?.();
+      },
+    });
+    subscription.start();
+    return () => subscription.close();
+  }
+
+  useSkill(): Promise<never> {
+    return Promise.reject(
+      new RemoteHarnessUnsupportedError(
+        'RemoteSession.useSkill() requires Harness skill routes that are not mounted by the current server contract',
+      ),
+    );
+  }
+
+  listSkills(): Promise<never> {
+    return Promise.reject(
+      new RemoteHarnessUnsupportedError(
+        'RemoteSession.listSkills() requires Harness skill descriptor routes that are not mounted by the current server contract',
+      ),
+    );
+  }
+
+  getSkill(): Promise<never> {
+    return Promise.reject(
+      new RemoteHarnessUnsupportedError(
+        'RemoteSession.getSkill() requires Harness skill descriptor routes that are not mounted by the current server contract',
+      ),
+    );
+  }
+
+  private async settleOperation(
+    source: 'message' | 'queue',
+    operationId: string,
+    options: { runId?: string } = {},
+  ): Promise<RemoteHarnessAgentResult> {
+    const initial = await this.lookupOperation(source, operationId);
+    if (initial.status !== 'pending') return resultValueOrThrow(initial);
+
+    return new Promise((resolve, reject) => {
+      let unsubscribe: RemoteHarnessEventUnsubscribe = () => {};
+      let pollTimer: ReturnType<typeof setInterval> | undefined;
+      let settled = false;
+      const cleanup = () => {
+        unsubscribe();
+        if (pollTimer !== undefined) {
+          clearInterval(pollTimer);
+          pollTimer = undefined;
+        }
+      };
+      const finishFromLookup = async () => {
+        if (settled) return;
+        try {
+          const result = await this.lookupOperation(source, operationId);
+          if (result.status === 'pending') return;
+          const value = resultValueOrThrow(result);
+          settled = true;
+          cleanup();
+          resolve(value);
+        } catch (error) {
+          if (error instanceof RemoteHarnessOperationError) {
+            settled = true;
+            cleanup();
+            reject(error);
+            return;
+          }
+          if (isAbortError(error)) {
+            settled = true;
+            cleanup();
+            reject(error);
+            return;
+          }
+          const status = errorStatus(error);
+          if (status === undefined || status >= 500) return;
+          settled = true;
+          cleanup();
+          reject(error);
+        }
+      };
+      unsubscribe = this.subscribeToEvents(
+        async event => {
+          if (!eventMatchesOperation(event, source, operationId, options.runId)) return;
+          await finishFromLookup();
+        },
+        {
+          onReplayGap: finishFromLookup,
+          onError: () => void finishFromLookup(),
+        },
+        false,
+      );
+      pollTimer = setInterval(() => void finishFromLookup(), 1000);
+    });
+  }
+
+  private lookupOperation(source: 'message' | 'queue', operationId: string): Promise<OperationResult> {
+    return source === 'message' ? this.lookupMessageResult(operationId) : this.lookupQueueResult(operationId);
+  }
+
+  private async requestJsonWithResponse<T>(
+    path: string,
+    options: HarnessRequestOptions = {},
+  ): Promise<{ data: T; response: Response }> {
+    const response = await requestRaw(this.options, this.apiPrefix, path, options);
+    return { data: (await response.json()) as T, response };
+  }
+
+  private requestJson<T>(path: string, options: HarnessRequestOptions = {}): Promise<T> {
+    return requestJson(this.options, this.apiPrefix, path, options);
+  }
+
+  private sessionPath(): string {
+    return `/harness/${encodeURIComponent(this.harnessName)}/sessions/${encodeURIComponent(this.id)}`;
+  }
+}
+
+class RemoteHarnessEventSubscription extends BaseResource {
+  private closed = false;
+  private lastEventId: string | undefined;
+  private abortController: AbortController | undefined;
+  private reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+
+  constructor(
+    options: ClientOptions,
+    private readonly path: string,
+    private readonly listener: RemoteHarnessEventListener,
+    private readonly subscriptionOptions: RemoteHarnessSubscriptionOptions & {
+      onEventId?: (eventId: string) => void;
+      onReplayGap?: () => Promise<void>;
+    },
+  ) {
+    super(options);
+    this.lastEventId = subscriptionOptions.lastEventId;
+  }
+
+  start(): void {
+    void this.run().catch(error => {
+      if (!this.closed && !this.subscriptionOptions.signal?.aborted) {
+        void this.subscriptionOptions.onError?.(error);
+      }
+    });
+  }
+
+  close(): void {
+    this.closed = true;
+    this.abortController?.abort();
+    void this.reader?.cancel();
+  }
+
+  private async run(): Promise<void> {
+    let reconnectDelayMs = this.options.backoffMs ?? 100;
+    const maxReconnectDelayMs = this.options.maxBackoffMs ?? 1000;
+    while (!this.closed && !this.subscriptionOptions.signal?.aborted) {
+      try {
+        await this.readOnce();
+        if (!this.subscriptionOptions.reconnect) return;
+        await delayUnlessClosed(reconnectDelayMs, () => this.closed || !!this.subscriptionOptions.signal?.aborted);
+        reconnectDelayMs = Math.min(reconnectDelayMs * 2, maxReconnectDelayMs);
+      } catch (error) {
+        if (this.closed || this.subscriptionOptions.signal?.aborted) return;
+        if (isReplayGapError(error)) {
+          await this.subscriptionOptions.onReplayGap?.();
+          this.lastEventId = undefined;
+          continue;
+        }
+        const status = errorStatus(error);
+        if (status !== undefined && status >= 400 && status < 500) {
+          await this.subscriptionOptions.onError?.(error);
+          return;
+        }
+        if (!this.subscriptionOptions.reconnect) {
+          await this.subscriptionOptions.onError?.(error);
+          return;
+        }
+        await this.subscriptionOptions.onError?.(error);
+        await delayUnlessClosed(reconnectDelayMs, () => this.closed || !!this.subscriptionOptions.signal?.aborted);
+        reconnectDelayMs = Math.min(reconnectDelayMs * 2, maxReconnectDelayMs);
+      }
+    }
+  }
+
+  private async readOnce(): Promise<void> {
+    const response = await this.requestEventStream();
+    const body = response.body;
+    if (!body) return;
+
+    const reader = body.getReader();
+    this.reader = reader;
+    const decoder = new TextDecoder();
+    let buffer = '';
+    const abort = () => {
+      this.abortController?.abort();
+      void reader.cancel();
+    };
+    this.options.abortSignal?.addEventListener('abort', abort, { once: true });
+    this.subscriptionOptions.signal?.addEventListener('abort', abort, { once: true });
+
+    try {
+      while (!this.closed) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const chunks = buffer.split('\n\n');
+        buffer = chunks.pop() ?? '';
+        for (const chunk of chunks) {
+          const event = parseHarnessSseChunk(chunk);
+          if (!event) continue;
+          if (this.closed) return;
+          await this.listener(event);
+          this.lastEventId = event.id;
+          this.subscriptionOptions.onEventId?.(event.id);
+        }
+      }
+    } finally {
+      this.options.abortSignal?.removeEventListener('abort', abort);
+      this.subscriptionOptions.signal?.removeEventListener('abort', abort);
+      if (this.reader === reader) this.reader = undefined;
+      this.abortController = undefined;
+      reader.releaseLock();
+    }
+  }
+
+  private async requestEventStream(): Promise<Response> {
+    const controller = new AbortController();
+    this.abortController = controller;
+    const abort = () => controller.abort();
+    this.options.abortSignal?.addEventListener('abort', abort, { once: true });
+    this.subscriptionOptions.signal?.addEventListener('abort', abort, { once: true });
+
+    try {
+      return await requestRaw(this.options, this.apiPrefix, `${this.path}/events`, {
+        stream: true,
+        headers: this.lastEventId ? { 'Last-Event-ID': this.lastEventId } : undefined,
+        signal: controller.signal,
+        retries: 0,
+      });
+    } finally {
+      this.options.abortSignal?.removeEventListener('abort', abort);
+      this.subscriptionOptions.signal?.removeEventListener('abort', abort);
+    }
+  }
+}
+
+async function requestRaw(
+  clientOptions: ClientOptions,
+  apiPrefix: string,
+  path: string,
+  options: HarnessRequestOptions = {},
+): Promise<Response> {
+  const { retries: requestRetriesOverride, stream: _stream, signal: requestSignal, ...fetchOptions } = options;
+  const {
+    baseUrl,
+    retries = 3,
+    backoffMs = 100,
+    maxBackoffMs = 1000,
+    headers = {},
+    credentials,
+    fetch: customFetch,
+  } = clientOptions;
+  const requestRetries = requestRetriesOverride ?? retries;
+  const fetchFn = customFetch || fetch;
+  let delay = backoffMs;
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt <= requestRetries; attempt++) {
+    try {
+      const response = await fetchFn(`${baseUrl.replace(/\/$/, '')}${apiPrefix}${path}`, {
+        ...fetchOptions,
+        headers: {
+          ...(fetchOptions.body &&
+          !(fetchOptions.body instanceof FormData) &&
+          (fetchOptions.method === 'POST' ||
+            fetchOptions.method === 'PUT' ||
+            fetchOptions.method === 'PATCH' ||
+            fetchOptions.method === 'DELETE')
+            ? { 'content-type': 'application/json' }
+            : {}),
+          ...headers,
+          ...fetchOptions.headers,
+        },
+        signal: requestSignal ?? clientOptions.abortSignal,
+        credentials: fetchOptions.credentials ?? credentials,
+        body:
+          fetchOptions.body instanceof FormData
+            ? fetchOptions.body
+            : fetchOptions.body
+              ? JSON.stringify(fetchOptions.body)
+              : undefined,
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        let parsedBody: unknown;
+        let errorMessage = `HTTP error! status: ${response.status}`;
+        try {
+          parsedBody = JSON.parse(errorBody);
+          errorMessage += ` - ${JSON.stringify(parsedBody)}`;
+        } catch {
+          if (errorBody) errorMessage += ` - ${errorBody}`;
+        }
+        throw new MastraClientError(response.status, response.statusText, errorMessage, parsedBody);
+      }
+
+      return response;
+    } catch (error) {
+      lastError = error as Error;
+      const status = (error as Error & { status?: number }).status;
+      if (status !== undefined && status >= 400 && status < 500) {
+        throw error;
+      }
+      if (attempt === requestRetries) break;
+      await new Promise(resolve => setTimeout(resolve, delay));
+      delay = Math.min(delay * 2, maxBackoffMs);
+    }
+  }
+
+  throw lastError || new Error('Request failed');
+}
+
+async function requestJson<T>(
+  clientOptions: ClientOptions,
+  apiPrefix: string,
+  path: string,
+  options: HarnessRequestOptions = {},
+): Promise<T> {
+  const response = await requestRaw(clientOptions, apiPrefix, path, options);
+  return (await response.json()) as T;
+}
+
+function parseSessionVersionFromEtag(etag: string | null): number | undefined {
+  const match = etag ? /^"([0-9]+)"$/.exec(etag) : null;
+  return match ? Number(match[1]) : undefined;
+}
+
+function parseHarnessSseChunk(chunk: string): HarnessEvent | undefined {
+  const dataLines: string[] = [];
+  for (const line of chunk.split('\n')) {
+    if (line.startsWith('data:')) {
+      dataLines.push(line.slice(line.startsWith('data: ') ? 6 : 5));
+    }
+  }
+  if (dataLines.length === 0) return undefined;
+  return JSON.parse(dataLines.join('\n')) as HarnessEvent;
+}
+
+function eventMatchesOperation(
+  event: HarnessEvent,
+  source: 'message' | 'queue',
+  operationId: string,
+  runId?: string,
+): boolean {
+  if (event.type !== 'agent_end') return false;
+  if (source === 'message') {
+    return event.signalId === operationId || (runId !== undefined && event.runId === runId);
+  }
+  return event.queuedItemId === operationId;
+}
+
+function resultValueOrThrow(result: OperationResult): RemoteHarnessAgentResult {
+  switch (result.status) {
+    case 'completed':
+      return result.result;
+    case 'failed':
+    case 'expired':
+    case 'not_found':
+      throw new RemoteHarnessOperationError(result);
+    case 'pending':
+      throw new Error('Harness operation is still pending');
+  }
+}
+
+function isReplayGapError(error: unknown): boolean {
+  if (errorStatus(error) !== 412 || !(error instanceof MastraClientError)) return false;
+  return (
+    typeof error.body !== 'object' ||
+    error.body === null ||
+    !('code' in error.body) ||
+    error.body.code === 'harness.event_replay_unavailable'
+  );
+}
+
+function errorStatus(error: unknown): number | undefined {
+  return typeof (error as { status?: unknown })?.status === 'number' ? (error as { status: number }).status : undefined;
+}
+
+function isAbortError(error: unknown): boolean {
+  return typeof (error as { name?: unknown })?.name === 'string' && (error as { name: string }).name === 'AbortError';
+}
+
+async function delayUnlessClosed(ms: number, isClosed: () => boolean): Promise<void> {
+  if (ms <= 0 || isClosed()) return;
+  await new Promise<void>(resolve => {
+    const timeout = setTimeout(resolve, ms);
+    if (isClosed()) {
+      clearTimeout(timeout);
+      resolve();
+    }
+  });
+}

--- a/client-sdks/client-js/src/resources/harness.ts
+++ b/client-sdks/client-js/src/resources/harness.ts
@@ -689,7 +689,7 @@ class RemoteHarnessEventSubscription extends BaseResource {
         const { done, value } = await reader.read();
         if (done) break;
         buffer += decoder.decode(value, { stream: true });
-        const chunks = buffer.split('\n\n');
+        const chunks = buffer.split(/\r?\n\r?\n/);
         buffer = chunks.pop() ?? '';
         for (const chunk of chunks) {
           const event = parseHarnessSseChunk(chunk);
@@ -793,6 +793,9 @@ async function requestRaw(
       return response;
     } catch (error) {
       lastError = error as Error;
+      if (isAbortError(error)) {
+        throw error;
+      }
       const status = (error as Error & { status?: number }).status;
       if (status !== undefined && status >= 400 && status < 500) {
         throw error;
@@ -823,7 +826,7 @@ function parseSessionVersionFromEtag(etag: string | null): number | undefined {
 
 function parseHarnessSseChunk(chunk: string): HarnessEvent | undefined {
   const dataLines: string[] = [];
-  for (const line of chunk.split('\n')) {
+  for (const line of chunk.split(/\r?\n/)) {
     if (line.startsWith('data:')) {
       dataLines.push(line.slice(line.startsWith('data: ') ? 6 : 5));
     }
@@ -873,7 +876,11 @@ function errorStatus(error: unknown): number | undefined {
 }
 
 function isAbortError(error: unknown): boolean {
-  return typeof (error as { name?: unknown })?.name === 'string' && (error as { name: string }).name === 'AbortError';
+  const candidate = error as { code?: unknown; name?: unknown };
+  return (
+    (typeof candidate.name === 'string' && candidate.name === 'AbortError') ||
+    (typeof candidate.code === 'string' && candidate.code === 'ERR_ABORTED')
+  );
 }
 
 async function delayUnlessClosed(ms: number, isClosed: () => boolean): Promise<void> {

--- a/client-sdks/client-js/src/resources/index.ts
+++ b/client-sdks/client-js/src/resources/index.ts
@@ -20,3 +20,4 @@ export * from './workspace';
 export * from './stored-skill';
 export * from './responses';
 export * from './channels';
+export * from './harness';

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -77653,7 +77653,6 @@ export type PostHarnessNameSessions_Body = {
         | string
         | {
             fresh: true;
-            [x: string]: never;
           }
       )
     | undefined;
@@ -77661,7 +77660,6 @@ export type PostHarnessNameSessions_Body = {
   origin?: 'top-level' | undefined;
   modeId?: string | undefined;
   modelId?: string | undefined;
-  [x: string]: never;
 };
 
 type PostHarnessNameSessions_Response_Auxiliary_10 =
@@ -77927,6 +77925,845 @@ export interface GetHarnessNameSessionsSessionId_RouteContract {
   body: never;
   request: GetHarnessNameSessionsSessionId_Request;
   response: GetHarnessNameSessionsSessionId_Response;
+  responseType: 'datastream-response';
+}
+
+// ============================================================================
+// Route: POST /harness/:name/sessions/:sessionId/messages
+// ============================================================================
+export type PostHarnessNameSessionsSessionIdMessages_PathParams = {
+  /** Harness registration name */
+  name: string;
+  /** Harness session id */
+  sessionId: string;
+};
+
+type PostHarnessNameSessionsSessionIdMessages_Body_Auxiliary_2 =
+  | string
+  | number
+  | boolean
+  | null
+  | PostHarnessNameSessionsSessionIdMessages_Body_Auxiliary_2[]
+  | {
+      [key: string]: PostHarnessNameSessionsSessionIdMessages_Body_Auxiliary_2;
+    };
+
+export type PostHarnessNameSessionsSessionIdMessages_Body = {
+  content: string;
+  admissionId: string;
+  mode?: string | undefined;
+  model?: string | undefined;
+  attachments?:
+    | {
+        attachmentId: string;
+        resourceId: string;
+        ownerSessionId?: string | undefined;
+        bytes?: number | undefined;
+        sha256?: string | undefined;
+        source?: ('inline' | 'preupload' | 'url' | 'provider') | undefined;
+        kind?: ('file' | 'primitive' | 'element') | undefined;
+        name?: string | undefined;
+        mimeType?: string | undefined;
+        primitiveType?: string | undefined;
+        elementType?: string | undefined;
+        renderer?:
+          | {
+              [key: string]: PostHarnessNameSessionsSessionIdMessages_Body_Auxiliary_2;
+            }
+          | undefined;
+        schemaId?: string | undefined;
+        metadata?:
+          | {
+              [key: string]: PostHarnessNameSessionsSessionIdMessages_Body_Auxiliary_2;
+            }
+          | undefined;
+        object?:
+          | {
+              [key: string]: PostHarnessNameSessionsSessionIdMessages_Body_Auxiliary_2;
+            }
+          | undefined;
+      }[]
+    | undefined;
+};
+
+export type PostHarnessNameSessionsSessionIdMessages_Response = {
+  accepted: true;
+  signalId: string;
+  runId?: string | undefined;
+  duplicate: boolean;
+};
+
+export type PostHarnessNameSessionsSessionIdMessages_Request = Simplify<
+  (PostHarnessNameSessionsSessionIdMessages_PathParams extends never
+    ? {}
+    : { params: PostHarnessNameSessionsSessionIdMessages_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostHarnessNameSessionsSessionIdMessages_Body extends never
+      ? {}
+      : {} extends PostHarnessNameSessionsSessionIdMessages_Body
+        ? { body?: PostHarnessNameSessionsSessionIdMessages_Body }
+        : { body: PostHarnessNameSessionsSessionIdMessages_Body })
+>;
+
+export interface PostHarnessNameSessionsSessionIdMessages_RouteContract {
+  pathParams: PostHarnessNameSessionsSessionIdMessages_PathParams;
+  queryParams: never;
+  body: PostHarnessNameSessionsSessionIdMessages_Body;
+  request: PostHarnessNameSessionsSessionIdMessages_Request;
+  response: PostHarnessNameSessionsSessionIdMessages_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: POST /harness/:name/sessions/:sessionId/queue
+// ============================================================================
+export type PostHarnessNameSessionsSessionIdQueue_PathParams = {
+  /** Harness registration name */
+  name: string;
+  /** Harness session id */
+  sessionId: string;
+};
+
+type PostHarnessNameSessionsSessionIdQueue_Body_Auxiliary_2 =
+  | string
+  | number
+  | boolean
+  | null
+  | PostHarnessNameSessionsSessionIdQueue_Body_Auxiliary_2[]
+  | {
+      [key: string]: PostHarnessNameSessionsSessionIdQueue_Body_Auxiliary_2;
+    };
+
+export type PostHarnessNameSessionsSessionIdQueue_Body = {
+  content: string;
+  admissionId: string;
+  mode?: string | undefined;
+  model?: string | undefined;
+  yolo?: boolean | undefined;
+  attachments?:
+    | {
+        attachmentId: string;
+        resourceId: string;
+        ownerSessionId?: string | undefined;
+        bytes?: number | undefined;
+        sha256?: string | undefined;
+        source?: ('inline' | 'preupload' | 'url' | 'provider') | undefined;
+        kind?: ('file' | 'primitive' | 'element') | undefined;
+        name?: string | undefined;
+        mimeType?: string | undefined;
+        primitiveType?: string | undefined;
+        elementType?: string | undefined;
+        renderer?:
+          | {
+              [key: string]: PostHarnessNameSessionsSessionIdQueue_Body_Auxiliary_2;
+            }
+          | undefined;
+        schemaId?: string | undefined;
+        metadata?:
+          | {
+              [key: string]: PostHarnessNameSessionsSessionIdQueue_Body_Auxiliary_2;
+            }
+          | undefined;
+        object?:
+          | {
+              [key: string]: PostHarnessNameSessionsSessionIdQueue_Body_Auxiliary_2;
+            }
+          | undefined;
+      }[]
+    | undefined;
+};
+
+export type PostHarnessNameSessionsSessionIdQueue_Response = {
+  accepted: true;
+  queuedItemId: string;
+  duplicate: boolean;
+};
+
+export type PostHarnessNameSessionsSessionIdQueue_Request = Simplify<
+  (PostHarnessNameSessionsSessionIdQueue_PathParams extends never
+    ? {}
+    : { params: PostHarnessNameSessionsSessionIdQueue_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostHarnessNameSessionsSessionIdQueue_Body extends never
+      ? {}
+      : {} extends PostHarnessNameSessionsSessionIdQueue_Body
+        ? { body?: PostHarnessNameSessionsSessionIdQueue_Body }
+        : { body: PostHarnessNameSessionsSessionIdQueue_Body })
+>;
+
+export interface PostHarnessNameSessionsSessionIdQueue_RouteContract {
+  pathParams: PostHarnessNameSessionsSessionIdQueue_PathParams;
+  queryParams: never;
+  body: PostHarnessNameSessionsSessionIdQueue_Body;
+  request: PostHarnessNameSessionsSessionIdQueue_Request;
+  response: PostHarnessNameSessionsSessionIdQueue_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: GET /harness/:name/sessions/:sessionId/message-results/:signalId
+// ============================================================================
+export type GetHarnessNameSessionsSessionIdMessageResultsSignalId_PathParams = {
+  /** Harness registration name */
+  name: string;
+  /** Harness session id */
+  sessionId: string;
+  /** Message signal id */
+  signalId: string;
+};
+
+export type GetHarnessNameSessionsSessionIdMessageResultsSignalId_Response =
+  | {
+      status: 'pending';
+      source: 'message' | 'queue';
+      runId?: string | undefined;
+    }
+  | {
+      status: 'completed';
+      source: 'message' | 'queue';
+      runId?: string | undefined;
+      result: unknown;
+    }
+  | {
+      status: 'failed';
+      source: 'message' | 'queue';
+      runId?: string | undefined;
+      error: {
+        code: string;
+        message: string;
+      };
+    }
+  | {
+      status: 'expired';
+      source: 'message' | 'queue';
+      runId?: string | undefined;
+      expiredAt?: number | undefined;
+    }
+  | {
+      status: 'not_found';
+      source: 'message' | 'queue';
+    };
+
+export type GetHarnessNameSessionsSessionIdMessageResultsSignalId_Request = Simplify<
+  (GetHarnessNameSessionsSessionIdMessageResultsSignalId_PathParams extends never
+    ? {}
+    : { params: GetHarnessNameSessionsSessionIdMessageResultsSignalId_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
+>;
+
+export interface GetHarnessNameSessionsSessionIdMessageResultsSignalId_RouteContract {
+  pathParams: GetHarnessNameSessionsSessionIdMessageResultsSignalId_PathParams;
+  queryParams: never;
+  body: never;
+  request: GetHarnessNameSessionsSessionIdMessageResultsSignalId_Request;
+  response: GetHarnessNameSessionsSessionIdMessageResultsSignalId_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: GET /harness/:name/sessions/:sessionId/queue/:queuedItemId/result
+// ============================================================================
+export type GetHarnessNameSessionsSessionIdQueueQueuedItemIdResult_PathParams = {
+  /** Harness registration name */
+  name: string;
+  /** Harness session id */
+  sessionId: string;
+  /** Queued item id */
+  queuedItemId: string;
+};
+
+export type GetHarnessNameSessionsSessionIdQueueQueuedItemIdResult_Response =
+  | {
+      status: 'pending';
+      source: 'message' | 'queue';
+      runId?: string | undefined;
+    }
+  | {
+      status: 'completed';
+      source: 'message' | 'queue';
+      runId?: string | undefined;
+      result: unknown;
+    }
+  | {
+      status: 'failed';
+      source: 'message' | 'queue';
+      runId?: string | undefined;
+      error: {
+        code: string;
+        message: string;
+      };
+    }
+  | {
+      status: 'expired';
+      source: 'message' | 'queue';
+      runId?: string | undefined;
+      expiredAt?: number | undefined;
+    }
+  | {
+      status: 'not_found';
+      source: 'message' | 'queue';
+    };
+
+export type GetHarnessNameSessionsSessionIdQueueQueuedItemIdResult_Request = Simplify<
+  (GetHarnessNameSessionsSessionIdQueueQueuedItemIdResult_PathParams extends never
+    ? {}
+    : { params: GetHarnessNameSessionsSessionIdQueueQueuedItemIdResult_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
+>;
+
+export interface GetHarnessNameSessionsSessionIdQueueQueuedItemIdResult_RouteContract {
+  pathParams: GetHarnessNameSessionsSessionIdQueueQueuedItemIdResult_PathParams;
+  queryParams: never;
+  body: never;
+  request: GetHarnessNameSessionsSessionIdQueueQueuedItemIdResult_Request;
+  response: GetHarnessNameSessionsSessionIdQueueQueuedItemIdResult_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: GET /harness/:name/sessions/:sessionId/events
+// ============================================================================
+export type GetHarnessNameSessionsSessionIdEvents_PathParams = {
+  /** Harness registration name */
+  name: string;
+  /** Harness session id */
+  sessionId: string;
+};
+
+export type GetHarnessNameSessionsSessionIdEvents_Request = Simplify<
+  (GetHarnessNameSessionsSessionIdEvents_PathParams extends never
+    ? {}
+    : { params: GetHarnessNameSessionsSessionIdEvents_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
+>;
+
+export interface GetHarnessNameSessionsSessionIdEvents_RouteContract {
+  pathParams: GetHarnessNameSessionsSessionIdEvents_PathParams;
+  queryParams: never;
+  body: never;
+  request: GetHarnessNameSessionsSessionIdEvents_Request;
+  response: unknown;
+  responseType: 'datastream-response';
+}
+
+// ============================================================================
+// Route: GET /harness/:name/sessions/:sessionId/state
+// ============================================================================
+export type GetHarnessNameSessionsSessionIdState_PathParams = {
+  /** Harness registration name */
+  name: string;
+  /** Harness session id */
+  sessionId: string;
+};
+
+export type GetHarnessNameSessionsSessionIdState_Request = Simplify<
+  (GetHarnessNameSessionsSessionIdState_PathParams extends never
+    ? {}
+    : { params: GetHarnessNameSessionsSessionIdState_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
+>;
+
+export interface GetHarnessNameSessionsSessionIdState_RouteContract {
+  pathParams: GetHarnessNameSessionsSessionIdState_PathParams;
+  queryParams: never;
+  body: never;
+  request: GetHarnessNameSessionsSessionIdState_Request;
+  response: unknown;
+  responseType: 'datastream-response';
+}
+
+// ============================================================================
+// Route: PATCH /harness/:name/sessions/:sessionId/state
+// ============================================================================
+export type PatchHarnessNameSessionsSessionIdState_PathParams = {
+  /** Harness registration name */
+  name: string;
+  /** Harness session id */
+  sessionId: string;
+};
+
+type PatchHarnessNameSessionsSessionIdState_Body_Auxiliary_0 =
+  | string
+  | number
+  | boolean
+  | null
+  | PatchHarnessNameSessionsSessionIdState_Body_Auxiliary_0[]
+  | {
+      [key: string]: PatchHarnessNameSessionsSessionIdState_Body_Auxiliary_0;
+    };
+
+export type PatchHarnessNameSessionsSessionIdState_Body = {
+  [key: string]: PatchHarnessNameSessionsSessionIdState_Body_Auxiliary_0;
+};
+
+export type PatchHarnessNameSessionsSessionIdState_Request = Simplify<
+  (PatchHarnessNameSessionsSessionIdState_PathParams extends never
+    ? {}
+    : { params: PatchHarnessNameSessionsSessionIdState_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PatchHarnessNameSessionsSessionIdState_Body extends never
+      ? {}
+      : {} extends PatchHarnessNameSessionsSessionIdState_Body
+        ? { body?: PatchHarnessNameSessionsSessionIdState_Body }
+        : { body: PatchHarnessNameSessionsSessionIdState_Body })
+>;
+
+export interface PatchHarnessNameSessionsSessionIdState_RouteContract {
+  pathParams: PatchHarnessNameSessionsSessionIdState_PathParams;
+  queryParams: never;
+  body: PatchHarnessNameSessionsSessionIdState_Body;
+  request: PatchHarnessNameSessionsSessionIdState_Request;
+  response: unknown;
+  responseType: 'datastream-response';
+}
+
+// ============================================================================
+// Route: PATCH /harness/:name/sessions/:sessionId/mode
+// ============================================================================
+export type PatchHarnessNameSessionsSessionIdMode_PathParams = {
+  /** Harness registration name */
+  name: string;
+  /** Harness session id */
+  sessionId: string;
+};
+
+export type PatchHarnessNameSessionsSessionIdMode_Body = {
+  mode: string;
+};
+
+export type PatchHarnessNameSessionsSessionIdMode_Response = {
+  modeId: string;
+};
+
+export type PatchHarnessNameSessionsSessionIdMode_Request = Simplify<
+  (PatchHarnessNameSessionsSessionIdMode_PathParams extends never
+    ? {}
+    : { params: PatchHarnessNameSessionsSessionIdMode_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PatchHarnessNameSessionsSessionIdMode_Body extends never
+      ? {}
+      : {} extends PatchHarnessNameSessionsSessionIdMode_Body
+        ? { body?: PatchHarnessNameSessionsSessionIdMode_Body }
+        : { body: PatchHarnessNameSessionsSessionIdMode_Body })
+>;
+
+export interface PatchHarnessNameSessionsSessionIdMode_RouteContract {
+  pathParams: PatchHarnessNameSessionsSessionIdMode_PathParams;
+  queryParams: never;
+  body: PatchHarnessNameSessionsSessionIdMode_Body;
+  request: PatchHarnessNameSessionsSessionIdMode_Request;
+  response: PatchHarnessNameSessionsSessionIdMode_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: PATCH /harness/:name/sessions/:sessionId/model
+// ============================================================================
+export type PatchHarnessNameSessionsSessionIdModel_PathParams = {
+  /** Harness registration name */
+  name: string;
+  /** Harness session id */
+  sessionId: string;
+};
+
+export type PatchHarnessNameSessionsSessionIdModel_Body = {
+  model: string;
+};
+
+export type PatchHarnessNameSessionsSessionIdModel_Response = {
+  modelId: string;
+};
+
+export type PatchHarnessNameSessionsSessionIdModel_Request = Simplify<
+  (PatchHarnessNameSessionsSessionIdModel_PathParams extends never
+    ? {}
+    : { params: PatchHarnessNameSessionsSessionIdModel_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PatchHarnessNameSessionsSessionIdModel_Body extends never
+      ? {}
+      : {} extends PatchHarnessNameSessionsSessionIdModel_Body
+        ? { body?: PatchHarnessNameSessionsSessionIdModel_Body }
+        : { body: PatchHarnessNameSessionsSessionIdModel_Body })
+>;
+
+export interface PatchHarnessNameSessionsSessionIdModel_RouteContract {
+  pathParams: PatchHarnessNameSessionsSessionIdModel_PathParams;
+  queryParams: never;
+  body: PatchHarnessNameSessionsSessionIdModel_Body;
+  request: PatchHarnessNameSessionsSessionIdModel_Request;
+  response: PatchHarnessNameSessionsSessionIdModel_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: PATCH /harness/:name/sessions/:sessionId/permissions
+// ============================================================================
+export type PatchHarnessNameSessionsSessionIdPermissions_PathParams = {
+  /** Harness registration name */
+  name: string;
+  /** Harness session id */
+  sessionId: string;
+};
+
+export type PatchHarnessNameSessionsSessionIdPermissions_Body =
+  | {
+      action: 'grantCategory';
+      category: string;
+    }
+  | {
+      action: 'grantTool';
+      toolName: string;
+    }
+  | {
+      action: 'revokeCategory';
+      category: string;
+    }
+  | {
+      action: 'revokeTool';
+      toolName: string;
+    }
+  | {
+      action: 'setPolicy';
+      category?: string | undefined;
+      toolName?: string | undefined;
+      policy: 'allow' | 'ask' | 'deny';
+    };
+
+export type PatchHarnessNameSessionsSessionIdPermissions_Response = {
+  grants: {
+    categories: string[];
+    tools: string[];
+  };
+  rules: {
+    categories: {
+      [key: string]: 'allow' | 'ask' | 'deny';
+    };
+    tools: {
+      [key: string]: 'allow' | 'ask' | 'deny';
+    };
+  };
+};
+
+export type PatchHarnessNameSessionsSessionIdPermissions_Request = Simplify<
+  (PatchHarnessNameSessionsSessionIdPermissions_PathParams extends never
+    ? {}
+    : { params: PatchHarnessNameSessionsSessionIdPermissions_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PatchHarnessNameSessionsSessionIdPermissions_Body extends never
+      ? {}
+      : {} extends PatchHarnessNameSessionsSessionIdPermissions_Body
+        ? { body?: PatchHarnessNameSessionsSessionIdPermissions_Body }
+        : { body: PatchHarnessNameSessionsSessionIdPermissions_Body })
+>;
+
+export interface PatchHarnessNameSessionsSessionIdPermissions_RouteContract {
+  pathParams: PatchHarnessNameSessionsSessionIdPermissions_PathParams;
+  queryParams: never;
+  body: PatchHarnessNameSessionsSessionIdPermissions_Body;
+  request: PatchHarnessNameSessionsSessionIdPermissions_Request;
+  response: PatchHarnessNameSessionsSessionIdPermissions_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: POST /harness/:name/sessions/:sessionId/inbox/:itemId
+// ============================================================================
+export type PostHarnessNameSessionsSessionIdInboxItemId_PathParams = {
+  /** Harness registration name */
+  name: string;
+  /** Harness session id */
+  sessionId: string;
+  /** Pending inbox item id */
+  itemId: string;
+};
+
+type PostHarnessNameSessionsSessionIdInboxItemId_Body_Auxiliary_2 =
+  | string
+  | number
+  | boolean
+  | null
+  | PostHarnessNameSessionsSessionIdInboxItemId_Body_Auxiliary_2[]
+  | {
+      [key: string]: PostHarnessNameSessionsSessionIdInboxItemId_Body_Auxiliary_2;
+    };
+
+export type PostHarnessNameSessionsSessionIdInboxItemId_Body =
+  | {
+      kind: 'tool-approval';
+      approved: boolean;
+      reason?: string | undefined;
+      responseId: string;
+    }
+  | {
+      kind: 'tool-suspension';
+      resumeData: PostHarnessNameSessionsSessionIdInboxItemId_Body_Auxiliary_2;
+      responseId: string;
+    }
+  | {
+      kind: 'question';
+      answer: PostHarnessNameSessionsSessionIdInboxItemId_Body_Auxiliary_2;
+      responseId: string;
+    }
+  | {
+      kind: 'plan-approval';
+      approved: boolean;
+      revision?: string | undefined;
+      responseId: string;
+      transitionToMode?: string | undefined;
+    };
+
+export type PostHarnessNameSessionsSessionIdInboxItemId_Response = {
+  itemId: string;
+  kind: 'tool-approval' | 'tool-suspension' | 'question' | 'plan-approval';
+  status: 'accepted' | 'applied';
+  responseId: string;
+  duplicate: boolean;
+};
+
+export type PostHarnessNameSessionsSessionIdInboxItemId_Request = Simplify<
+  (PostHarnessNameSessionsSessionIdInboxItemId_PathParams extends never
+    ? {}
+    : { params: PostHarnessNameSessionsSessionIdInboxItemId_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostHarnessNameSessionsSessionIdInboxItemId_Body extends never
+      ? {}
+      : {} extends PostHarnessNameSessionsSessionIdInboxItemId_Body
+        ? { body?: PostHarnessNameSessionsSessionIdInboxItemId_Body }
+        : { body: PostHarnessNameSessionsSessionIdInboxItemId_Body })
+>;
+
+export interface PostHarnessNameSessionsSessionIdInboxItemId_RouteContract {
+  pathParams: PostHarnessNameSessionsSessionIdInboxItemId_PathParams;
+  queryParams: never;
+  body: PostHarnessNameSessionsSessionIdInboxItemId_Body;
+  request: PostHarnessNameSessionsSessionIdInboxItemId_Request;
+  response: PostHarnessNameSessionsSessionIdInboxItemId_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: PUT /harness/:name/sessions/:sessionId/goal
+// ============================================================================
+export type PutHarnessNameSessionsSessionIdGoal_PathParams = {
+  /** Harness registration name */
+  name: string;
+  /** Harness session id */
+  sessionId: string;
+};
+
+export type PutHarnessNameSessionsSessionIdGoal_Body = {
+  objective: string;
+  judgeModel?: string | undefined;
+  maxTurns?: number | undefined;
+  kickoff?: boolean | undefined;
+};
+
+export type PutHarnessNameSessionsSessionIdGoal_Response = {
+  goal: {
+    id: string;
+    objective: string;
+    status: 'active' | 'paused' | 'done';
+    turnsUsed: number;
+    maxTurns: number;
+    judgeModelId: string;
+    createdAt: number;
+    lastDecision?:
+      | {
+          decision: 'done' | 'continue' | 'waiting';
+          reason: string;
+          judgedAt: number;
+        }
+      | undefined;
+  } | null;
+};
+
+export type PutHarnessNameSessionsSessionIdGoal_Request = Simplify<
+  (PutHarnessNameSessionsSessionIdGoal_PathParams extends never
+    ? {}
+    : { params: PutHarnessNameSessionsSessionIdGoal_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PutHarnessNameSessionsSessionIdGoal_Body extends never
+      ? {}
+      : {} extends PutHarnessNameSessionsSessionIdGoal_Body
+        ? { body?: PutHarnessNameSessionsSessionIdGoal_Body }
+        : { body: PutHarnessNameSessionsSessionIdGoal_Body })
+>;
+
+export interface PutHarnessNameSessionsSessionIdGoal_RouteContract {
+  pathParams: PutHarnessNameSessionsSessionIdGoal_PathParams;
+  queryParams: never;
+  body: PutHarnessNameSessionsSessionIdGoal_Body;
+  request: PutHarnessNameSessionsSessionIdGoal_Request;
+  response: PutHarnessNameSessionsSessionIdGoal_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: GET /harness/:name/sessions/:sessionId/goal
+// ============================================================================
+export type GetHarnessNameSessionsSessionIdGoal_PathParams = {
+  /** Harness registration name */
+  name: string;
+  /** Harness session id */
+  sessionId: string;
+};
+
+export type GetHarnessNameSessionsSessionIdGoal_Response = {
+  goal: {
+    id: string;
+    objective: string;
+    status: 'active' | 'paused' | 'done';
+    turnsUsed: number;
+    maxTurns: number;
+    judgeModelId: string;
+    createdAt: number;
+    lastDecision?:
+      | {
+          decision: 'done' | 'continue' | 'waiting';
+          reason: string;
+          judgedAt: number;
+        }
+      | undefined;
+  } | null;
+};
+
+export type GetHarnessNameSessionsSessionIdGoal_Request = Simplify<
+  (GetHarnessNameSessionsSessionIdGoal_PathParams extends never
+    ? {}
+    : { params: GetHarnessNameSessionsSessionIdGoal_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
+>;
+
+export interface GetHarnessNameSessionsSessionIdGoal_RouteContract {
+  pathParams: GetHarnessNameSessionsSessionIdGoal_PathParams;
+  queryParams: never;
+  body: never;
+  request: GetHarnessNameSessionsSessionIdGoal_Request;
+  response: GetHarnessNameSessionsSessionIdGoal_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: POST /harness/:name/sessions/:sessionId/goal/pause
+// ============================================================================
+export type PostHarnessNameSessionsSessionIdGoalPause_PathParams = {
+  /** Harness registration name */
+  name: string;
+  /** Harness session id */
+  sessionId: string;
+};
+
+export type PostHarnessNameSessionsSessionIdGoalPause_Response = {
+  goal: {
+    id: string;
+    objective: string;
+    status: 'active' | 'paused' | 'done';
+    turnsUsed: number;
+    maxTurns: number;
+    judgeModelId: string;
+    createdAt: number;
+    lastDecision?:
+      | {
+          decision: 'done' | 'continue' | 'waiting';
+          reason: string;
+          judgedAt: number;
+        }
+      | undefined;
+  } | null;
+};
+
+export type PostHarnessNameSessionsSessionIdGoalPause_Request = Simplify<
+  (PostHarnessNameSessionsSessionIdGoalPause_PathParams extends never
+    ? {}
+    : { params: PostHarnessNameSessionsSessionIdGoalPause_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
+>;
+
+export interface PostHarnessNameSessionsSessionIdGoalPause_RouteContract {
+  pathParams: PostHarnessNameSessionsSessionIdGoalPause_PathParams;
+  queryParams: never;
+  body: never;
+  request: PostHarnessNameSessionsSessionIdGoalPause_Request;
+  response: PostHarnessNameSessionsSessionIdGoalPause_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: POST /harness/:name/sessions/:sessionId/goal/resume
+// ============================================================================
+export type PostHarnessNameSessionsSessionIdGoalResume_PathParams = {
+  /** Harness registration name */
+  name: string;
+  /** Harness session id */
+  sessionId: string;
+};
+
+export type PostHarnessNameSessionsSessionIdGoalResume_Response = {
+  goal: {
+    id: string;
+    objective: string;
+    status: 'active' | 'paused' | 'done';
+    turnsUsed: number;
+    maxTurns: number;
+    judgeModelId: string;
+    createdAt: number;
+    lastDecision?:
+      | {
+          decision: 'done' | 'continue' | 'waiting';
+          reason: string;
+          judgedAt: number;
+        }
+      | undefined;
+  } | null;
+};
+
+export type PostHarnessNameSessionsSessionIdGoalResume_Request = Simplify<
+  (PostHarnessNameSessionsSessionIdGoalResume_PathParams extends never
+    ? {}
+    : { params: PostHarnessNameSessionsSessionIdGoalResume_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
+>;
+
+export interface PostHarnessNameSessionsSessionIdGoalResume_RouteContract {
+  pathParams: PostHarnessNameSessionsSessionIdGoalResume_PathParams;
+  queryParams: never;
+  body: never;
+  request: PostHarnessNameSessionsSessionIdGoalResume_Request;
+  response: PostHarnessNameSessionsSessionIdGoalResume_Response;
+  responseType: 'json';
+}
+
+// ============================================================================
+// Route: DELETE /harness/:name/sessions/:sessionId/goal
+// ============================================================================
+export type DeleteHarnessNameSessionsSessionIdGoal_PathParams = {
+  /** Harness registration name */
+  name: string;
+  /** Harness session id */
+  sessionId: string;
+};
+
+export type DeleteHarnessNameSessionsSessionIdGoal_Request = Simplify<
+  (DeleteHarnessNameSessionsSessionIdGoal_PathParams extends never
+    ? {}
+    : { params: DeleteHarnessNameSessionsSessionIdGoal_PathParams }) &
+    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
+>;
+
+export interface DeleteHarnessNameSessionsSessionIdGoal_RouteContract {
+  pathParams: DeleteHarnessNameSessionsSessionIdGoal_PathParams;
+  queryParams: never;
+  body: never;
+  request: DeleteHarnessNameSessionsSessionIdGoal_Request;
+  response: unknown;
   responseType: 'datastream-response';
 }
 
@@ -78428,6 +79265,22 @@ export interface RouteTypes {
   'GET /harness/:name/sessions': GetHarnessNameSessions_RouteContract;
   'POST /harness/:name/sessions': PostHarnessNameSessions_RouteContract;
   'GET /harness/:name/sessions/:sessionId': GetHarnessNameSessionsSessionId_RouteContract;
+  'POST /harness/:name/sessions/:sessionId/messages': PostHarnessNameSessionsSessionIdMessages_RouteContract;
+  'POST /harness/:name/sessions/:sessionId/queue': PostHarnessNameSessionsSessionIdQueue_RouteContract;
+  'GET /harness/:name/sessions/:sessionId/message-results/:signalId': GetHarnessNameSessionsSessionIdMessageResultsSignalId_RouteContract;
+  'GET /harness/:name/sessions/:sessionId/queue/:queuedItemId/result': GetHarnessNameSessionsSessionIdQueueQueuedItemIdResult_RouteContract;
+  'GET /harness/:name/sessions/:sessionId/events': GetHarnessNameSessionsSessionIdEvents_RouteContract;
+  'GET /harness/:name/sessions/:sessionId/state': GetHarnessNameSessionsSessionIdState_RouteContract;
+  'PATCH /harness/:name/sessions/:sessionId/state': PatchHarnessNameSessionsSessionIdState_RouteContract;
+  'PATCH /harness/:name/sessions/:sessionId/mode': PatchHarnessNameSessionsSessionIdMode_RouteContract;
+  'PATCH /harness/:name/sessions/:sessionId/model': PatchHarnessNameSessionsSessionIdModel_RouteContract;
+  'PATCH /harness/:name/sessions/:sessionId/permissions': PatchHarnessNameSessionsSessionIdPermissions_RouteContract;
+  'POST /harness/:name/sessions/:sessionId/inbox/:itemId': PostHarnessNameSessionsSessionIdInboxItemId_RouteContract;
+  'PUT /harness/:name/sessions/:sessionId/goal': PutHarnessNameSessionsSessionIdGoal_RouteContract;
+  'GET /harness/:name/sessions/:sessionId/goal': GetHarnessNameSessionsSessionIdGoal_RouteContract;
+  'POST /harness/:name/sessions/:sessionId/goal/pause': PostHarnessNameSessionsSessionIdGoalPause_RouteContract;
+  'POST /harness/:name/sessions/:sessionId/goal/resume': PostHarnessNameSessionsSessionIdGoalResume_RouteContract;
+  'DELETE /harness/:name/sessions/:sessionId/goal': DeleteHarnessNameSessionsSessionIdGoal_RouteContract;
   'DELETE /harness/:name/sessions/:sessionId': DeleteHarnessNameSessionsSessionId_RouteContract;
   'GET /channels/platforms': GetChannelsPlatforms_RouteContract;
   'GET /channels/:platform/installations': GetChannelsPlatformInstallations_RouteContract;
@@ -78690,6 +79543,48 @@ export interface Client {
   '/harness/:name/sessions/:sessionId': {
     DELETE: DeleteHarnessNameSessionsSessionId_RouteContract;
     GET: GetHarnessNameSessionsSessionId_RouteContract;
+  };
+  '/harness/:name/sessions/:sessionId/events': {
+    GET: GetHarnessNameSessionsSessionIdEvents_RouteContract;
+  };
+  '/harness/:name/sessions/:sessionId/goal': {
+    DELETE: DeleteHarnessNameSessionsSessionIdGoal_RouteContract;
+    GET: GetHarnessNameSessionsSessionIdGoal_RouteContract;
+    PUT: PutHarnessNameSessionsSessionIdGoal_RouteContract;
+  };
+  '/harness/:name/sessions/:sessionId/goal/pause': {
+    POST: PostHarnessNameSessionsSessionIdGoalPause_RouteContract;
+  };
+  '/harness/:name/sessions/:sessionId/goal/resume': {
+    POST: PostHarnessNameSessionsSessionIdGoalResume_RouteContract;
+  };
+  '/harness/:name/sessions/:sessionId/inbox/:itemId': {
+    POST: PostHarnessNameSessionsSessionIdInboxItemId_RouteContract;
+  };
+  '/harness/:name/sessions/:sessionId/message-results/:signalId': {
+    GET: GetHarnessNameSessionsSessionIdMessageResultsSignalId_RouteContract;
+  };
+  '/harness/:name/sessions/:sessionId/messages': {
+    POST: PostHarnessNameSessionsSessionIdMessages_RouteContract;
+  };
+  '/harness/:name/sessions/:sessionId/mode': {
+    PATCH: PatchHarnessNameSessionsSessionIdMode_RouteContract;
+  };
+  '/harness/:name/sessions/:sessionId/model': {
+    PATCH: PatchHarnessNameSessionsSessionIdModel_RouteContract;
+  };
+  '/harness/:name/sessions/:sessionId/permissions': {
+    PATCH: PatchHarnessNameSessionsSessionIdPermissions_RouteContract;
+  };
+  '/harness/:name/sessions/:sessionId/queue': {
+    POST: PostHarnessNameSessionsSessionIdQueue_RouteContract;
+  };
+  '/harness/:name/sessions/:sessionId/queue/:queuedItemId/result': {
+    GET: GetHarnessNameSessionsSessionIdQueueQueuedItemIdResult_RouteContract;
+  };
+  '/harness/:name/sessions/:sessionId/state': {
+    GET: GetHarnessNameSessionsSessionIdState_RouteContract;
+    PATCH: PatchHarnessNameSessionsSessionIdState_RouteContract;
   };
   '/logs': {
     GET: GetLogs_RouteContract;

--- a/docs/src/content/en/docs/server/mastra-client.mdx
+++ b/docs/src/content/en/docs/server/mastra-client.mdx
@@ -57,8 +57,33 @@ The Mastra Client SDK exposes all resources served by the Mastra Server.
 - **[Vectors](/reference/client-js/vectors)**: Use vector embeddings for semantic search.
 - **[Responses](/reference/client-js/responses)**: Use Mastra Agents as a Responses API with an OpenAI-compatible, agent-backed interface. This API is currently experimental.
 - **[Conversations](/reference/client-js/conversations)**: Work with the stored conversation threads and item history behind Mastra Agents as a Responses API. This API is currently experimental.
+- **Harness**: Create remote Harness sessions, reconnect to session events, and settle durable message or queue operations.
 - **[Logs](/reference/client-js/logs)**: View logs and debug system behavior.
 - **[Telemetry](/reference/client-js/telemetry)**: View app performance and trace activity.
+
+## Harness sessions
+
+Use `getHarness()` when your server registers Harness v1 routes and your client needs reconnectable sessions with durable operation recovery.
+
+```typescript
+import { mastraClient } from 'lib/mastra-client'
+
+const harness = mastraClient.getHarness('default')
+const session = await harness.session({ threadId: { fresh: true } })
+
+const unsubscribe = session.subscribe(event => {
+  console.log(event.type)
+})
+
+const result = await session.message({
+  content: 'Summarize the workspace status',
+  admissionId: 'workspace-summary-1',
+})
+
+unsubscribe()
+```
+
+`message()` and `queue()` submit work once, then resolve through the server result lookup endpoints. Pass a stable `admissionId` when the caller needs to recover from an interrupted request without admitting duplicate work.
 
 ## Generating responses
 

--- a/docs/src/content/en/reference/client-js/mastra-client.mdx
+++ b/docs/src/content/en/reference/client-js/mastra-client.mdx
@@ -151,10 +151,10 @@ You can also pass `requestContext` as a `Record<string, any>`.
     description: 'Retrieves a specific workflow instance by ID.',
   },
   {
-    name: 'getHarness(name)',
+    name: "getHarness(name = 'default')",
     type: 'RemoteHarness',
     description:
-      'Retrieves a Harness v1 client resource by registration name. Use it to create or load remote sessions, subscribe to session events, and recover durable message or queue results.',
+      'Retrieves a Harness v1 client resource by registration name, defaulting to `default` when omitted. Use it to create or load remote sessions, subscribe to session events, and recover durable message or queue results.',
   },
   {
     name: 'responses',

--- a/docs/src/content/en/reference/client-js/mastra-client.mdx
+++ b/docs/src/content/en/reference/client-js/mastra-client.mdx
@@ -151,6 +151,12 @@ You can also pass `requestContext` as a `Record<string, any>`.
     description: 'Retrieves a specific workflow instance by ID.',
   },
   {
+    name: 'getHarness(name)',
+    type: 'RemoteHarness',
+    description:
+      'Retrieves a Harness v1 client resource by registration name. Use it to create or load remote sessions, subscribe to session events, and recover durable message or queue results.',
+  },
+  {
     name: 'responses',
     type: 'Responses',
     description:

--- a/packages/server/scripts/generate-route-types.ts
+++ b/packages/server/scripts/generate-route-types.ts
@@ -61,12 +61,16 @@ function renderSchemaType(aliasName: string, schema: z4.$ZodType, deprecated: bo
   });
 
   const auxiliaryDeclarations = [...auxiliaryTypeStore.definitions.values()]
-    .map(definition => printNode(definition.node))
+    .map(definition => stripImpossibleNeverIndexSignatures(printNode(definition.node)))
     .join('\n\n');
 
-  const aliasDeclaration = `${deprecated ? '/** @deprecated */\n' : ''}export type ${aliasName} = ${printNode(node)};`;
+  const aliasDeclaration = `${deprecated ? '/** @deprecated */\n' : ''}export type ${aliasName} = ${stripImpossibleNeverIndexSignatures(printNode(node))};`;
 
   return auxiliaryDeclarations ? `${auxiliaryDeclarations}\n\n${aliasDeclaration}` : aliasDeclaration;
+}
+
+function stripImpossibleNeverIndexSignatures(typeScript: string): string {
+  return typeScript.replace(/^\s*\[x: string\]: never;\n/gm, '');
 }
 
 function getRoutePart(


### PR DESCRIPTION
Linear: PF-366

## Summary
- Adds first-party @mastra/client-js RemoteHarness and RemoteSession resources via MastraClient#getHarness(name).
- Supports remote session list/create/load/snapshot, state/mode/model/permissions/inbox/goal/close, durable message and queue admission, SSE event subscription with Last-Event-ID replay, and result lookup settlement.
- Adds public Harness client types, docs, and a changeset with a usage example.
- Regenerates client route types for Harness routes and fixes impossible strict-object never index signatures from zod-to-ts output.

## Coordination
- Open overlap checked: mbenhamd/mastra#136 / PF-365 touches attachment server routes and URL ingestion. This PR stays in client-js/docs/generated route types and does not implement PF-365 attachment server behavior.
- Built on origin/main after PF-546 merge commit 4ac6a83ed73083b7843758ab89bf0c4ff85a3a90.

## Validation
- pnpm --dir client-sdks/client-js exec vitest run src/resources/harness.test.ts: 24 passed.
- pnpm --filter @mastra/client-js exec tsc -p tsconfig.json --noEmit: passed.
- pnpm --filter @mastra/client-js exec eslint src/client.ts src/index.ts src/resources/index.ts src/resources/harness.ts src/resources/harness.test.ts: passed.
- pnpm --filter @mastra/server exec eslint scripts/generate-route-types.ts: passed.
- pnpm --filter @mastra/client-js build:lib: passed.
- git diff --check: passed.
- Local Codex review passes: correctness/safety and merge-readiness rerun after fixes; final pass reported no findings.
- CodeRabbit CLI local review: no findings.

## Notes
- pnpm --filter @mastra/client-js test:unit -- src/resources/harness.test.ts unexpectedly fanned out across the package and hit an unrelated existing agent.vnext.test.ts URL assertion; the direct Vitest harness invocation above passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a "Harness" client to the Mastra JavaScript SDK so apps can open and control remote sessions (cloud-hosted chat/task sessions). It lets clients create/load sessions, send durable messages or queued work, subscribe to live session events with safe replay, and recover interrupted operations.

## Overview

Adds first-party `@mastra/client-js` RemoteHarness and RemoteSession APIs surfaced via MastraClient.getHarness(name). Implements session lifecycle (list, create, load, snapshot), session management (state, mode, model, permissions, inbox, goals, close), durable message/queue admission and settlement, SSE event subscription with Last-Event-ID replay and reconnect semantics (including replay-gap handling and polling fallback), result lookup settlement for interrupted ops, public types/errors, docs, tests, and regenerated route types with a fix for impossible zod-to-ts index signatures.

## Changes

### Core Client API
- MastraClient.getHarness(name?: string = 'default'): RemoteHarness — new public method.

### New Harness Resource (client-sdks/client-js/src/resources/harness.ts)
- RemoteHarness: listSessions(), session(create/load), getSession(), getSnapshot().
- RemoteSession:
  - refresh(), getSnapshot(), getState<T>(), setState<T>(updates, options?) — optimistic PATCH via ETag/If-Match.
  - switchMode(), switchModel(), patchPermissions(), permissions helpers.
  - inbox response helpers.
  - goal lifecycle: put/get, pause, resume, delete.
  - message()/admitMessage() and queue()/admitQueue() with stable admission IDs for safe retries.
  - settleMessage/settleQueue and lookupMessageResult/lookupQueueResult — initial lookup + SSE-driven matching + polling fallback, with cleanup and abort behavior.
  - subscribe(listener, options) — SSE subscription with Last-Event-ID replay, replay-gap detection, reconnect/backoff, and unsubscribe abort semantics.
- Error classes:
  - RemoteHarnessUnsupportedError
  - RemoteHarnessOperationError (wraps failed/expired/not_found results)
  - RemoteHarnessStateVersionError (ETag/version mismatches)
- New exported types for snapshots, admissions, operation results, inbox responses, goals, permissions, listener/options, and related unions/interfaces.
- Internal helpers: HTTP/SSE plumbing, retry/backoff, JSON/error parsing, ETag extraction, SSE chunk parsing, and optimistic patch helpers.

### Route Types
- client-sdks/client-js/src/route-types.generated.ts: Adds route contract types for harness session endpoints (messages, queue, message-results/:signalId, queue/:queuedItemId/result, events, state GET/PATCH, mode/model/permissions PATCH, inbox response, goal endpoints and subroutes).
- Removes impossible `[x: string]: never` index signatures produced by zod-to-ts.

### Public Exports
- client-sdks/client-js/src/index.ts: Re-exports harness types and classes (RemoteHarness, RemoteSession, errors, request/response types, listener/options).
- client-sdks/client-js/src/resources/index.ts: export * from './harness'.

### Tests
- client-sdks/client-js/src/resources/harness.test.ts: New Vitest suite (24 passing tests) covering session creation/loading, non-idempotent failure handling, message/queue admission & settlement, ETag/If-Match conditional patching, SSE subscription/reconnect and replay semantics (including replay-gap handling and CRLF parsing), unsubscribe abort behavior, settlement recovery and polling fallback, and useSkill() rejection when server routes are absent (RemoteHarnessUnsupportedError).

### Documentation
- docs/src/content/en/docs/server/mastra-client.mdx: Added "Harness sessions" section with usage and stable admissionId recovery example.
- docs/src/content/en/reference/client-js/mastra-client.mdx: Documented getHarness(name = 'default').

### Changeset
- .changeset/pf-366-client-js-remote-harness.md: Describes new RemoteHarness/RemoteSession support and includes a TypeScript usage example.

### Codegen Script
- packages/server/scripts/generate-route-types.ts: Post-processes zod-to-ts output to strip impossible `[x: string]: never` index signatures.

## Implementation Notes / Key Behaviors

- Optimistic state patching uses ETag/If-Match and throws RemoteHarnessStateVersionError on version mismatches.
- Durable admission accepts stable admission IDs so interrupted submissions can be retried/recovered without duplication.
- Settlement: initial lookup, SSE-driven matching with Last-Event-ID replay and replay-gap detection, then polling fallback; resolves/rejects based on final operation result and cleans up subscriptions/timers.
- SSE subscription advances the public replay cursor only after listeners successfully handle events; reconnects with backoff and aborts on unsubscribe or unrecoverable stream errors.
- HTTP helpers include retry/backoff, JSON/error parsing into MastraClientError, ETag extraction, and SSE chunk parsing.

## Validation

- Vitest: src/resources/harness.test.ts passed (24 tests).
- Typecheck: pnpm --filter `@mastra/client-js` exec tsc -p tsconfig.json --noEmit: passed.
- Lint: eslint passed for modified client and generation script files.
- Build: `@mastra/client-js` build:lib passed.
- git diff --check: passed.
- Local automated reviews (Codex, CodeRabbit CLI): no findings after fixes.

## Notes & Coordination

- Confirmed overlap with PF-365 (mbenhamd/mastra#136): this PR updates client-js and generated route types only and does not implement PF-365 server behavior (attachment/URL ingestion).
- Built on origin/main after PF-546 merge commit.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->