### PR TITLE
[PF-374] Follow up wakeup worker review comments

### DIFF
--- a/.changeset/pf-374-harness-wakeup-storage.md
+++ b/.changeset/pf-374-harness-wakeup-storage.md
@@ -1,0 +1,6 @@
+---
+"@mastra/libsql": patch
+"@mastra/pg": patch
+---
+
+Scheduled Harness wakeups now keep their queue admission setting after storage recovery, preventing recovered work from running in the wrong mode.

--- a/.changeset/pf-374-harness-wakeup-worker.md
+++ b/.changeset/pf-374-harness-wakeup-worker.md
@@ -6,9 +6,9 @@
 
 Harness sessions can now be reliably resumed from scheduled or proactive triggers, even after server restarts.
 
-LibSQL and PostgreSQL wakeup ledgers now preserve `yolo` queue-admission overrides during durable wakeup recovery.
+LibSQL and PostgreSQL now preserve the queue admission override flag while recovering scheduled Harness work.
 
-PostgreSQL storage now imports and includes the favorites domain in schema export, so store initialization and exported DDL include favorites consistently.
+PostgreSQL storage now includes favorites during setup and migrations, so favorites remain available after store initialization and restarts.
 
 ```ts
 import { Mastra } from '@mastra/core';

--- a/.changeset/pf-374-harness-wakeup-worker.md
+++ b/.changeset/pf-374-harness-wakeup-worker.md
@@ -1,14 +1,10 @@
 ---
 "@mastra/core": minor
-"@mastra/libsql": patch
-"@mastra/pg": patch
 ---
 
 Harness sessions can now be reliably resumed from scheduled or proactive triggers, even after server restarts.
 
-LibSQL and PostgreSQL now preserve the queue admission override flag while recovering scheduled Harness work.
-
-PostgreSQL storage now includes favorites during setup and migrations, so favorites remain available after store initialization and restarts.
+Server restarts and interrupted shutdowns no longer leave duplicate Harness wakeup workers running.
 
 ```ts
 import { Mastra } from '@mastra/core';

--- a/.changeset/pf-374-pg-favorites.md
+++ b/.changeset/pf-374-pg-favorites.md
@@ -1,0 +1,5 @@
+---
+"@mastra/pg": patch
+---
+
+Fixed PostgreSQL storage to preserve agent and skill favorites after store initialization and across restarts.

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -4157,7 +4157,14 @@ export class Mastra<
     let startupComplete = false;
     try {
       for (const worker of targets) {
-        await this.#startWorker(worker);
+        const start = this.#startWorker(worker, { onlyIfWorkersStarted: !name }).finally(() => {
+          this.#pendingWorkerStarts.delete(start);
+        });
+        this.#pendingWorkerStarts.add(start);
+        await start;
+        if (!name && !this.#workersStarted) {
+          return;
+        }
       }
 
       // For push-mode pubsubs (e.g. EventEmitterPubSub) there is no
@@ -4242,19 +4249,31 @@ export class Mastra<
       }
       this.#logger?.error(message, error);
     };
