### PR TITLE
[PF-367] Add React Harness session hooks

### DIFF
--- a/.changeset/pf-367-react-harness-hooks.md
+++ b/.changeset/pf-367-react-harness-hooks.md
@@ -1,0 +1,27 @@
+---
+'@mastra/react': patch
+---
+
+Add React Harness hooks for building reconnectable session UIs that stay in sync with remote Harness state.
+
+```tsx
+import { useHarnessSession } from '@mastra/react';
+
+function HarnessPanel() {
+  const { snapshot, pendingInbox, durableWork, isLoading, error } = useHarnessSession({
+    harnessName: 'default',
+    sessionId: 'session-1',
+  });
+
+  if (isLoading) return <span>Loading session...</span>;
+  if (error) return <span>{error.message}</span>;
+
+  return (
+    <SessionView
+      snapshot={snapshot}
+      pendingInbox={pendingInbox}
+      durableWork={durableWork}
+    />
+  );
+}
+```

--- a/.changeset/pf-367-react-harness-hooks.md
+++ b/.changeset/pf-367-react-harness-hooks.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/react': patch
+'@mastra/react': minor
 ---
 
 Add React Harness hooks for building reconnectable session UIs that stay in sync with remote Harness state.

--- a/client-sdks/react/src/harness/hooks.test.tsx
+++ b/client-sdks/react/src/harness/hooks.test.tsx
@@ -331,6 +331,29 @@ describe('useRemoteHarnessSession', () => {
     expect(session.subscribe).toHaveBeenCalledTimes(1);
   });
 
