### PR TITLE
[PF-557] Preserve inherited Agent PubSub routing

### DIFF
--- a/.changeset/pf-557-agent-pubsub-inheritance.md
+++ b/.changeset/pf-557-agent-pubsub-inheritance.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed inherited Agent PubSub handling so parent runtimes can pass shared signal routing to child agents without marking it as agent-owned configuration.

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -661,6 +661,121 @@ describe('Agent signals', () => {
     await nextRunPromise;
   });
 
+  it('passes parent PubSub to child agent execution without mutating shared child agents', async () => {
+    const pubsub = new EventEmitterPubSub();
+    const childCalls: Array<{ _pubsub?: PubSub }> = [];
+    const createDelegatingModel = () => {
+      let callCount = 0;
+      return new MockLanguageModelV2({
+        doGenerate: async () => {
+          callCount += 1;
+          if (callCount === 1) {
+            return {
+              rawCall: { rawPrompt: null, rawSettings: {} },
+              finishReason: 'tool-calls' as const,
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              text: '',
+              content: [
+                {
+                  type: 'tool-call' as const,
+                  toolCallId: `call-${callCount}`,
+                  toolName: 'agent-child',
+                  input: JSON.stringify({ prompt: 'ask child' }),
+                },
+              ],
+              warnings: [],
+            };
+          }
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            finishReason: 'stop' as const,
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            text: 'parent response',
+            content: [{ type: 'text' as const, text: 'parent response' }],
+            warnings: [],
+          };
+        },
+      });
+    };
+
+    class CapturingChildAgent extends Agent {
+      override async generate(_messages: any, options?: any) {
+        childCalls.push(options ?? {});
+        return {
+          text: 'child response',
+          finishReason: 'stop',
+          runId: 'child-run',
+          response: { dbMessages: [] },
+        } as any;
+      }
+
+      override async stream(_messages: any, options?: any) {
+        childCalls.push(options ?? {});
+        const output = buildFakeOutput({
+          runId: options?.runId ?? 'child-stream-run',
+          fullOutput: {
+            text: 'child response',
+            finishReason: 'stop',
+            response: { dbMessages: [] },
+          },
+        }) as any;
+        return {
+          ...output,
+          messageList: {
+            get: {
+              response: {
+                db: () => [],
+              },
+            },
+          },
+          toolResults: Promise.resolve([]),
+        } as any;
+      }
+    }
+
+    const child = new CapturingChildAgent({
+      id: 'standalone-child-agent',
+      name: 'Standalone Child Agent',
+      instructions: 'Test',
+      model: createTextStreamModel('child response'),
+    });
+    const parent = new Agent({
+      id: 'standalone-parent-agent',
+      name: 'Standalone Parent Agent',
+      instructions: 'Test',
+      model: createDelegatingModel(),
+      pubsub,
+      agents: { child },
+    });
+
+    await parent.generate('delegate to child', {
+      runId: 'parent-run',
+      maxSteps: 3,
+    });
+
+    expect(childCalls.at(-1)?._pubsub).toBe(pubsub);
+    expect(child.getPubSub()).toBeUndefined();
+
+    const secondPubSub = new EventEmitterPubSub();
+    const secondParent = new Agent({
+      id: 'second-standalone-parent-agent',
+      name: 'Second Standalone Parent Agent',
+      instructions: 'Test',
+      model: createDelegatingModel(),
+      pubsub: secondPubSub,
+      agents: { child },
+    });
+
+    await secondParent.generate('delegate to child again', {
+      runId: 'second-parent-run',
+      maxSteps: 3,
+    });
+
+    expect(childCalls.at(-1)?._pubsub).toBe(secondPubSub);
+    expect(child.getPubSub()).toBeUndefined();
+    expect(child.hasOwnPubSub()).toBe(false);
+  });
+
   it('preserves an injected PubSub when forking an agent', () => {
     const pubsub = new AsyncFanoutPubSub();
     const agent = new Agent({
@@ -674,7 +789,7 @@ describe('Agent signals', () => {
     const fork = agent.__fork();
 
     expect(fork.getPubSub()).toBe(pubsub);
-    expect(fork.hasOwnPubSub()).toBe(true);
+    expect(fork.hasOwnPubSub()).toBe(false);
   });
 
   it('keeps one PubSub for a stream run when the agent gets a PubSub during execution setup', async () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -325,6 +325,7 @@ export class Agent<
   maxRetries?: number;
   #mastra?: Mastra;
   #pubsub?: PubSub;
+  #inheritedPubSub?: PubSub;
   #memory?: DynamicArgument<MastraMemory, TRequestContext>;
   #skillsFormat?: SkillFormat;
   #workflows?: DynamicArgument<Record<string, AnyWorkflow>, TRequestContext>;
@@ -560,7 +561,7 @@ export class Agent<
   }
 
   getPubSub() {
-    return this.#pubsub ?? this.#mastra?.pubsub;
+    return this.#pubsub ?? this.#inheritedPubSub ?? this.#mastra?.pubsub;
   }
 
   #getThreadTarget(options?: { memory?: AgentExecutionOptionsBase<any>['memory']; requestContext?: RequestContext }) {
@@ -2592,6 +2593,9 @@ export class Agent<
     if (this.#pubsub) {
       fork.#pubsub = this.#pubsub;
     }
+    if (this.#inheritedPubSub) {
+      fork.#inheritedPubSub = this.#inheritedPubSub;
+    }
 
     fork.source = this.source;
     fork._agentNetworkAppend = this._agentNetworkAppend;
@@ -2797,7 +2801,7 @@ export class Agent<
   }
 
   public __setPubSub(pubsub: PubSub) {
-    this.#pubsub = pubsub;
+    this.#inheritedPubSub = pubsub;
   }
 
   public __setWorkspace(workspace: DynamicArgument<AnyWorkspace | undefined, TRequestContext>) {
@@ -3854,6 +3858,7 @@ export class Agent<
     methodType,
     autoResumeSuspendedTools,
     delegation,
+    pubsub,
     backgroundTaskEnabled,
     ...rest
   }: {
@@ -3864,6 +3869,7 @@ export class Agent<
     methodType: AgentMethodType;
     autoResumeSuspendedTools?: boolean;
     delegation?: DelegationConfig;
+    pubsub?: PubSub;
     backgroundTaskEnabled?: boolean;
   } & Partial<ObservabilityContext>) {
     const observabilityContext = resolveObservabilityContext(rest);
@@ -4234,6 +4240,7 @@ export class Agent<
                 const generateResult = resumeData
                   ? await resolvedAgent.resumeGenerate(resumeData, {
                       runId: suspendedToolRunId,
+                      _pubsub: pubsub,
                       requestContext,
                       ...resolveObservabilityContext(context ?? {}),
                       ...(effectiveInstructions && { instructions: effectiveInstructions }),
@@ -4251,6 +4258,7 @@ export class Agent<
                       disableBackgroundTasks: true,
                     })
                   : await resolvedAgent.generate(messagesForSubAgent, {
+                      _pubsub: pubsub,
                       requestContext,
                       ...resolveObservabilityContext(context ?? {}),
                       ...(effectiveInstructions && { instructions: effectiveInstructions }),
@@ -4352,6 +4360,7 @@ export class Agent<
                 const streamResult = resumeData
                   ? await resolvedAgent.resumeStream(resumeData, {
                       runId: suspendedToolRunId,
+                      _pubsub: pubsub,
                       requestContext,
                       ...resolveObservabilityContext(context ?? {}),
                       ...(effectiveInstructions && { instructions: effectiveInstructions }),
@@ -4371,6 +4380,7 @@ export class Agent<
                       disableBackgroundTasks: true,
                     })
                   : await resolvedAgent.stream(messagesForSubAgent, {
+                      _pubsub: pubsub,
                       requestContext,
                       ...resolveObservabilityContext(context ?? {}),
                       ...(effectiveInstructions && { instructions: effectiveInstructions }),
@@ -5038,6 +5048,7 @@ export class Agent<
       ...options,
       requestContext,
       methodType: 'stream',
+      pubsub: this.getPubSub() ?? defaultAgentThreadPubSub,
     });
   }
 
@@ -5057,6 +5068,7 @@ export class Agent<
     memoryConfig,
     autoResumeSuspendedTools,
     delegation,
+    pubsub,
     backgroundTaskEnabled,
     inputProcessors,
     ...rest
@@ -5072,6 +5084,7 @@ export class Agent<
     memoryConfig?: MemoryConfigInternal;
     autoResumeSuspendedTools?: boolean;
     delegation?: DelegationConfig;
+    pubsub?: PubSub;
     backgroundTaskEnabled?: boolean;
     inputProcessors?: InputProcessorOrWorkflow[];
   } & Partial<ObservabilityContext>): Promise<Record<string, CoreTool>> {
@@ -5140,6 +5153,7 @@ export class Agent<
       ...observabilityContext,
       autoResumeSuspendedTools,
       delegation,
+      pubsub,
     });
 
     const workflowTools = await this.listWorkflowTools({
@@ -5878,7 +5892,7 @@ export class Agent<
     // Create the workflow with all necessary context
     const executionWorkflow = createPrepareStreamWorkflow<OUTPUT>({
       capabilities: capabilities as AgentCapabilities,
-      options: { ...options, methodType } as any,
+      options: { ...options, methodType, _pubsub: pubsub } as any,
       threadFromArgs,
       resourceId,
       runId,

--- a/packages/core/src/agent/workflows/prepare-stream/prepare-tools-step.ts
+++ b/packages/core/src/agent/workflows/prepare-stream/prepare-tools-step.ts
@@ -55,6 +55,7 @@ export function createPrepareToolsStep<OUTPUT = undefined>({
         memoryConfig: options.memory?.options,
         autoResumeSuspendedTools: options.autoResumeSuspendedTools,
         delegation: options.delegation,
+        pubsub: options._pubsub,
         backgroundTaskEnabled,
         inputProcessors: options.inputProcessors,
       });


### PR DESCRIPTION
## Summary
- Hand-port the remaining safe Agent PubSub inheritance semantics from upstream PR #16665 without merging upstream/main wholesale.
- Keep constructor-owned PubSub separate from inherited runtime PubSub so hasOwnPubSub() continues to protect explicit agent configuration.
- Pass the captured parent run PubSub into sub-agent generate/stream execution instead of mutating shared child agent singletons.
- Add a regression test for two parents reusing the same child agent while preserving per-parent PubSub routing.

## Upstream sync evidence
- Fresh base: origin/main at 2fdd3ae4141d862ef343ae6d9022edb6e7aed5cc, after PR #138 merge.
- upstream/main fetched on 2026-05-20; fork remains divergent (135 ahead / 550 behind), so a blind upstream merge is still unsafe for Harness v1.
- Requested upstream memory commit 1be079325f05cdec100cc6967572576dfc9e2e44 is already present in the fork as 472d6437c3.
- Upstream PR #16665 is mostly present via prior fork commits 3ce3de9f48 and 13bade03e3; this PR carries the remaining inherited PubSub semantics with a fork-safe execution-scoped adjustment.

## Review evidence
- Claude council: confirmed not to merge upstream/main wholesale; memory commit already present; only remaining #16665 delta was inherited Agent PubSub semantics.
- Codex review pass 1: found shared-child PubSub mutation risk; fixed by execution-scoped propagation instead of mutating child singleton.
- Codex review pass 2 retry: found missing prepare-tools propagation from execute path; fixed by passing _pubsub into prepare-stream workflow options.
- CodeRabbit CLI: no findings.

## Validation
- pnpm --dir packages/core exec vitest run src/agent/__tests__/agent-signals.test.ts --typecheck.enabled=false
- pnpm --dir packages/core exec vitest run src/harness/v1/session.signal.test.ts src/harness/v1/session.signal-routing.test.ts --typecheck.enabled=false
- pnpm --dir packages/core exec eslint src/agent/agent.ts src/agent/workflows/prepare-stream/prepare-tools-step.ts src/agent/__tests__/agent-signals.test.ts
- pnpm --filter ./packages/core typecheck
- git diff --check
- CodeRabbit CLI: no findings

## Known baseline
- src/harness/signal-messages.test.ts still fails 5 tests on this branch, and the same 5 tests fail on a fresh origin/main baseline worktree after dependency prep. Not introduced by PF-557.

Linear: PF-557


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Imagine you have a parent Agent that delegates work to a child Agent. Previously, the child Agent would permanently adopt the parent's signal routing preferences. This PR fixes it so the parent's preferences are passed along only for that specific task—the child Agent doesn't keep them afterward. This way, if two different parents use the same child Agent, each parent's signal preferences stay separate and don't get mixed up.

## Changes

### Test Coverage
Added comprehensive test coverage in `agent-signals.test.ts` to verify that:
- An Agent instance correctly passes its parent `PubSub` to a shared child agent during delegated tool execution
- The child agent does not permanently install or mutate the inherited `PubSub`
- Two different parents with different `PubSub` instances can reuse the same child agent while maintaining separate signal routing
- A forked agent correctly reports `hasOwnPubSub()` as `false`

### Core Agent Implementation
Updated `agent.ts` to introduce PubSub inheritance semantics:
- Introduced internal `#inheritedPubSub` tracking separate from constructor-owned `#pubsub`
- Modified `getPubSub()` to prioritize `#pubsub`, then `#inheritedPubSub`, then the Mastra instance pubsub
- Updated `__fork()` and `__setPubSub()` to properly handle inherited pubsub
- Extended tool execution paths (`getToolsForExecution()` and `convertTools()`) to explicitly thread pubsub through tool-building so sub-agent resume paths receive the correct routing
- Modified sub-agent delegation to pass `_pubsub: pubsub` into `resolvedAgent.resumeGenerate()` and `resolvedAgent.resumeStream()` calls
- Updated agentic-loop `createPrepareStreamWorkflow()` to always include `_pubsub: pubsub` in options

### Tool Preparation
Updated `prepare-tools-step.ts` to pass the `pubsub` argument (sourced from `options._pubsub`) into `capabilities.convertTools()`, ensuring signal routing is available throughout the tool conversion step.

### Documentation
Added a Changesets entry documenting the patch release for `@mastra/core` that fixes inherited Agent PubSub handling.

## Validation
- Targeted vitest testing on agent-signals.test.ts and harness/v1 session signal tests
- ESLint validation on modified files
- Typecheck of packages/core
- git diff --check verification
- CodeRabbit CLI analysis performed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->