### PR TITLE
[PF-357] Fail closed recovered runtime dependency drift

### DIFF
--- a/.changeset/pf-357-runtime-dependency-drift.md
+++ b/.changeset/pf-357-runtime-dependency-drift.md
@@ -1,0 +1,6 @@
+---
+"@mastra/core": patch
+"@mastra/server": patch
+---
+
+Added fail-closed runtime dependency drift checks for recovered Harness queue and resume work, and mapped runtime drift responses on Harness server routes.

--- a/.changeset/pf-357-runtime-dependency-drift.md
+++ b/.changeset/pf-357-runtime-dependency-drift.md
@@ -3,4 +3,5 @@
 "@mastra/server": patch
 ---
 
-Added fail-closed runtime dependency drift checks for recovered Harness queue and resume work, and mapped runtime drift responses on Harness server routes.
+Improved Harness recovery safety by rejecting resumed or queued work when runtime dependencies changed after restart.
+Added HTTP 409 (`harness.runtime_dependency_drifted`) responses for these drift conflicts on Harness routes.

--- a/packages/core/src/harness/v1/errors.ts
+++ b/packages/core/src/harness/v1/errors.ts
@@ -23,6 +23,24 @@ export class HarnessConfigError extends Error {
   }
 }
 
+export type HarnessRuntimeDependencyKind = 'mode' | 'agent' | 'workspace_provider';
+
+export class HarnessRuntimeDependencyDriftError extends Error {
+  readonly name = 'HarnessRuntimeDependencyDriftError';
+  readonly code = 'harness.runtime_dependency_drifted';
+
+  constructor(
+    public readonly dependencyKind: HarnessRuntimeDependencyKind,
+    public readonly dependencyId: string,
+    public readonly reason: string,
+    public readonly context?: string,
+  ) {
+    super(
+      `Runtime dependency drifted${context ? ` during ${context}` : ''}: ${dependencyKind} "${dependencyId}" ${reason}`,
+    );
+  }
+}
+
 /**
  * `harness.session({ sessionId })` could not find a record, or `{ sessionId,
  * resourceId }` found one whose `resourceId` did not match. Existence across

--- a/packages/core/src/harness/v1/harness.test.ts
+++ b/packages/core/src/harness/v1/harness.test.ts
@@ -1481,6 +1481,20 @@ describe('Harness v1 — construction', () => {
     ).toThrow(HarnessConfigError);
   });
 
+  it('preserves the unbound Mastra config error when resolving mode agents', () => {
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+
+    expect(() => harness.getAgentForMode('default')).toThrow(
+      expect.objectContaining({ field: 'mastra', name: 'HarnessConfigError' }),
+    );
+    expect(() =>
+      harness._resolveAgentForRuntimeDependencies({ modeId: 'default', agentId: 'default' }, 'queued item recovery'),
+    ).toThrow(expect.objectContaining({ field: 'mastra', name: 'HarnessConfigError' }));
+  });
+
   it('throws HarnessConfigError for duplicate mode ids', () => {
     expect(
       () =>

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -1064,9 +1064,10 @@ export class Harness {
     if (!mode) {
       throw new HarnessConfigError('modeId', `unknown mode "${modeId}"`);
     }
+    const mastra = this.mastra;
     let agent: Agent | undefined;
     try {
-      agent = this.mastra.getAgent(mode.agentId as never) as Agent | undefined;
+      agent = mastra.getAgent(mode.agentId as never) as Agent | undefined;
     } catch {
       agent = undefined;
     }
@@ -1108,9 +1109,10 @@ export class Harness {
       );
     }
     const agentId = refs.agentId ?? mode.agentId;
+    const mastra = this.mastra;
     let agent: Agent | undefined;
     try {
-      agent = this.mastra.getAgent(agentId as never) as Agent | undefined;
+      agent = mastra.getAgent(agentId as never) as Agent | undefined;
     } catch {
       agent = undefined;
     }

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -44,6 +44,7 @@ import type {
   AgentSignalResultStatus,
   OperationAdmissionTombstone,
   QueueAdmissionReceipt,
+  HarnessRuntimeDependencyRefs,
 } from '../../storage/domains/harness';
 import {
   HarnessStorageAttachmentInUseError,
@@ -67,6 +68,7 @@ import {
   HarnessAttachmentUnavailableError,
   HarnessConfigError,
   HarnessModelNotFoundError,
+  HarnessRuntimeDependencyDriftError,
   HarnessSessionClosedError,
   HarnessSessionClosingError,
   HarnessSessionDeleteBlockedError,
@@ -1062,7 +1064,74 @@ export class Harness {
     if (!mode) {
       throw new HarnessConfigError('modeId', `unknown mode "${modeId}"`);
     }
-    return this.mastra.getAgent(mode.agentId as never) as Agent;
+    const agent = this.mastra.getAgent(mode.agentId as never) as Agent | undefined;
+    if (!agent) {
+      throw new HarnessConfigError(
+        `modes[${mode.id}].agentId`,
+        `references unknown agent "${mode.agentId}" — Mastra has no such agent registered`,
+      );
+    }
+    return agent;
+  }
+
+  /** @internal — capture stable runtime ids for work that may be recovered after restart. */
+  _runtimeDependenciesForMode(modeId: string, modelId?: string): HarnessRuntimeDependencyRefs {
+    const mode = this._getMode(modeId);
+    return {
+      modeId,
+      agentId: mode.agentId,
+      ...(modelId ? { modelId } : {}),
+      workspaceProviderId: this._workspaceDependencyId(),
+    };
+  }
+
+  /** @internal — validate persisted runtime ids before recovered work invokes an agent. */
+  _resolveAgentForRuntimeDependencies(
+    refs: HarnessRuntimeDependencyRefs,
+    context: string,
+  ): { mode: HarnessMode; agent: Agent } {
+    const mode = this._modesById.get(refs.modeId);
+    if (!mode) {
+      throw new HarnessRuntimeDependencyDriftError('mode', refs.modeId, 'is not registered on this harness', context);
+    }
+    if (refs.agentId !== undefined && refs.agentId !== mode.agentId) {
+      throw new HarnessRuntimeDependencyDriftError(
+        'agent',
+        refs.agentId,
+        `was recorded for mode "${refs.modeId}", but the mode now points at agent "${mode.agentId}"`,
+        context,
+      );
+    }
+    const agentId = refs.agentId ?? mode.agentId;
+    let agent: Agent | undefined;
+    try {
+      agent = this.mastra.getAgent(agentId as never) as Agent | undefined;
+    } catch {
+      agent = undefined;
+    }
+    if (!agent) {
+      throw new HarnessRuntimeDependencyDriftError(
+        'agent',
+        agentId,
+        'is not registered on this Mastra instance',
+        context,
+      );
+    }
+    if ('workspaceProviderId' in refs && this._workspaceDependencyId() !== refs.workspaceProviderId) {
+      throw new HarnessRuntimeDependencyDriftError(
+        'workspace_provider',
+        refs.workspaceProviderId ?? 'unconfigured',
+        `was recorded, but the current workspace dependency is "${this._workspaceDependencyId() ?? 'unconfigured'}"`,
+        context,
+      );
+    }
+    return { mode, agent };
+  }
+
+  private _workspaceDependencyId(): string | null {
+    if (this._workspaceKind === undefined) return null;
+    if (this._workspaceKind === 'shared') return `shared:${this.ownerId}`;
+    return this._workspaceRegistry.providerId ?? null;
   }
 
   /**

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -1064,7 +1064,12 @@ export class Harness {
     if (!mode) {
       throw new HarnessConfigError('modeId', `unknown mode "${modeId}"`);
     }
-    const agent = this.mastra.getAgent(mode.agentId as never) as Agent | undefined;
+    let agent: Agent | undefined;
+    try {
+      agent = this.mastra.getAgent(mode.agentId as never) as Agent | undefined;
+    } catch {
+      agent = undefined;
+    }
     if (!agent) {
       throw new HarnessConfigError(
         `modes[${mode.id}].agentId`,

--- a/packages/core/src/harness/v1/index.ts
+++ b/packages/core/src/harness/v1/index.ts
@@ -59,6 +59,7 @@ export {
   HarnessInboxItemNotFoundError,
   HarnessInboxResponseConflictError,
   HarnessQueueFullError,
+  HarnessRuntimeDependencyDriftError,
   HarnessSessionClosedError,
   HarnessSessionClosingError,
   HarnessSessionDeleteBlockedError,

--- a/packages/core/src/harness/v1/session.display-state.test.ts
+++ b/packages/core/src/harness/v1/session.display-state.test.ts
@@ -110,6 +110,8 @@ describe('Session.getDisplayState — shape', () => {
       question: 'pick one',
       options: [{ label: 'a' }, { label: 'b' }],
     });
+    expect((ds.pending as unknown as Record<string, unknown>).runtimeDependencies).toBeUndefined();
+    expect(session.getRecord().pendingResume?.runtimeDependencies).toBeDefined();
     // Legacy boolean fields are gone — make sure consumers know to use `pending`.
     expect((ds as unknown as Record<string, unknown>).hasPendingQuestion).toBeUndefined();
   });

--- a/packages/core/src/harness/v1/session.queue.test.ts
+++ b/packages/core/src/harness/v1/session.queue.test.ts
@@ -479,13 +479,15 @@ describe('Session.queue() — suspension', () => {
     });
     const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
 
-    const queued = session.queue({ content: 'sensitive' });
+    const queued = session.queue({ content: 'sensitive', model: 'queued-model' });
     await new Promise(resolve => setImmediate(resolve));
 
     // Mid-flight: item still in the queue, suspension captured.
     expect(session.getRecord().pendingQueue?.length).toBe(1);
     expect(session.getRecord().pendingResume?.kind).toBe('tool-approval');
+    expect(session.getRecord().pendingResume?.runtimeDependencies?.modelId).toBe('queued-model');
     const receipt = Object.values(session.getRecord().queueAdmissionReceipts ?? {})[0];
+    expect(receipt?.runtimeDependencies?.modelId).toBe('queued-model');
     expect(receipt?.signalId).toBeDefined();
     let signalEvidence = await storage.loadMessageResultEvidence({
       harnessName: 'default',
@@ -1435,6 +1437,336 @@ describe('Session.queue() — crash replay', () => {
       status: 'completed',
       modeId: 'default',
       result: expect.objectContaining({ text: 'mode recovered' }),
+    });
+  });
+
+  it('fails closed when replayed queued work references a missing mode', async () => {
+    const storage = new InMemoryStore();
+    const harnessStore = await storage.getStore('harness');
+    if (!harnessStore) throw new Error('expected harness storage');
+    const sessionId = 'sess-queued-missing-mode';
+    const queuedItemId = 'q-queued-missing-mode';
+    const now = Date.now();
+    await harnessStore.saveSession(
+      {
+        harnessName: 'default',
+        id: sessionId,
+        resourceId: 'u',
+        threadId: 't-queued-missing-mode',
+        origin: 'top-level',
+        ownsThread: false,
+        modeId: 'default',
+        modelId: 'default',
+        subagentModelOverrides: {},
+        permissionRules: { categories: {}, tools: {} },
+        sessionGrants: { categories: [], tools: [] },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        pendingQueue: [
+          {
+            id: queuedItemId,
+            admissionId: 'queue-missing-mode',
+            admissionHash: 'hash-missing-mode',
+            enqueuedAt: now,
+            content: 'do not run',
+            attachments: [],
+          },
+        ],
+        queueAdmissionReceipts: {
+          [queuedItemId]: {
+            admissionId: 'queue-missing-mode',
+            admissionHash: 'hash-missing-mode',
+            queuedItemId,
+            modeId: 'removed-mode',
+            runtimeDependencies: { modeId: 'removed-mode', agentId: 'removed-agent', modelId: 'default' },
+            status: 'accepted',
+            runId: 'stale-run',
+            signalId: 'stale-signal',
+            attempts: 1,
+            enqueuedAt: now,
+            acceptedAt: now,
+            updatedAt: now,
+          },
+        },
+        state: undefined,
+        createdAt: now,
+        lastActivityAt: now,
+        version: 0,
+      },
+      { harnessName: 'default', ifVersion: 0 },
+    );
+
+    const replayAgent = new MockAgent({ id: 'default' });
+    const replayHarness = new Harness({
+      agents: { default: replayAgent } as any,
+      storage,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+
+    const replaySession = await replayHarness.session({ sessionId });
+    await replaySession.waitForIdle({ timeoutMs: 1000 });
+
+    expect(replayAgent.streamCalls).toHaveLength(0);
+    expect(replaySession.getRecord().pendingQueue).toEqual([]);
+    expect(replaySession.getRecord().queueAdmissionReceipts?.[queuedItemId]).toMatchObject({
+      status: 'failed',
+      error: {
+        code: 'harness.runtime_dependency_drifted',
+        message: expect.stringContaining('mode "removed-mode" is not registered'),
+      },
+    });
+  });
+
+  it('fails closed when a replayed queued receipt observes mode-to-agent binding drift', async () => {
+    const storage = new InMemoryStore();
+    const harnessStore = await storage.getStore('harness');
+    if (!harnessStore) throw new Error('expected harness storage');
+    const sessionId = 'sess-queued-agent-drift';
+    const queuedItemId = 'q-queued-agent-drift';
+    const now = Date.now();
+    await harnessStore.saveSession(
+      {
+        harnessName: 'default',
+        id: sessionId,
+        resourceId: 'u',
+        threadId: 't-queued-agent-drift',
+        origin: 'top-level',
+        ownsThread: false,
+        modeId: 'default',
+        modelId: 'default',
+        subagentModelOverrides: {},
+        permissionRules: { categories: {}, tools: {} },
+        sessionGrants: { categories: [], tools: [] },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        pendingQueue: [
+          {
+            id: queuedItemId,
+            admissionId: 'queue-agent-drift',
+            admissionHash: 'hash-agent-drift',
+            enqueuedAt: now,
+            content: 'do not retarget',
+            attachments: [],
+          },
+        ],
+        queueAdmissionReceipts: {
+          [queuedItemId]: {
+            admissionId: 'queue-agent-drift',
+            admissionHash: 'hash-agent-drift',
+            queuedItemId,
+            modeId: 'default',
+            runtimeDependencies: { modeId: 'default', agentId: 'old-agent', modelId: 'default' },
+            status: 'accepted',
+            runId: 'stale-run',
+            signalId: 'stale-signal',
+            attempts: 1,
+            enqueuedAt: now,
+            acceptedAt: now,
+            updatedAt: now,
+          },
+        },
+        state: undefined,
+        createdAt: now,
+        lastActivityAt: now,
+        version: 0,
+      },
+      { harnessName: 'default', ifVersion: 0 },
+    );
+
+    const newAgent = new MockAgent({ id: 'new-agent' });
+    const replayHarness = new Harness({
+      agents: { 'new-agent': newAgent } as any,
+      storage,
+      modes: [{ id: 'default', agentId: 'new-agent' }],
+      defaultModeId: 'default',
+    });
+
+    const replaySession = await replayHarness.session({ sessionId });
+    await replaySession.waitForIdle({ timeoutMs: 1000 });
+
+    expect(newAgent.streamCalls).toHaveLength(0);
+    expect(replaySession.getRecord().pendingQueue).toEqual([]);
+    expect(replaySession.getRecord().queueAdmissionReceipts?.[queuedItemId]).toMatchObject({
+      status: 'failed',
+      error: {
+        code: 'harness.runtime_dependency_drifted',
+        message: expect.stringContaining('old-agent'),
+      },
+    });
+  });
+
+  it('fails closed when queued work admitted without a workspace provider replays with one configured', async () => {
+    const storage = new InMemoryStore();
+    const harnessStore = await storage.getStore('harness');
+    if (!harnessStore) throw new Error('expected harness storage');
+    const sessionId = 'sess-queued-workspace-drift';
+    const queuedItemId = 'q-queued-workspace-drift';
+    const now = Date.now();
+    await harnessStore.saveSession(
+      {
+        harnessName: 'default',
+        id: sessionId,
+        resourceId: 'u',
+        threadId: 't-queued-workspace-drift',
+        origin: 'top-level',
+        ownsThread: false,
+        modeId: 'default',
+        modelId: 'default',
+        subagentModelOverrides: {},
+        permissionRules: { categories: {}, tools: {} },
+        sessionGrants: { categories: [], tools: [] },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        pendingQueue: [
+          {
+            id: queuedItemId,
+            admissionId: 'queue-workspace-drift',
+            admissionHash: 'hash-workspace-drift',
+            enqueuedAt: now,
+            content: 'do not run with new workspace',
+            attachments: [],
+          },
+        ],
+        queueAdmissionReceipts: {
+          [queuedItemId]: {
+            admissionId: 'queue-workspace-drift',
+            admissionHash: 'hash-workspace-drift',
+            queuedItemId,
+            modeId: 'default',
+            runtimeDependencies: {
+              modeId: 'default',
+              agentId: 'default',
+              modelId: 'default',
+              workspaceProviderId: null,
+            },
+            status: 'accepted',
+            runId: 'stale-run',
+            signalId: 'stale-signal',
+            attempts: 1,
+            enqueuedAt: now,
+            acceptedAt: now,
+            updatedAt: now,
+          },
+        },
+        state: undefined,
+        createdAt: now,
+        lastActivityAt: now,
+        version: 0,
+      },
+      { harnessName: 'default', ifVersion: 0 },
+    );
+
+    const replayAgent = new MockAgent({ id: 'default' });
+    const replayHarness = new Harness({
+      agents: { default: replayAgent } as any,
+      storage,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      workspace: {
+        kind: 'per-resource',
+        provider: {
+          providerId: 'workspace-now-configured',
+          resumable: false,
+          create: async () => ({}) as any,
+        },
+      },
+    });
+
+    const replaySession = await replayHarness.session({ sessionId });
+    await replaySession.waitForIdle({ timeoutMs: 1000 });
+
+    expect(replayAgent.streamCalls).toHaveLength(0);
+    expect(replaySession.getRecord().pendingQueue).toEqual([]);
+    expect(replaySession.getRecord().queueAdmissionReceipts?.[queuedItemId]).toMatchObject({
+      status: 'failed',
+      error: {
+        code: 'harness.runtime_dependency_drifted',
+        message: expect.stringContaining('workspace_provider "unconfigured"'),
+      },
+    });
+  });
+
+  it('fails closed when queued work admitted with a shared workspace replays after restart', async () => {
+    const storage = new InMemoryStore();
+    const harnessStore = await storage.getStore('harness');
+    if (!harnessStore) throw new Error('expected harness storage');
+    const sessionId = 'sess-queued-shared-workspace-drift';
+    const queuedItemId = 'q-queued-shared-workspace-drift';
+    const now = Date.now();
+    await harnessStore.saveSession(
+      {
+        harnessName: 'default',
+        id: sessionId,
+        resourceId: 'u',
+        threadId: 't-queued-shared-workspace-drift',
+        origin: 'top-level',
+        ownsThread: false,
+        modeId: 'default',
+        modelId: 'default',
+        subagentModelOverrides: {},
+        permissionRules: { categories: {}, tools: {} },
+        sessionGrants: { categories: [], tools: [] },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        pendingQueue: [
+          {
+            id: queuedItemId,
+            admissionId: 'queue-shared-workspace-drift',
+            admissionHash: 'hash-shared-workspace-drift',
+            enqueuedAt: now,
+            content: 'do not run with a new shared workspace',
+            attachments: [],
+          },
+        ],
+        queueAdmissionReceipts: {
+          [queuedItemId]: {
+            admissionId: 'queue-shared-workspace-drift',
+            admissionHash: 'hash-shared-workspace-drift',
+            queuedItemId,
+            modeId: 'default',
+            runtimeDependencies: {
+              modeId: 'default',
+              agentId: 'default',
+              modelId: 'default',
+              workspaceProviderId: 'shared:harness-old-owner',
+            },
+            status: 'accepted',
+            runId: 'stale-run',
+            signalId: 'stale-signal',
+            attempts: 1,
+            enqueuedAt: now,
+            acceptedAt: now,
+            updatedAt: now,
+          },
+        },
+        state: undefined,
+        createdAt: now,
+        lastActivityAt: now,
+        version: 0,
+      },
+      { harnessName: 'default', ifVersion: 0 },
+    );
+
+    const replayAgent = new MockAgent({ id: 'default' });
+    const replayHarness = new Harness({
+      agents: { default: replayAgent } as any,
+      storage,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      workspace: {
+        kind: 'shared',
+        workspace: { init: vi.fn(async () => {}), destroy: vi.fn(async () => {}) } as any,
+      },
+    });
+
+    const replaySession = await replayHarness.session({ sessionId });
+    await replaySession.waitForIdle({ timeoutMs: 1000 });
+
+    expect(replayAgent.streamCalls).toHaveLength(0);
+    expect(replaySession.getRecord().pendingQueue).toEqual([]);
+    expect(replaySession.getRecord().queueAdmissionReceipts?.[queuedItemId]).toMatchObject({
+      status: 'failed',
+      error: {
+        code: 'harness.runtime_dependency_drifted',
+        message: expect.stringContaining('workspace_provider "shared:harness-old-owner"'),
+      },
     });
   });
 

--- a/packages/core/src/harness/v1/session.queue.test.ts
+++ b/packages/core/src/harness/v1/session.queue.test.ts
@@ -1858,7 +1858,7 @@ describe('Session.queue() — crash replay', () => {
     expect(receipt?.signalId).not.toBe('stale-signal');
   });
 
-  it('completes an accepted receipt from durable signal result evidence after hydration', async () => {
+  it('completes an accepted receipt from durable signal result evidence after hydration even if runtime deps drifted', async () => {
     const storage = new InMemoryStore();
     const harnessStore = await storage.getStore('harness');
     if (!harnessStore) throw new Error('expected harness storage');
@@ -1897,6 +1897,7 @@ describe('Session.queue() — crash replay', () => {
             status: 'accepted',
             runId: 'stale-run',
             signalId: 'stale-signal',
+            runtimeDependencies: { modeId: 'default', agentId: 'old-agent', modelId: 'default' },
             attempts: 1,
             enqueuedAt: now,
             acceptedAt: now,
@@ -1924,12 +1925,12 @@ describe('Session.queue() — crash replay', () => {
       updatedAt: now,
     });
 
-    const replayAgent = new MockAgent({ id: 'default' });
+    const replayAgent = new MockAgent({ id: 'new-agent' });
     replayAgent.enqueueRun({ finishReason: 'stop', text: 'must not run' });
     const replayHarness = new Harness({
-      agents: { default: replayAgent } as any,
+      agents: { 'new-agent': replayAgent } as any,
       storage,
-      modes: [{ id: 'default', agentId: 'default' }],
+      modes: [{ id: 'default', agentId: 'new-agent' }],
       defaultModeId: 'default',
     });
 

--- a/packages/core/src/harness/v1/session.suspend.test.ts
+++ b/packages/core/src/harness/v1/session.suspend.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it } from 'vitest';
 import { Agent } from '../../agent';
 import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
 import { InMemoryDB } from '../../storage/domains/inmemory-db';
+import { InMemoryStore } from '../../storage/mock';
 import type { MastraModelOutput } from '../../stream/base/output';
 import { buildFakeOutput } from './__test-utils__/fake-output';
 
@@ -502,6 +503,68 @@ describe('Session — respondToToolApproval / Suspension / Question / PlanApprov
     await session.respondToQuestion({ answer: 'red' });
 
     expect(agent.resumeCalls[0]!.resumeData).toEqual({ answer: 'red' });
+  });
+
+  it('fails closed when a recovered question resume observes mode-to-agent binding drift', async () => {
+    const storage = new InMemoryStore();
+    const harnessStore = await storage.getStore('harness');
+    if (!harnessStore) throw new Error('expected harness storage');
+    const sessionId = 'sess-question-agent-drift';
+    const requestedAt = Date.now();
+    await harnessStore.saveSession(
+      {
+        harnessName: 'default',
+        id: sessionId,
+        resourceId: 'u',
+        threadId: 't-question-agent-drift',
+        origin: 'top-level',
+        ownsThread: false,
+        modeId: 'default',
+        modelId: 'default',
+        subagentModelOverrides: {},
+        permissionRules: { categories: {}, tools: {} },
+        sessionGrants: { categories: [], tools: [] },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        pendingQueue: [],
+        pendingResume: {
+          kind: 'question',
+          itemId: 'question:tc-Q',
+          runId: 'run-Q',
+          toolCallId: 'tc-Q',
+          toolName: 'ask_user',
+          source: 'parent',
+          requestedAt,
+          modeId: 'default',
+          runtimeDependencies: { modeId: 'default', agentId: 'old-agent', modelId: 'default' },
+          payload: { question: 'pick' },
+        },
+        state: undefined,
+        createdAt: requestedAt,
+        lastActivityAt: requestedAt,
+        version: 0,
+      },
+      { harnessName: 'default', ifVersion: 0 },
+    );
+    const agent = new FakeAgent();
+    const harness = new Harness({
+      agents: { default: agent } as any,
+      storage,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+
+    const session = await harness.session({ sessionId });
+    await expect(
+      session.respondToQuestion({ itemId: 'question:tc-Q', responseId: 'answer-1', answer: 'red' }),
+    ).rejects.toMatchObject({ code: 'harness.runtime_dependency_drifted' });
+
+    expect(agent.resumeCalls).toHaveLength(0);
+    expect(session.getRecord().inboxResponseReceipts?.['answer-1']).toMatchObject({
+      status: 'failed',
+      error: { code: 'harness.runtime_dependency_drifted' },
+    });
+    expect(session.getRecord().pendingResume).toMatchObject({ runId: 'run-Q' });
+    expect(session.getRecord().pendingResume?.resumedAt).toBeUndefined();
   });
 
   it('rejects an active question resume when the live session is marked deleted', async () => {

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -5986,6 +5986,17 @@ export class Session {
         );
       }
     }
+    if (
+      currentReceipt &&
+      (currentReceipt.status === 'admitting' || currentReceipt.status === 'accepted') &&
+      currentReceipt.runId &&
+      currentReceipt.signalId
+    ) {
+      const recoveredTerminal = await this._withActiveDeletedWaiter(activeDeleted =>
+        this._recoverQueuedTerminalEvidence(item, currentReceipt, effectiveModeId, activeDeleted),
+      );
+      if (recoveredTerminal) return recoveredTerminal;
+    }
     const runtimeDependencies = this._runtimeDependenciesForQueuedTurn(item, currentReceipt, effectiveModeId);
     const { mode, agent } = this._harness._resolveAgentForRuntimeDependencies(
       runtimeDependencies,
@@ -6132,20 +6143,8 @@ export class Session {
         return this._awaitQueuedRunCompletion(item, receipt.runId!, receipt.signalId!, modeId, activeDeleted);
       }
 
-      const evidence = await this._raceActiveTurnWaiter(this._loadQueueSignalResultEvidence(receipt), activeDeleted);
-      if (evidence.status === 'completed') {
-        const full = evidence.result as FullOutput<unknown>;
-        await this._raceActiveTurnWaiter(this._markQueuedTurnCompleted(item.id, full), activeDeleted);
-        if (receipt.postRunFinalizedAt === undefined) {
-          await this._finalizeCompletedQueuedTurn(item, full, modeId, activeDeleted);
-        }
-        return full;
-      }
-      if (evidence.status === 'failed') {
-        throw publicErrorProjectionToError(
-          evidence.error ?? { code: 'harness.queue_failed', message: 'queued turn failed' },
-        );
-      }
+      const terminalEvidence = await this._recoverQueuedTerminalEvidence(item, receipt, modeId, activeDeleted);
+      if (terminalEvidence) return terminalEvidence;
 
       const recovery = await this._raceActiveTurnWaiter(this._inspectQueueReceiptMemory(receipt), activeDeleted);
       if (recovery.status === 'pending') {
@@ -6157,6 +6156,32 @@ export class Session {
 
       return undefined;
     });
+  }
+
+  private async _recoverQueuedTerminalEvidence(
+    item: QueuedItem,
+    receipt: QueueAdmissionReceipt,
+    modeId: string,
+    activeTurnWaiter?: Promise<never>,
+  ): Promise<FullOutput<unknown> | undefined> {
+    if (!receipt.runId || !receipt.signalId) return undefined;
+
+    const evidence = await this._raceActiveTurnWaiter(this._loadQueueSignalResultEvidence(receipt), activeTurnWaiter);
+    if (evidence.status === 'completed') {
+      const full = evidence.result as FullOutput<unknown>;
+      await this._raceActiveTurnWaiter(this._markQueuedTurnCompleted(item.id, full), activeTurnWaiter);
+      if (receipt.postRunFinalizedAt === undefined) {
+        await this._finalizeCompletedQueuedTurn(item, full, modeId, activeTurnWaiter);
+      }
+      return full;
+    }
+    if (evidence.status === 'failed') {
+      throw publicErrorProjectionToError(
+        evidence.error ?? { code: 'harness.queue_failed', message: 'queued turn failed' },
+      );
+    }
+
+    return undefined;
   }
 
   private _queueReceiptTerminalFailureError(queuedItemId: string): Error | undefined {

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -46,6 +46,7 @@ import type {
   AgentSignalResultStatus,
   HarnessStorage,
   HarnessStorageAttachmentUnavailableError,
+  HarnessRuntimeDependencyRefs,
   InboxResponseReceipt,
   QueueAdmissionReceipt,
   PendingResume,
@@ -384,8 +385,8 @@ export interface SessionDisplayState {
   // Tokens
   tokenUsage: TokenUsage;
 
-  // Pending interrupt (full payload, not just a boolean — UIs need the args)
-  pending: SessionRecord['pendingResume'] | null;
+  // Pending interrupt (full UX payload, not recovery-only metadata)
+  pending: SessionDisplayPending | null;
 
   // Queue
   queueDepth: number;
@@ -393,6 +394,14 @@ export interface SessionDisplayState {
 
   // Goal
   goal?: SessionRecord['goal'];
+}
+
+export type SessionDisplayPending = Omit<NonNullable<SessionRecord['pendingResume']>, 'runtimeDependencies'>;
+
+function pendingResumeForDisplay(pending: SessionRecord['pendingResume']): SessionDisplayPending | null {
+  if (!pending) return null;
+  const { runtimeDependencies: _runtimeDependencies, ...displayPending } = pending;
+  return displayPending;
 }
 
 /**
@@ -2173,13 +2182,14 @@ export class Session {
 
     // Resolve the effective mode (per-call override wins, else session's).
     const effectiveModeId = opts.mode ?? this._record.modeId;
+    const effectiveModelId = opts.model ?? this._record.modelId;
     const mode = this._harness._getMode(effectiveModeId);
     const agent = this._harness.getAgentForMode(effectiveModeId);
     const admissionHashes =
       opts.admissionId !== undefined
         ? this._computeMessageAdmissionHashes(opts, {
             modeId: effectiveModeId,
-            modelId: opts.model ?? this._record.modelId,
+            modelId: effectiveModelId,
           })
         : undefined;
     const admissionHash = admissionHashes?.primary;
@@ -2257,6 +2267,7 @@ export class Session {
       requestContext = await Promise.race([
         this._buildRequestContext({
           modeId: effectiveModeId,
+          modelId: effectiveModelId,
           abortSignal: turnAbortSignal,
         }),
         activeTurnWaiter.promise,
@@ -2292,7 +2303,10 @@ export class Session {
         ]);
         const full = result as FullOutput<unknown>;
         this._recordTurnCompletion(full);
-        await Promise.race([this._maybeCaptureSuspend(full, undefined, effectiveModeId), activeTurnWaiter.promise]);
+        await Promise.race([
+          this._maybeCaptureSuspend(full, undefined, effectiveModeId, effectiveModelId),
+          activeTurnWaiter.promise,
+        ]);
         this._emitTurnEvent({
           type: 'agent_end',
           reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
@@ -2577,7 +2591,10 @@ export class Session {
           return full;
         })
         .then(async full => {
-          await Promise.race([this._maybeCaptureSuspend(full, undefined, effectiveModeId), activeTurnWaiter.promise]);
+          await Promise.race([
+            this._maybeCaptureSuspend(full, undefined, effectiveModeId, effectiveModelId),
+            activeTurnWaiter.promise,
+          ]);
           this._emitTurnEvent({
             type: 'agent_end',
             reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
@@ -2650,7 +2667,10 @@ export class Session {
           throw err;
         }
       }
-      await Promise.race([this._maybeCaptureSuspend(full, undefined, effectiveModeId), activeTurnWaiter.promise]);
+      await Promise.race([
+        this._maybeCaptureSuspend(full, undefined, effectiveModeId, effectiveModelId),
+        activeTurnWaiter.promise,
+      ]);
       this._emitTurnEvent({
         type: 'agent_end',
         reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
@@ -3242,6 +3262,7 @@ export class Session {
         const requestContext = await Promise.race([
           this._buildRequestContext({
             modeId: effectiveModeId,
+            modelId: this._record.modelId,
             abortSignal: turnAbortSignal,
           }),
           activeTurnWaiter.promise,
@@ -3278,7 +3299,10 @@ export class Session {
       const result: Promise<AgentResult> = completionOrDelete
         .then(async full => {
           this._recordTurnCompletion(full);
-          await Promise.race([this._maybeCaptureSuspend(full, undefined, effectiveModeId), activeTurnWaiter.promise]);
+          await Promise.race([
+            this._maybeCaptureSuspend(full, undefined, effectiveModeId, this._record.modelId),
+            activeTurnWaiter.promise,
+          ]);
           this._emitTurnEvent({
             type: 'agent_end',
             reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
@@ -3391,6 +3415,7 @@ export class Session {
         const requestContext = await Promise.race([
           this._buildRequestContext({
             modeId: effectiveModeId,
+            modelId: this._record.modelId,
             abortSignal: turnAbortSignal,
           }),
           activeTurnWaiter.promise,
@@ -3428,7 +3453,10 @@ export class Session {
       const result = completionOrDelete
         .then(async full => {
           this._recordTurnCompletion(full);
-          await Promise.race([this._maybeCaptureSuspend(full, undefined, effectiveModeId), activeTurnWaiter.promise]);
+          await Promise.race([
+            this._maybeCaptureSuspend(full, undefined, effectiveModeId, this._record.modelId),
+            activeTurnWaiter.promise,
+          ]);
           this._emitTurnEvent({
             type: 'agent_end',
             reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
@@ -3493,6 +3521,7 @@ export class Session {
     full: FullOutput<unknown>,
     queuedItemId = this._currentQueuedItemId,
     modeId = this._record.modeId,
+    modelId = this._modelIdForQueuedItem(queuedItemId),
   ): Promise<void> {
     if (full.finishReason !== 'suspended') return;
     const payload = full.suspendPayload as
@@ -3520,6 +3549,7 @@ export class Session {
       requestedAt: Date.now(),
       ...(queuedItemId !== undefined ? { queuedItemId } : {}),
       modeId,
+      runtimeDependencies: this._harness._runtimeDependenciesForMode(modeId, modelId),
       payload: this._buildResumePayload(kind, payload),
     };
 
@@ -3777,8 +3807,8 @@ export class Session {
       // Tokens — copy so the caller can't mutate the running aggregate
       tokenUsage: { ...this._tokenUsage },
 
-      // Pending interrupt — full payload, single field (see §5.1)
-      pending: rec.pendingResume ?? null,
+      // Pending interrupt — UX payload only; recovery metadata stays internal.
+      pending: pendingResumeForDisplay(rec.pendingResume),
 
       // Queue
       queueDepth: rec.pendingQueue.length,
@@ -4730,6 +4760,58 @@ export class Session {
       this._ensureQueuedItemContext(pendingQueuedItemId);
     }
 
+    // For plan-approval, resolve the active-mode flip before finalizing the
+    // resumed turn. Queued terminal resumes persist this flip with the
+    // completed receipt so crash recovery cannot observe "completed plan
+    // approval, old mode".
+    //
+    // Resolution order on approval:
+    //   1. Caller-supplied `transitionToMode` overrides everything.
+    //   2. Falls back to the submitting mode's declared `transitionsTo`
+    //      (captured into `pending.transitionModeId` at suspend time).
+    //   3. Otherwise no flip.
+    let modeFlipTarget: string | undefined;
+    if (expectedKind === 'plan-approval') {
+      const data = resumeData as { approved: boolean; transitionToMode?: string };
+      if (data.approved) {
+        const candidate = data.transitionToMode ?? pending.transitionModeId;
+        if (candidate && candidate !== this._record.modeId) {
+          // Validate the target mode exists before we hand off to the agent.
+          // (Caller-supplied `transitionToMode` is also validated up-front in
+          // `respondToPlanApproval`; this catches the pending-record path.)
+          this._harness._getMode(candidate);
+          modeFlipTarget = candidate;
+        }
+      }
+    }
+
+    const previousModeId = this._record.modeId;
+    const resumeModeId = this._modeIdForPendingResume(pending);
+    const resumeRuntimeDependencies = this._runtimeDependenciesForPendingResume(pending);
+    let agent: Agent;
+    try {
+      agent = this._harness._resolveAgentForRuntimeDependencies(
+        resumeRuntimeDependencies,
+        `pending ${expectedKind} resume`,
+      ).agent;
+    } catch (err) {
+      if (responseId !== undefined) {
+        await this._recordInboxResponsePreDispatchFailure(
+          {
+            responseId,
+            responseHash: responseHash!,
+            itemId,
+            queuedItemId: pendingQueuedItemId,
+            kind: expectedKind,
+            pending,
+            response: persistedResponse,
+          },
+          err,
+        );
+      }
+      throw err;
+    }
+
     // Mark resumed under the lease BEFORE calling the agent (idempotency
     // marker per §5.4 / §5.7). On crash here, the next caller observes
     // resumedAt set and rejects rather than double-resuming.
@@ -4817,34 +4899,6 @@ export class Session {
       );
     }
 
-    // For plan-approval, resolve the active-mode flip before finalizing the
-    // resumed turn. Queued terminal resumes persist this flip with the
-    // completed receipt so crash recovery cannot observe "completed plan
-    // approval, old mode".
-    //
-    // Resolution order on approval:
-    //   1. Caller-supplied `transitionToMode` overrides everything.
-    //   2. Falls back to the submitting mode's declared `transitionsTo`
-    //      (captured into `pending.transitionModeId` at suspend time).
-    //   3. Otherwise no flip.
-    let modeFlipTarget: string | undefined;
-    if (expectedKind === 'plan-approval') {
-      const data = resumeData as { approved: boolean; transitionToMode?: string };
-      if (data.approved) {
-        const candidate = data.transitionToMode ?? pending.transitionModeId;
-        if (candidate && candidate !== this._record.modeId) {
-          // Validate the target mode exists before we hand off to the agent.
-          // (Caller-supplied `transitionToMode` is also validated up-front in
-          // `respondToPlanApproval`; this catches the pending-record path.)
-          this._harness._getMode(candidate);
-          modeFlipTarget = candidate;
-        }
-      }
-    }
-
-    const previousModeId = this._record.modeId;
-    const resumeModeId = this._modeIdForPendingResume(pending);
-
     // Resumed runs run under a session-owned AbortController too, so
     // `session.abort()` can cancel an in-flight resume (e.g. ESC after the
     // user approved a tool that's now grinding through a long workflow).
@@ -4860,7 +4914,6 @@ export class Session {
         throw new HarnessSessionDeletedError(this.id);
       }
     };
-    const agent = this._harness.getAgentForMode(resumeModeId);
     let full: FullOutput<unknown>;
     try {
       assertResumedTurnNotDeleted();
@@ -4982,7 +5035,7 @@ export class Session {
       // Mirror message()'s post-run hook so the next respond* call sees the
       // new pending record.
       await Promise.race([
-        this._maybeCaptureSuspend(full, pendingQueuedItemId, resumeModeId),
+        this._maybeCaptureSuspend(full, pendingQueuedItemId, resumeModeId, resumeRuntimeDependencies.modelId),
         activeTurnWaiter.promise,
       ]);
 
@@ -5120,6 +5173,57 @@ export class Session {
     });
   }
 
+  private async _recordInboxResponsePreDispatchFailure(
+    input: {
+      responseId: string;
+      responseHash: string;
+      itemId: string;
+      queuedItemId?: string;
+      kind: PendingResume['kind'];
+      pending: PendingResume;
+      response: unknown;
+    },
+    err: unknown,
+  ): Promise<void> {
+    const failedAt = Date.now();
+    await this._flushUpdate(prev => {
+      const currentReceipt = getOwnRecordValue(prev.inboxResponseReceipts, input.responseId);
+      if (currentReceipt !== undefined) {
+        this._assertMatchingInboxReceipt(currentReceipt, {
+          kind: input.kind,
+          itemId: input.itemId,
+          responseId: input.responseId,
+          responseHash: input.responseHash,
+        });
+        return prev;
+      }
+      return {
+        ...prev,
+        inboxResponseReceipts: {
+          ...(prev.inboxResponseReceipts ?? {}),
+          [input.responseId]: {
+            responseId: input.responseId,
+            responseHash: input.responseHash,
+            resumeAttemptId: input.responseId,
+            itemId: input.itemId,
+            ...(input.queuedItemId !== undefined ? { queuedItemId: input.queuedItemId } : {}),
+            kind: input.kind,
+            runId: input.pending.runId,
+            toolCallId: input.pending.toolCallId,
+            pendingRequestedAt: input.pending.requestedAt,
+            response: input.response,
+            status: 'failed',
+            error: projectHarnessPublicError(err),
+            retryable: false,
+            acceptedAt: failedAt,
+            failedAt,
+            updatedAt: failedAt,
+          } satisfies InboxResponseReceipt,
+        },
+      };
+    });
+  }
+
   private async _markInboxResponseFailed(responseId: string, err: unknown): Promise<void> {
     const failedAt = Date.now();
     await this._flushUpdate(prev => {
@@ -5215,6 +5319,21 @@ export class Session {
     const queuedItem = queuedItemId ? this._record.pendingQueue.find(item => item.id === queuedItemId) : undefined;
     const receipt = queuedItemId ? this._record.queueAdmissionReceipts?.[queuedItemId] : undefined;
     return pending.modeId ?? receipt?.modeId ?? queuedItem?.mode ?? this._record.modeId;
+  }
+
+  private _modelIdForQueuedItem(queuedItemId: string | undefined): string {
+    const queuedItem = queuedItemId ? this._record.pendingQueue.find(item => item.id === queuedItemId) : undefined;
+    const receipt = queuedItemId ? this._record.queueAdmissionReceipts?.[queuedItemId] : undefined;
+    return queuedItem?.model ?? receipt?.runtimeDependencies?.modelId ?? this._record.modelId;
+  }
+
+  private _runtimeDependenciesForPendingResume(pending: PendingResume): HarnessRuntimeDependencyRefs {
+    const queuedItemId = this._queuedItemIdForPendingResume(pending);
+    const queuedItem = queuedItemId ? this._record.pendingQueue.find(item => item.id === queuedItemId) : undefined;
+    const receipt = queuedItemId ? this._record.queueAdmissionReceipts?.[queuedItemId] : undefined;
+    const modeId = this._modeIdForPendingResume(pending);
+    const modelId = queuedItem?.model ?? this._record.modelId;
+    return pending.runtimeDependencies ?? receipt?.runtimeDependencies ?? { modeId, ...(modelId ? { modelId } : {}) };
   }
 
   private async _maybeRecoverStaleQueuedResume(): Promise<QueueResumeRecoveryResult> {
@@ -5494,6 +5613,10 @@ export class Session {
       admissionHash,
       queuedItemId: item.id,
       modeId: effectiveModeId,
+      runtimeDependencies: this._harness._runtimeDependenciesForMode(
+        effectiveModeId,
+        item.model ?? this._record.modelId,
+      ),
       status: 'queued',
       attempts: 0,
       enqueuedAt: item.enqueuedAt,
@@ -5839,8 +5962,6 @@ export class Session {
     await this._validateQueuedAttachmentRefs(item);
     const currentReceipt = this._record.queueAdmissionReceipts?.[item.id];
     const effectiveModeId = currentReceipt?.modeId ?? item.mode ?? this._record.modeId;
-    const mode = this._harness._getMode(effectiveModeId);
-    const agent = this._harness.getAgentForMode(effectiveModeId);
     const identity = this._queueSignalIdentity(item);
     let shouldMarkAdmitting = true;
     if (currentReceipt) {
@@ -5864,14 +5985,20 @@ export class Session {
           },
         );
       }
-      if (
-        (currentReceipt.status === 'admitting' || currentReceipt.status === 'accepted') &&
-        currentReceipt.runId &&
-        currentReceipt.signalId
-      ) {
-        const recovered = await this._recoverQueuedDispatch(item, currentReceipt, agent, effectiveModeId);
-        if (recovered) return recovered;
-      }
+    }
+    const runtimeDependencies = this._runtimeDependenciesForQueuedTurn(item, currentReceipt, effectiveModeId);
+    const { mode, agent } = this._harness._resolveAgentForRuntimeDependencies(
+      runtimeDependencies,
+      `queued item "${item.id}" recovery`,
+    );
+    if (
+      currentReceipt &&
+      (currentReceipt.status === 'admitting' || currentReceipt.status === 'accepted') &&
+      currentReceipt.runId &&
+      currentReceipt.signalId
+    ) {
+      const recovered = await this._recoverQueuedDispatch(item, currentReceipt, agent, effectiveModeId);
+      if (recovered) return recovered;
     }
     if (shouldMarkAdmitting) {
       await this._updateQueueAdmissionReceipt(item.id, (receipt, now) => ({
@@ -5906,6 +6033,7 @@ export class Session {
       const requestContext = await Promise.race([
         this._buildRequestContext({
           modeId: effectiveModeId,
+          modelId: this._modelIdForQueuedItem(item.id),
           abortSignal: turnAbortController.signal,
         }),
         activeTurnWaiter.promise,
@@ -5979,6 +6107,15 @@ export class Session {
     } finally {
       finishQueuedTurn();
     }
+  }
+
+  private _runtimeDependenciesForQueuedTurn(
+    item: QueuedItem,
+    receipt: QueueAdmissionReceipt | undefined,
+    modeId: string,
+  ): HarnessRuntimeDependencyRefs {
+    const modelId = item.model ?? this._record.modelId;
+    return receipt?.runtimeDependencies ?? { modeId, ...(modelId ? { modelId } : {}) };
   }
 
   private async _recoverQueuedDispatch(
@@ -6248,7 +6385,7 @@ export class Session {
   }
 
   private async _registerQuestion(
-    params: RegisterQuestionParams & { runId?: string; toolCallId?: string; modeId?: string },
+    params: RegisterQuestionParams & { runId?: string; toolCallId?: string; modeId?: string; modelId?: string },
   ): Promise<void> {
     this._assertOpenForTurn('ctx.registerQuestion');
     if (typeof params.questionId !== 'string' || params.questionId.length === 0) {
@@ -6278,6 +6415,10 @@ export class Session {
       source: (this._record.subagentDepth ?? 0) > 0 ? 'subagent' : 'parent',
       requestedAt: Date.now(),
       modeId: params.modeId ?? this._record.modeId,
+      runtimeDependencies: this._harness._runtimeDependenciesForMode(
+        params.modeId ?? this._record.modeId,
+        params.modelId ?? this._modelIdForQueuedItem(this._currentQueuedItemId),
+      ),
       payload: {
         question: params.question,
         ...(params.options ? { options: params.options } : {}),
@@ -6307,7 +6448,7 @@ export class Session {
   }
 
   private async _registerPlanApproval(
-    params: RegisterPlanApprovalParams & { runId?: string; toolCallId?: string; modeId?: string },
+    params: RegisterPlanApprovalParams & { runId?: string; toolCallId?: string; modeId?: string; modelId?: string },
   ): Promise<void> {
     this._assertOpenForTurn('ctx.registerPlanApproval');
     if (typeof params.planId !== 'string' || params.planId.length === 0) {
@@ -6335,6 +6476,10 @@ export class Session {
       source: (this._record.subagentDepth ?? 0) > 0 ? 'subagent' : 'parent',
       requestedAt: Date.now(),
       modeId: submittingModeId,
+      runtimeDependencies: this._harness._runtimeDependenciesForMode(
+        submittingModeId,
+        params.modelId ?? this._modelIdForQueuedItem(this._currentQueuedItemId),
+      ),
       payload: {
         ...(params.title !== undefined ? { title: params.title } : {}),
         plan: params.plan,
@@ -6694,7 +6839,11 @@ export class Session {
    * of the session. Functional `setState` updates serialize through the
    * same `_flushUpdate` chain that backs `Session.setState`.
    */
