### PR TITLE
[PF-358] Harden PG Harness index names

### DIFF
--- a/stores/pg/src/storage/domains/harness/index.test.ts
+++ b/stores/pg/src/storage/domains/harness/index.test.ts
@@ -4,7 +4,7 @@ import { createSampleSessionRecord } from '@internal/storage-test-utils';
 import { HarnessStorageThreadDeleteFenceConflictError, TABLE_HARNESS_SESSION_EVENTS } from '@mastra/core/storage';
 import { describe, expect, it, beforeAll, beforeEach, afterAll, vi } from 'vitest';
 
-import { exportSchemas, PostgresStore } from '../..';
+import { exportSchemas, HarnessPG, PostgresStore } from '../..';
 import { TEST_CONFIG } from '../../test-utils';
 
 vi.setConfig({ testTimeout: 60_000, hookTimeout: 60_000 });
@@ -59,6 +59,61 @@ describe('HarnessPG', () => {
       'idx_harness_sessions_active_key',
       'idx_harness_wakeups_idempotency',
     ]);
+  });
+
+  it('keeps long schema-prefixed default index names valid and unique', async () => {
+    const schemaName = 'migration_test_schema_1779266119440_dfd7f958d5b5e8';
+    const indexNames = HarnessPG.getDefaultIndexDefs(`${schemaName}_`).map(index => index.name);
+
+    expect(indexNames).toHaveLength(new Set(indexNames).size);
+    for (const indexName of indexNames) {
+      expect(Buffer.byteLength(indexName, 'utf-8')).toBeLessThanOrEqual(63);
+    }
+
+    const ddl = HarnessPG.getExportDDL(schemaName).join('\n');
+    expect(ddl).toContain('CREATE INDEX');
+    expect(ddl).toMatch(/_idx_[0-9a-f]{8}/);
+    expect(ddl).not.toContain(`${schemaName}_idx_harness_session_events_replay`);
+  });
+
+  it('preserves existing mixed-case short schema index names', () => {
+    const indexNames = HarnessPG.getDefaultIndexDefs('TenantA_').map(index => index.name);
+
+    expect(indexNames).toContain('TenantA_idx_harness_sessions_active_key');
+    for (const indexName of indexNames) {
+      expect(indexName.startsWith('TenantA_')).toBe(true);
+      expect(Buffer.byteLength(indexName, 'utf-8')).toBeLessThanOrEqual(63);
+    }
+  });
+
+  it('initializes Harness indexes for long schema names', async () => {
+    const schemaName = `harness_long_schema_${randomUUID().replaceAll('-', '_')}`;
+    const longSchemaStore = new PostgresStore({
+      ...TEST_CONFIG,
+      id: 'pg-harness-long-schema-indexes',
+      schemaName,
+    });
+    try {
+      await longSchemaStore.init();
+      const expectedNames = HarnessPG.getDefaultIndexDefs(`${schemaName}_`).map(index => index.name);
+      const indexes = await longSchemaStore.db.manyOrNone<{ indexname: string }>(
+        `SELECT indexname FROM pg_indexes
+         WHERE schemaname = $1
+           AND indexname = ANY($2)
+         ORDER BY indexname`,
+        [schemaName, expectedNames],
+      );
+
+      expect(indexes.map(row => row.indexname)).toEqual([...expectedNames].sort());
+    } finally {
+      await longSchemaStore.close().catch(() => {});
+      const cleanupStore = new PostgresStore({ ...TEST_CONFIG, id: 'pg-harness-long-schema-index-cleanup' });
+      try {
+        await cleanupStore.db.none(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+      } finally {
+        await cleanupStore.close();
+      }
+    }
   });
 
   it('allows legacy duplicate active sessions when default indexes are skipped', async () => {

--- a/stores/pg/src/storage/domains/harness/index.ts
+++ b/stores/pg/src/storage/domains/harness/index.ts
@@ -87,6 +87,7 @@ import { parseSqlIdentifier } from '@mastra/core/utils';
 import type { DbClient, QueryValues, TxClient } from '../../client';
 import { PgDB, generateIndexSQL, generateTableSQL, resolvePgConfig } from '../../db';
 import type { PgDomainConfig } from '../../db';
+import { POSTGRES_IDENTIFIER_MAX_LENGTH, truncateIdentifier } from '../../db/constraint-utils';
 
 type HarnessWakeupClaimStatus = Extract<HarnessWakeupItem['status'], 'due' | 'claimed' | 'failed'>;
 type PgHarnessExecuteArgs = string | { sql: string; args?: QueryValues };
@@ -220,58 +221,58 @@ function qualifyHarnessTableNames(sql: string, schemaName?: string): string {
 function harnessIndexDefs(schemaPrefix: string): CreateIndexOptions[] {
   return [
     {
-      name: `${schemaPrefix}idx_harness_sessions_active_key`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_sessions_active_key'),
       table: TABLE_HARNESS_SESSIONS,
       columns: ['harness_name', 'resource_id', 'thread_id'],
       unique: true,
       where: '"closed_at" IS NULL',
     },
     {
-      name: `${schemaPrefix}idx_harness_sessions_thread_scope`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_sessions_thread_scope'),
       table: TABLE_HARNESS_SESSIONS,
       columns: ['harness_name', 'resource_id', 'thread_id', 'last_activity_at'],
     },
     {
-      name: `${schemaPrefix}idx_harness_sessions_thread_global`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_sessions_thread_global'),
       table: TABLE_HARNESS_SESSIONS,
       columns: ['thread_id', 'last_activity_at'],
     },
     {
-      name: `${schemaPrefix}idx_harness_sessions_active_thread`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_sessions_active_thread'),
       table: TABLE_HARNESS_SESSIONS,
       columns: ['harness_name', 'thread_id', 'last_activity_at'],
       where: '"closed_at" IS NULL',
     },
     {
-      name: `${schemaPrefix}idx_harness_sessions_active_thread_global`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_sessions_active_thread_global'),
       table: TABLE_HARNESS_SESSIONS,
       columns: ['thread_id', 'last_activity_at'],
       where: '"closed_at" IS NULL',
     },
     {
-      name: `${schemaPrefix}idx_harness_session_events_replay`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_session_events_replay'),
       table: TABLE_HARNESS_SESSION_EVENTS,
       columns: ['harness_name', 'session_id', 'resource_id', 'thread_id', 'epoch', 'sequence'],
     },
     {
-      name: `${schemaPrefix}idx_harness_channel_inbox_idempotency`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_channel_inbox_idempotency'),
       table: TABLE_HARNESS_CHANNEL_INBOX,
       columns: ['harness_name', 'channel_id', 'idempotency_key'],
       unique: true,
     },
     {
-      name: `${schemaPrefix}idx_harness_channel_inbox_claim`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_channel_inbox_claim'),
       table: TABLE_HARNESS_CHANNEL_INBOX,
       columns: ['harness_name', 'channel_id', 'status', 'next_attempt_at', 'claim_expires_at', 'received_at'],
     },
     {
-      name: `${schemaPrefix}idx_harness_channel_action_tokens_transport`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_channel_action_tokens_transport'),
       table: TABLE_HARNESS_CHANNEL_ACTION_TOKENS,
       columns: ['harness_name', 'channel_id', 'transport_hash'],
       unique: true,
     },
     {
-      name: `${schemaPrefix}idx_harness_channel_action_tokens_pending`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_channel_action_tokens_pending'),
       table: TABLE_HARNESS_CHANNEL_ACTION_TOKENS,
       columns: [
         'harness_name',
@@ -288,55 +289,63 @@ function harnessIndexDefs(schemaPrefix: string): CreateIndexOptions[] {
       unique: true,
     },
     {
-      name: `${schemaPrefix}idx_harness_channel_action_receipts_token`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_channel_action_receipts_token'),
       table: TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS,
       columns: ['harness_name', 'channel_id', 'action_token_id'],
       unique: true,
     },
     {
-      name: `${schemaPrefix}idx_harness_channel_action_receipts_action`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_channel_action_receipts_action'),
       table: TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS,
       columns: ['harness_name', 'channel_id', 'action_id', 'created_at'],
     },
     {
-      name: `${schemaPrefix}idx_harness_channel_action_receipts_claim`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_channel_action_receipts_claim'),
       table: TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS,
       columns: ['harness_name', 'channel_id', 'status', 'next_attempt_at', 'claim_expires_at', 'created_at'],
     },
     {
-      name: `${schemaPrefix}idx_harness_channel_outbox_idempotency`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_channel_outbox_idempotency'),
       table: TABLE_HARNESS_CHANNEL_OUTBOX,
       columns: ['harness_name', 'binding_id', 'idempotency_key'],
       unique: true,
     },
     {
-      name: `${schemaPrefix}idx_harness_channel_outbox_claim`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_channel_outbox_claim'),
       table: TABLE_HARNESS_CHANNEL_OUTBOX,
       columns: ['harness_name', 'channel_id', 'status', 'next_attempt_at', 'claim_expires_at', 'created_at', 'id'],
     },
     {
-      name: `${schemaPrefix}idx_harness_channel_outbox_binding_order`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_channel_outbox_binding_order'),
       table: TABLE_HARNESS_CHANNEL_OUTBOX,
       columns: ['harness_name', 'binding_id', 'status', 'created_at', 'id'],
     },
     {
-      name: `${schemaPrefix}idx_harness_wakeups_idempotency`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_wakeups_idempotency'),
       table: TABLE_HARNESS_WAKEUPS,
       columns: ['harness_name', 'idempotency_key'],
       unique: true,
     },
     {
-      name: `${schemaPrefix}idx_harness_wakeups_source_fire`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_wakeups_source_fire'),
       table: TABLE_HARNESS_WAKEUPS,
       columns: ['harness_name', 'source', 'source_id', 'fire_id'],
       unique: true,
     },
     {
-      name: `${schemaPrefix}idx_harness_wakeups_claim`,
+      name: harnessIndexName(schemaPrefix, 'idx_harness_wakeups_claim'),
       table: TABLE_HARNESS_WAKEUPS,
       columns: ['harness_name', 'source', 'status', 'due_at', 'next_attempt_at', 'claim_expires_at'],
     },
   ];
+}
+
+function harnessIndexName(schemaPrefix: string, baseName: string): string {
+  const name = `${schemaPrefix}${baseName}`;
+  if (Buffer.byteLength(name, 'utf-8') <= POSTGRES_IDENTIFIER_MAX_LENGTH) return name;
+
+  const suffix = `_${createHash('sha256').update(name).digest('hex').slice(0, 8)}`;
+  return `${truncateIdentifier(name, POSTGRES_IDENTIFIER_MAX_LENGTH - Buffer.byteLength(suffix, 'utf-8'))}${suffix}`;
 }
 
 /**
@@ -3578,7 +3587,8 @@ export class HarnessPG extends HarnessStorage {
   async #createDefaultIndexes(indexNames?: readonly string[]): Promise<void> {
     if (this.#skipDefaultIndexes) return;
     const prefix = this.#schemaPrefix();
-    const allowedNames = indexNames === undefined ? undefined : new Set(indexNames.map(name => `${prefix}${name}`));
+    const allowedNames =
+      indexNames === undefined ? undefined : new Set(indexNames.map(name => harnessIndexName(prefix, name)));
     for (const indexDef of this.getDefaultIndexDefinitions()) {
       if (allowedNames !== undefined && !allowedNames.has(indexDef.name)) continue;
       await this.#db.createIndex(indexDef);


### PR DESCRIPTION
## Summary
- keeps PostgreSQL Harness default index names under the 63-byte identifier limit when valid long schema prefixes are used
- preserves existing short/default and mixed-case schema-prefixed index names unchanged
- applies the same deterministic name mapping to lazy Harness default-index creation paths

## Validation
- pnpm --dir /tmp/mastra-fork-pf-539/stores/pg exec vitest run src/storage/domains/harness/index.test.ts --config vitest.config.ts --reporter=verbose
- pnpm --dir /tmp/mastra-fork-pf-539/stores/pg exec eslint src/storage/domains/harness/index.ts src/storage/domains/harness/index.test.ts
- git -C /tmp/mastra-fork-pf-539 diff --check
- pnpm --dir /tmp/mastra-fork-pf-539 --filter @mastra/pg build:lib
- local Codex review pass 1: no findings after fixing the mixed-case compatibility finding
- local Codex review pass 2: no findings
- coderabbit review --plain: no findings

## Notes
- I also ran pnpm --filter @mastra/pg test -- src/storage/domains/harness/index.test.ts during review. That package script ran broader PG tests despite the file argument and failed on pre-existing suite noise: background-task timestamp assertions plus one channel diagnostics row assertion under the broad parallel run. The direct Harness Vitest command above passed before and after that run.

Linear: PF-358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

PostgreSQL has a rule that names (like index names) can't be longer than 63 bytes. When developers use long schema prefixes, the auto-generated index names can break this rule. This PR adds a smart system that automatically shortens long index names and adds a unique fingerprint to the end so they stay valid and don't collide with each other.

## Overview

This PR hardens PostgreSQL Harness index naming by implementing a deterministic truncation strategy to ensure all generated index names remain within PostgreSQL's 63-byte identifier limit, particularly when long schema prefixes are used.

## Changes

### stores/pg/src/storage/domains/harness/index.ts

- Introduced `harnessIndexName` helper function that enforces the PostgreSQL identifier length limit (63 bytes)
- When an index name exceeds the limit, the function truncates the schema prefix and appends a short SHA256-based suffix to maintain uniqueness
- Updated `harnessIndexDefs` to use `harnessIndexName(schemaPrefix, baseName)` instead of raw string concatenation
- Updated `#createDefaultIndexes` filtering logic so `allowedNames` correctly matches newly generated index names
- Added imports for `POSTGRES_IDENTIFIER_MAX_LENGTH` and `truncateIdentifier`
- Preserves existing short/default and mixed-case schema-prefixed index names unchanged

### stores/pg/src/storage/domains/harness/index.test.ts

- Added three new test cases focused on PostgreSQL Harness default index behavior:
  - Verifies that long schema-prefixed default index names remain valid with correct byte-length constraints
  - Confirms mixed-case short schema prefixes are preserved in generated index names
  - Tests full initialization flow with a long `schemaName`, validating the expected Harness indexes are created, with schema cleanup in a `finally` block
- Imported `HarnessPG` for testing

## Validation

- Targeted Vitest run: `pnpm --dir /tmp/mastra-fork-pf-539/stores/pg exec vitest run src/storage/domains/harness/index.test.ts --config vitest.config.ts --reporter=verbose` ✓
- ESLint: `pnpm --dir /tmp/mastra-fork-pf-539/stores/pg exec eslint src/storage/domains/harness/index.ts src/storage/domains/harness/index.test.ts` ✓
- Git diff check ✓
- Built package: `pnpm --dir /tmp/mastra-fork-pf-539 --filter `@mastra/pg` build:lib` ✓
- Local code reviews completed with no findings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->