-
-    // Stop registered workers in reverse order
-    for (const worker of [...this.#workers].reverse()) {
-      if (worker.isRunning) {
-        try {
-          await worker.stop();
-        } catch (error) {
-          recordStopError(`Failed to stop worker "${worker.name}"`, error);
+    const pendingWorkerStartsAtShutdown = [...this.#pendingWorkerStarts];
+    const settlePendingWorkerStarts = async (starts: Promise<void>[] = [...this.#pendingWorkerStarts]) => {
+      const pendingWorkerStartResults = await Promise.allSettled(starts);
+      for (const result of pendingWorkerStartResults) {
+        if (result.status === 'rejected') {
+          recordStopError('Failed to finish pending worker startup during shutdown', result.reason);
         }
       }
-    }
+    };
+    const stopRunningWorkers = async () => {
+      for (const worker of [...this.#workers].reverse()) {
+        if (worker.isRunning) {
+          try {
+            await worker.stop();
+          } catch (error) {
+            recordStopError(`Failed to stop worker "${worker.name}"`, error);
+          }
+        }
+      }
+    };
 
-    await Promise.all([...this.#pendingWorkerStarts]);
+    await stopRunningWorkers();
+    await settlePendingWorkerStarts(pendingWorkerStartsAtShutdown);
+    await settlePendingWorkerStarts();
+    await stopRunningWorkers();
 
     // Tear down the in-process push subscription wired during startWorkers().
     if (this.#pushSubscription) {

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -613,6 +613,10 @@ export class Mastra<
   #toolPayloadTransform?: ToolPayloadTransformPolicy;
   #workers: MastraWorker[] = [];
   #workerFilter?: Set<string>;
+  #autoCreateWorkers = true;
+  #workersStarted = false;
+  #pendingWorkerStarts = new Set<Promise<void>>();
+  #harnessWakeupConfig?: HarnessWakeupWorkerConfig;
   // Lazily-constructed processor used by handleWorkflowEvent(). Shared between
   // pull-mode workers (OrchestrationWorker) and push-mode entry points
   // (in-process EventEmitter listener, the /api/workers/events HTTP route).
@@ -1005,10 +1009,12 @@ export class Mastra<
     //   - "false": disables all event processing in this instance
     //   - comma-separated names (e.g. "scheduler,orchestration"): only those
     //     workers will be started by `startWorkers()` when called without an
-    //     explicit `name` argument. Construction still creates all workers so
-    //     a later explicit `startWorkers('foo')` still works.
+    //     explicit `name` argument. Construction creates storage-independent
+    //     workers immediately; storage-gated workers can be added when storage
+    //     becomes available.
     const rawWorkersEnv = process.env.MASTRA_WORKERS;
     let workersOption: MastraWorker[] | false | undefined;
+    this.#harnessWakeupConfig = config?.harnessWakeups;
     if (rawWorkersEnv === 'false') {
       workersOption = false;
     } else {
@@ -1025,9 +1031,11 @@ export class Mastra<
     }
 
     if (workersOption === false) {
+      this.#autoCreateWorkers = false;
       // Explicitly disabled — no event processing in this instance.
       // PubSub still exists for publishing events.
     } else if (Array.isArray(workersOption)) {
+      this.#autoCreateWorkers = false;
       this.#workers = workersOption;
       for (const w of this.#workers) {
         w.__registerMastra(this);
@@ -1057,7 +1065,7 @@ export class Mastra<
         config?.storage !== undefined ||
         Object.values(configuredHarnesses).some(harness => harness?._internalGetSessionStorage() !== undefined);
       if (hasHarnessWakeupStorage && Object.keys(configuredHarnesses).length > 0) {
-        defaultWorkers.push(new HarnessWakeupWorker(config?.harnessWakeups));
+        defaultWorkers.push(new HarnessWakeupWorker(this.#harnessWakeupConfig));
       }
       this.#workers = defaultWorkers;
       for (const w of this.#workers) {
@@ -1341,6 +1349,36 @@ export class Mastra<
     void bgManager.init(this.#pubsub).catch(error => {
       this.#logger?.error('Failed to initialize background task manager', error);
     });
+  }
+
+  #ensureHarnessWakeupWorker(): void {
+    if (!this.#autoCreateWorkers || this.#workers.some(worker => worker.name === 'harnessWakeups')) {
+      return;
+    }
+    if (Object.keys(this.#harnesses).length === 0) {
+      return;
+    }
+    const hasHarnessWakeupStorage =
+      this.#storage !== undefined ||
+      Object.values(this.#harnesses).some(harness => harness?._internalGetSessionStorage() !== undefined);
+    if (!hasHarnessWakeupStorage) {
+      return;
+    }
+
+    const worker = new HarnessWakeupWorker(this.#harnessWakeupConfig);
+    worker.__registerMastra(this);
+    this.#workers.push(worker);
+
+    if (this.#workersStarted && (!this.#workerFilter || this.#workerFilter.has(worker.name))) {
+      const start = this.#startWorker(worker, { onlyIfWorkersStarted: true })
+        .catch(error => {
+          this.#logger?.error?.('Failed to start worker "harnessWakeups"', error);
+        })
+        .finally(() => {
+          this.#pendingWorkerStarts.delete(start);
+        });
+      this.#pendingWorkerStarts.add(start);
+    }
   }
 
   /**
@@ -3490,6 +3528,7 @@ export class Mastra<
     // would have bailed out early in __init(). Retry it now that storage
     // is available so declarative schedules still get registered + fired.
     this.#ensureScheduler();
+    this.#ensureHarnessWakeupWorker();
   }
 
   public setLogger({ logger }: { logger: TLogger }) {
@@ -4094,13 +4133,6 @@ export class Mastra<
    * user-defined event listeners.
    */
   public async startWorkers(name?: string): Promise<void> {
-    const deps: WorkerDeps = {
-      pubsub: this.#pubsub,
-      storage: this.#storage!,
-      logger: this.#logger as unknown as IMastraLogger,
-      mastra: this,
-    };
-
     let targets: MastraWorker[];
     if (name) {
       targets = this.#workers.filter(w => w.name === name);
@@ -4115,65 +4147,92 @@ export class Mastra<
         );
       }
     } else {
-      targets = this.#workers;
+      targets = [...this.#workers];
     }
 
-    for (const worker of targets) {
-      await worker.init(deps);
-      await worker.start();
-    }
-
-    // For push-mode pubsubs (e.g. EventEmitterPubSub) there is no
-    // OrchestrationWorker pulling events — wire handleWorkflowEvent directly
-    // to the pubsub so workflow events still get processed in-process.
     if (!name) {
-      const modes = this.#pubsub.supportedModes ?? ['pull'];
-      const pushOnly = modes.includes('push') && !modes.includes('pull');
-      if (pushOnly && !this.#pushSubscription) {
-        const cb: EventCallback = (event, ack) => {
-          void this.handleWorkflowEvent(event)
-            .then(result => {
-              if (result.ok && ack) {
-                return ack().catch(err =>
-                  this.#logger?.error?.('Error acking workflow event in push subscription', err),
-                );
-              }
-              // Push transports without nack semantics (EventEmitter) treat
-              // a non-ack as a failure signal; we already logged inside handle().
-            })
-            .catch(err => this.#logger?.error?.('Unhandled error in workflow event push subscription', err));
-        };
-        await this.#pubsub.subscribe('workflows', cb);
-        this.#pushSubscription = { topic: 'workflows', cb };
+      this.#workersStarted = true;
+    }
+
+    let startupComplete = false;
+    try {
+      for (const worker of targets) {
+        await this.#startWorker(worker);
       }
-    }
 
-    // Subscribe user-defined event listeners (non-workflow topics, or legacy inline WEP)
-    // Only when starting all workers (not when targeting a specific one).
-    // Idempotent: skip pairs we've already subscribed.
-    if (!name) {
-      for (const topic in this.#events) {
-        if (!this.#events[topic]) {
-          continue;
-        }
-
-        const listeners = Array.isArray(this.#events[topic]) ? this.#events[topic] : [this.#events[topic]];
-        for (const listener of listeners) {
-          const alreadySubscribed = this.#userEventSubscriptions.some(
-            sub => sub.topic === topic && sub.cb === listener,
-          );
-          if (alreadySubscribed) continue;
-          await this.#pubsub.subscribe(topic, listener);
-          this.#userEventSubscriptions.push({ topic, cb: listener });
+      // For push-mode pubsubs (e.g. EventEmitterPubSub) there is no
+      // OrchestrationWorker pulling events — wire handleWorkflowEvent directly
+      // to the pubsub so workflow events still get processed in-process.
+      if (!name) {
+        const modes = this.#pubsub.supportedModes ?? ['pull'];
+        const pushOnly = modes.includes('push') && !modes.includes('pull');
+        if (pushOnly && !this.#pushSubscription) {
+          const cb: EventCallback = (event, ack) => {
+            void this.handleWorkflowEvent(event)
+              .then(result => {
+                if (result.ok && ack) {
+                  return ack().catch(err =>
+                    this.#logger?.error?.('Error acking workflow event in push subscription', err),
+                  );
+                }
+                // Push transports without nack semantics (EventEmitter) treat
+                // a non-ack as a failure signal; we already logged inside handle().
+              })
+              .catch(err => this.#logger?.error?.('Unhandled error in workflow event push subscription', err));
+          };
+          await this.#pubsub.subscribe('workflows', cb);
+          this.#pushSubscription = { topic: 'workflows', cb };
         }
       }
+
+      // Subscribe user-defined event listeners (non-workflow topics, or legacy inline WEP)
+      // Only when starting all workers (not when targeting a specific one).
+      // Idempotent: skip pairs we've already subscribed.
+      if (!name) {
+        for (const topic in this.#events) {
+          if (!this.#events[topic]) {
+            continue;
+          }
+
+          const listeners = Array.isArray(this.#events[topic]) ? this.#events[topic] : [this.#events[topic]];
+          for (const listener of listeners) {
+            const alreadySubscribed = this.#userEventSubscriptions.some(
+              sub => sub.topic === topic && sub.cb === listener,
+            );
+            if (alreadySubscribed) continue;
+            await this.#pubsub.subscribe(topic, listener);
+            this.#userEventSubscriptions.push({ topic, cb: listener });
+          }
+        }
+      }
+
+      startupComplete = true;
+    } finally {
+      if (!name && !startupComplete) {
+        this.#workersStarted = false;
+      }
     }
+  }
+
+  async #startWorker(worker: MastraWorker, opts: { onlyIfWorkersStarted?: boolean } = {}): Promise<void> {
+    const deps: WorkerDeps = {
+      pubsub: this.#pubsub,
+      storage: this.#storage!,
+      logger: this.#logger as unknown as IMastraLogger,
+      mastra: this,
+    };
+    await worker.init(deps);
+    if (opts.onlyIfWorkersStarted && !this.#workersStarted) {
+      return;
+    }
+    await worker.start();
   }
 
   /**
    * Stop all running workers and unsubscribe event listeners.
    */
   public async stopWorkers(): Promise<void> {
+    this.#workersStarted = false;
     let stopError: unknown;
     let hasStopError = false;
     const recordStopError = (message: string, error: unknown) => {
@@ -4194,6 +4253,8 @@ export class Mastra<
         }
       }
     }
+
+    await Promise.all([...this.#pendingWorkerStarts]);
 
     // Tear down the in-process push subscription wired during startWorkers().
     if (this.#pushSubscription) {

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -60,6 +60,16 @@ import type { AnyWorkspace, RegisteredWorkspace, Workspace } from '../workspace'
 import { createOnScorerHook } from './hooks';
 import type { VersionOverrides, VersionSelector } from './types';
 
+const PENDING_WORKER_START_SHUTDOWN_TIMEOUT_MS = 30_000;
+
+type PendingWorkerStart = {
+  worker: MastraWorker;
+  promise: Promise<void>;
+  phase: 'init' | 'start' | 'settled';
+  token: number;
+  ignoreShutdownError?: boolean;
+};
+
 /**
  * Creates an error for when a null/undefined value is passed to an add* method.
  * This commonly occurs when config is spread ({ ...config }) and the original
@@ -615,7 +625,15 @@ export class Mastra<
   #workerFilter?: Set<string>;
   #autoCreateWorkers = true;
   #workersStarted = false;
-  #pendingWorkerStarts = new Set<Promise<void>>();
+  #workerLifecycleGeneration = 0;
+  #workerShutdownGeneration = 0;
+  #workerStartSequence = 0;
+  #allWorkersStartPromise?: Promise<void>;
+  #workersStopPromise?: Promise<void>;
+  #pendingWorkerStarts = new Set<PendingWorkerStart>();
+  #workerStartPromises = new WeakMap<MastraWorker, Promise<void>>();
+  #latestWorkerStartTokens = new WeakMap<MastraWorker, number>();
+  #latestWorkerStartLifecycleGenerations = new WeakMap<MastraWorker, number>();
   #harnessWakeupConfig?: HarnessWakeupWorkerConfig;
   // Lazily-constructed processor used by handleWorkflowEvent(). Shared between
   // pull-mode workers (OrchestrationWorker) and push-mode entry points
@@ -1370,14 +1388,16 @@ export class Mastra<
     this.#workers.push(worker);
 
     if (this.#workersStarted && (!this.#workerFilter || this.#workerFilter.has(worker.name))) {
-      const start = this.#startWorker(worker, { onlyIfWorkersStarted: true })
-        .catch(error => {
+      void this.#trackWorkerStart(worker, {
+        onlyIfWorkersStarted: true,
+        onlyIfLifecycleGeneration: this.#workerLifecycleGeneration,
+        startLifecycleGeneration: this.#workerLifecycleGeneration,
+        stopIfWorkersStopped: true,
+        stopIfLifecycleGenerationChangesFrom: this.#workerLifecycleGeneration,
+        onError: error => {
           this.#logger?.error?.('Failed to start worker "harnessWakeups"', error);
-        })
-        .finally(() => {
-          this.#pendingWorkerStarts.delete(start);
-        });
-      this.#pendingWorkerStarts.add(start);
+        },
+      });
     }
   }
 
@@ -4133,6 +4153,31 @@ export class Mastra<
    * user-defined event listeners.
    */
   public async startWorkers(name?: string): Promise<void> {
+    if (this.#workersStopPromise) {
+      await this.#workersStopPromise;
+    }
+
+    if (!name) {
+      if (this.#allWorkersStartPromise) {
+        return this.#allWorkersStartPromise;
+      }
+
+      const start = this.#startWorkers(name);
+      this.#allWorkersStartPromise = start;
+      try {
+        await start;
+      } finally {
+        if (this.#allWorkersStartPromise === start) {
+          this.#allWorkersStartPromise = undefined;
+        }
+      }
+      return;
+    }
+
+    return this.#startWorkers(name);
+  }
+
+  async #startWorkers(name?: string): Promise<void> {
     let targets: MastraWorker[];
     if (name) {
       targets = this.#workers.filter(w => w.name === name);
@@ -4150,19 +4195,52 @@ export class Mastra<
       targets = [...this.#workers];
     }
 
-    if (!name) {
+    let startupLifecycleGeneration: number | undefined;
+    let startupShutdownGeneration: number | undefined;
+    let workersRunningBeforeStartup: WeakSet<MastraWorker> | undefined;
+    let workersStartingBeforeStartup: WeakSet<MastraWorker> | undefined;
+    let workersStartedBeforeStartup = false;
+    let startupPushSubscription:
+      | {
+          topic: string;
+          cb: EventCallback;
+          subscribed: boolean;
+        }
+      | undefined;
+    const startupUserEventSubscriptions: Array<{
+      topic: string;
+      cb: (event: Event, ack?: () => Promise<void>) => Promise<void>;
+      subscribed: boolean;
+    }> = [];
+    if (name) {
+      startupShutdownGeneration = this.#workerShutdownGeneration;
+    } else {
+      workersStartedBeforeStartup = this.#workersStarted;
+      workersRunningBeforeStartup = new WeakSet(this.#workers.filter(worker => worker.isRunning));
+      workersStartingBeforeStartup = new WeakSet([...this.#pendingWorkerStarts].map(start => start.worker));
+      this.#workerLifecycleGeneration += 1;
+      startupLifecycleGeneration = this.#workerLifecycleGeneration;
       this.#workersStarted = true;
     }
 
     let startupComplete = false;
     try {
       for (const worker of targets) {
-        const start = this.#startWorker(worker, { onlyIfWorkersStarted: !name }).finally(() => {
-          this.#pendingWorkerStarts.delete(start);
+        await this.#trackWorkerStart(worker, {
+          onlyIfWorkersStarted: !name,
+          onlyIfLifecycleGeneration: name ? undefined : startupLifecycleGeneration,
+          onlyIfShutdownGeneration: name ? startupShutdownGeneration : undefined,
+          startLifecycleGeneration: name ? undefined : startupLifecycleGeneration,
+          stopIfWorkersStopped: !name,
+          stopIfLifecycleGenerationChangesFrom: startupLifecycleGeneration,
         });
-        this.#pendingWorkerStarts.add(start);
-        await start;
-        if (!name && !this.#workersStarted) {
+        if (
+          startupLifecycleGeneration !== undefined &&
+          ((!name && !this.#workersStarted) || this.#workerLifecycleGeneration !== startupLifecycleGeneration)
+        ) {
+          return;
+        }
+        if (startupShutdownGeneration !== undefined && this.#workerShutdownGeneration !== startupShutdownGeneration) {
           return;
         }
       }
@@ -4187,8 +4265,30 @@ export class Mastra<
               })
               .catch(err => this.#logger?.error?.('Unhandled error in workflow event push subscription', err));
           };
+          startupPushSubscription = { topic: 'workflows', cb, subscribed: false };
+          this.#pushSubscription = startupPushSubscription;
           await this.#pubsub.subscribe('workflows', cb);
-          this.#pushSubscription = { topic: 'workflows', cb };
+          startupPushSubscription.subscribed = true;
+          if (
+            !this.#workersStarted ||
+            (startupLifecycleGeneration !== undefined && this.#workerLifecycleGeneration !== startupLifecycleGeneration)
+          ) {
+            const ownsPushSubscription = this.#pushSubscription === startupPushSubscription;
+            try {
+              await this.#pubsub.unsubscribe('workflows', cb);
+            } catch (error) {
+              if (ownsPushSubscription || !this.#pushSubscription) {
+                this.#pushSubscription = startupPushSubscription;
+                throw error;
+              }
+              this.#logger?.error('Failed to cleanup stale workflow push subscription after shutdown', error);
+            }
+            if (ownsPushSubscription && this.#pushSubscription === startupPushSubscription) {
+              this.#pushSubscription = undefined;
+            }
+            startupPushSubscription = undefined;
+            return;
+          }
         }
       }
 
@@ -4207,21 +4307,247 @@ export class Mastra<
               sub => sub.topic === topic && sub.cb === listener,
             );
             if (alreadySubscribed) continue;
+            const subscription = { topic, cb: listener, subscribed: false };
+            this.#userEventSubscriptions.push(subscription);
+            startupUserEventSubscriptions.push(subscription);
             await this.#pubsub.subscribe(topic, listener);
-            this.#userEventSubscriptions.push({ topic, cb: listener });
+            subscription.subscribed = true;
+            if (
+              !this.#workersStarted ||
+              (startupLifecycleGeneration !== undefined &&
+                this.#workerLifecycleGeneration !== startupLifecycleGeneration)
+            ) {
+              const ownsUserEventSubscription = this.#userEventSubscriptions.some(
+                sub => sub === subscription || (sub.topic === topic && sub.cb === listener),
+              );
+              try {
+                await this.#pubsub.unsubscribe(topic, listener);
+              } catch (error) {
+                if (ownsUserEventSubscription) {
+                  throw error;
+                }
+                if (!this.#userEventSubscriptions.includes(subscription)) {
+                  this.#userEventSubscriptions.push(subscription);
+                  throw error;
+                }
+                this.#logger?.error(
+                  `Failed to cleanup stale event listener for topic "${topic}" after shutdown`,
+                  error,
+                );
+              }
+              this.#userEventSubscriptions = this.#userEventSubscriptions.filter(
+                sub => sub !== subscription && (sub.topic !== topic || sub.cb !== listener),
+              );
+              const startupIndex = startupUserEventSubscriptions.indexOf(subscription);
+              if (startupIndex >= 0) {
+                startupUserEventSubscriptions.splice(startupIndex, 1);
+              }
+              if (this.#pushSubscription !== startupPushSubscription) {
+                startupPushSubscription = undefined;
+              }
+              return;
+            }
           }
         }
       }
 
       startupComplete = true;
     } finally {
-      if (!name && !startupComplete) {
-        this.#workersStarted = false;
+      if (
+        !name &&
+        !startupComplete &&
+        (this.#workerLifecycleGeneration === startupLifecycleGeneration || !this.#workersStarted)
+      ) {
+        this.#workersStarted =
+          this.#workerLifecycleGeneration === startupLifecycleGeneration ? workersStartedBeforeStartup : false;
+        this.#workerLifecycleGeneration += 1;
+        for (const worker of [...this.#workers].reverse()) {
+          if (
+            worker.isRunning &&
+            !workersRunningBeforeStartup?.has(worker) &&
+            !workersStartingBeforeStartup?.has(worker) &&
+            this.#latestWorkerStartLifecycleGenerations.get(worker) === startupLifecycleGeneration
+          ) {
+            try {
+              await worker.stop();
+              this.#latestWorkerStartTokens.delete(worker);
+              this.#latestWorkerStartLifecycleGenerations.delete(worker);
+            } catch (error) {
+              this.#logger?.error(`Failed to stop worker "${worker.name}" after failed startup`, error);
+            }
+          }
+        }
+        if (startupPushSubscription) {
+          try {
+            await this.#pubsub.unsubscribe(startupPushSubscription.topic, startupPushSubscription.cb);
+            if (this.#pushSubscription === startupPushSubscription) {
+              this.#pushSubscription = undefined;
+            }
+          } catch (error) {
+            this.#logger?.error('Failed to unsubscribe workflow push subscription after failed startup', error);
+            if (!startupPushSubscription.subscribed && this.#pushSubscription === startupPushSubscription) {
+              this.#pushSubscription = undefined;
+            }
+          }
+        }
+        for (const subscription of startupUserEventSubscriptions) {
+          const { topic, cb } = subscription;
+          try {
+            await this.#pubsub.unsubscribe(topic, cb);
+            this.#userEventSubscriptions = this.#userEventSubscriptions.filter(
+              sub => sub !== subscription && (sub.topic !== topic || sub.cb !== cb),
+            );
+          } catch (error) {
+            this.#logger?.error(
+              `Failed to unsubscribe event listener for topic "${topic}" after failed startup`,
+              error,
+            );
+            if (!subscription.subscribed) {
+              this.#userEventSubscriptions = this.#userEventSubscriptions.filter(sub => sub !== subscription);
+            }
+          }
+        }
       }
     }
   }
 
-  async #startWorker(worker: MastraWorker, opts: { onlyIfWorkersStarted?: boolean } = {}): Promise<void> {
+  #trackWorkerStart(
+    worker: MastraWorker,
+    opts: {
+      onlyIfWorkersStarted?: boolean;
+      onlyIfLifecycleGeneration?: number;
+      onlyIfShutdownGeneration?: number;
+      onError?: (error: unknown) => void;
+      startLifecycleGeneration?: number;
+      stopIfWorkersStopped?: boolean;
+      stopIfLifecycleGenerationChangesFrom?: number;
+    } = {},
+  ): Promise<void> {
+    const existingStart = this.#workerStartPromises.get(worker);
+    if (existingStart) {
+      const queuedStart = existingStart.then(() => {
+        if (worker.isRunning) {
+          return;
+        }
+        return this.#trackWorkerStart(worker, opts);
+      });
+      if (opts.onError) {
+        return queuedStart.catch(error => {
+          opts.onError?.(error);
+        });
+      }
+      return queuedStart;
+    }
+
+    const startToken = ++this.#workerStartSequence;
+    let didStart = false;
+    const wasRunningBeforeStart = worker.isRunning;
+    const previousStartToken = this.#latestWorkerStartTokens.get(worker);
+    const hadPreviousStartLifecycleGeneration = this.#latestWorkerStartLifecycleGenerations.has(worker);
+    const previousStartLifecycleGeneration = this.#latestWorkerStartLifecycleGenerations.get(worker);
+    const removeCurrentStartToken = () => {
+      if (previousStartToken !== undefined) {
+        this.#latestWorkerStartTokens.set(worker, previousStartToken);
+        if (hadPreviousStartLifecycleGeneration) {
+          this.#latestWorkerStartLifecycleGenerations.set(worker, previousStartLifecycleGeneration!);
+        } else {
+          this.#latestWorkerStartLifecycleGenerations.delete(worker);
+        }
+      } else {
+        this.#latestWorkerStartTokens.delete(worker);
+        this.#latestWorkerStartLifecycleGenerations.delete(worker);
+      }
+    };
+    const recordLatestStartToken = () => {
+      const latestStartToken = this.#latestWorkerStartTokens.get(worker);
+      if (latestStartToken === undefined || latestStartToken < startToken) {
+        this.#latestWorkerStartTokens.set(worker, startToken);
+        if (opts.startLifecycleGeneration !== undefined) {
+          this.#latestWorkerStartLifecycleGenerations.set(worker, opts.startLifecycleGeneration);
+        } else {
+          this.#latestWorkerStartLifecycleGenerations.delete(worker);
+        }
+      }
+    };
+    const pending: PendingWorkerStart = {
+      worker,
+      phase: 'init',
+      token: startToken,
+      ignoreShutdownError: Boolean(opts.onError),
+      promise: Promise.resolve(),
+    };
+    const start = this.#startWorker(worker, {
+      ...opts,
+      onBeforeStart: () => {
+        pending.phase = 'start';
+        recordLatestStartToken();
+      },
+      onAfterStart: () => {
+        didStart = true;
+        recordLatestStartToken();
+      },
+    });
+    const promise = start.finally(async () => {
+      pending.phase = 'settled';
+      if (this.#workerStartPromises.get(worker) === promise) {
+        this.#workerStartPromises.delete(worker);
+      }
+      this.#pendingWorkerStarts.delete(pending);
+      if (!didStart && this.#latestWorkerStartTokens.get(worker) === startToken) {
+        if (!wasRunningBeforeStart && worker.isRunning) {
+          try {
+            await worker.stop();
+            if (this.#latestWorkerStartTokens.get(worker) === startToken) {
+              removeCurrentStartToken();
+            }
+          } catch (error) {
+            this.#logger?.error(`Failed to stop worker "${worker.name}" after failed startup`, error);
+          }
+        } else {
+          removeCurrentStartToken();
+        }
+      }
+      const lifecycleChanged =
+        opts.stopIfLifecycleGenerationChangesFrom !== undefined &&
+        this.#workerLifecycleGeneration !== opts.stopIfLifecycleGenerationChangesFrom;
+      const isLatestStart = this.#latestWorkerStartTokens.get(worker) === startToken;
+      if (
+        opts.stopIfWorkersStopped &&
+        isLatestStart &&
+        (!this.#workersStarted || lifecycleChanged) &&
+        worker.isRunning
+      ) {
+        try {
+          await worker.stop();
+          if (this.#latestWorkerStartTokens.get(worker) === startToken) {
+            removeCurrentStartToken();
+          }
+        } catch (error) {
+          this.#logger?.error(`Failed to stop worker "${worker.name}" after late startup completion`, error);
+        }
+      }
+    });
+    pending.promise = promise;
+    this.#pendingWorkerStarts.add(pending);
+    this.#workerStartPromises.set(worker, promise);
+    if (opts.onError) {
+      return promise.catch(error => {
+        opts.onError?.(error);
+      });
+    }
+    return promise;
+  }
+
+  async #startWorker(
+    worker: MastraWorker,
+    opts: {
+      onlyIfWorkersStarted?: boolean;
+      onlyIfLifecycleGeneration?: number;
+      onlyIfShutdownGeneration?: number;
+      onBeforeStart?: () => void;
+      onAfterStart?: () => void;
+    } = {},
+  ): Promise<void> {
     const deps: WorkerDeps = {
       pubsub: this.#pubsub,
       storage: this.#storage!,
@@ -4232,14 +4558,46 @@ export class Mastra<
     if (opts.onlyIfWorkersStarted && !this.#workersStarted) {
       return;
     }
+    if (
+      opts.onlyIfLifecycleGeneration !== undefined &&
+      this.#workerLifecycleGeneration !== opts.onlyIfLifecycleGeneration
+    ) {
+      return;
+    }
+    if (
+      opts.onlyIfShutdownGeneration !== undefined &&
+      this.#workerShutdownGeneration !== opts.onlyIfShutdownGeneration
+    ) {
+      return;
+    }
+    opts.onBeforeStart?.();
     await worker.start();
+    opts.onAfterStart?.();
   }
 
   /**
    * Stop all running workers and unsubscribe event listeners.
    */
   public async stopWorkers(): Promise<void> {
+    if (this.#workersStopPromise) {
+      return this.#workersStopPromise;
+    }
+
+    const stop = this.#stopWorkers();
+    this.#workersStopPromise = stop;
+    try {
+      await stop;
+    } finally {
+      if (this.#workersStopPromise === stop) {
+        this.#workersStopPromise = undefined;
+      }
+    }
+  }
+
+  async #stopWorkers(): Promise<void> {
     this.#workersStarted = false;
+    this.#workerLifecycleGeneration += 1;
+    this.#workerShutdownGeneration += 1;
     let stopError: unknown;
     let hasStopError = false;
     const recordStopError = (message: string, error: unknown) => {
@@ -4250,11 +4608,71 @@ export class Mastra<
       this.#logger?.error(message, error);
     };
     const pendingWorkerStartsAtShutdown = [...this.#pendingWorkerStarts];
-    const settlePendingWorkerStarts = async (starts: Promise<void>[] = [...this.#pendingWorkerStarts]) => {
-      const pendingWorkerStartResults = await Promise.allSettled(starts);
+    const timedOutWorkerStarts = new Set<PendingWorkerStart>();
+    const waitForPendingWorkerStart = async (start: PendingWorkerStart) => {
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      try {
+        return await Promise.race([
+          start.promise.then(
+            () => ({ status: 'fulfilled' as const, start }),
+            reason => ({ status: 'rejected' as const, reason, start }),
+          ),
+          new Promise<{ status: 'timed-out'; reason: Error; start: PendingWorkerStart }>(resolve => {
+            timeout = setTimeout(() => {
+              resolve({
+                status: 'timed-out',
+                reason: new Error(
+                  `Timed out waiting for worker "${start.worker.name}" startup during shutdown after ${PENDING_WORKER_START_SHUTDOWN_TIMEOUT_MS}ms`,
+                ),
+                start,
+              });
+            }, PENDING_WORKER_START_SHUTDOWN_TIMEOUT_MS);
+          }),
+        ]);
+      } finally {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+      }
+    };
+    const cleanupTimedOutWorkerStart = (start: PendingWorkerStart) => {
+      void start.promise.then(
+        async () => {
+          if (this.#latestWorkerStartTokens.get(start.worker) === start.token && start.worker.isRunning) {
+            try {
+              await start.worker.stop();
+              if (this.#latestWorkerStartTokens.get(start.worker) === start.token) {
+                this.#latestWorkerStartTokens.delete(start.worker);
+                this.#latestWorkerStartLifecycleGenerations.delete(start.worker);
+              }
+            } catch (error) {
+              this.#logger?.error(`Failed to stop worker "${start.worker.name}" after late startup completion`, error);
+            }
+          }
+        },
+        () => {},
+      );
+    };
+    const settlePendingWorkerStarts = async (starts: PendingWorkerStart[] = [...this.#pendingWorkerStarts]) => {
+      const unsettledStarts = starts.filter(start => !timedOutWorkerStarts.has(start));
+      const pendingWorkerStartResults = await Promise.all(unsettledStarts.map(waitForPendingWorkerStart));
       for (const result of pendingWorkerStartResults) {
         if (result.status === 'rejected') {
-          recordStopError('Failed to finish pending worker startup during shutdown', result.reason);
+          if (!result.start.ignoreShutdownError) {
+            recordStopError('Failed to finish pending worker startup during shutdown', result.reason);
+          }
+        } else if (result.status === 'timed-out') {
+          timedOutWorkerStarts.add(result.start);
+          if (result.start.phase !== 'start') {
+            this.#pendingWorkerStarts.delete(result.start);
+            if (this.#workerStartPromises.get(result.start.worker) === result.start.promise) {
+              this.#workerStartPromises.delete(result.start.worker);
+            }
+          }
+          cleanupTimedOutWorkerStart(result.start);
+          if (!result.start.ignoreShutdownError) {
+            recordStopError('Timed out waiting for pending worker startup during shutdown', result.reason);
+          }
         }
       }
     };
@@ -4263,6 +4681,8 @@ export class Mastra<
         if (worker.isRunning) {
           try {
             await worker.stop();
+            this.#latestWorkerStartTokens.delete(worker);
+            this.#latestWorkerStartLifecycleGenerations.delete(worker);
           } catch (error) {
             recordStopError(`Failed to stop worker "${worker.name}"`, error);
           }
@@ -4273,6 +4693,9 @@ export class Mastra<
     await stopRunningWorkers();
     await settlePendingWorkerStarts(pendingWorkerStartsAtShutdown);
     await settlePendingWorkerStarts();
+    if (timedOutWorkerStarts.size > 0 && ![...timedOutWorkerStarts].some(start => start.phase === 'start')) {
+      this.#allWorkersStartPromise = undefined;
+    }
     await stopRunningWorkers();
 
     // Tear down the in-process push subscription wired during startWorkers().

--- a/packages/core/src/mastra/workers-filter.test.ts
+++ b/packages/core/src/mastra/workers-filter.test.ts
@@ -1,12 +1,104 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PubSub } from '../events/pubsub';
+import type { Event, EventCallback, SubscribeOptions } from '../events/types';
 import { Harness } from '../harness/v1/harness';
 import { InMemoryHarness } from '../storage/domains/harness/inmemory';
 import { InMemoryDB } from '../storage/domains/inmemory-db';
 import { MockStore } from '../storage/mock';
-import { HarnessWakeupWorker } from '../worker';
+import { HarnessWakeupWorker, MastraWorker } from '../worker';
+import type { WorkerDeps } from '../worker';
 import { Mastra } from './index';
 
 const ORIGINAL_ENV = process.env.MASTRA_WORKERS;
+
+class StartupCleanupPubSub extends PubSub {
+  failSubscribeTopic?: string;
+  failNextUnsubscribeTopic?: string;
+  gateSubscribeTopic?: string;
+  readonly subscribeCalls: string[] = [];
+  readonly unsubscribeCalls: string[] = [];
+  #subscribeGateStarted?: () => void;
+  #releaseSubscribeGate?: () => void;
+  subscribeGateStarted = Promise.resolve();
+
+  override get supportedModes(): ReadonlyArray<'push'> {
+    return ['push'];
+  }
+
+  resetSubscribeGate(): void {
+    this.subscribeGateStarted = new Promise<void>(resolve => {
+      this.#subscribeGateStarted = resolve;
+    });
+  }
+
+  releaseSubscribeGate(): void {
+    this.#releaseSubscribeGate?.();
+  }
+
+  async publish(_topic: string, _event: Omit<Event, 'id' | 'createdAt'>): Promise<void> {}
+
+  async subscribe(topic: string, _cb: EventCallback, _options?: SubscribeOptions): Promise<void> {
+    this.subscribeCalls.push(topic);
+    if (topic === this.gateSubscribeTopic) {
+      this.#subscribeGateStarted?.();
+      await new Promise<void>(resolve => {
+        this.#releaseSubscribeGate = resolve;
+      });
+    }
+    if (topic === this.failSubscribeTopic) {
+      throw new Error(`subscribe failed: ${topic}`);
+    }
+  }
+
+  async unsubscribe(topic: string, _cb: EventCallback): Promise<void> {
+    this.unsubscribeCalls.push(topic);
+    if (topic === this.failNextUnsubscribeTopic) {
+      this.failNextUnsubscribeTopic = undefined;
+      throw new Error(`unsubscribe failed: ${topic}`);
+    }
+  }
+
+  async flush(): Promise<void> {}
+}
+
+class ControllableWorker extends MastraWorker {
+  readonly name: string;
+  running = false;
+  initCalls = 0;
+  startCalls = 0;
+  stopCalls = 0;
+  onInit?: (call: number) => Promise<void>;
+  onStart?: (call: number) => Promise<void>;
+
+  constructor(name = 'controllable') {
+    super();
+    this.name = name;
+  }
+
+  override async init(deps: WorkerDeps): Promise<void> {
+    await super.init(deps);
+    this.initCalls += 1;
+    await this.onInit?.(this.initCalls);
+  }
+
+  async start(): Promise<void> {
+    this.startCalls += 1;
+    if (this.onStart) {
+      await this.onStart(this.startCalls);
+      return;
+    }
+    this.running = true;
+  }
+
+  async stop(): Promise<void> {
+    this.stopCalls += 1;
+    this.running = false;
+  }
+
+  get isRunning(): boolean {
+    return this.running;
+  }
+}
 
 describe('Mastra workers filter (MASTRA_WORKERS env)', () => {
   beforeEach(() => {
@@ -100,6 +192,473 @@ describe('Mastra workers filter (MASTRA_WORKERS env)', () => {
     expect(start).not.toHaveBeenCalled();
   });
 
+  it('times out shutdown waiting for an initial worker startup that never settles', async () => {
+    const mastra = new Mastra({
+      storage: new MockStore(),
+      backgroundTasks: { enabled: true },
+      logger: false,
+    });
+    const initialWorker = mastra.workers[0];
+    if (!initialWorker) {
+      throw new Error('expected an initial worker to hold startWorkers in flight');
+    }
+
+    let resolveInit!: () => void;
+    const init = vi.spyOn(initialWorker, 'init').mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveInit = resolve;
+        }),
+    );
+    const start = vi.spyOn(initialWorker, 'start').mockResolvedValue(undefined);
+
+    const starting = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(init).toHaveBeenCalledTimes(1);
+    });
+
+    vi.useFakeTimers();
+    try {
+      const stopping = expect(mastra.stopWorkers()).rejects.toThrow('Timed out waiting for worker');
+      await vi.advanceTimersByTimeAsync(30_000);
+      await stopping;
+
+      resolveInit();
+      await starting;
+      expect(start).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('can retry all-worker startup after shutdown times out waiting for a pending startup', async () => {
+    const worker = new ControllableWorker();
+    let resolveOldInit!: () => void;
+    worker.onInit = async call => {
+      if (call === 1) {
+        await new Promise<void>(resolve => {
+          resolveOldInit = resolve;
+        });
+      }
+    };
+    const mastra = new Mastra({
+      workers: [worker],
+      logger: false,
+    });
+
+    const oldStart = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(worker.initCalls).toBe(1);
+    });
+
+    vi.useFakeTimers();
+    try {
+      const stopping = expect(mastra.stopWorkers()).rejects.toThrow('Timed out waiting for worker');
+      await vi.advanceTimersByTimeAsync(30_000);
+      await stopping;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    await mastra.startWorkers();
+    expect(worker.initCalls).toBe(2);
+    expect(worker.startCalls).toBe(1);
+    expect(worker.running).toBe(true);
+
+    resolveOldInit();
+    await oldStart;
+    expect(worker.startCalls).toBe(1);
+    expect(worker.running).toBe(true);
+
+    await mastra.stopWorkers();
+  });
+
+  it('does not keep timed-out init starts in later shutdown tracking after retry succeeds', async () => {
+    const worker = new ControllableWorker();
+    worker.onInit = async call => {
+      if (call === 1) {
+        await new Promise<void>(() => {});
+      }
+    };
+    const mastra = new Mastra({
+      workers: [worker],
+      logger: false,
+    });
+
+    void mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(worker.initCalls).toBe(1);
+    });
+
+    vi.useFakeTimers();
+    try {
+      const timedOutStop = expect(mastra.stopWorkers()).rejects.toThrow('Timed out waiting for worker');
+      await vi.advanceTimersByTimeAsync(30_000);
+      await timedOutStop;
+
+      await mastra.startWorkers();
+      expect(worker.initCalls).toBe(2);
+      expect(worker.startCalls).toBe(1);
+      expect(worker.running).toBe(true);
+
+      const finalStop = mastra.stopWorkers();
+      await vi.runOnlyPendingTimersAsync();
+      await expect(finalStop).resolves.toBeUndefined();
+      expect(worker.stopCalls).toBe(1);
+      expect(worker.running).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not start a named worker whose init resolves after a shutdown timeout', async () => {
+    const worker = new ControllableWorker();
+    let resolveOldInit!: () => void;
+    worker.onInit = async call => {
+      if (call === 1) {
+        await new Promise<void>(resolve => {
+          resolveOldInit = resolve;
+        });
+      }
+    };
+    const mastra = new Mastra({
+      workers: [worker],
+      logger: false,
+    });
+
+    const oldStart = mastra.startWorkers('controllable');
+    await vi.waitFor(() => {
+      expect(worker.initCalls).toBe(1);
+    });
+
+    vi.useFakeTimers();
+    try {
+      const stopping = expect(mastra.stopWorkers()).rejects.toThrow('Timed out waiting for worker');
+      await vi.advanceTimersByTimeAsync(30_000);
+      await stopping;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    await mastra.startWorkers('controllable');
+    expect(worker.initCalls).toBe(2);
+    expect(worker.startCalls).toBe(1);
+    expect(worker.running).toBe(true);
+
+    resolveOldInit();
+    await oldStart;
+    expect(worker.startCalls).toBe(1);
+    expect(worker.running).toBe(true);
+
+    await mastra.stopWorkers();
+  });
+
+  it('does not retry all-worker startup while an old worker start call is still pending', async () => {
+    const worker = new ControllableWorker();
+    let resolveOldStart!: () => void;
+    worker.onStart = async call => {
+      if (call === 1) {
+        await new Promise<void>(resolve => {
+          resolveOldStart = resolve;
+        });
+      }
+      worker.running = true;
+    };
+    const mastra = new Mastra({
+      workers: [worker],
+      logger: false,
+    });
+
+    const oldStart = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(worker.startCalls).toBe(1);
+    });
+
+    vi.useFakeTimers();
+    try {
+      const stopping = expect(mastra.stopWorkers()).rejects.toThrow('Timed out waiting for worker');
+      await vi.advanceTimersByTimeAsync(30_000);
+      await stopping;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const retryWhileOldStartPending = mastra.startWorkers();
+    const retryState = await Promise.race([
+      retryWhileOldStartPending.then(() => 'settled' as const),
+      new Promise<'pending'>(resolve => setTimeout(() => resolve('pending'), 0)),
+    ]);
+    expect(retryState).toBe('pending');
+    expect(worker.startCalls).toBe(1);
+
+    resolveOldStart();
+    await oldStart;
+    await retryWhileOldStartPending;
+    await vi.waitFor(() => {
+      expect(worker.stopCalls).toBe(1);
+    });
+    expect(worker.running).toBe(false);
+
+    await mastra.startWorkers();
+    expect(worker.startCalls).toBe(2);
+    expect(worker.running).toBe(true);
+
+    await mastra.stopWorkers();
+  });
+
+  it('queues a named startup retry until an old worker start call settles', async () => {
+    const worker = new ControllableWorker();
+    let resolveOldStart!: () => void;
+    worker.onStart = async call => {
+      if (call === 1) {
+        await new Promise<void>(resolve => {
+          resolveOldStart = resolve;
+        });
+      }
+      worker.running = true;
+    };
+    const mastra = new Mastra({
+      workers: [worker],
+      logger: false,
+    });
+
+    const oldStart = mastra.startWorkers('controllable');
+    await vi.waitFor(() => {
+      expect(worker.startCalls).toBe(1);
+    });
+
+    vi.useFakeTimers();
+    try {
+      const stopping = expect(mastra.stopWorkers()).rejects.toThrow('Timed out waiting for worker');
+      await vi.advanceTimersByTimeAsync(30_000);
+      await stopping;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const retryWhileOldStartPending = mastra.startWorkers('controllable');
+    const retryState = await Promise.race([
+      retryWhileOldStartPending.then(() => 'settled' as const),
+      new Promise<'pending'>(resolve => setTimeout(() => resolve('pending'), 0)),
+    ]);
+    expect(retryState).toBe('pending');
+    expect(worker.startCalls).toBe(1);
+
+    resolveOldStart();
+    await oldStart;
+    await retryWhileOldStartPending;
+    expect(worker.stopCalls).toBe(1);
+    expect(worker.startCalls).toBe(2);
+    expect(worker.running).toBe(true);
+
+    await mastra.stopWorkers();
+  });
+
+  it('cleans up a timed-out named startup after a filtered all-worker startup', async () => {
+    process.env.MASTRA_WORKERS = 'worker-b';
+    const workerA = new ControllableWorker('worker-a');
+    const workerB = new ControllableWorker('worker-b');
+    let resolveOldStart!: () => void;
+    workerA.onStart = async call => {
+      if (call === 1) {
+        await new Promise<void>(resolve => {
+          resolveOldStart = resolve;
+        });
+      }
+      workerA.running = true;
+    };
+    const mastra = new Mastra({
+      workers: [workerA, workerB],
+      logger: false,
+    });
+
+    const oldStart = mastra.startWorkers('worker-a');
+    await vi.waitFor(() => {
+      expect(workerA.startCalls).toBe(1);
+    });
+
+    vi.useFakeTimers();
+    try {
+      const stopping = expect(mastra.stopWorkers()).rejects.toThrow('Timed out waiting for worker');
+      await vi.advanceTimersByTimeAsync(30_000);
+      await stopping;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    await mastra.startWorkers();
+    expect(workerB.running).toBe(true);
+    expect(workerA.running).toBe(false);
+
+    resolveOldStart();
+    await oldStart;
+    await vi.waitFor(() => {
+      expect(workerA.stopCalls).toBe(1);
+    });
+    expect(workerA.running).toBe(false);
+    expect(workerB.running).toBe(true);
+
+    await mastra.stopWorkers();
+  });
+
+  it('does not cancel a named startup in init when a filtered all-worker startup runs', async () => {
+    process.env.MASTRA_WORKERS = 'worker-b';
+    const workerA = new ControllableWorker('worker-a');
+    const workerB = new ControllableWorker('worker-b');
+    let resolveWorkerAInit!: () => void;
+    workerA.onInit = async call => {
+      if (call === 1) {
+        await new Promise<void>(resolve => {
+          resolveWorkerAInit = resolve;
+        });
+      }
+    };
+    const mastra = new Mastra({
+      workers: [workerA, workerB],
+      logger: false,
+    });
+
+    const namedStart = mastra.startWorkers('worker-a');
+    await vi.waitFor(() => {
+      expect(workerA.initCalls).toBe(1);
+    });
+
+    await mastra.startWorkers();
+    expect(workerB.running).toBe(true);
+    expect(workerA.startCalls).toBe(0);
+
+    resolveWorkerAInit();
+    await namedStart;
+
+    expect(workerA.startCalls).toBe(1);
+    expect(workerA.running).toBe(true);
+
+    await mastra.stopWorkers();
+  });
+
+  it('does not stop an excluded named worker when filtered all-worker startup fails', async () => {
+    process.env.MASTRA_WORKERS = 'worker-b';
+    const workerA = new ControllableWorker('worker-a');
+    const workerB = new ControllableWorker('worker-b');
+    let resolveWorkerAStart!: () => void;
+    let rejectWorkerBStart!: () => void;
+    workerA.onStart = async () => {
+      await new Promise<void>(resolve => {
+        resolveWorkerAStart = resolve;
+      });
+      workerA.running = true;
+    };
+    workerB.onStart = async () => {
+      await new Promise<void>((_resolve, reject) => {
+        rejectWorkerBStart = reject;
+      });
+    };
+    const mastra = new Mastra({
+      workers: [workerA, workerB],
+      logger: false,
+    });
+
+    const namedStart = mastra.startWorkers('worker-a');
+    await vi.waitFor(() => {
+      expect(workerA.startCalls).toBe(1);
+    });
+
+    const filteredStart = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(workerB.startCalls).toBe(1);
+    });
+
+    resolveWorkerAStart();
+    await namedStart;
+    expect(workerA.running).toBe(true);
+
+    rejectWorkerBStart(new Error('filtered startup failed'));
+    await expect(filteredStart).rejects.toThrow('filtered startup failed');
+    expect(workerA.stopCalls).toBe(0);
+    expect(workerA.running).toBe(true);
+
+    await mastra.stopWorkers();
+  });
+
+  it('does not stop a pending named worker when overlapping all-worker startup fails', async () => {
+    const workerA = new ControllableWorker('a');
+    const workerB = new ControllableWorker('b');
+    let resolveNamedWorkerStart!: () => void;
+    workerA.onStart = async call => {
+      if (call === 1) {
+        await new Promise<void>(resolve => {
+          resolveNamedWorkerStart = resolve;
+        });
+      }
+      workerA.running = true;
+    };
+    let rejectWorkerBStart!: (error: Error) => void;
+    workerB.onStart = async () =>
+      new Promise<void>((_resolve, reject) => {
+        rejectWorkerBStart = reject;
+      });
+    const mastra = new Mastra({
+      workers: [workerA, workerB],
+      logger: false,
+    });
+
+    const namedStart = mastra.startWorkers('a');
+    await vi.waitFor(() => {
+      expect(workerA.startCalls).toBe(1);
+    });
+
+    const allStart = mastra.startWorkers();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(workerA.startCalls).toBe(1);
+
+    resolveNamedWorkerStart();
+    await namedStart;
+    expect(workerA.running).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(workerB.startCalls).toBe(1);
+    });
+
+    rejectWorkerBStart(new Error('all-worker startup failed'));
+    await expect(allStart).rejects.toThrow('all-worker startup failed');
+
+    expect(workerA.stopCalls).toBe(0);
+    expect(workerA.running).toBe(true);
+
+    await mastra.stopWorkers();
+  });
+
+  it('deduplicates overlapping named startup calls for the same worker', async () => {
+    const worker = new ControllableWorker();
+    let resolveStart!: () => void;
+    worker.onStart = async () => {
+      await new Promise<void>(resolve => {
+        resolveStart = resolve;
+      });
+      worker.running = true;
+    };
+    const mastra = new Mastra({
+      workers: [worker],
+      logger: false,
+    });
+
+    const firstStart = mastra.startWorkers('controllable');
+    await vi.waitFor(() => {
+      expect(worker.startCalls).toBe(1);
+    });
+    const secondStart = mastra.startWorkers('controllable');
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(worker.startCalls).toBe(1);
+
+    resolveStart();
+    await Promise.all([firstStart, secondStart]);
+
+    expect(worker.running).toBe(true);
+
+    await mastra.stopWorkers();
+  });
+
   it('stops an initial worker whose start completes after stopWorkers begins', async () => {
     const mastra = new Mastra({
       storage: new MockStore(),
@@ -180,6 +739,457 @@ describe('Mastra workers filter (MASTRA_WORKERS env)', () => {
     await expect(stopping).rejects.toThrow('worker startup failed');
     expect(firstStop).toHaveBeenCalledTimes(1);
     expect(firstRunning).toBe(false);
+  });
+
+  it('cleans up already-running initial workers when all-worker startup fails', async () => {
+    const mastra = new Mastra({
+      storage: new MockStore(),
+      backgroundTasks: { enabled: true },
+      logger: false,
+    });
+    const [firstWorker, secondWorker] = mastra.workers;
+    if (!firstWorker || !secondWorker) {
+      throw new Error('expected at least two workers to model failed startup cleanup');
+    }
+
+    let firstRunning = false;
+    vi.spyOn(firstWorker, 'init').mockResolvedValue(undefined);
+    vi.spyOn(firstWorker, 'isRunning', 'get').mockImplementation(() => firstRunning);
+    vi.spyOn(firstWorker, 'start').mockImplementation(async () => {
+      firstRunning = true;
+    });
+    const firstStop = vi.spyOn(firstWorker, 'stop').mockImplementation(async () => {
+      firstRunning = false;
+    });
+
+    vi.spyOn(secondWorker, 'init').mockResolvedValue(undefined);
+    vi.spyOn(secondWorker, 'start').mockRejectedValue(new Error('worker startup failed'));
+
+    await expect(mastra.startWorkers()).rejects.toThrow('worker startup failed');
+
+    expect(firstStop).toHaveBeenCalledTimes(1);
+    expect(firstRunning).toBe(false);
+  });
+
+  it('stops a worker that becomes running before its startup rejects', async () => {
+    const worker = new ControllableWorker();
+    worker.onStart = async () => {
+      worker.running = true;
+      throw new Error('partial startup failed');
+    };
+    const mastra = new Mastra({
+      workers: [worker],
+      logger: false,
+    });
+
+    await expect(mastra.startWorkers()).rejects.toThrow('partial startup failed');
+
+    expect(worker.stopCalls).toBe(1);
+    expect(worker.running).toBe(false);
+  });
+
+  it('deduplicates concurrent all-worker startup calls', async () => {
+    const worker = new ControllableWorker();
+    let resolveStart!: () => void;
+    worker.onStart = async () => {
+      await new Promise<void>(resolve => {
+        resolveStart = resolve;
+      });
+      worker.running = true;
+    };
+    const mastra = new Mastra({
+      workers: [worker],
+      logger: false,
+    });
+
+    const oldStart = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(worker.startCalls).toBe(1);
+    });
+    const concurrentStart = mastra.startWorkers();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(worker.startCalls).toBe(1);
+    resolveStart();
+    await Promise.all([oldStart, concurrentStart]);
+
+    expect(worker.running).toBe(true);
+
+    await mastra.stopWorkers();
+    expect(worker.stopCalls).toBe(1);
+    expect(worker.running).toBe(false);
+  });
+
+  it('waits for an in-flight shutdown before starting all workers again', async () => {
+    const worker = new ControllableWorker();
+    let resolveStop!: () => void;
+    worker.onStart = async () => {
+      worker.running = true;
+    };
+    const originalStop = worker.stop.bind(worker);
+    worker.stop = async () => {
+      if (worker.stopCalls === 0) {
+        worker.stopCalls += 1;
+        await new Promise<void>(resolve => {
+          resolveStop = resolve;
+        });
+        worker.running = false;
+        return;
+      }
+      await originalStop();
+    };
+    const mastra = new Mastra({
+      workers: [worker],
+      logger: false,
+    });
+
+    await mastra.startWorkers();
+    expect(worker.startCalls).toBe(1);
+
+    const stopping = mastra.stopWorkers();
+    await vi.waitFor(() => {
+      expect(worker.stopCalls).toBe(1);
+    });
+    const starting = mastra.startWorkers();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(worker.startCalls).toBe(1);
+
+    resolveStop();
+    await Promise.all([stopping, starting]);
+
+    expect(worker.startCalls).toBe(2);
+    expect(worker.running).toBe(true);
+
+    await mastra.stopWorkers();
+  });
+
+  it('does not let a failed repeated all-worker startup stop already-running workers', async () => {
+    const pubsub = new StartupCleanupPubSub();
+    const worker = new ControllableWorker();
+    const mastra = new Mastra({
+      workers: [worker],
+      pubsub,
+      events: {
+        first: async () => {},
+      },
+      logger: false,
+    });
+
+    await mastra.startWorkers();
+    expect(worker.running).toBe(true);
+    expect(pubsub.subscribeCalls).toEqual(['workflows', 'first']);
+
+    worker.onStart = async () => {
+      throw new Error('repeat startup failed');
+    };
+    await expect(mastra.startWorkers()).rejects.toThrow('repeat startup failed');
+
+    expect(worker.stopCalls).toBe(0);
+    expect(worker.running).toBe(true);
+    expect(pubsub.unsubscribeCalls).toEqual([]);
+
+    worker.onStart = undefined;
+    await mastra.stopWorkers();
+    expect(worker.stopCalls).toBe(1);
+    expect(worker.running).toBe(false);
+    expect(pubsub.unsubscribeCalls).toEqual(['workflows', 'first']);
+  });
+
+  it('still cleans up all-worker-owned starts after an overlapping named start fails', async () => {
+    const workerA = new ControllableWorker('a');
+    const workerB = new ControllableWorker('b');
+    let rejectWorkerBStart!: (error: Error) => void;
+    workerA.onStart = async call => {
+      if (call === 2) {
+        throw new Error('named startup failed');
+      }
+      workerA.running = true;
+    };
+    workerB.onStart = async () =>
+      new Promise<void>((_resolve, reject) => {
+        rejectWorkerBStart = reject;
+      });
+    const mastra = new Mastra({
+      workers: [workerA, workerB],
+      logger: false,
+    });
+
+    const allStart = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(workerB.startCalls).toBe(1);
+    });
+    expect(workerA.running).toBe(true);
+
+    await expect(mastra.startWorkers('a')).rejects.toThrow('named startup failed');
+    expect(workerA.running).toBe(true);
+
+    rejectWorkerBStart(new Error('all-worker startup failed'));
+    await expect(allStart).rejects.toThrow('all-worker startup failed');
+
+    expect(workerA.stopCalls).toBe(1);
+    expect(workerA.running).toBe(false);
+  });
+
+  it('does not restore the started flag when stopWorkers interrupts a repeated all-worker startup', async () => {
+    const harnessWakeupsInit = vi.spyOn(HarnessWakeupWorker.prototype, 'init').mockResolvedValue(undefined);
+    const harnessWakeupsStart = vi.spyOn(HarnessWakeupWorker.prototype, 'start').mockResolvedValue(undefined);
+    const mastra = new Mastra({
+      harness: new Harness({ modes: [] }),
+      logger: false,
+    });
+    const worker = mastra.workers[0];
+    if (!worker) {
+      throw new Error('expected an initial worker to model repeated startup shutdown');
+    }
+    let workerRunning = false;
+    let resolveRepeatStart!: () => void;
+    let workerStartCalls = 0;
+    vi.spyOn(worker, 'init').mockResolvedValue(undefined);
+    vi.spyOn(worker, 'isRunning', 'get').mockImplementation(() => workerRunning);
+    vi.spyOn(worker, 'start').mockImplementation(async () => {
+      workerStartCalls += 1;
+      if (workerStartCalls === 2) {
+        await new Promise<void>(resolve => {
+          resolveRepeatStart = resolve;
+        });
+      }
+      workerRunning = true;
+    });
+    vi.spyOn(worker, 'stop').mockImplementation(async () => {
+      workerRunning = false;
+    });
+
+    await mastra.startWorkers();
+    expect(workerRunning).toBe(true);
+
+    const repeatedStart = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(workerStartCalls).toBe(2);
+    });
+    const stopping = mastra.stopWorkers();
+    resolveRepeatStart();
+    await Promise.all([repeatedStart, stopping]);
+
+    mastra.setStorage(new MockStore());
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(harnessWakeupsInit).not.toHaveBeenCalled();
+    expect(harnessWakeupsStart).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates concurrent all-worker startup calls while init is pending', async () => {
+    const worker = new ControllableWorker();
+    let resolveOldInit!: () => void;
+    worker.onInit = async call => {
+      if (call === 1) {
+        await new Promise<void>(resolve => {
+          resolveOldInit = resolve;
+        });
+      }
+    };
+    const mastra = new Mastra({
+      workers: [worker],
+      logger: false,
+    });
+
+    const oldStart = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(worker.initCalls).toBe(1);
+    });
+    const concurrentStart = mastra.startWorkers();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(worker.initCalls).toBe(1);
+    expect(worker.startCalls).toBe(0);
+
+    resolveOldInit();
+    await Promise.all([oldStart, concurrentStart]);
+
+    expect(worker.startCalls).toBe(1);
+    expect(worker.running).toBe(true);
+
+    await mastra.stopWorkers();
+  });
+
+  it('cleans up push and user event subscriptions when all-worker startup fails', async () => {
+    const pubsub = new StartupCleanupPubSub();
+    pubsub.failSubscribeTopic = 'second';
+    const mastra = new Mastra({
+      workers: false,
+      pubsub,
+      logger: false,
+      events: {
+        first: async () => {},
+        second: async () => {},
+      },
+    });
+
+    await expect(mastra.startWorkers()).rejects.toThrow('subscribe failed: second');
+
+    expect(pubsub.subscribeCalls).toEqual(['workflows', 'first', 'second']);
+    expect(pubsub.unsubscribeCalls).toEqual(['workflows', 'first', 'second']);
+
+    pubsub.failSubscribeTopic = undefined;
+    await mastra.startWorkers();
+    expect(pubsub.subscribeCalls).toEqual(['workflows', 'first', 'second', 'workflows', 'first', 'second']);
+
+    await mastra.stopWorkers();
+  });
+
+  it('does not retain a failed workflow push subscription when startup cleanup also fails', async () => {
+    const pubsub = new StartupCleanupPubSub();
+    pubsub.failSubscribeTopic = 'workflows';
+    pubsub.failNextUnsubscribeTopic = 'workflows';
+    const mastra = new Mastra({
+      workers: false,
+      pubsub,
+      logger: false,
+    });
+
+    await expect(mastra.startWorkers()).rejects.toThrow('subscribe failed: workflows');
+    expect(pubsub.subscribeCalls).toEqual(['workflows']);
+    expect(pubsub.unsubscribeCalls).toEqual(['workflows']);
+
+    pubsub.failSubscribeTopic = undefined;
+    await mastra.startWorkers();
+    expect(pubsub.subscribeCalls).toEqual(['workflows', 'workflows']);
+
+    await mastra.stopWorkers();
+  });
+
+  it('does not retain a failed user event subscription when startup cleanup also fails', async () => {
+    const pubsub = new StartupCleanupPubSub();
+    pubsub.failSubscribeTopic = 'second';
+    pubsub.failNextUnsubscribeTopic = 'second';
+    const mastra = new Mastra({
+      workers: false,
+      pubsub,
+      logger: false,
+      events: {
+        first: async () => {},
+        second: async () => {},
+      },
+    });
+
+    await expect(mastra.startWorkers()).rejects.toThrow('subscribe failed: second');
+    expect(pubsub.subscribeCalls).toEqual(['workflows', 'first', 'second']);
+    expect(pubsub.unsubscribeCalls).toEqual(['workflows', 'first', 'second']);
+
+    pubsub.failSubscribeTopic = undefined;
+    await mastra.startWorkers();
+    expect(pubsub.subscribeCalls).toEqual(['workflows', 'first', 'second', 'workflows', 'first', 'second']);
+
+    await mastra.stopWorkers();
+  });
+
+  it('cleans up a push workflow subscription when stopWorkers runs during startup subscribe', async () => {
+    const pubsub = new StartupCleanupPubSub();
+    pubsub.gateSubscribeTopic = 'workflows';
+    pubsub.resetSubscribeGate();
+    const mastra = new Mastra({
+      workers: false,
+      pubsub,
+      logger: false,
+    });
+
+    const starting = mastra.startWorkers();
+    await pubsub.subscribeGateStarted;
+
+    await mastra.stopWorkers();
+    pubsub.failNextUnsubscribeTopic = 'workflows';
+    pubsub.releaseSubscribeGate();
+    await expect(starting).rejects.toThrow('unsubscribe failed: workflows');
+
+    expect(pubsub.subscribeCalls).toEqual(['workflows']);
+    expect(pubsub.unsubscribeCalls).toEqual(['workflows', 'workflows', 'workflows']);
+
+    await mastra.stopWorkers();
+    expect(pubsub.unsubscribeCalls).toEqual(['workflows', 'workflows', 'workflows']);
+  });
+
+  it('retains a push workflow subscription for retry cleanup when stop-during-startup unsubscribe fails', async () => {
+    const pubsub = new StartupCleanupPubSub();
+    pubsub.gateSubscribeTopic = 'workflows';
+    pubsub.failNextUnsubscribeTopic = 'workflows';
+    pubsub.resetSubscribeGate();
+    const mastra = new Mastra({
+      workers: false,
+      pubsub,
+      logger: false,
+    });
+
+    const starting = mastra.startWorkers();
+    await pubsub.subscribeGateStarted;
+
+    await expect(mastra.stopWorkers()).rejects.toThrow('unsubscribe failed: workflows');
+    pubsub.releaseSubscribeGate();
+    await starting;
+
+    expect(pubsub.subscribeCalls).toEqual(['workflows']);
+    expect(pubsub.unsubscribeCalls).toEqual(['workflows', 'workflows']);
+
+    pubsub.gateSubscribeTopic = undefined;
+    await mastra.startWorkers();
+    await mastra.stopWorkers();
+  });
+
+  it('cleans up a user event subscription when stopWorkers runs during startup subscribe', async () => {
+    const pubsub = new StartupCleanupPubSub();
+    const mastra = new Mastra({
+      workers: false,
+      pubsub,
+      logger: false,
+      events: {
+        first: async () => {},
+      },
+    });
+
+    pubsub.gateSubscribeTopic = 'first';
+    pubsub.resetSubscribeGate();
+    const starting = mastra.startWorkers();
+    await pubsub.subscribeGateStarted;
+
+    await mastra.stopWorkers();
+    pubsub.failNextUnsubscribeTopic = 'first';
+    pubsub.releaseSubscribeGate();
+    await expect(starting).rejects.toThrow('unsubscribe failed: first');
+
+    expect(pubsub.subscribeCalls).toEqual(['workflows', 'first']);
+    expect(pubsub.unsubscribeCalls).toEqual(['workflows', 'first', 'first', 'workflows', 'first']);
+
+    await mastra.stopWorkers();
+    expect(pubsub.unsubscribeCalls).toEqual(['workflows', 'first', 'first', 'workflows', 'first']);
+  });
+
+  it('cleans up a user event subscription on retry when stop-during-startup unsubscribe fails', async () => {
+    const pubsub = new StartupCleanupPubSub();
+    const mastra = new Mastra({
+      workers: false,
+      pubsub,
+      logger: false,
+      events: {
+        first: async () => {},
+      },
+    });
+
+    pubsub.gateSubscribeTopic = 'first';
+    pubsub.failNextUnsubscribeTopic = 'first';
+    pubsub.resetSubscribeGate();
+    const starting = mastra.startWorkers();
+    await pubsub.subscribeGateStarted;
+
+    await expect(mastra.stopWorkers()).rejects.toThrow('unsubscribe failed: first');
+    pubsub.releaseSubscribeGate();
+    await starting;
+
+    expect(pubsub.subscribeCalls).toEqual(['workflows', 'first']);
+    expect(pubsub.unsubscribeCalls).toEqual(['workflows', 'first', 'first']);
+
+    pubsub.gateSubscribeTopic = undefined;
+    await mastra.startWorkers();
+    await mastra.stopWorkers();
+    expect(pubsub.unsubscribeCalls).toEqual(['workflows', 'first', 'first', 'workflows', 'first']);
   });
 
   it('stops already-running workers before waiting for later pending startups', async () => {
@@ -406,6 +1416,209 @@ describe('Mastra workers filter (MASTRA_WORKERS env)', () => {
     expect(start).not.toHaveBeenCalled();
   });
 
+  it('stops a late-started harness wakeup worker when all-worker startup fails', async () => {
+    let harnessWakeupsRunning = false;
+    vi.spyOn(HarnessWakeupWorker.prototype, 'init').mockResolvedValue(undefined);
+    vi.spyOn(HarnessWakeupWorker.prototype, 'isRunning', 'get').mockImplementation(() => harnessWakeupsRunning);
+    let resolveHarnessWakeupsStart!: () => void;
+    const harnessWakeupsStart = vi.spyOn(HarnessWakeupWorker.prototype, 'start').mockImplementation(async () => {
+      await new Promise<void>(resolve => {
+        resolveHarnessWakeupsStart = resolve;
+      });
+      harnessWakeupsRunning = true;
+    });
+    const harnessWakeupsStop = vi.spyOn(HarnessWakeupWorker.prototype, 'stop').mockImplementation(async () => {
+      harnessWakeupsRunning = false;
+    });
+
+    const mastra = new Mastra({
+      harness: new Harness({ modes: [] }),
+      logger: false,
+    });
+    const initialWorker = mastra.workers[0];
+    if (!initialWorker) {
+      throw new Error('expected an initial worker to fail startWorkers');
+    }
+
+    let resolveInitialInit!: () => void;
+    vi.spyOn(initialWorker, 'init').mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveInitialInit = resolve;
+        }),
+    );
+    vi.spyOn(initialWorker, 'start').mockRejectedValue(new Error('worker startup failed'));
+
+    const starting = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(initialWorker.init).toHaveBeenCalledTimes(1);
+    });
+
+    mastra.setStorage(new MockStore());
+    await vi.waitFor(() => {
+      expect(harnessWakeupsStart).toHaveBeenCalledTimes(1);
+    });
+
+    resolveInitialInit();
+    await expect(starting).rejects.toThrow('worker startup failed');
+    expect(harnessWakeupsStop).not.toHaveBeenCalled();
+
+    resolveHarnessWakeupsStart();
+    await vi.waitFor(() => {
+      expect(harnessWakeupsStop).toHaveBeenCalledTimes(1);
+    });
+    expect(harnessWakeupsRunning).toBe(false);
+  });
+
+  it('stops an old late-started harness wakeup worker when startup is retried before it settles', async () => {
+    let harnessWakeupsRunning = false;
+    vi.spyOn(HarnessWakeupWorker.prototype, 'init').mockResolvedValue(undefined);
+    vi.spyOn(HarnessWakeupWorker.prototype, 'isRunning', 'get').mockImplementation(() => harnessWakeupsRunning);
+    let harnessWakeupsStartCalls = 0;
+    let resolveOldHarnessWakeupsStart!: () => void;
+    const harnessWakeupsStart = vi.spyOn(HarnessWakeupWorker.prototype, 'start').mockImplementation(async () => {
+      harnessWakeupsStartCalls += 1;
+      if (harnessWakeupsStartCalls === 1) {
+        await new Promise<void>(resolve => {
+          resolveOldHarnessWakeupsStart = resolve;
+        });
+      }
+      harnessWakeupsRunning = true;
+    });
+    const harnessWakeupsStop = vi.spyOn(HarnessWakeupWorker.prototype, 'stop').mockImplementation(async () => {
+      harnessWakeupsRunning = false;
+    });
+
+    const mastra = new Mastra({
+      harness: new Harness({ modes: [] }),
+      logger: false,
+    });
+    const initialWorker = mastra.workers[0];
+    if (!initialWorker) {
+      throw new Error('expected an initial worker to fail startWorkers');
+    }
+
+    let initialInitCalls = 0;
+    let resolveInitialInit!: () => void;
+    vi.spyOn(initialWorker, 'init').mockImplementation(() => {
+      initialInitCalls += 1;
+      if (initialInitCalls === 1) {
+        return new Promise<void>(resolve => {
+          resolveInitialInit = resolve;
+        });
+      }
+      return Promise.resolve();
+    });
+
+    let initialStartCalls = 0;
+    let resolveRetryInitialStart!: () => void;
+    vi.spyOn(initialWorker, 'start').mockImplementation(() => {
+      initialStartCalls += 1;
+      if (initialStartCalls === 1) {
+        return Promise.reject(new Error('worker startup failed'));
+      }
+      return new Promise<void>(resolve => {
+        resolveRetryInitialStart = resolve;
+      });
+    });
+
+    const starting = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(initialWorker.init).toHaveBeenCalledTimes(1);
+    });
+
+    mastra.setStorage(new MockStore());
+    await vi.waitFor(() => {
+      expect(harnessWakeupsStart).toHaveBeenCalledTimes(1);
+    });
+
+    resolveInitialInit();
+    await expect(starting).rejects.toThrow('worker startup failed');
+
+    const retrying = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(initialStartCalls).toBe(2);
+    });
+
+    resolveOldHarnessWakeupsStart();
+    await vi.waitFor(() => {
+      expect(harnessWakeupsStop).toHaveBeenCalledTimes(1);
+    });
+    expect(harnessWakeupsRunning).toBe(false);
+
+    resolveRetryInitialStart();
+    await retrying;
+    expect(harnessWakeupsStart).toHaveBeenCalledTimes(2);
+    expect(harnessWakeupsRunning).toBe(true);
+
+    await mastra.stopWorkers();
+  });
+
+  it('does not stop a newer harness wakeup worker when an old late start settles after retry', async () => {
+    let harnessWakeupsRunning = false;
+    vi.spyOn(HarnessWakeupWorker.prototype, 'init').mockResolvedValue(undefined);
+    vi.spyOn(HarnessWakeupWorker.prototype, 'isRunning', 'get').mockImplementation(() => harnessWakeupsRunning);
+    let harnessWakeupsStartCalls = 0;
+    let resolveOldHarnessWakeupsStart!: () => void;
+    const harnessWakeupsStart = vi.spyOn(HarnessWakeupWorker.prototype, 'start').mockImplementation(async () => {
+      harnessWakeupsStartCalls += 1;
+      if (harnessWakeupsStartCalls === 1) {
+        await new Promise<void>(resolve => {
+          resolveOldHarnessWakeupsStart = resolve;
+        });
+      }
+      harnessWakeupsRunning = true;
+    });
+    const harnessWakeupsStop = vi.spyOn(HarnessWakeupWorker.prototype, 'stop').mockImplementation(async () => {
+      harnessWakeupsRunning = false;
+    });
+
+    const mastra = new Mastra({
+      harness: new Harness({ modes: [] }),
+      logger: false,
+    });
+    const initialWorker = mastra.workers[0];
+    if (!initialWorker) {
+      throw new Error('expected an initial worker to fail startWorkers');
+    }
+
+    let resolveInitialInit!: () => void;
+    vi.spyOn(initialWorker, 'init').mockImplementationOnce(
+      () =>
+        new Promise<void>(resolve => {
+          resolveInitialInit = resolve;
+        }),
+    );
+    vi.spyOn(initialWorker, 'start')
+      .mockRejectedValueOnce(new Error('worker startup failed'))
+      .mockResolvedValue(undefined);
+
+    const starting = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(initialWorker.init).toHaveBeenCalledTimes(1);
+    });
+    mastra.setStorage(new MockStore());
+    await vi.waitFor(() => {
+      expect(harnessWakeupsStart).toHaveBeenCalledTimes(1);
+    });
+
+    resolveInitialInit();
+    await expect(starting).rejects.toThrow('worker startup failed');
+
+    const retrying = mastra.startWorkers();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(harnessWakeupsStart).toHaveBeenCalledTimes(1);
+
+    resolveOldHarnessWakeupsStart();
+    await retrying;
+
+    expect(harnessWakeupsStop).toHaveBeenCalledTimes(1);
+    expect(harnessWakeupsStart).toHaveBeenCalledTimes(2);
+    expect(harnessWakeupsRunning).toBe(true);
+
+    await mastra.stopWorkers();
+  });
+
   it('does not start a late-registered harness wakeup worker while workers are stopping', async () => {
     let resolveInit!: () => void;
     const init = vi.spyOn(HarnessWakeupWorker.prototype, 'init').mockImplementation(
@@ -431,6 +1644,39 @@ describe('Mastra workers filter (MASTRA_WORKERS env)', () => {
     await stopped;
 
     expect(start).not.toHaveBeenCalled();
+  });
+
+  it('does not fail shutdown when a late-registered harness wakeup worker startup fails', async () => {
+    const startupError = new Error('late harness startup failed');
+    let rejectInit!: (error: Error) => void;
+    const init = vi.spyOn(HarnessWakeupWorker.prototype, 'init').mockImplementation(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectInit = reject;
+        }),
+    );
+    const start = vi.spyOn(HarnessWakeupWorker.prototype, 'start').mockResolvedValue(undefined);
+    const error = vi.fn();
+    const mastra = new Mastra({
+      harness: new Harness({ modes: [] }),
+      logger: false,
+    });
+    mastra.setLogger({
+      logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error, trackException: vi.fn() } as any,
+    });
+
+    await mastra.startWorkers();
+    mastra.setStorage(new MockStore());
+    await vi.waitFor(() => {
+      expect(init).toHaveBeenCalledTimes(1);
+    });
+
+    const stopped = mastra.stopWorkers();
+    rejectInit(startupError);
+    await expect(stopped).resolves.toBeUndefined();
+
+    expect(start).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith('Failed to start worker "harnessWakeups"', startupError);
   });
 
   it('disables all workers when MASTRA_WORKERS=false', async () => {

--- a/packages/core/src/mastra/workers-filter.test.ts
+++ b/packages/core/src/mastra/workers-filter.test.ts
@@ -3,6 +3,7 @@ import { Harness } from '../harness/v1/harness';
 import { InMemoryHarness } from '../storage/domains/harness/inmemory';
 import { InMemoryDB } from '../storage/domains/inmemory-db';
 import { MockStore } from '../storage/mock';
+import { HarnessWakeupWorker } from '../worker';
 import { Mastra } from './index';
 
 const ORIGINAL_ENV = process.env.MASTRA_WORKERS;
@@ -79,6 +80,141 @@ describe('Mastra workers filter (MASTRA_WORKERS env)', () => {
     expect(mastra.workers.map(worker => worker.name)).toContain('harnessWakeups');
   });
 
+  it('registers harness wakeup worker when storage is attached after construction', () => {
+    const mastra = new Mastra({
+      harness: new Harness({ modes: [] }),
+      logger: false,
+    });
+
+    expect(mastra.workers.map(worker => worker.name)).not.toContain('harnessWakeups');
+
+    mastra.setStorage(new MockStore());
+
+    expect(mastra.workers.map(worker => worker.name)).toContain('harnessWakeups');
+  });
+
+  it('starts a late-registered harness wakeup worker when workers are already running', async () => {
+    const init = vi.spyOn(HarnessWakeupWorker.prototype, 'init').mockResolvedValue(undefined);
+    const start = vi.spyOn(HarnessWakeupWorker.prototype, 'start').mockResolvedValue(undefined);
+    const mastra = new Mastra({
+      harness: new Harness({ modes: [] }),
+      logger: false,
+    });
+
+    await mastra.startWorkers();
+    mastra.setStorage(new MockStore());
+
+    await vi.waitFor(() => {
+      expect(start).toHaveBeenCalledTimes(1);
+    });
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts a late-registered harness wakeup worker while workers are still starting', async () => {
+    const init = vi.spyOn(HarnessWakeupWorker.prototype, 'init').mockResolvedValue(undefined);
+    const start = vi.spyOn(HarnessWakeupWorker.prototype, 'start').mockResolvedValue(undefined);
+    const mastra = new Mastra({
+      harness: new Harness({ modes: [] }),
+      logger: false,
+    });
+    const initialWorker = mastra.workers[0];
+    if (!initialWorker) {
+      throw new Error('expected an initial worker to hold startWorkers in flight');
+    }
+    let releaseStart!: () => void;
+    vi.spyOn(initialWorker, 'init').mockResolvedValue(undefined);
+    const initialStart = vi.spyOn(initialWorker, 'start').mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          releaseStart = resolve;
+        }),
+    );
+
+    const starting = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(initialStart).toHaveBeenCalledTimes(1);
+    });
+    mastra.setStorage(new MockStore());
+
+    await vi.waitFor(() => {
+      expect(start).toHaveBeenCalledTimes(1);
+    });
+    expect(init).toHaveBeenCalledTimes(1);
+
+    releaseStart();
+    await starting;
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start a late-registered harness wakeup worker after workers are stopped', async () => {
+    const init = vi.spyOn(HarnessWakeupWorker.prototype, 'init').mockResolvedValue(undefined);
+    const start = vi.spyOn(HarnessWakeupWorker.prototype, 'start').mockResolvedValue(undefined);
+    const mastra = new Mastra({
+      harness: new Harness({ modes: [] }),
+      logger: false,
+    });
+
+    await mastra.startWorkers();
+    await mastra.stopWorkers();
+    mastra.setStorage(new MockStore());
+
+    expect(mastra.workers.map(worker => worker.name)).toContain('harnessWakeups');
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(init).not.toHaveBeenCalled();
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it('does not keep late worker startup armed after all-worker startup fails', async () => {
+    const init = vi.spyOn(HarnessWakeupWorker.prototype, 'init').mockResolvedValue(undefined);
+    const start = vi.spyOn(HarnessWakeupWorker.prototype, 'start').mockResolvedValue(undefined);
+    const mastra = new Mastra({
+      harness: new Harness({ modes: [] }),
+      logger: false,
+    });
+    const initialWorker = mastra.workers[0];
+    if (!initialWorker) {
+      throw new Error('expected an initial worker to fail startWorkers');
+    }
+    vi.spyOn(initialWorker, 'init').mockResolvedValue(undefined);
+    vi.spyOn(initialWorker, 'start').mockRejectedValue(new Error('worker startup failed'));
+
+    await expect(mastra.startWorkers()).rejects.toThrow('worker startup failed');
+    mastra.setStorage(new MockStore());
+
+    expect(mastra.workers.map(worker => worker.name)).toContain('harnessWakeups');
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(init).not.toHaveBeenCalled();
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it('does not start a late-registered harness wakeup worker while workers are stopping', async () => {
+    let resolveInit!: () => void;
+    const init = vi.spyOn(HarnessWakeupWorker.prototype, 'init').mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveInit = resolve;
+        }),
+    );
+    const start = vi.spyOn(HarnessWakeupWorker.prototype, 'start').mockResolvedValue(undefined);
+    const mastra = new Mastra({
+      harness: new Harness({ modes: [] }),
+      logger: false,
+    });
+
+    await mastra.startWorkers();
+    mastra.setStorage(new MockStore());
+    await vi.waitFor(() => {
+      expect(init).toHaveBeenCalledTimes(1);
+    });
+
+    const stopped = mastra.stopWorkers();
+    resolveInit();
+    await stopped;
+
+    expect(start).not.toHaveBeenCalled();
+  });
+
   it('disables all workers when MASTRA_WORKERS=false', async () => {
     process.env.MASTRA_WORKERS = 'false';
 
@@ -87,6 +223,8 @@ describe('Mastra workers filter (MASTRA_WORKERS env)', () => {
       logger: false,
     });
 
+    expect(mastra.workers).toEqual([]);
+    mastra.setStorage(new MockStore());
     expect(mastra.workers).toEqual([]);
   });
 

--- a/packages/core/src/mastra/workers-filter.test.ts
+++ b/packages/core/src/mastra/workers-filter.test.ts
@@ -68,6 +68,224 @@ describe('Mastra workers filter (MASTRA_WORKERS env)', () => {
     }
   });
 