+  it('trims retained events when maxEvents shrinks', async () => {
+    const session = new FakeRemoteSession([makeSnapshot()]);
+    const rendered = renderHarnessHookWithOptions(session, renderCount => ({
+      maxEvents: renderCount === 0 ? 3 : 1,
+      refreshOnEvent: false,
+    }));
+    const firstEvent = makeEvent({ id: 'harness-v1:epoch-1:1' });
+    const secondEvent = makeEvent({ id: 'harness-v1:epoch-1:2' });
+    const thirdEvent = makeEvent({ id: 'harness-v1:epoch-1:3' });
+
+    await vi.waitFor(() => expect(rendered.latest().snapshot).toBeDefined());
+    await act(async () => {
+      await session.emit(firstEvent);
+      await session.emit(secondEvent);
+      await session.emit(thirdEvent);
+    });
+
+    expect(rendered.latest().events).toEqual([firstEvent, secondEvent, thirdEvent]);
+    rendered.rerender(1);
+
+    expect(rendered.latest().events).toEqual([thirdEvent]);
+  });
+
   it('passes replay options through to client-js and refreshes on replay gaps', async () => {
     const first = makeSnapshot();
     const second = makeSnapshot({ durableWork: { active: [], recentTerminal: [], truncated: true, sessionOwnedOnly: true } });
@@ -478,6 +501,23 @@ describe('useRemoteHarnessSession', () => {
     expect(session.unsubscribe).toHaveBeenCalledTimes(1);
   });
 
+  it('clears subscribed state when a terminal stream error is reported', async () => {
+    const onError = vi.fn();
+    const session = new FakeRemoteSession([makeSnapshot()]);
+    const rendered = renderHarnessHook(session, { onError });
+
+    await vi.waitFor(() => expect(rendered.latest().isSubscribed).toBe(true));
+    const subscribeOptions = session.subscribe.mock.calls[0]?.[1];
+
+    await act(async () => {
+      await subscribeOptions.onError(Object.assign(new Error('forbidden'), { status: 403 }));
+    });
+
+    expect(rendered.latest().isSubscribed).toBe(false);
+    expect(rendered.latest().error?.message).toBe('forbidden');
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ status: 403 }));
+  });
+
   it('does not run queued event refreshes after cleanup', async () => {
     const initialRefresh = createDeferred<HarnessSessionSnapshot>();
     const session = new FakeRemoteSession([makeSnapshot()]);
@@ -506,5 +546,31 @@ describe('useRemoteHarnessSession', () => {
     expect(session.unsubscribe).toHaveBeenCalledTimes(1);
     expect(session.refresh).toHaveBeenCalledTimes(1);
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('resolves queued refresh waiters during cleanup', async () => {
+    const first = makeSnapshot();
+    const second = makeSnapshot({ pendingInbox: [{ itemId: 'question-2', kind: 'question' } as any] });
+    const firstRefresh = createDeferred<HarnessSessionSnapshot>();
+    const session = new FakeRemoteSession([first]);
+    const rendered = renderHarnessHook(session);
+
+    await vi.waitFor(() => expect(rendered.latest().snapshot).toBe(first));
+    session.refresh.mockReset();
+    session.refresh.mockImplementationOnce(() => firstRefresh.promise);
+
+    const firstRefreshPromise = rendered.latest().refresh();
+    const queuedRefreshPromise = rendered.latest().refresh();
+    expect(session.refresh).toHaveBeenCalledTimes(1);
+
+    act(() => root.unmount());
+    await expect(queuedRefreshPromise).resolves.toBeUndefined();
+
+    await act(async () => {
+      firstRefresh.resolve(second);
+      await expect(firstRefreshPromise).resolves.toBe(second);
+    });
+
+    expect(session.refresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/client-sdks/react/src/harness/hooks.test.tsx
+++ b/client-sdks/react/src/harness/hooks.test.tsx
@@ -69,6 +69,16 @@ function makeEvent(overrides: Partial<HarnessEvent> = {}): HarnessEvent {
   } as HarnessEvent;
 }
 
+function createDeferred<T>() {
+  let resolve: (value: T) => void;
+  let reject: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, reject: reject!, resolve: resolve! };
+}
+
 class FakeRemoteSession {
   readonly refresh = vi.fn<() => Promise<HarnessSessionSnapshot>>();
   readonly subscribe = vi.fn<
@@ -256,6 +266,31 @@ describe('useRemoteHarnessSession', () => {
     expect(session.refresh).toHaveBeenCalledTimes(2);
   });
 
+  it('refreshes from events before waiting for slow consumer callbacks', async () => {
+    const first = makeSnapshot();
+    const second = makeSnapshot({ pendingInbox: [{ itemId: 'approval-1', kind: 'tool-approval' } as any] });
+    const eventCallback = createDeferred<void>();
+    const onEvent = vi.fn(() => eventCallback.promise);
+    const session = new FakeRemoteSession([first, second]);
+    const rendered = renderHarnessHook(session, { onEvent });
+
+    await vi.waitFor(() => expect(rendered.latest().snapshot).toBe(first));
+    const event = makeEvent();
+    let eventPromise: void | Promise<void>;
+    act(() => {
+      eventPromise = session.emit(event);
+    });
+
+    await vi.waitFor(() => expect(session.refresh).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(rendered.latest().snapshot).toBe(second));
+    expect(onEvent).toHaveBeenCalledWith(event);
+
+    await act(async () => {
+      eventCallback.resolve();
+      await eventPromise;
+    });
+  });
+
   it('keeps event cursors moving when consumer event callbacks reject', async () => {
     const first = makeSnapshot();
     const second = makeSnapshot({ pendingInbox: [{ itemId: 'question-1', kind: 'question' } as any] });
@@ -353,6 +388,50 @@ describe('useRemoteHarnessSession', () => {
     await vi.waitFor(() => expect(rendered.latest().snapshot).toBe(third));
   });
 
+  it('allocates a fresh queued refresh promise for each queued refresh cycle', async () => {
+    const first = makeSnapshot();
+    const second = makeSnapshot({ pendingInbox: [{ itemId: 'question-2', kind: 'question' } as any] });
+    const third = makeSnapshot({ pendingInbox: [{ itemId: 'question-3', kind: 'question' } as any] });
+    const fourth = makeSnapshot({ pendingInbox: [{ itemId: 'question-4', kind: 'question' } as any] });
+    const firstRefresh = createDeferred<HarnessSessionSnapshot>();
+    const secondRefresh = createDeferred<HarnessSessionSnapshot>();
+    const thirdRefresh = createDeferred<HarnessSessionSnapshot>();
+    const session = new FakeRemoteSession([first]);
+    const rendered = renderHarnessHook(session);
+
+    await vi.waitFor(() => expect(rendered.latest().snapshot).toBe(first));
+    session.refresh.mockReset();
+    session.refresh
+      .mockImplementationOnce(() => firstRefresh.promise)
+      .mockImplementationOnce(() => secondRefresh.promise)
+      .mockImplementationOnce(() => thirdRefresh.promise);
+
+    const firstRefreshPromise = rendered.latest().refresh();
+    const queuedRefreshPromise = rendered.latest().refresh();
+    expect(session.refresh).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      firstRefresh.resolve(second);
+      await expect(firstRefreshPromise).resolves.toBe(second);
+    });
+    await vi.waitFor(() => expect(session.refresh).toHaveBeenCalledTimes(2));
+
+    const nextQueuedRefreshPromise = rendered.latest().refresh();
+    expect(session.refresh).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      secondRefresh.resolve(third);
+      await expect(queuedRefreshPromise).resolves.toBe(third);
+    });
+    await vi.waitFor(() => expect(session.refresh).toHaveBeenCalledTimes(3));
+
+    await act(async () => {
+      thirdRefresh.resolve(fourth);
+      await expect(nextQueuedRefreshPromise).resolves.toBe(fourth);
+    });
+    await vi.waitFor(() => expect(rendered.latest().snapshot).toBe(fourth));
+  });
+
   it('unsubscribes from the RemoteSession stream on cleanup', async () => {
     const session = new FakeRemoteSession([makeSnapshot()]);
     renderHarnessHook(session);
@@ -378,8 +457,33 @@ describe('useRemoteHarnessSession', () => {
     expect(rendered.latest().isSubscribed).toBe(false);
   });
 
-  it('does not refresh from an in-flight event callback after cleanup', async () => {
-    const session = new FakeRemoteSession([makeSnapshot(), makeSnapshot()]);
+  it('clears subscribed state when a resubscribe fails', async () => {
+    const subscribeError = new Error('resubscribe failed');
+    const onError = vi.fn();
+    const session = new FakeRemoteSession([makeSnapshot()]);
+    const rendered = renderHarnessHookWithOptions(session, renderCount => ({
+      lastEventId: `harness-v1:epoch-1:${renderCount + 1}`,
+      onError,
+    }));
+
+    await vi.waitFor(() => expect(rendered.latest().isSubscribed).toBe(true));
+    session.subscribe.mockImplementationOnce(() => {
+      throw subscribeError;
+    });
+    rendered.rerender(1);
+
+    await vi.waitFor(() => expect(rendered.latest().error).toBe(subscribeError));
+    expect(onError).toHaveBeenCalledWith(subscribeError);
+    expect(rendered.latest().isSubscribed).toBe(false);
+    expect(session.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not run queued event refreshes after cleanup', async () => {
+    const initialRefresh = createDeferred<HarnessSessionSnapshot>();
+    const session = new FakeRemoteSession([makeSnapshot()]);
+    session.refresh.mockReset();
+    session.refresh.mockImplementationOnce(() => initialRefresh.promise);
+    session.refresh.mockResolvedValue(makeSnapshot());
     const onError = vi.fn();
     let resolveEvent: (() => void) | undefined;
     const onEvent = vi.fn(
@@ -393,8 +497,11 @@ describe('useRemoteHarnessSession', () => {
     await vi.waitFor(() => expect(session.refresh).toHaveBeenCalledTimes(1));
     const eventPromise = session.emit(makeEvent());
     act(() => root.unmount());
-    resolveEvent?.();
-    await eventPromise;
+    await act(async () => {
+      initialRefresh.resolve(makeSnapshot());
+      resolveEvent?.();
+      await eventPromise;
+    });
 
     expect(session.unsubscribe).toHaveBeenCalledTimes(1);
     expect(session.refresh).toHaveBeenCalledTimes(1);

--- a/client-sdks/react/src/harness/hooks.test.tsx
+++ b/client-sdks/react/src/harness/hooks.test.tsx
@@ -1,0 +1,403 @@
+// @vitest-environment jsdom
+
+import type { HarnessSessionSnapshot, RemoteHarnessEventUnsubscribe } from '@mastra/client-js';
+import type { HarnessEvent } from '@mastra/core/harness/v1';
+import { act } from 'react';
+import type { Root } from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockMastraClient = vi.hoisted(() => ({
+  getHarness: vi.fn(),
+}));
+
+vi.mock('@mastra/client-js', () => ({
+  MastraClient: class MockMastraClient {},
+}));
+
+vi.mock('../mastra-client-context', () => ({
+  useMastraClient: () => mockMastraClient,
+}));
+
+import type { UseRemoteHarnessSessionResult } from './hooks';
+import { useHarnessSession, useRemoteHarnessSession } from './hooks';
+
+function makeSnapshot(overrides: Partial<HarnessSessionSnapshot> = {}): HarnessSessionSnapshot {
+  return {
+    summary: {
+      sessionId: 'session-1',
+      harnessName: 'default',
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      lifecycle: 'active',
+      createdAt: 1,
+      lastActivityAt: 2,
+      modeId: 'ask',
+      modelId: 'openai/gpt-5',
+      busy: false,
+      queueDepth: 0,
+      pendingInbox: { count: 0, kinds: [], sessionOwnedOnly: true },
+      durableWork: {
+        activeCount: 0,
+        waitingCount: 0,
+        retryingCount: 0,
+        failedCount: 0,
+        sessionOwnedOnly: true,
+      },
+      ...overrides.summary,
+    },
+    state: {},
+    queue: { depth: 0, queuedItemIds: [] },
+    pendingInbox: [],
+    durableWork: { active: [], recentTerminal: [], truncated: false, sessionOwnedOnly: true },
+    channelBindings: [],
+    tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    messages: { cursor: { threadId: 'thread-1', route: 'thread-messages' } },
+    ...overrides,
+  } as HarnessSessionSnapshot;
+}
+
+function makeEvent(overrides: Partial<HarnessEvent> = {}): HarnessEvent {
+  return {
+    id: 'harness-v1:epoch-1:1',
+    type: 'agent_end',
+    sessionId: 'session-1',
+    runId: 'run-1',
+    reason: 'complete',
+    timestamp: 3,
+    ...overrides,
+  } as HarnessEvent;
+}
+
+class FakeRemoteSession {
+  readonly refresh = vi.fn<() => Promise<HarnessSessionSnapshot>>();
+  readonly subscribe = vi.fn<
+    (listener: (event: HarnessEvent) => void | Promise<void>, options: any) => RemoteHarnessEventUnsubscribe
+  >();
+  listener: ((event: HarnessEvent) => void | Promise<void>) | undefined;
+  unsubscribe = vi.fn();
+
+  constructor(snapshots: HarnessSessionSnapshot[]) {
+    for (const snapshot of snapshots) {
+      this.refresh.mockResolvedValueOnce(snapshot);
+    }
+    this.refresh.mockResolvedValue(snapshots.at(-1) ?? makeSnapshot());
+    this.subscribe.mockImplementation(listener => {
+      this.listener = listener;
+      return this.unsubscribe;
+    });
+  }
+
+  emit(event: HarnessEvent) {
+    return this.listener?.(event);
+  }
+}
+
+let root: Root;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  mockMastraClient.getHarness.mockReset();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function renderHarnessHook(
+  session: FakeRemoteSession,
+  options: Parameters<typeof useRemoteHarnessSession>[1] = {},
+): { latest: () => UseRemoteHarnessSessionResult } {
+  let latest: UseRemoteHarnessSessionResult | undefined;
+
+  function Probe() {
+    latest = useRemoteHarnessSession(session as any, options);
+    return null;
+  }
+
+  act(() => {
+    root.render(<Probe />);
+  });
+
+  return {
+    latest: () => {
+      if (!latest) throw new Error('hook did not render');
+      return latest;
+    },
+  };
+}
+
+function renderHarnessHookWithOptions(
+  session: FakeRemoteSession,
+  getOptions: (renderCount: number) => Parameters<typeof useRemoteHarnessSession>[1],
+): { latest: () => UseRemoteHarnessSessionResult; rerender: (renderCount: number) => void } {
+  let latest: UseRemoteHarnessSessionResult | undefined;
+
+  function Probe({ renderCount }: { renderCount: number }) {
+    latest = useRemoteHarnessSession(session as any, getOptions(renderCount));
+    return null;
+  }
+
+  act(() => {
+    root.render(<Probe renderCount={0} />);
+  });
+
+  return {
+    latest: () => {
+      if (!latest) throw new Error('hook did not render');
+      return latest;
+    },
+    rerender: renderCount => {
+      act(() => {
+        root.render(<Probe renderCount={renderCount} />);
+      });
+    },
+  };
+}
+
+function renderHarnessSessionHook(
+  options: Parameters<typeof useHarnessSession>[0] = {},
+): { latest: () => UseRemoteHarnessSessionResult; rerender: (nextOptions: Parameters<typeof useHarnessSession>[0]) => void } {
+  let latest: UseRemoteHarnessSessionResult | undefined;
+
+  function Probe({ hookOptions }: { hookOptions: Parameters<typeof useHarnessSession>[0] }) {
+    latest = useHarnessSession(hookOptions);
+    return null;
+  }
+
+  act(() => {
+    root.render(<Probe hookOptions={options} />);
+  });
+
+  return {
+    latest: () => {
+      if (!latest) throw new Error('hook did not render');
+      return latest;
+    },
+    rerender: nextOptions => {
+      act(() => {
+        root.render(<Probe hookOptions={nextOptions} />);
+      });
+    },
+  };
+}
+
+describe('useHarnessSession', () => {
+  it('opens a named RemoteSession through the Mastra client context', async () => {
+    const remoteSession = new FakeRemoteSession([makeSnapshot()]);
+    const openSession = vi.fn().mockResolvedValue(remoteSession);
+    mockMastraClient.getHarness.mockReturnValue({ session: openSession });
+
+    const rendered = renderHarnessSessionHook({
+      harnessName: 'doxa',
+      modeId: 'ask',
+      sessionId: 'session-1',
+    });
+
+    await vi.waitFor(() => expect(rendered.latest().session).toBe(remoteSession));
+
+    expect(mockMastraClient.getHarness).toHaveBeenCalledWith('doxa');
+    expect(openSession).toHaveBeenCalledWith({ modeId: 'ask', sessionId: 'session-1' });
+  });
+
+  it('clears open errors when the hook is disabled', async () => {
+    const openError = new Error('open failed');
+    mockMastraClient.getHarness.mockReturnValue({ session: vi.fn().mockRejectedValue(openError) });
+    const rendered = renderHarnessSessionHook({ harnessName: 'doxa' });
+
+    await vi.waitFor(() => expect(rendered.latest().error).toBe(openError));
+    rendered.rerender({ enabled: false, harnessName: 'doxa' });
+
+    await vi.waitFor(() => expect(rendered.latest().error).toBeUndefined());
+  });
+});
+
+describe('useRemoteHarnessSession', () => {
+  it('exposes snapshot pending inbox and durable work summaries from RemoteSession.refresh()', async () => {
+    const snapshot = makeSnapshot({
+      pendingInbox: [{ itemId: 'inbox-1', kind: 'question', status: 'pending', createdAt: 4 } as any],
+      durableWork: {
+        active: [{ id: 'work-1', kind: 'message', status: 'running' } as any],
+        recentTerminal: [],
+        truncated: false,
+        sessionOwnedOnly: true,
+      },
+    });
+    const session = new FakeRemoteSession([snapshot]);
+    const rendered = renderHarnessHook(session);
+
+    await vi.waitFor(() => expect(rendered.latest().snapshot).toBe(snapshot));
+
+    expect(rendered.latest().pendingInbox).toEqual(snapshot.pendingInbox);
+    expect(rendered.latest().durableWork).toEqual(snapshot.durableWork);
+    expect(session.subscribe).toHaveBeenCalledWith(expect.any(Function), expect.objectContaining({ reconnect: true }));
+  });
+
+  it('tracks events and refreshes from the RemoteSession subscription without legacy agent resources', async () => {
+    const first = makeSnapshot();
+    const second = makeSnapshot({ pendingInbox: [{ itemId: 'approval-1', kind: 'tool-approval' } as any] });
+    const session = new FakeRemoteSession([first, second]);
+    const onEvent = vi.fn();
+    const rendered = renderHarnessHook(session, { onEvent });
+    const event = makeEvent();
+
+    await vi.waitFor(() => expect(rendered.latest().snapshot).toBe(first));
+    await act(async () => {
+      await session.emit(event);
+    });
+
+    expect(rendered.latest().events).toEqual([event]);
+    await vi.waitFor(() => expect(rendered.latest().pendingInbox).toEqual(second.pendingInbox));
+    expect(onEvent).toHaveBeenCalledWith(event);
+    expect(session.refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps event cursors moving when consumer event callbacks reject', async () => {
+    const first = makeSnapshot();
+    const second = makeSnapshot({ pendingInbox: [{ itemId: 'question-1', kind: 'question' } as any] });
+    const session = new FakeRemoteSession([first, second]);
+    const eventError = new Error('consumer callback failed');
+    const onEvent = vi.fn().mockRejectedValue(eventError);
+    const onError = vi.fn();
+    const rendered = renderHarnessHook(session, { onEvent, onError });
+    const event = makeEvent();
+
+    await vi.waitFor(() => expect(rendered.latest().snapshot).toBe(first));
+    await expect(
+      act(async () => {
+        await session.emit(event);
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(rendered.latest().events).toEqual([event]);
+    await vi.waitFor(() => expect(rendered.latest().pendingInbox).toEqual(second.pendingInbox));
+    expect(onError).toHaveBeenCalledWith(eventError);
+    expect(session.refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the stream open when callback identities change across renders', async () => {
+    const session = new FakeRemoteSession([makeSnapshot()]);
+    const rendered = renderHarnessHookWithOptions(session, renderCount => ({
+      onEvent: vi.fn(() => {
+        void renderCount;
+      }),
+      onError: vi.fn(),
+      onReplayGap: vi.fn(),
+    }));
+
+    await vi.waitFor(() => expect(rendered.latest().snapshot).toBeDefined());
+    rendered.rerender(1);
+
+    expect(session.unsubscribe).not.toHaveBeenCalled();
+    expect(session.subscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes replay options through to client-js and refreshes on replay gaps', async () => {
+    const first = makeSnapshot();
+    const second = makeSnapshot({ durableWork: { active: [], recentTerminal: [], truncated: true, sessionOwnedOnly: true } });
+    const session = new FakeRemoteSession([first, second]);
+    const onReplayGap = vi.fn();
+    const rendered = renderHarnessHook(session, {
+      lastEventId: 'harness-v1:epoch-1:7',
+      reconnect: true,
+      onReplayGap,
+    });
+
+    await vi.waitFor(() => expect(rendered.latest().snapshot).toBe(first));
+    const subscribeOptions = session.subscribe.mock.calls[0]?.[1];
+    expect(subscribeOptions).toMatchObject({ lastEventId: 'harness-v1:epoch-1:7', reconnect: true });
+
+    await act(async () => {
+      await subscribeOptions.onReplayGap();
+    });
+
+    expect(rendered.latest().snapshot).toBe(second);
+    expect(onReplayGap).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces refresh requests while a snapshot refresh is in flight', async () => {
+    const first = makeSnapshot();
+    const second = makeSnapshot({ pendingInbox: [{ itemId: 'question-2', kind: 'question' } as any] });
+    const third = makeSnapshot({ pendingInbox: [{ itemId: 'question-3', kind: 'question' } as any] });
+    const session = new FakeRemoteSession([first]);
+    const rendered = renderHarnessHook(session);
+
+    await vi.waitFor(() => expect(rendered.latest().snapshot).toBe(first));
+    session.refresh.mockReset();
+
+    let resolveFirstRefresh: (() => void) | undefined;
+    session.refresh.mockImplementationOnce(
+      () =>
+        new Promise<HarnessSessionSnapshot>(resolve => {
+          resolveFirstRefresh = () => resolve(second);
+        }),
+    );
+    session.refresh.mockResolvedValue(third);
+
+    const firstRefresh = rendered.latest().refresh();
+    const queuedRefresh = rendered.latest().refresh();
+
+    expect(session.refresh).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFirstRefresh?.();
+      await expect(firstRefresh).resolves.toBe(second);
+      await expect(queuedRefresh).resolves.toBe(third);
+    });
+
+    await vi.waitFor(() => expect(session.refresh).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(rendered.latest().snapshot).toBe(third));
+  });
+
+  it('unsubscribes from the RemoteSession stream on cleanup', async () => {
+    const session = new FakeRemoteSession([makeSnapshot()]);
+    renderHarnessHook(session);
+
+    await vi.waitFor(() => expect(session.subscribe).toHaveBeenCalledTimes(1));
+    act(() => root.unmount());
+
+    expect(session.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports synchronous subscription failures', async () => {
+    const subscribeError = new Error('subscribe failed');
+    const onError = vi.fn();
+    const session = new FakeRemoteSession([makeSnapshot()]);
+    session.subscribe.mockImplementationOnce(() => {
+      throw subscribeError;
+    });
+    const rendered = renderHarnessHook(session, { onError });
+
+    await vi.waitFor(() => expect(rendered.latest().error).toBe(subscribeError));
+
+    expect(onError).toHaveBeenCalledWith(subscribeError);
+    expect(rendered.latest().isSubscribed).toBe(false);
+  });
+
+  it('does not refresh from an in-flight event callback after cleanup', async () => {
+    const session = new FakeRemoteSession([makeSnapshot(), makeSnapshot()]);
+    const onError = vi.fn();
+    let resolveEvent: (() => void) | undefined;
+    const onEvent = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          resolveEvent = resolve;
+        }),
+    );
+    renderHarnessHook(session, { onError, onEvent });
+
+    await vi.waitFor(() => expect(session.refresh).toHaveBeenCalledTimes(1));
+    const eventPromise = session.emit(makeEvent());
+    act(() => root.unmount());
+    resolveEvent?.();
+    await eventPromise;
+
+    expect(session.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(session.refresh).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/client-sdks/react/src/harness/hooks.ts
+++ b/client-sdks/react/src/harness/hooks.ts
@@ -1,0 +1,329 @@
+import type {
+  HarnessSessionSnapshot,
+  RemoteHarnessEventUnsubscribe,
+  RemoteHarnessSessionOptions,
+  RemoteHarnessSubscriptionOptions,
+  RemoteSession,
+} from '@mastra/client-js';
+import type { HarnessEvent } from '@mastra/core/harness/v1';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useMastraClient } from '../mastra-client-context';
+
+export interface UseRemoteHarnessSessionOptions {
+  /** Enables the hook. Disabled hooks keep no active refresh or event subscription. */
+  enabled?: boolean;
+  /** Opens an event subscription against the remote session. Defaults to true. */
+  subscribe?: boolean;
+  /** Allows the underlying client-js subscription to reconnect after retryable failures. Defaults to true. */
+  reconnect?: boolean;
+  /** Initial replay cursor passed through to client-js as Last-Event-ID. */
+  lastEventId?: string;
+  /** Refreshes the durable session snapshot after events. Defaults to true and coalesces concurrent refreshes. */
+  refreshOnEvent?: boolean;
+  /** Maximum recent events retained in hook state. Set to 0 to keep only callbacks. */
+  maxEvents?: number;
+  onEvent?: (event: HarnessEvent) => void | Promise<void>;
+  onError?: (error: unknown) => void | Promise<void>;
+  onReplayGap?: () => void | Promise<void>;
+}
+
+export interface UseHarnessSessionOptions extends RemoteHarnessSessionOptions, UseRemoteHarnessSessionOptions {
+  /** Harness resource name. Defaults to the server's default Harness. */
+  harnessName?: string;
+}
+
+export interface UseRemoteHarnessSessionResult {
+  session: RemoteSession | undefined;
+  snapshot: HarnessSessionSnapshot | undefined;
+  events: HarnessEvent[];
+  pendingInbox: HarnessSessionSnapshot['pendingInbox'];
+  durableWork: HarnessSessionSnapshot['durableWork'];
+  isLoading: boolean;
+  isSubscribed: boolean;
+  error: Error | undefined;
+  refresh: () => Promise<HarnessSessionSnapshot | undefined>;
+}
+
+const DEFAULT_MAX_EVENTS = 100;
+const EMPTY_PENDING_INBOX: HarnessSessionSnapshot['pendingInbox'] = [];
+const EMPTY_DURABLE_WORK: HarnessSessionSnapshot['durableWork'] = {
+  active: [],
+  recentTerminal: [],
+  truncated: false,
+  sessionOwnedOnly: true,
+};
+
+export function useHarnessSession(options: UseHarnessSessionOptions = {}): UseRemoteHarnessSessionResult {
+  const {
+    harnessName = 'default',
+    enabled = true,
+    subscribe,
+    reconnect,
+    lastEventId,
+    refreshOnEvent,
+    maxEvents,
+    onEvent,
+    onError,
+    onReplayGap,
+    ...sessionOptions
+  } = options;
+  const client = useMastraClient();
+  const [session, setSession] = useState<RemoteSession>();
+  const [openError, setOpenError] = useState<Error>();
+  const [isOpening, setIsOpening] = useState(false);
+  const sessionOptionsKey = useMemo(() => JSON.stringify(sessionOptions), [sessionOptions]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setSession(undefined);
+      setOpenError(undefined);
+      setIsOpening(false);
+      return;
+    }
+
+    let active = true;
+    setSession(undefined);
+    setOpenError(undefined);
+    setIsOpening(true);
+    void client
+      .getHarness(harnessName)
+      .session(sessionOptions)
+      .then(remoteSession => {
+        if (active) setSession(remoteSession);
+      })
+      .catch(error => {
+        if (active) {
+          setSession(undefined);
+          setOpenError(asError(error));
+        }
+      })
+      .finally(() => {
+        if (active) setIsOpening(false);
+      });
+
+    return () => {
+      active = false;
+    };
+    // sessionOptionsKey intentionally captures the create/open DTO without
+    // requiring callers to memoize object literals.
+  }, [client, enabled, harnessName, sessionOptionsKey]);
+
+  const state = useRemoteHarnessSession(session, {
+    enabled: enabled && openError === undefined,
+    subscribe,
+    reconnect,
+    lastEventId,
+    refreshOnEvent,
+    maxEvents,
+    onEvent,
+    onError,
+    onReplayGap,
+  });
+
+  return { ...state, isLoading: isOpening || state.isLoading, error: openError ?? state.error };
+}
+
+export function useRemoteHarnessSession(
+  session: RemoteSession | null | undefined,
+  options: UseRemoteHarnessSessionOptions = {},
+): UseRemoteHarnessSessionResult {
+  const {
+    enabled = true,
+    subscribe = true,
+    reconnect = true,
+    lastEventId,
+    refreshOnEvent = true,
+    maxEvents = DEFAULT_MAX_EVENTS,
+    onEvent,
+    onError,
+    onReplayGap,
+  } = options;
+  const [snapshot, setSnapshot] = useState<HarnessSessionSnapshot>();
+  const [events, setEvents] = useState<HarnessEvent[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubscribed, setIsSubscribed] = useState(false);
+  const [error, setError] = useState<Error>();
+  const mounted = useRef(false);
+  const refreshSessionRef = useRef<() => Promise<HarnessSessionSnapshot | undefined>>(async () => undefined);
+  const callbacks = useRef({ onError, onEvent, onReplayGap });
+  const eventOptions = useRef({ maxEvents, refreshOnEvent });
+  const refreshInFlight = useRef<Promise<HarnessSessionSnapshot | undefined> | undefined>(undefined);
+  const refreshQueued = useRef(false);
+  const queuedRefreshPromise = useRef<Promise<HarnessSessionSnapshot | undefined> | undefined>(undefined);
+  const resolveQueuedRefresh = useRef<((snapshot: HarnessSessionSnapshot | undefined) => void) | undefined>(undefined);
+  const rejectQueuedRefresh = useRef<((error: unknown) => void) | undefined>(undefined);
+  const refreshGeneration = useRef(0);
+
+  const refresh = useCallback(async () => refreshSessionRef.current(), []);
+  const clearQueuedRefresh = useCallback(() => {
+    queuedRefreshPromise.current = undefined;
+    resolveQueuedRefresh.current = undefined;
+    rejectQueuedRefresh.current = undefined;
+  }, []);
+  const getQueuedRefreshPromise = useCallback(() => {
+    if (queuedRefreshPromise.current === undefined) {
+      queuedRefreshPromise.current = new Promise<HarnessSessionSnapshot | undefined>((resolve, reject) => {
+        resolveQueuedRefresh.current = resolve;
+        rejectQueuedRefresh.current = reject;
+      });
+    }
+    return queuedRefreshPromise.current;
+  }, []);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    callbacks.current = { onError, onEvent, onReplayGap };
+  }, [onError, onEvent, onReplayGap]);
+
+  useEffect(() => {
+    eventOptions.current = { maxEvents, refreshOnEvent };
+  }, [maxEvents, refreshOnEvent]);
+
+  useEffect(() => {
+    refreshGeneration.current += 1;
+    refreshInFlight.current = undefined;
+    refreshQueued.current = false;
+    resolveQueuedRefresh.current?.(undefined);
+    clearQueuedRefresh();
+    const generation = refreshGeneration.current;
+
+    refreshSessionRef.current = async () => {
+      if (!enabled || !session || !mounted.current) return undefined;
+      if (refreshInFlight.current !== undefined) {
+        refreshQueued.current = true;
+        return getQueuedRefreshPromise();
+      }
+
+      setIsLoading(true);
+      const request = session
+        .refresh()
+        .then(nextSnapshot => {
+          if (mounted.current && refreshGeneration.current === generation) {
+            setSnapshot(nextSnapshot);
+            setError(undefined);
+          }
+          return nextSnapshot;
+        })
+        .catch(caught => {
+          if (mounted.current && refreshGeneration.current === generation) setError(asError(caught));
+          throw caught;
+        })
+        .finally(() => {
+          if (!mounted.current || refreshGeneration.current !== generation) return;
+          if (refreshInFlight.current === request) refreshInFlight.current = undefined;
+          const shouldRefreshAgain = refreshQueued.current;
+          refreshQueued.current = false;
+
+          if (shouldRefreshAgain) {
+            const queuedRefresh = refreshSessionRef.current();
+            void queuedRefresh.then(resolveQueuedRefresh.current, rejectQueuedRefresh.current).finally(clearQueuedRefresh);
+          } else {
+            setIsLoading(false);
+          }
+        });
+
+      refreshInFlight.current = request;
+      return request;
+    };
+  }, [clearQueuedRefresh, enabled, getQueuedRefreshPromise, session]);
+
+  useEffect(() => {
+    setSnapshot(undefined);
+    setEvents([]);
+    setError(undefined);
+    if (!enabled || !session) {
+      setIsLoading(false);
+      return;
+    }
+
+    void refreshSessionRef.current().catch(() => {});
+  }, [enabled, session]);
+
+  useEffect(() => {
+    if (!enabled || !session || !subscribe) {
+      setIsSubscribed(false);
+      return;
+    }
+
+    let active = true;
+    let unsubscribe: RemoteHarnessEventUnsubscribe | undefined;
+    const reportError = async (caught: unknown) => {
+      if (!active || !mounted.current) return;
+      if (active && mounted.current) setError(asError(caught));
+      try {
+        await callbacks.current.onError?.(caught);
+      } catch (errorCallbackFailure) {
+        if (active && mounted.current) setError(asError(errorCallbackFailure));
+      }
+    };
+    const refreshIfActive = async () => {
+      if (!active || !mounted.current) return;
+      await refreshSessionRef.current().catch(reportError);
+    };
+    const subscriptionOptions: RemoteHarnessSubscriptionOptions = {
+      reconnect,
+      lastEventId,
+      onError: reportError,
+      onReplayGap: async () => {
+        await refreshIfActive();
+        try {
+          await callbacks.current.onReplayGap?.();
+        } catch (caught) {
+          await reportError(caught);
+        }
+      },
+    };
+
+    try {
+      unsubscribe = session.subscribe(async event => {
+        if (!active || !mounted.current) return;
+        setEvents(prev => appendEvent(prev, event, eventOptions.current.maxEvents));
+        try {
+          await callbacks.current.onEvent?.(event);
+        } catch (caught) {
+          await reportError(caught);
+        }
+        if (eventOptions.current.refreshOnEvent) {
+          void refreshIfActive();
+        }
+      }, subscriptionOptions);
+    } catch (caught) {
+      void reportError(caught);
+      return;
+    }
+    setIsSubscribed(true);
+
+    return () => {
+      active = false;
+      unsubscribe?.();
+    };
+  }, [enabled, lastEventId, reconnect, session, subscribe]);
+
+  return {
+    session: session ?? undefined,
+    snapshot,
+    events,
+    pendingInbox: snapshot?.pendingInbox ?? EMPTY_PENDING_INBOX,
+    durableWork: snapshot?.durableWork ?? EMPTY_DURABLE_WORK,
+    isLoading,
+    isSubscribed,
+    error,
+    refresh,
+  };
+}
+
+function asError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}
+
+function appendEvent(events: HarnessEvent[], event: HarnessEvent, maxEvents: number): HarnessEvent[] {
+  if (maxEvents <= 0) return [];
+  return [...events, event].slice(-maxEvents);
+}

--- a/client-sdks/react/src/harness/hooks.ts
+++ b/client-sdks/react/src/harness/hooks.ts
@@ -6,7 +6,7 @@ import type {
   RemoteSession,
 } from '@mastra/client-js';
 import type { HarnessEvent } from '@mastra/core/harness/v1';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { useMastraClient } from '../mastra-client-context';
 
@@ -53,6 +53,7 @@ const EMPTY_DURABLE_WORK: HarnessSessionSnapshot['durableWork'] = {
   truncated: false,
   sessionOwnedOnly: true,
 };
+const useCommittedRefEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
 export function useHarnessSession(options: UseHarnessSessionOptions = {}): UseRemoteHarnessSessionResult {
   const {
@@ -175,16 +176,20 @@ export function useRemoteHarnessSession(
     mounted.current = true;
     return () => {
       mounted.current = false;
+      refreshQueued.current = false;
+      resolveQueuedRefresh.current?.(undefined);
+      clearQueuedRefresh();
     };
-  }, []);
+  }, [clearQueuedRefresh]);
 
-  useEffect(() => {
+  useCommittedRefEffect(() => {
     callbacks.current = { onError, onEvent, onReplayGap };
-  }, [onError, onEvent, onReplayGap]);
+    eventOptions.current = { maxEvents, refreshOnEvent };
+  });
 
   useEffect(() => {
-    eventOptions.current = { maxEvents, refreshOnEvent };
-  }, [maxEvents, refreshOnEvent]);
+    setEvents(prev => trimEvents(prev, maxEvents));
+  }, [maxEvents]);
 
   useEffect(() => {
     refreshGeneration.current += 1;
@@ -273,7 +278,10 @@ export function useRemoteHarnessSession(
     const subscriptionOptions: RemoteHarnessSubscriptionOptions = {
       reconnect,
       lastEventId,
-      onError: reportError,
+      onError: async caught => {
+        if (isTerminalSubscriptionError(caught, reconnect) && active && mounted.current) setIsSubscribed(false);
+        await reportError(caught);
+      },
       onReplayGap: async () => {
         await refreshIfActive();
         try {
@@ -328,6 +336,16 @@ function asError(value: unknown): Error {
 }
 
 function appendEvent(events: HarnessEvent[], event: HarnessEvent, maxEvents: number): HarnessEvent[] {
-  if (maxEvents <= 0) return [];
-  return [...events, event].slice(-maxEvents);
+  return trimEvents([...events, event], maxEvents);
+}
+
+function trimEvents(events: HarnessEvent[], maxEvents: number): HarnessEvent[] {
+  if (maxEvents <= 0) return events.length === 0 ? events : [];
+  return events.length <= maxEvents ? events : events.slice(-maxEvents);
+}
+
+function isTerminalSubscriptionError(error: unknown, reconnect: boolean): boolean {
+  if (!reconnect) return true;
+  const status = typeof (error as { status?: unknown })?.status === 'number' ? (error as { status: number }).status : undefined;
+  return status !== undefined && status >= 400 && status < 500;
 }

--- a/client-sdks/react/src/harness/hooks.ts
+++ b/client-sdks/react/src/harness/hooks.ts
@@ -222,8 +222,11 @@ export function useRemoteHarnessSession(
           refreshQueued.current = false;
 
           if (shouldRefreshAgain) {
+            const resolveQueued = resolveQueuedRefresh.current;
+            const rejectQueued = rejectQueuedRefresh.current;
+            clearQueuedRefresh();
             const queuedRefresh = refreshSessionRef.current();
-            void queuedRefresh.then(resolveQueuedRefresh.current, rejectQueuedRefresh.current).finally(clearQueuedRefresh);
+            void queuedRefresh.then(resolveQueued, rejectQueued);
           } else {
             setIsLoading(false);
           }
@@ -281,17 +284,18 @@ export function useRemoteHarnessSession(
       },
     };
 
+    setIsSubscribed(false);
     try {
       unsubscribe = session.subscribe(async event => {
         if (!active || !mounted.current) return;
         setEvents(prev => appendEvent(prev, event, eventOptions.current.maxEvents));
+        if (eventOptions.current.refreshOnEvent) {
+          void refreshIfActive();
+        }
         try {
           await callbacks.current.onEvent?.(event);
         } catch (caught) {
           await reportError(caught);
-        }
-        if (eventOptions.current.refreshOnEvent) {
-          void refreshIfActive();
         }
       }, subscriptionOptions);
     } catch (caught) {

--- a/client-sdks/react/src/harness/index.ts
+++ b/client-sdks/react/src/harness/index.ts
@@ -1,0 +1,1 @@
+export * from './hooks';

--- a/client-sdks/react/src/index.ts
+++ b/client-sdks/react/src/index.ts
@@ -1,6 +1,7 @@
 export * from './mastra-react-provider';
 export * from './agent/hooks'; // Agent hooks
 export * from './agent/types';
+export * from './harness';
 export type { MastraClientCredentials, MastraClientProviderProps } from './mastra-client-context';
 export { useMastraClient } from './mastra-client-context';
 export * from './lib/ai-sdk';


### PR DESCRIPTION
## Summary
- Adds `useHarnessSession` and `useRemoteHarnessSession` exports from `@mastra/react` for remote Harness sessions.
- Exposes snapshots, recent typed events, pending inbox items, durable work summaries, loading/error state, and manual refresh.
- Subscribes only through client-js `RemoteSession.subscribe()` and refreshes through `RemoteSession.refresh()`; no legacy agent stream resources or server/storage/R2 behavior are touched.
- Coalesces concurrent snapshot refreshes, avoids callback-driven SSE resubscribe churn, reports callback/subscription failures, and cleans up subscriptions on unmount.

## Coordination
- Linear: PF-367.
- Base was freshly checked against fork `origin/main` at `6cf00b6bfea9417d12999ba17e23165f1041be02` before commit.
- Official `upstream/main` was fetched at `71a820b2353fa1406772c50760a3732058a8b337`; fork compare remains `136 ahead / 550 behind`, expected because Harness v1 fork work is not upstreamed yet.
- Open PR check before opening this PR: none open in `mbenhamd/mastra`.
- Related completed work: PF-366 / PR #138, PF-444, PF-557 / PR #139.

## Validation
- `pnpm --filter @mastra/react exec vitest run src/harness/hooks.test.tsx` (11 tests)
- `pnpm --filter @mastra/react exec eslint src/harness/hooks.ts src/harness/hooks.test.tsx src/harness/index.ts src/index.ts`
- `pnpm --filter @mastra/react exec tsc -p tsconfig.build.json --noEmit`
- `pnpm --filter @mastra/react build:js`
- `git diff --cached --check`
- Local Codex review pass 1: no blockers; valid review findings fixed.
- Local Codex review pass 2: no blockers; valid review findings fixed.
- Claude council review: valid lifecycle/performance findings fixed.
- `coderabbit review --plain`: final rerun reported no findings.

## Known Baseline
- `pnpm --filter @mastra/react exec tsc -p tsconfig.json --noEmit` still fails on pre-existing test-file type errors in `src/lib/ai-sdk/utils/toUIMessage.test.ts` and `src/mastra-client-context.test.tsx`; production `tsconfig.build.json` passes for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds two React hooks that let apps connect to remote Harness sessions and keep UI state in sync automatically — handling live events, errors, refreshes, and cleanup so developers don't have to build that plumbing themselves.

## Overview

Introduces `useHarnessSession` and `useRemoteHarnessSession` in `@mastra/react` to manage reconnectable remote Harness sessions via `RemoteSession.refresh()` and `RemoteSession.subscribe()`, surfacing snapshot state, recent events, pending inbox items, durable work summaries, loading/error state, and a manual refresh API.

## Key Changes

### New Exports and API Surface
- client-sdks/react/src/harness/hooks.ts
  - Exports `useHarnessSession(options)` — opens and manages a named harness session (integrates with Mastra client harness APIs).
  - Exports `useRemoteHarnessSession(session, options)` — subscribes to and manages snapshot + event state for a provided `RemoteSession`.
  - Adds types: `UseHarnessSessionOptions`, `UseRemoteHarnessSessionOptions`, `UseRemoteHarnessSessionResult`.
- client-sdks/react/src/harness/index.ts
  - Re-exports hook APIs from `./hooks`.
- client-sdks/react/src/index.ts
  - Exposes harness hooks on package entrypoint via `export * from './harness'`.
- .changeset/pf-367-react-harness-hooks.md
  - Changeset entry (minor) documenting the new hooks with a TSX usage example.

### Hook Capabilities & Behavior
- Exposes durable `snapshot` plus derived `pendingInbox` and `durableWork`, and retains recent typed events (bounded by `maxEvents`).
- Surfaces loading and error state and provides a manual `refresh()` API.
- Refresh semantics:
  - Coalesces overlapping refresh calls (reuse in-flight promise).
  - Queues at most one follow-up refresh when requests arrive during completion (queued refresh cycle semantics).
- Subscription semantics:
  - Uses `RemoteSession.subscribe()` for event delivery (no changes to legacy agent streams or server/storage/R2).
  - Appends incoming events, optionally triggers `refreshOnEvent`, and handles replay gaps by refreshing then calling `onReplayGap`.
  - Preserves subscription across callback identity changes to avoid unnecessary resubscribe churn.
- Error handling:
  - Normalizes thrown callback/subscription errors into hook `error` state and surfaces subscription failures (sets `isSubscribed=false`).
- Cleanup:
  - Cleans up subscriptions on unmount and prevents queued/late refresh work after unmount.

### Lifecycle and Correctness Fixes (head commits)
- Queued refresh promises are cleared before starting a queued refresh cycle so later burst refresh calls allocate a fresh promise.
- Subscription state is reset before each subscribe attempt so failed resubscribe attempts report `isSubscribed=false`.
- `refreshOnEvent` now starts before awaiting `onEvent` to avoid regressions when callbacks are slow.
- Changeset bump set to minor to reflect new public hooks.
- Cleanup test reframed to assert queued event refreshes do not run after unmount.

## Tests & Validation
- Adds comprehensive Vitest suite: client-sdks/react/src/harness/hooks.test.tsx — local focused React hook tests expanded to 14 tests after fixes (covers session open, event handling, refresh sequencing/coalescing, replay-gap behavior, subscription/resubscribe error reporting, callback error propagation, trimming events, cleanup/unsubscribe, and queued-refresh semantics).
- ESLint run on touched files passed.
- Typecheck: `tsc -p tsconfig.build.json --noEmit` passed (project tsconfig still has unrelated pre-existing test-file type errors).
- Built `@mastra/react` JS bundle (`pnpm --filter `@mastra/react` build:js`) successfully.
- `git diff --cached --check` passed.
- Local automated/code-review tooling runs (Codex/CodeRabbit) completed with no remaining findings after fixes.

## Scope and Coordination
- Additive, non-breaking change to the React SDK public surface (no server or storage changes).
- Ticket: PF-367. Related work: PF-366 (PR `#138`), PF-444, PF-557 (PR `#139`).
- Author requests resolved bot threads be closed unless new issues are posted on the current head.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->