### PR TITLE
[PF-376] Add Harness core acceptance coverage

### DIFF
--- a/.changeset/pf-376-core-acceptance.md
+++ b/.changeset/pf-376-core-acceptance.md
@@ -1,0 +1,5 @@
+---
+"@mastra/libsql": patch
+---
+
+Fixed LibSQL storage package builds so the favorites store is available from the composite store.

--- a/packages/core/src/harness/v1/export-map.test.ts
+++ b/packages/core/src/harness/v1/export-map.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import * as legacyHarnessEntry from '../index';
+import * as harnessV1Entry from './index';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const packageJson = JSON.parse(readFileSync(resolve(packageRoot, 'package.json'), 'utf8')) as {
+  exports: Record<string, unknown>;
+};
+
+describe('Harness v1 — §15 package export acceptance', () => {
+  it('maps @mastra/core/harness/v1 to v1 dist targets without replacing the legacy harness entry', () => {
+    expect(packageJson.exports['./harness/v1']).toEqual({
+      import: {
+        types: './dist/harness/v1/index.d.ts',
+        default: './dist/harness/v1/index.js',
+      },
+      require: {
+        types: './dist/harness/v1/index.d.ts',
+        default: './dist/harness/v1/index.cjs',
+      },
+    });
+    expect(packageJson.exports['./harness']).toEqual({
+      import: {
+        types: './dist/harness/index.d.ts',
+        default: './dist/harness/index.js',
+      },
+      require: {
+        types: './dist/harness/index.d.ts',
+        default: './dist/harness/index.cjs',
+      },
+    });
+
+    expect(harnessV1Entry.Harness).toBeDefined();
+    expect(harnessV1Entry.Session).toBeDefined();
+    expect(harnessV1Entry.formatHarnessEventId).toBeTypeOf('function');
+    expect(harnessV1Entry.Harness).not.toBe(legacyHarnessEntry.Harness);
+  });
+});

--- a/packages/core/src/harness/v1/session.tool-context.test.ts
+++ b/packages/core/src/harness/v1/session.tool-context.test.ts
@@ -246,3 +246,87 @@ describe('HarnessRequestContext — queued turns', () => {
     ).rejects.toBeInstanceOf(HarnessValidationError);
   });
 });
+
+describe('HarnessRequestContext — §15 pending registration acceptance', () => {
+  it('commits a question pending row before emitting the pending event', async () => {
+    const { harness, storage, agent } = setupHarness();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const eventRecords: Array<Promise<unknown>> = [];
+    session.subscribe(event => {
+      if (event.type === 'suspension_required' && event.kind === 'question') {
+        eventRecords.push(storage.loadSession({ sessionId: session.id }));
+      }
+    });
+
+    await session.message({ content: 'capture context' });
+    const slot = getHarnessSlot(agent.streamCalls);
+
+    await (slot.registerQuestion as any)({
+      questionId: 'question-1',
+      question: 'Pick one',
+      options: [{ label: 'A' }],
+      selectionMode: 'single_select',
+      runId: 'run-question-1',
+      toolCallId: 'tool-question-1',
+    });
+
+    expect(eventRecords).toHaveLength(1);
+    await expect(eventRecords[0]).resolves.toMatchObject({
+      pendingResume: {
+        kind: 'question',
+        itemId: 'question-1',
+        runId: 'run-question-1',
+        toolCallId: 'tool-question-1',
+        payload: {
+          question: 'Pick one',
+          options: [{ label: 'A' }],
+          selectionMode: 'single_select',
+        },
+      },
+    });
+  });
+
+  it('commits a plan pending row before emitting the pending event', async () => {
+    const { harness, storage, agent } = setupHarness({
+      modes: [
+        { id: 'plan', agentId: 'default', transitionsTo: 'build' },
+        { id: 'build', agentId: 'default' },
+      ],
+      defaultModeId: 'plan',
+    });
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const eventRecords: Array<Promise<unknown>> = [];
+    session.subscribe(event => {
+      if (event.type === 'suspension_required' && event.kind === 'plan-approval') {
+        eventRecords.push(storage.loadSession({ sessionId: session.id }));
+      }
+    });
+
+    await session.message({ content: 'capture plan context', mode: 'plan' });
+    const slot = getHarnessSlot(agent.streamCalls);
+
+    await (slot.registerPlanApproval as any)({
+      planId: 'plan-1',
+      title: 'Plan title',
+      plan: 'Step 1',
+      runId: 'run-plan-1',
+      toolCallId: 'tool-plan-1',
+    });
+
+    expect(eventRecords).toHaveLength(1);
+    await expect(eventRecords[0]).resolves.toMatchObject({
+      pendingResume: {
+        kind: 'plan-approval',
+        itemId: 'plan-1',
+        runId: 'run-plan-1',
+        toolCallId: 'tool-plan-1',
+        modeId: 'plan',
+        transitionModeId: 'build',
+        payload: {
+          title: 'Plan title',
+          plan: 'Step 1',
+        },
+      },
+    });
+  });
+});

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -9,9 +9,9 @@
  * and state mutation, display snapshots, message listing, pending inbox
  * responses, permissions, code/workspace skills, subagents, goals, event
  * forwarding, abort, idle waiting, wakeup queue admission, and the core