+  it('does not start an initial worker whose init completes after stopWorkers begins', async () => {
+    const mastra = new Mastra({
+      storage: new MockStore(),
+      backgroundTasks: { enabled: true },
+      logger: false,
+    });
+    const initialWorker = mastra.workers[0];
+    if (!initialWorker) {
+      throw new Error('expected an initial worker to hold startWorkers in flight');
+    }
+
+    let resolveInit!: () => void;
+    const init = vi.spyOn(initialWorker, 'init').mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveInit = resolve;
+        }),
+    );
+    const start = vi.spyOn(initialWorker, 'start').mockResolvedValue(undefined);
+
+    const starting = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(init).toHaveBeenCalledTimes(1);
+    });
+
+    const stopping = mastra.stopWorkers();
+    resolveInit();
+    await Promise.all([starting, stopping]);
+
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it('stops an initial worker whose start completes after stopWorkers begins', async () => {
+    const mastra = new Mastra({
+      storage: new MockStore(),
+      backgroundTasks: { enabled: true },
+      logger: false,
+    });
+    const initialWorker = mastra.workers[0];
+    if (!initialWorker) {
+      throw new Error('expected an initial worker to hold startWorkers in flight');
+    }
+
+    let running = false;
+    let resolveStart!: () => void;
+    vi.spyOn(initialWorker, 'init').mockResolvedValue(undefined);
+    vi.spyOn(initialWorker, 'isRunning', 'get').mockImplementation(() => running);
+    const start = vi.spyOn(initialWorker, 'start').mockImplementation(async () => {
+      await new Promise<void>(resolve => {
+        resolveStart = resolve;
+      });
+      running = true;
+    });
+    const stop = vi.spyOn(initialWorker, 'stop').mockImplementation(async () => {
+      running = false;
+    });
+
+    const starting = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(start).toHaveBeenCalledTimes(1);
+    });
+
+    const stopping = mastra.stopWorkers();
+    resolveStart();
+    await Promise.all([starting, stopping]);
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(running).toBe(false);
+  });
+
+  it('cleans up already-running workers when a pending startup rejects during stopWorkers', async () => {
+    const mastra = new Mastra({
+      storage: new MockStore(),
+      backgroundTasks: { enabled: true },
+      logger: false,
+    });
+    const [firstWorker, secondWorker] = mastra.workers;
+    if (!firstWorker || !secondWorker) {
+      throw new Error('expected at least two workers to model partial startup cleanup');
+    }
+
+    let firstRunning = false;
+    vi.spyOn(firstWorker, 'init').mockResolvedValue(undefined);
+    vi.spyOn(firstWorker, 'isRunning', 'get').mockImplementation(() => firstRunning);
+    vi.spyOn(firstWorker, 'start').mockImplementation(async () => {
+      firstRunning = true;
+    });
+    const firstStop = vi.spyOn(firstWorker, 'stop').mockImplementation(async () => {
+      firstRunning = false;
+    });
+
+    let rejectSecondStart!: (error: Error) => void;
+    vi.spyOn(secondWorker, 'init').mockResolvedValue(undefined);
+    const secondStart = vi.spyOn(secondWorker, 'start').mockImplementation(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectSecondStart = reject;
+        }),
+    );
+
+    const starting = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(secondStart).toHaveBeenCalledTimes(1);
+    });
+
+    const stopping = mastra.stopWorkers();
+    rejectSecondStart(new Error('worker startup failed'));
+
+    await expect(starting).rejects.toThrow('worker startup failed');
+    await expect(stopping).rejects.toThrow('worker startup failed');
+    expect(firstStop).toHaveBeenCalledTimes(1);
+    expect(firstRunning).toBe(false);
+  });
+
+  it('stops already-running workers before waiting for later pending startups', async () => {
+    const mastra = new Mastra({
+      storage: new MockStore(),
+      backgroundTasks: { enabled: true },
+      logger: false,
+    });
+    const [firstWorker, secondWorker] = mastra.workers;
+    if (!firstWorker || !secondWorker) {
+      throw new Error('expected at least two workers to model partial startup shutdown');
+    }
+
+    let firstRunning = false;
+    vi.spyOn(firstWorker, 'init').mockResolvedValue(undefined);
+    vi.spyOn(firstWorker, 'isRunning', 'get').mockImplementation(() => firstRunning);
+    vi.spyOn(firstWorker, 'start').mockImplementation(async () => {
+      firstRunning = true;
+    });
+    const firstStop = vi.spyOn(firstWorker, 'stop').mockImplementation(async () => {
+      firstRunning = false;
+    });
+
+    let secondRunning = false;
+    let resolveSecondStart!: () => void;
+    vi.spyOn(secondWorker, 'init').mockResolvedValue(undefined);
+    vi.spyOn(secondWorker, 'isRunning', 'get').mockImplementation(() => secondRunning);
+    const secondStart = vi.spyOn(secondWorker, 'start').mockImplementation(async () => {
+      await new Promise<void>(resolve => {
+        resolveSecondStart = resolve;
+      });
+      secondRunning = true;
+    });
+    const secondStop = vi.spyOn(secondWorker, 'stop').mockImplementation(async () => {
+      secondRunning = false;
+    });
+
+    const starting = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(secondStart).toHaveBeenCalledTimes(1);
+    });
+
+    const stopping = mastra.stopWorkers();
+    await vi.waitFor(() => {
+      expect(firstStop).toHaveBeenCalledTimes(1);
+    });
+    expect(firstRunning).toBe(false);
+
+    resolveSecondStart();
+    await Promise.all([starting, stopping]);
+
+    expect(secondStop).toHaveBeenCalledTimes(1);
+    expect(secondRunning).toBe(false);
+  });
+
+  it('keeps pending startup rejection evidence when it settles during a slow stop', async () => {
+    const mastra = new Mastra({
+      storage: new MockStore(),
+      backgroundTasks: { enabled: true },
+      logger: false,
+    });
+    const [firstWorker, secondWorker] = mastra.workers;
+    if (!firstWorker || !secondWorker) {
+      throw new Error('expected at least two workers to model startup rejection during slow stop');
+    }
+
+    let firstRunning = false;
+    let resolveFirstStop!: () => void;
+    vi.spyOn(firstWorker, 'init').mockResolvedValue(undefined);
+    vi.spyOn(firstWorker, 'isRunning', 'get').mockImplementation(() => firstRunning);
+    vi.spyOn(firstWorker, 'start').mockImplementation(async () => {
+      firstRunning = true;
+    });
+    const firstStop = vi.spyOn(firstWorker, 'stop').mockImplementation(async () => {
+      await new Promise<void>(resolve => {
+        resolveFirstStop = resolve;
+      });
+      firstRunning = false;
+    });
+
+    let rejectSecondStart!: (error: Error) => void;
+    vi.spyOn(secondWorker, 'init').mockResolvedValue(undefined);
+    const secondStart = vi.spyOn(secondWorker, 'start').mockImplementation(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectSecondStart = reject;
+        }),
+    );
+
+    const starting = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(secondStart).toHaveBeenCalledTimes(1);
+    });
+
+    const stopping = mastra.stopWorkers();
+    await vi.waitFor(() => {
+      expect(firstStop).toHaveBeenCalledTimes(1);
+    });
+    rejectSecondStart(new Error('worker startup failed during stop'));
+    resolveFirstStop();
+
+    await expect(starting).rejects.toThrow('worker startup failed during stop');
+    await expect(stopping).rejects.toThrow('worker startup failed during stop');
+    expect(firstRunning).toBe(false);
+  });
+
   it('registers harness wakeup worker for harness session storage without top-level storage', () => {
     const mastra = new Mastra({
       harness: new Harness({

--- a/packages/core/src/worker/worker.test.ts
+++ b/packages/core/src/worker/worker.test.ts
@@ -584,7 +584,8 @@ describe('HarnessWakeupWorker', () => {
   it('marks retryable failures failed with a later retry time', async () => {
     const item = sampleWakeup({ attempts: 2 });
     const storage = createWakeupStorage([item]);
-    const worker = new HarnessWakeupWorker({ retryBackoffMs: () => 1234, maxAttempts: 5 });
+    const retryBackoffMs = vi.fn(() => 1234);
+    const worker = new HarnessWakeupWorker({ retryBackoffMs, maxAttempts: 5 });
     const deps = createMockDeps();
     deps._storage.getStore.mockResolvedValue(storage);
     deps.mastra = {
@@ -609,12 +610,16 @@ describe('HarnessWakeupWorker', () => {
       expect.objectContaining({
         id: item.id,
         status: 'failed',
+        attempts: 2,
         nextAttemptAt: expect.any(Number),
         lastError: expect.objectContaining({ code: 'session_locked', retryable: true }),
         claimId: undefined,
       }),
       { claimId: item.claimId },
     );
+    // Storage increments attempts when the row is claimed; the worker must
+    // persist the claimed attempt count instead of double-counting failures.
+    expect(retryBackoffMs).toHaveBeenCalledWith(2);
   });
 
   it('renews ownership before admitting a claimed wakeup', async () => {


### PR DESCRIPTION
## Summary

Follow-up to merged PR #145. That PR merged at `dcf59d5d24cacbda7707042a1ee28385ec38d32b` before the late valid review feedback around storage-attached Harness wakeup worker registration was landed.

This PR:
- registers the default `harnessWakeups` worker when Harness storage is attached after construction via `setStorage()`;
- preserves `workers: false` and explicit custom worker arrays as opt-outs from auto-created workers;
- starts the late worker when all-worker startup is active or already complete and the `MASTRA_WORKERS` filter permits `harnessWakeups`;
- avoids starting late workers after stop intent, during stop drain, or after failed all-worker startup;
- snapshots all-worker startup targets so a worker registered during `startWorkers()` is not double-started;
- records the storage-owned retry attempt accounting in the worker test; and
- tightens the PF-374 changeset wording from the #145 review pass.

## Scope / Coordination

- Linear: PF-374
- Open PR overlap checked before push: `gh pr list --repo mbenhamd/mastra --state open` returned none.
- Touched files are limited to:
  - `.changeset/pf-374-harness-wakeup-worker.md`
  - `packages/core/src/mastra/index.ts`
  - `packages/core/src/mastra/workers-filter.test.ts`
  - `packages/core/src/worker/worker.test.ts`

## Validation

- `pnpm --filter ./packages/core exec vitest run src/mastra/workers-filter.test.ts src/worker/worker.test.ts`
- `pnpm --filter ./packages/core exec eslint src/mastra/index.ts src/mastra/workers-filter.test.ts src/worker/worker.test.ts`
- `git -C /tmp/mastra-fork-pf-374-worker diff --check`
- `pnpm --filter ./packages/core exec vitest run src/worker/worker.test.ts src/mastra/workers-filter.test.ts src/harness/v1/harness.test.ts src/harness/v1/session.tool-context.test.ts src/harness/v1/session.queue.test.ts`
- `pnpm --filter ./packages/core check`
- local Codex correctness/concurrency review: no findings after fixes
- local Codex tests/maintainability review: stale comment finding fixed before push
- CodeRabbit CLI: no findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

You can start the server before the database exists; this PR makes sure the special "wake scheduled tasks" worker is registered and started correctly once storage is attached later, without starting it twice or interfering with shutdown.

## Overview

Follow-up to PR `#145` that implements deferred, conditional registration and stronger lifecycle coordination for the Harness wakeup worker when storage (harness/session storage) is attached after Mastra construction. It preserves explicit opt-outs, respects the MASTRA_WORKERS filter, avoids double-starts and racey startup/shutdown interactions, snapshots all-worker startup targets to prevent duplicate starts, tightens changeset wording, and records storage-owned retry attempt accounting in tests.

## Key Changes

packages/core/src/mastra/index.ts — Worker lifecycle and late-registration fixes
- Added internal state and gating for auto-created workers and startup/shutdown coordination (e.g., `#autoCreateWorkers`, `#workersStarted`, `#pendingWorkerStarts`, startup/shutdown tokens, and a shutdown wait timeout constant).
- Constructor records harness wakeup config, disables auto-creation when `workers: false` or when `workers` is an explicit array, and conditions inclusion of `HarnessWakeupWorker` on that config.
- Introduced `#ensureHarnessWakeupWorker()` to conditionally register the default `harnessWakeups` worker once storage becomes available (and harnesses exist); `setStorage()` now calls this.
- Start logic refactored: `startWorkers()` serializes against concurrent shutdown, caches the global start promise, marks workers-started early for "start all" flows, and uses `#trackWorkerStart()`/`#startWorker()` helpers to record per-start tokens and in-flight promises so workers registered during startup are not double-started.
- Late-registered `harnessWakeups` is started immediately only when all-worker startup is active or complete and when `MASTRA_WORKERS` permits it.
- Prevents starting late workers after a stop intent, during stop drain, or after a failed all-worker startup.
- `stopWorkers()` reworked to snapshot pending worker-starts at shutdown, wait for pending startups with per-start timeouts, optionally stop workers that finish late (if still valid), and perform cleanup of subscriptions and push wiring with rollback when startup is invalidated.

packages/core/src/mastra/workers-filter.test.ts — Tests for dynamic registration and shutdown races
- Expanded coverage for `startWorkers()`/`stopWorkers()` orchestration under filtering, concurrency, retries, timeouts, and partial failures.
- Added deterministic test helpers (e.g., `StartupCleanupPubSub`, `ControllableWorker`) to gate `init`/`start`/`stop` and simulate pending/rejecting startups.
- New tests specifically verify late registration/arming/starting of `harnessWakeups` when storage is attached after construction, covering these behaviors:
  - `harnessWakeups` absent before `setStorage()` and registered after `setStorage()`.
  - Late registration starts the worker when workers are running or still starting (if permitted).
  - Late registration does not start the worker after `stopWorkers()`, during stop drain, or after a failed all-worker startup.
  - A late-registered startup failure does not block shutdown, is logged, and does not keep shutdown from resolving.
  - `MASTRA_WORKERS=false` and explicit worker opt-outs remain respected after `setStorage()`.

packages/core/src/worker/worker.test.ts — Retry accounting tightening
- Adjusted the HarnessWakeupWorker retry test to spy on `retryBackoffMs` and assert it is called with the persisted attempt count (ensuring storage-owned retry attempt accounting is recorded and avoiding double-counting).

.changeset/pf-374-harness-wakeup-worker.md (and related changesets) — Metadata and release notes
- Updated changeset to bump `@mastra/core` to minor and `@mastra/libsql`/`@mastra/pg` to patch.
- Clarified release-note text to preserve the Harness session resumption messaging and removed prior LibSQL/Postgres yolo override and PostgreSQL favorites schema-export notes from that changeset.
- Added a sentence noting worker startup/shutdown now clean up interrupted Harness wakeup starts without leaving duplicate workers running.
- Added changesets for LibSQL/Postgres to document queue-admission override preservation and favorites persistence where applicable.

## Notes / Validation
- Tests updated/added: workers-filter.test.ts, worker.test.ts (targeted Vitest runs performed).
- Per-file ESLint, pnpm checks, git diff --check and local CLI reviews performed (no findings); stale comment fixed.
- Commit message: "[PF-374] Bound pending worker startup shutdown" — focuses on bounding/hardening interactions between pending worker startup and shutdown to prevent double-starts and avoid starting workers during stop/drain/failed startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->