-  private async _buildRequestContext(turn: { modeId: string; abortSignal: AbortSignal }): Promise<RequestContext> {
+  private async _buildRequestContext(turn: {
+    modeId: string;
+    modelId: string;
+    abortSignal: AbortSignal;
+  }): Promise<RequestContext> {
     const session = this;
     const stateSnapshot = (this._record.state ?? {}) as unknown;
     // Resolve the workspace eagerly so tools see a populated `ctx.workspace`
@@ -6721,8 +6870,9 @@ export class Session {
           updatesOrUpdater as Partial<unknown> | ((prev: unknown) => unknown),
         )) as HarnessRequestContext<unknown>['setState'],
       abortSignal: turn.abortSignal,
-      registerQuestion: params => session._registerQuestion({ ...params, modeId: turn.modeId }),
-      registerPlanApproval: params => session._registerPlanApproval({ ...params, modeId: turn.modeId }),
+      registerQuestion: params => session._registerQuestion({ ...params, modeId: turn.modeId, modelId: turn.modelId }),
+      registerPlanApproval: params =>
+        session._registerPlanApproval({ ...params, modeId: turn.modeId, modelId: turn.modelId }),
       // Subagent linkage — set from the record so spawned sessions report
       // their depth + parent linkage on the harness slot.
       subagentDepth: this._record.subagentDepth ?? 0,

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -139,6 +139,12 @@ export interface PendingResume {
   /** Mode whose backing agent produced this pending resume. */
   modeId?: string;
   /**
+   * Runtime identities captured when this work was admitted. Recovery uses
+   * these stable ids to fail closed if the process restarts with a different
+   * execution surface.
+   */
+  runtimeDependencies?: HarnessRuntimeDependencyRefs;
+  /**
    * Idempotency marker. Set by the resume helper before calling
    * `agent.resumeStream(...)` and observed on replay so a crash between
    * "wrote resumedAt" and "cleared pendingResume" does not double-resume.
@@ -408,6 +414,11 @@ export interface QueueAdmissionReceipt {
   admissionHash: string;
   queuedItemId: string;
   modeId?: string;
+  /**
+   * Runtime identities captured at queue admission. Legacy receipts omit this
+   * and fall back to id-only validation for backwards compatibility.
+   */
+  runtimeDependencies?: HarnessRuntimeDependencyRefs;
   status: 'queued' | 'admitting' | 'accepted' | 'completed' | 'admission_failed' | 'failed' | 'dead';
   runId?: string;
   signalId?: string;
@@ -423,6 +434,25 @@ export interface QueueAdmissionReceipt {
   deadAt?: number;
   nextAttemptAt?: number;
   updatedAt: number;
+}
+
+export interface HarnessRuntimeDependencyRefs {
+  modeId: string;
+  agentId?: string;
+  /**
+   * Evidence-only selected model id. The current Harness model catalog is a
+   * UX surface, not an execution registry, so recovery does not fail closed on
+   * this field until a stable runtime model registry exists.
+   */
+  modelId?: string;
+  /**
+   * Provider-backed workspaces persist the configured provider id. Shared
+   * workspaces have no durable provider id, so new work records a process-
+   * scoped shared sentinel and fails closed after restart. Explicitly null
+   * means no workspace was configured at admission. Undefined means legacy
+   * evidence that predates runtime dependency capture.
+   */
+  workspaceProviderId?: string | null;
 }
 
 export interface HarnessSessionEventRecord {

--- a/packages/server/src/server/handlers/harness.test.ts
+++ b/packages/server/src/server/handlers/harness.test.ts
@@ -132,6 +132,7 @@ async function expectHarnessHttpError(promise: Promise<unknown>, status: number,
     expect(httpError.status).toBe(status);
     const body = await httpError.getResponse().json();
     expect(body).toMatchObject({ code });
+    return body;
   }
 }
 
@@ -2385,7 +2386,7 @@ describe('Harness server routes', () => {
     const harness = { session: vi.fn(async () => session) };
     const mastra = { getHarness: vi.fn(() => harness) };
 
-    await expectHarnessHttpError(
+    const body = await expectHarnessHttpError(
       RESPOND_HARNESS_INBOX_ROUTE.handler(
         makeParams({
           mastra,
@@ -2402,6 +2403,14 @@ describe('Harness server routes', () => {
       409,
       'harness.runtime_dependency_drifted',
     );
+    expect(body).toMatchObject({
+      details: {
+        dependencyKind: 'workspace_provider',
+        dependencyId: 'unconfigured',
+        reason: 'was recorded, but the current workspace dependency is "workspace-now-configured"',
+        context: 'pending question resume',
+      },
+    });
   });
 
   it('sets, reads, pauses, resumes, and clears session goals', async () => {

--- a/packages/server/src/server/handlers/harness.test.ts
+++ b/packages/server/src/server/handlers/harness.test.ts
@@ -7,6 +7,7 @@ import {
   HarnessAttachmentInUseError,
   HarnessAttachmentUnavailableError,
   HarnessInboxResponseConflictError,
+  HarnessRuntimeDependencyDriftError,
 } from '@mastra/core/harness/v1';
 import { RequestContext, MASTRA_RESOURCE_ID_KEY } from '@mastra/core/request-context';
 import { describe, expect, it, vi } from 'vitest';
@@ -2367,6 +2368,39 @@ describe('Harness server routes', () => {
       ),
       409,
       'harness.inbox_response_conflict',
+    );
+  });
+
+  it('maps runtime dependency drift to the wire error code', async () => {
+    const session = {
+      respondToQuestion: vi.fn(async () => {
+        throw new HarnessRuntimeDependencyDriftError(
+          'workspace_provider',
+          'unconfigured',
+          'was recorded, but the current workspace dependency is "workspace-now-configured"',
+          'pending question resume',
+        );
+      }),
+    };
+    const harness = { session: vi.fn(async () => session) };
+    const mastra = { getHarness: vi.fn(() => harness) };
+
+    await expectHarnessHttpError(
+      RESPOND_HARNESS_INBOX_ROUTE.handler(
+        makeParams({
+          mastra,
+          name: 'code',
+          sessionId: 'session-1',
+          itemId: 'item-1',
+          requestBody: {
+            kind: 'question',
+            answer: 'yes',
+            responseId: 'response-1',
+          },
+        }),
+      ),
+      409,
+      'harness.runtime_dependency_drifted',
     );
   });
 

--- a/packages/server/src/server/handlers/harness.ts
+++ b/packages/server/src/server/handlers/harness.ts
@@ -1408,11 +1408,17 @@ function mapHarnessError(error: unknown): never {
   if (name === 'HarnessStorageChannelDiagnosticsUnsupportedError') {
     throwHarnessHttpError(501, 'harness.channel_diagnostics_unsupported', message, undefined, false);
   }
-  if (name === 'HarnessRuntimeDependencyDriftError' || name === 'harness.runtime_dependency_drifted') {
+  if (
+    name === 'HarnessRuntimeDependencyDriftError' ||
+    name === 'harness.runtime_dependency_drifted' ||
+    harnessErrorString(error, 'code') === 'harness.runtime_dependency_drifted'
+  ) {
+    const context = harnessErrorProp(error, 'context');
     throwHarnessHttpError(409, 'harness.runtime_dependency_drifted', message, {
-      dependencyKind: harnessErrorString(error, 'dependencyKind'),
-      dependencyId: harnessErrorString(error, 'dependencyId'),
-      context: harnessErrorString(error, 'context'),
+      dependencyKind: harnessErrorString(error, 'dependencyKind') ?? harnessErrorString(error, 'kind'),
+      dependencyId: harnessErrorString(error, 'dependencyId') ?? harnessErrorString(error, 'id'),
+      reason: harnessErrorString(error, 'reason'),
+      ...(context !== undefined ? { context } : {}),
     });
   }
   if (name === 'HarnessQueueFullError') {

--- a/packages/server/src/server/handlers/harness.ts
+++ b/packages/server/src/server/handlers/harness.ts
@@ -65,6 +65,7 @@ import { enforceThreadAccess, getEffectiveResourceId } from './utils';
 
 type SessionLifecycleStatus = 'active' | 'closing' | 'closed';
 type PendingInboxKind = 'tool-approval' | 'tool-suspension' | 'question' | 'plan-approval';
+type PublicPendingResume = Omit<NonNullable<SessionRecord['pendingResume']>, 'runtimeDependencies'>;
 type UrlAttachmentInput = {
   kind: 'url';
   url: string;
@@ -1407,6 +1408,13 @@ function mapHarnessError(error: unknown): never {
   if (name === 'HarnessStorageChannelDiagnosticsUnsupportedError') {
     throwHarnessHttpError(501, 'harness.channel_diagnostics_unsupported', message, undefined, false);
   }
+  if (name === 'HarnessRuntimeDependencyDriftError' || name === 'harness.runtime_dependency_drifted') {
+    throwHarnessHttpError(409, 'harness.runtime_dependency_drifted', message, {
+      dependencyKind: harnessErrorString(error, 'dependencyKind'),
+      dependencyId: harnessErrorString(error, 'dependencyId'),
+      context: harnessErrorString(error, 'context'),
+    });
+  }
   if (name === 'HarnessQueueFullError') {
     throwHarnessHttpError(429, 'harness.queue_full', message, {
       sessionId: harnessErrorString(error, 'sessionId'),
@@ -1629,10 +1637,16 @@ function displayStateFromRecord(record: SessionRecord): SessionDisplayState {
     toolInputBuffers: {},
     activeSubagents: {},
     tokenUsage: { ...record.tokenUsage },
-    pending: record.pendingResume ?? null,
+    pending: pendingResumeForDisplay(record.pendingResume),
     queueDepth: record.pendingQueue.length,
     ...(record.goal !== undefined ? { goal: record.goal } : {}),
   };
+}
+
+function pendingResumeForDisplay(pending: SessionRecord['pendingResume']): PublicPendingResume | null {
+  if (!pending) return null;
+  const { runtimeDependencies: _runtimeDependencies, ...displayPending } = pending;
+  return displayPending;
 }
 
 function snapshotFromRecord(
@@ -1648,7 +1662,7 @@ function snapshotFromRecord(
       depth: record.pendingQueue.length,
       queuedItemIds: record.pendingQueue.map(item => item.id),
     },
-    pendingInbox: record.pendingResume ? [record.pendingResume] : [],
+    pendingInbox: record.pendingResume ? [pendingResumeForDisplay(record.pendingResume)] : [],
     durableWork: {
       active: [],
       recentTerminal: [],


### PR DESCRIPTION
[PF-357] Runtime dependency drift fail-closed checks

Linear: PF-357

## Summary
- Captures stable runtime dependency evidence for recovered Harness queue and pending-resume work: mode, agent, selected model evidence, and workspace dependency identity.
- Fails closed before recovered queue/resume work invokes an agent when mode bindings, agents, or workspace dependency identities drift after restart.
- Keeps terminal queue receipts replayable without revalidating later runtime drift, and records failed inbox-response evidence for pre-dispatch drift without poisoning `pendingResume.resumedAt`.
- Strips recovery-only `runtimeDependencies` metadata from public display state and server snapshots/pending inbox payloads.
- Maps runtime dependency drift to `409 harness.runtime_dependency_drifted` on Harness server routes.

## Validation
- `pnpm --dir packages/core check`
- `pnpm --dir packages/core exec eslint src/harness/v1/errors.ts src/harness/v1/harness.ts src/harness/v1/index.ts src/harness/v1/session.ts src/harness/v1/session.queue.test.ts src/harness/v1/session.suspend.test.ts src/harness/v1/session.display-state.test.ts src/storage/domains/harness/types.ts`
- `pnpm exec vitest run packages/core/src/harness/v1/session.queue.test.ts packages/core/src/harness/v1/session.suspend.test.ts packages/core/src/harness/v1/session.display-state.test.ts --project unit:packages/core`
- `pnpm --dir packages/server exec eslint src/server/handlers/harness.ts src/server/handlers/harness.test.ts`
- `pnpm --dir packages/server exec vitest run src/server/handlers/harness.test.ts`
- `pnpm --dir packages/core build:lib`
- `pnpm --dir packages/server build:lib`
- `git diff --check`
- Local CodeRabbit CLI: `Review completed: No findings`

## Review Evidence
- Gemini council flagged model-catalog validation as unsafe because Harness models are UX/auth evidence, not an execution registry. This PR stores model ids as evidence but does not fail closed on model catalog membership.
- Local Codex review found and the PR fixed:
  - validate drift before writing `pendingResume.resumedAt`;
  - explicit no-workspace/shared-workspace dependency identity;
  - no public leakage of `runtimeDependencies`;
  - server route mapping for runtime drift;
  - changeset coverage for `@mastra/server`.
- CodeRabbit CLI findings were fixed, including per-turn model capture and duplicate `responseId` conflict validation in the pre-dispatch failure path.

## Coordination / Overlap
- Open PR #141 (`PF-373` channel diagnostics) overlaps `packages/core/src/harness/v1/harness.ts`, `packages/core/src/harness/v1/index.ts`, `packages/core/src/storage/domains/harness/types.ts`, `packages/server/src/server/handlers/harness.ts`, and `packages/server/src/server/handlers/harness.test.ts`. If #141 merges first, this PR should be rebased and revalidated before merge.
- Open PR #140 (`PF-367` React hooks) only touches `client-sdks/react/**` and is independent.
- This PR intentionally does not sync the fork with latest `mastra-ai/mastra:main`; upstream sync should remain a separate PR to keep Harness v1 diffs upstreamable/minimal.

## Notes
- Based on `origin/main` commit `6cf00b6bfea9417d12999ba17e23165f1041be02`.
- After fetching, `origin/main...upstream/main` is `136 ahead / 556 behind`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 Summary

When paused or queued work is recovered after a restart, the system now records which mode, agent, model evidence, and workspace were used and checks them before resuming; if any of those have changed, the system refuses to resume the work to avoid running with stale configuration.

---

## Overview

Implements fail-closed runtime dependency drift detection for recovered Harness queue items and pending-resume work. The harness snapshots stable runtime identifiers (mode, agent, selected-model evidence, and workspace provider identity) when work is suspended or admitted to the queue and re-validates those references before any recovered work invokes an agent. On detected drift, execution is blocked and a typed drift error is returned instead of proceeding with stale settings.

---

## Key Changes

### Error Handling
- Added HarnessRuntimeDependencyDriftError (code: "harness.runtime_dependency_drifted") and HarnessRuntimeDependencyKind ('mode' | 'agent' | 'workspace_provider') in packages/core/src/harness/v1/errors.ts.
- Server error mapping returns HTTP 409 with code harness.runtime_dependency_drifted and includes dependency metadata (dependencyKind, dependencyId, reason, context).

### Runtime Dependency Tracking & Validation
- New HarnessRuntimeDependencyRefs type (modeId, optional agentId, optional modelId (evidence-only), optional workspaceProviderId) in storage domain types.
- PendingResume and QueueAdmissionReceipt storage shapes optionally include runtimeDependencies to persist captured evidence.
- Harness helpers:
  - _runtimeDependenciesForMode(...) snapshots runtime refs.
  - _resolveAgentForRuntimeDependencies(...) re-validates persisted refs against current harness/mastra state and throws drift errors on mismatch.
  - getAgentForMode now guards mastra.getAgent and throws HarnessConfigError when a mode’s agent is missing.

### Session & Queue Behavior
- Session threads effective modelId and runtime dependency refs through admission hashing, RequestContext, suspend capture, queue admission, queued-turn execution, and resume paths.
- Per-turn model evidence is persisted into pendingResume and queue receipts.
- Recovery validates persisted runtimeDependencies before dispatch; if mismatched, recovered work fails closed (no agent invocation) and a failed inbox-response receipt is recorded for pre-dispatch failures without setting pendingResume.resumedAt.
- Terminal queue receipts remain replayable without later runtime revalidation; only recovered/dispatch-time work is fail-closed.

### Public Display & Snapshots
- RuntimeDependencies are recovery-only and omitted from public display/snapshot shapes.
- Added SessionDisplayPending type and pendingResumeForDisplay helper to strip runtimeDependencies for UI-facing displayState and server snapshots/pending inbox payloads.

### Tests & Validation
- Tests added/updated for per-turn model capture, crash-replay/hydration scenarios (missing modes, mode→agent drift, missing workspace providers, workspace ownership drift), resume fail-closed behavior without agent invocation, failed inbox-response receipts, and server handler mapping to 409/harness.runtime_dependency_drifted.
- Validation performed: pnpm checks, eslint, vitest tests for core and server files, built packages/core and packages/server, git diff --check, local CodeRabbit CLI ("Review completed: No findings").

---

## Review Notes & Coordination
- Gemini council flagged model-catalog membership validation as unsafe; PR stores model ids as evidence but intentionally does not fail closed on catalog membership.
- Codex and CodeRabbit CLI findings were addressed (examples: validate drift before writing pendingResume.resumedAt, explicit workspace dependency identities, prevent public leakage of runtimeDependencies, per-turn model capture, duplicate responseId conflict validation).
- Overlap with open PR `#141` — if `#141` merges first this PR should be rebased and revalidated.
- Changeset bumped `@mastra/core` and `@mastra/server` to patch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->