- * admission/mutation primitives used by remote routes. Remote SDKs, full
- * channel routing, and request-context `registerQuestion` /
- * `registerPlanApproval` support remain follow-up lanes.
+ * admission/mutation primitives used by remote routes, plus request-context
+ * `registerQuestion` / `registerPlanApproval` pending registration. Remote
+ * SDKs and full channel routing remain follow-up lanes.
  *
  * Lifecycle states tracked here:
  *   - 'live'    — session is in the harness's live map and holds the lease.

--- a/packages/core/src/storage/domains/harness/inmemory.test.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { InMemoryDB } from '../inmemory-db';
 import type { HarnessStorageParentSessionUnavailableError } from './base';
 import {
+  HarnessStorageAttachmentInUseError,
+  HarnessStorageAttachmentUnavailableError,
   HarnessStorageChannelActionClaimConflictError,
   HarnessStorageChannelActionReceiptTransitionError,
   HarnessStorageChannelInboxClaimConflictError,
@@ -592,6 +594,59 @@ describe('InMemoryHarness admission storage contract', () => {
         await expect(fence.assertActive()).rejects.toBeInstanceOf(HarnessStorageThreadDeleteFenceConflictError);
       },
     );
+  });
+
+  it('keeps §15 attachment-reference admission atomic and delete-guarded', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    await storage.saveSession(sampleSession(), { ownerId: 'h', ifVersion: 0 });
+    const initial = await storage.loadSession({ sessionId: 'session-1' });
+    if (!initial) throw new Error('expected session');
+
+    await storage.saveAttachment({
+      sessionId: 'session-1',
+      attachmentId: 'attachment-1',
+      name: 'note.txt',
+      mimeType: 'text/plain',
+      source: 'preupload',
+      data: new Uint8Array([1, 2, 3]),
+    });
+    await expect(
+      storage.saveSessionWithAttachmentReferences(
+        { ...initial, state: { admitted: 'missing-ref' } },
+        { ownerId: 'h', ifVersion: initial.version },
+        [
+          { sessionId: 'session-1', attachmentId: 'attachment-1', source: 'queued_item', sourceId: 'queued-valid' },
+          { sessionId: 'session-1', attachmentId: 'missing', source: 'queued_item', sourceId: 'queued-missing' },
+        ],
+      ),
+    ).rejects.toBeInstanceOf(HarnessStorageAttachmentUnavailableError);
+    await expect(storage.loadSession({ sessionId: 'session-1' })).resolves.toMatchObject({
+      version: initial.version,
+      state: {},
+    });
+    await expect(
+      storage.listAttachmentReferences({ sessionId: 'session-1', attachmentId: 'attachment-1' }),
+    ).resolves.toEqual([]);
+
+    const saved = await storage.saveSessionWithAttachmentReferences(
+      { ...initial, state: { admitted: 'queued-ref' } },
+      { ownerId: 'h', ifVersion: initial.version },
+      [{ sessionId: 'session-1', attachmentId: 'attachment-1', source: 'queued_item', sourceId: 'queued-1' }],
+    );
+
+    expect(saved.version).toBe(initial.version + 1);
+    await expect(
+      storage.listAttachmentReferences({ sessionId: 'session-1', attachmentId: 'attachment-1' }),
+    ).resolves.toEqual([{ source: 'queued_item', sourceId: 'queued-1' }]);
+    await expect(
+      storage.deleteAttachment({ sessionId: 'session-1', attachmentId: 'attachment-1' }),
+    ).rejects.toBeInstanceOf(HarnessStorageAttachmentInUseError);
+    await expect(
+      storage.loadAttachment({ sessionId: 'session-1', attachmentId: 'attachment-1' }),
+    ).resolves.toMatchObject({
+      name: 'note.txt',
+      data: new Uint8Array([1, 2, 3]),
+    });
   });
 
   it('compacts terminal queue receipts into namespace-scoped tombstones', async () => {

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -15,6 +15,8 @@ import {
   TABLE_HARNESS_SESSIONS,
   TABLE_HARNESS_THREAD_DELETE_FENCES,
   TABLE_HARNESS_WAKEUPS,
+  HarnessStorageAttachmentInUseError,
+  HarnessStorageAttachmentUnavailableError,
   HarnessStorageChannelActionClaimConflictError,
   HarnessStorageChannelActionReceiptTransitionError,
   HarnessStorageChannelInboxClaimConflictError,
@@ -145,6 +147,58 @@ describe('HarnessLibSQL attachments', () => {
         },
       },
     );
+  });
+
+  it('keeps §15 attachment-reference admission atomic and delete-guarded', async () => {
+    await storage.saveSession(sampleSession(), { ownerId: 'h', ifVersion: 0 });
+    const initial = await storage.loadSession({ sessionId: 'session-1' });
+    if (!initial) throw new Error('expected session');
+
+    await storage.saveAttachment({
+      sessionId: 'session-1',
+      attachmentId: 'attachment-1',
+      name: 'note.txt',
+      mimeType: 'text/plain',
+      source: 'preupload',
+      data: new Uint8Array([1, 2, 3]),
+    });
+    await expect(
+      storage.saveSessionWithAttachmentReferences(
+        { ...initial, state: { admitted: 'missing-ref' } },
+        { ownerId: 'h', ifVersion: initial.version },
+        [
+          { sessionId: 'session-1', attachmentId: 'attachment-1', source: 'queued_item', sourceId: 'queued-valid' },
+          { sessionId: 'session-1', attachmentId: 'missing', source: 'queued_item', sourceId: 'queued-missing' },
+        ],
+      ),
+    ).rejects.toBeInstanceOf(HarnessStorageAttachmentUnavailableError);
+    await expect(storage.loadSession({ sessionId: 'session-1' })).resolves.toMatchObject({
+      version: initial.version,
+      state: {},
+    });
+    await expect(
+      storage.listAttachmentReferences({ sessionId: 'session-1', attachmentId: 'attachment-1' }),
+    ).resolves.toEqual([]);
+
+    const saved = await storage.saveSessionWithAttachmentReferences(
+      { ...initial, state: { admitted: 'queued-ref' } },
+      { ownerId: 'h', ifVersion: initial.version },
+      [{ sessionId: 'session-1', attachmentId: 'attachment-1', source: 'queued_item', sourceId: 'queued-1' }],
+    );
+
+    expect(saved.version).toBe(initial.version + 1);
+    await expect(
+      storage.listAttachmentReferences({ sessionId: 'session-1', attachmentId: 'attachment-1' }),
+    ).resolves.toEqual([{ source: 'queued_item', sourceId: 'queued-1' }]);
+    await expect(
+      storage.deleteAttachment({ sessionId: 'session-1', attachmentId: 'attachment-1' }),
+    ).rejects.toBeInstanceOf(HarnessStorageAttachmentInUseError);
+    await expect(
+      storage.loadAttachment({ sessionId: 'session-1', attachmentId: 'attachment-1' }),
+    ).resolves.toMatchObject({
+      name: 'note.txt',
+      data: new Uint8Array([1, 2, 3]),
+    });
   });
 
   it('backfills digest/source metadata when init sees the old attachment table shape', async () => {

--- a/stores/libsql/src/storage/index.test.ts
+++ b/stores/libsql/src/storage/index.test.ts
@@ -6,7 +6,7 @@ import {
 } from '@internal/storage-test-utils';
 import { createClient } from '@libsql/client';
 import { Mastra } from '@mastra/core/mastra';
-import { vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { DatasetsLibSQL } from './domains/datasets';
 import { ExperimentsLibSQL } from './domains/experiments';
@@ -33,6 +33,16 @@ const mastra = new Mastra({
 });
 
 createTestSuite(mastra.getStorage()!);
+
+describe('LibSQLStore domain wiring', () => {
+  it('initializes the favorites domain exposed by the composite store', async () => {
+    const store = new LibSQLStore({ id: 'libsql-favorites-wiring', url: 'file::memory:?cache=shared' });
+    await store.init();
+
+    expect(store.stores.favorites).toBeDefined();
+    await expect(store.getStore('favorites')).resolves.toBe(store.stores.favorites);
+  });
+});
 
 // Configuration validation tests
 createConfigValidationTests({

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -9,6 +9,7 @@ import { BlobsLibSQL } from './domains/blobs';
 import { ChannelsLibSQL } from './domains/channels';
 import { DatasetsLibSQL } from './domains/datasets';
 import { ExperimentsLibSQL } from './domains/experiments';
+import { FavoritesLibSQL } from './domains/favorites';
 import { HarnessLibSQL } from './domains/harness';
 import { MCPClientsLibSQL } from './domains/mcp-clients';
 import { MCPServersLibSQL } from './domains/mcp-servers';

--- a/stores/pg/src/storage/domains/harness/index.test.ts
+++ b/stores/pg/src/storage/domains/harness/index.test.ts
@@ -1,7 +1,12 @@
 import { randomUUID } from 'node:crypto';
 
 import { createSampleSessionRecord } from '@internal/storage-test-utils';
-import { HarnessStorageThreadDeleteFenceConflictError, TABLE_HARNESS_SESSION_EVENTS } from '@mastra/core/storage';
+import {
+  HarnessStorageAttachmentInUseError,
+  HarnessStorageAttachmentUnavailableError,
+  HarnessStorageThreadDeleteFenceConflictError,
+  TABLE_HARNESS_SESSION_EVENTS,
+} from '@mastra/core/storage';
 import { describe, expect, it, beforeAll, beforeEach, afterAll, vi } from 'vitest';
 
 import { exportSchemas, HarnessPG, PostgresStore } from '../..';
@@ -230,6 +235,61 @@ describe('HarnessPG', () => {
       elementType: 'citation-card',
       renderer: { id: 'citation-card', version: '2' },
       metadata: { doi: '10.1234/example' },
+    });
+  });
+
+  it('keeps §15 attachment-reference admission atomic and delete-guarded', async () => {
+    const harness = store.stores.harness;
+    expect(harness).toBeDefined();
+
+    await harness!.saveSession(createSampleSessionRecord(), { ownerId: 'h', ifVersion: 0 });
+    const initial = await harness!.loadSession({ sessionId: 'session-1' });
+    if (!initial) throw new Error('expected session');
+
+    await harness!.saveAttachment({
+      sessionId: 'session-1',
+      attachmentId: 'attachment-1',
+      name: 'note.txt',
+      mimeType: 'text/plain',
+      source: 'preupload',
+      data: new Uint8Array([1, 2, 3]),
+    });
+    await expect(
+      harness!.saveSessionWithAttachmentReferences(
+        { ...initial, state: { admitted: 'missing-ref' } },
+        { ownerId: 'h', ifVersion: initial.version },
+        [
+          { sessionId: 'session-1', attachmentId: 'attachment-1', source: 'queued_item', sourceId: 'queued-valid' },
+          { sessionId: 'session-1', attachmentId: 'missing', source: 'queued_item', sourceId: 'queued-missing' },
+        ],
+      ),
+    ).rejects.toBeInstanceOf(HarnessStorageAttachmentUnavailableError);
+    await expect(harness!.loadSession({ sessionId: 'session-1' })).resolves.toMatchObject({
+      version: initial.version,
+      state: {},
+    });
+    await expect(
+      harness!.listAttachmentReferences({ sessionId: 'session-1', attachmentId: 'attachment-1' }),
+    ).resolves.toEqual([]);
+
+    const saved = await harness!.saveSessionWithAttachmentReferences(
+      { ...initial, state: { admitted: 'queued-ref' } },
+      { ownerId: 'h', ifVersion: initial.version },
+      [{ sessionId: 'session-1', attachmentId: 'attachment-1', source: 'queued_item', sourceId: 'queued-1' }],
+    );
+
+    expect(saved.version).toBe(initial.version + 1);
+    await expect(
+      harness!.listAttachmentReferences({ sessionId: 'session-1', attachmentId: 'attachment-1' }),
+    ).resolves.toEqual([{ source: 'queued_item', sourceId: 'queued-1' }]);
+    await expect(
+      harness!.deleteAttachment({ sessionId: 'session-1', attachmentId: 'attachment-1' }),
+    ).rejects.toBeInstanceOf(HarnessStorageAttachmentInUseError);
+    await expect(
+      harness!.loadAttachment({ sessionId: 'session-1', attachmentId: 'attachment-1' }),
+    ).resolves.toMatchObject({
+      name: 'note.txt',
+      data: new Uint8Array([1, 2, 3]),
     });
   });
 


### PR DESCRIPTION
Linear: PF-376

## Scope

- Added core §15 acceptance coverage for Harness v1 pending question/plan registration using the live request-context slot and verifying the pending row is durable before `suspension_required` is emitted.
- Added export-map acceptance coverage for `@mastra/core/harness/v1` so the v1 entry remains distinct from the legacy `./harness` export.
- Added attachment-reference admission invariants across in-memory, LibSQL, and PG harness storage: mixed valid+missing references fail atomically, session state/version is unchanged, valid refs are not partially persisted, and referenced attachments cannot be deleted.
- Fixed LibSQL composite store wiring so the existing favorites domain is imported, initialized, and available from `getStore('favorites')`; this is covered by a focused LibSQL test and changeset.
- Updated the Harness v1 session source comment so request-context pending registration is no longer listed as a follow-up lane.

## Coordination

- Open PR overlap check before implementation: mbenhamd/mastra#146 is the only open PR. It touches PF-374 worker follow-up paths (`packages/core/src/mastra/index.ts`, worker tests, wakeup changeset) and does not overlap this PF-376 diff.
- This PR does not implement new storage/server/channel behavior; it closes core acceptance/test evidence and one LibSQL build wiring defect found while running the acceptance checks.

## Validation

- `timeout 180 pnpm --filter ./packages/core exec vitest run src/harness/v1/session.tool-context.test.ts src/harness/v1/export-map.test.ts src/storage/domains/harness/inmemory.test.ts` passed: 76 tests.
- `timeout 180 pnpm --filter ./stores/libsql exec vitest run src/storage/domains/harness/index.test.ts src/storage/index.test.ts` passed: 598 passed, 17 skipped.
- `pnpm --filter ./packages/core exec eslint src/harness/v1/session.ts src/harness/v1/session.tool-context.test.ts src/harness/v1/export-map.test.ts src/storage/domains/harness/inmemory.test.ts` passed.
- `pnpm --filter ./stores/libsql exec eslint src/storage/index.ts src/storage/index.test.ts src/storage/domains/harness/index.test.ts` passed.
- `pnpm --filter ./stores/pg exec eslint src/storage/domains/harness/index.test.ts` passed.
- `pnpm --filter ./packages/core check` passed.
- `timeout 180 pnpm --filter ./stores/libsql run build:lib` passed.
- `git diff --check` / `git diff --cached --check` passed.
- Local Codex review pass 1: no findings.
- Local Codex review pass 2: no findings; reran the focused core and LibSQL tests above.
- CodeRabbit CLI: first local run returned one valid changeset wording finding; fixed it. The follow-up CLI run produced no additional findings before the 5 minute timeout, so GitHub app review is still requested for PR review evidence.

## Not Run / Limitations

- `timeout 180 pnpm --filter ./stores/pg exec vitest run src/storage/domains/harness/index.test.ts` was attempted earlier and blocked by local PG not running: `ECONNREFUSED 127.0.0.1:5434`.
- `timeout 180 pnpm --filter ./stores/pg run build:lib` was attempted earlier and blocked by existing `_test-utils` type errors outside this PG harness test change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR adds comprehensive tests for Harness core functionality (like handling pending questions and plan approvals), ensures the Harness v1 export is properly distinct and exported, and validates that attachments used by sessions can't be deleted and references are handled correctly across different databases. It also fixes a bug where the favorites store wasn't available in LibSQL.

## Summary

### Test Coverage
- **Harness v1 export mappings**: Added tests validating that `@mastra/core/harness/v1` and `@mastra/core/harness` point to the correct v1 and non-v1 dist entrypoints with proper import/require targets and types.
- **Pending registration acceptance**: Added tests for HarnessRequestContext verifying that registering pending questions and plan approvals correctly persists state and emits `suspension_required` events with expected payloads including kind, itemId, runId, toolCallId, modeId, transitionModeId, and relevant question/plan data.

### Storage Invariants
- **Attachment-reference admission**: Added tests across in-memory, LibSQL, and PG storage backends validating:
  - Atomic failure: mixed valid+missing attachment references fail atomically with `HarnessStorageAttachmentUnavailableError`
  - Session durability: session state/version remains unchanged on failed admission
  - No partial persistence: valid references are not partially persisted on failure
  - Delete protection: referenced attachments cannot be deleted while in use (rejected with `HarnessStorageAttachmentInUseError`)

### Bug Fixes
- **LibSQL composite store wiring**: Fixed the missing import and initialization of `FavoritesLibSQL` domain so it is properly available via `getStore('favorites')`, verified by focused test.

### Documentation
- Updated Harness v1 session source comment to reflect request-context pending registration support (`registerQuestion`/`registerPlanApproval`) as follow-up lanes.

### Changeset
- Added `@mastra/libsql` (patch) entry documenting the favorites store availability fix.

### Validation
- Core harness tests: 76 passed
- LibSQL store tests: 598 passed, 17 skipped
- ESLint and type checks: passed
- LibSQL build: passed
- No findings from local code reviews

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->