### PR TITLE
[PF-378] Add channel acceptance coverage

### DIFF
--- a/packages/core/src/harness/v1/harness.test.ts
+++ b/packages/core/src/harness/v1/harness.test.ts
@@ -26,6 +26,7 @@ import type {
 } from '../../storage/domains/harness';
 import {
   HarnessStorage,
+  HarnessStorageChannelOutboxClaimConflictError,
   HarnessStorageDeleteGuardConflictError,
   HarnessStorageVersionConflictError,
 } from '../../storage/domains/harness';
@@ -1075,6 +1076,48 @@ describe('Harness v1 — construction', () => {
     expect(delivered).toEqual(['outbox-key-1']);
   });
 
+  it('uses canonical payload hashes for channel outbox idempotency', async () => {
+    const storage = makeStorage();
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      sessions: { storage },
+      channels: {
+        support: makeHarnessChannelConfig({ bindingId: 'support-binding' }),
+      },
+    });
+    new Mastra({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+      channels: { slack: makeChannelProvider('slack') },
+      harnesses: { primary: harness },
+    });
+
+    await expect(
+      harness.channels.enqueueOutbox(
+        channelOutboxInput({
+          payload: { b: 2, a: 1 },
+        }),
+      ),
+    ).resolves.toMatchObject({ duplicate: false, conflict: false });
+    await expect(
+      harness.channels.enqueueOutbox(
+        channelOutboxInput({
+          idempotencyKey: 'outbox-key-1',
+          payload: { a: 1, b: 2 },
+        }),
+      ),
+    ).resolves.toMatchObject({ duplicate: true, conflict: false });
+    await expect(
+      harness.channels.enqueueOutbox(
+        channelOutboxInput({
+          idempotencyKey: 'outbox-key-1',
+          payload: { a: 1, b: 2, c: null },
+        }),
+      ),
+    ).resolves.toMatchObject({ duplicate: true, conflict: true });
+  });
+
   it('returns session-scoped channel diagnostics without leaking provider payloads', async () => {
     const storage = makeStorage();
     const harness = new Harness({
@@ -1144,6 +1187,16 @@ describe('Harness v1 — construction', () => {
     expect(wire).not.toContain('secret');
     expect(wire).not.toContain('foreign-inbox');
     expect(wire).not.toContain('claim-secret');
+    await expect(
+      storage.claimChannelOutbox({
+        harnessName: 'primary',
+        channelId: 'support',
+        claimId: 'post-diagnostics',
+        limit: 10,
+        now: Date.now(),
+        claimTtlMs: 1000,
+      }),
+    ).resolves.toEqual([expect.objectContaining({ id: 'outbox-1', claimId: 'post-diagnostics' })]);
   });
 
   it('marks channel diagnostics truncated only when visible sessions exceed the cap', async () => {
@@ -1302,6 +1355,95 @@ describe('Harness v1 — construction', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('does not call the outbox provider or mutate after pre-delivery claim ownership is lost', async () => {
+    const db = new InMemoryDB();
+    const storage = new InMemoryHarness({ db });
+    const deliver = vi.fn(async () => ({ providerMessageId: 'provider-message-1' }));
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      sessions: { storage },
+      channels: {
+        support: makeHarnessChannelConfig({
+          adapter: { deliver },
+        }),
+      },
+    });
+    new Mastra({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+      channels: { slack: makeChannelProvider('slack') },
+      harnesses: { primary: harness },
+    });
+    const enqueued = await harness.channels.enqueueOutbox(channelOutboxInput());
+    const outboxItemId = enqueued.outboxItemId;
+    const dispatchNow = Date.now();
+    const claimTtlMs = 1_000;
+    const competingClaimId = 'claim-competing';
+    const competingClaimExpiresAt = dispatchNow + claimTtlMs * 5;
+    const renewSpy = vi.spyOn(storage, 'renewChannelOutboxClaim').mockImplementationOnce(async input => {
+      const claimed = db.harnessChannelOutbox.get(outboxItemId);
+      expect(claimed).toMatchObject({ status: 'claimed', claimId: 'claim-lost' });
+      db.harnessChannelOutbox.set(outboxItemId, {
+        ...claimed!,
+        claimId: competingClaimId,
+        claimExpiresAt: competingClaimExpiresAt,
+        updatedAt: dispatchNow + 1,
+      });
+      throw new HarnessStorageChannelOutboxClaimConflictError(outboxItemId, input.claimId);
+    });
+
+    await expect(
+      harness.channels.dispatchOutbox({ channelId: 'support', claimId: 'claim-lost', now: dispatchNow, claimTtlMs }),
+    ).resolves.toEqual({
+      claimed: 1,
+      sent: 0,
+      failed: 1,
+      dead: 0,
+      items: [
+        {
+          outboxItemId: expect.any(String),
+          status: 'failed',
+          error: {
+            code: 'unknown',
+            message: `Channel outbox item "${outboxItemId}" is not held by claim "claim-lost"; claim was lost before failure could be recorded`,
+          },
+        },
+      ],
+    });
+    expect(renewSpy).toHaveBeenCalledOnce();
+    expect(deliver).not.toHaveBeenCalled();
+    const retainedByCompetingClaim = db.harnessChannelOutbox.get(outboxItemId);
+    expect(retainedByCompetingClaim).toMatchObject({
+      status: 'claimed',
+      claimId: competingClaimId,
+      claimExpiresAt: competingClaimExpiresAt,
+    });
+    expect(retainedByCompetingClaim?.sentAt).toBeUndefined();
+    expect(retainedByCompetingClaim?.failedAt).toBeUndefined();
+    expect(retainedByCompetingClaim?.lastError).toBeUndefined();
+    await expect(
+      storage.claimChannelOutbox({
+        harnessName: 'primary',
+        channelId: 'support',
+        claimId: 'early-recovery',
+        limit: 10,
+        now: dispatchNow + claimTtlMs + 1,
+        claimTtlMs: 1000,
+      }),
+    ).resolves.toEqual([]);
+    await expect(
+      storage.claimChannelOutbox({
+        harnessName: 'primary',
+        channelId: 'support',
+        claimId: 'recovery',
+        limit: 10,
+        now: competingClaimExpiresAt + 1,
+        claimTtlMs: 1000,
+      }),
+    ).resolves.toEqual([expect.objectContaining({ id: outboxItemId, status: 'claimed', claimId: 'recovery' })]);
   });
 
   it('records terminal provider failures on outbox dispatch', async () => {

--- a/packages/core/src/storage/domains/harness/inmemory.test.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.test.ts
@@ -1658,6 +1658,30 @@ describe('InMemoryHarness channel outbox ledger', () => {
       duplicate: true,
       conflict: true,
     });
+    await expect(
+      storage.enqueueChannelOutbox(
+        sampleChannelOutbox({
+          id: 'outbox-operation-conflict',
+          operationKind: 'message-edit',
+        }),
+      ),
+    ).resolves.toEqual({
+      outboxItemId: 'outbox-1',
+      duplicate: true,
+      conflict: true,
+    });
+    await expect(
+      storage.enqueueChannelOutbox(
+        sampleChannelOutbox({
+          id: 'outbox-delivery-semantics-conflict',
+          deliverySemantics: 'at-least-once',
+        }),
+      ),
+    ).resolves.toEqual({
+      outboxItemId: 'outbox-1',
+      duplicate: true,
+      conflict: true,
+    });
   });
 
   it('claims at most the oldest due row for one binding while allowing different bindings', async () => {


### PR DESCRIPTION
Linear: PF-378

This is a tests-only Harness v1 acceptance slice for channel/outbox/diagnostics behavior.

Covers:
- Canonical payload hashing through the public channel outbox API: equivalent object key order dedupes, changed payload conflicts.
- Channel outbox idempotency conflicts when operation kind or delivery semantics change under the same idempotency key.
- Channel diagnostics stay read-only and redacted by proving the outbox row remains claimable after diagnostics.
- Pre-delivery outbox claim-loss safety: a competing claim can take ownership before renewal; the stale dispatcher does not call the provider, does not mark sent/failed, and the row remains recoverable after the competing claim expires.

Coordination:
- PF-378 is related to PF-374/PF-376. PR #146 overlaps wakeup worker readiness/shutdown files, so this PR intentionally keeps to channel/outbox/diagnostics acceptance coverage and leaves wakeup-worker-specific assertions ordered behind #146. PR #148 is adjacent §15 core acceptance coverage but does not overlap these files.

Validation:
- pnpm install --offline
- pnpm --filter @internal/llm-recorder run build
- pnpm --filter @internal/test-utils run build
- pnpm --filter @internal/core run build:lib
- pnpm --filter @internal/ai-sdk-v5 --filter @internal/ai-v6 run build
- pnpm --filter @internal/ai-sdk-v4 run build
- pnpm --filter ./packages/schema-compat run build
- pnpm --filter @internal/external-types run build:lib
- pnpm --filter @internal/external-types run build
- timeout 180 pnpm --filter ./packages/core exec vitest run src/harness/v1/harness.test.ts src/storage/domains/harness/inmemory.test.ts
- pnpm --filter ./packages/core exec eslint src/harness/v1/harness.test.ts src/storage/domains/harness/inmemory.test.ts
- timeout 180 pnpm --filter ./packages/core check
- git diff --check
- Local Codex review pass 1: no findings after fixing claim-loss simulation.
- Local Codex review pass 2: no findings.
- CodeRabbit CLI: no findings.

No changeset: tests-only, no runtime or package behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds test coverage to verify that a messaging system correctly detects duplicate messages (even if their fields are in different order), prevents conflicts when multiple workers try to process the same message simultaneously, and ensures messages remain safe and recoverable if a worker loses control of a message mid-delivery.

## Changes

### Test: Channel outbox idempotency with canonical payload hashing
**File:** `packages/core/src/harness/v1/harness.test.ts`

Added a new test verifying that the channel outbox deduplication mechanism uses canonical payload hashing. The test confirms that enqueueing with the same semantic payload but different key order is treated as a duplicate without conflict, while adding a non-canonical change (e.g., adding a `c: null` field) triggers both duplicate and conflict behavior.

### Test: Channel diagnostics with post-dispatch outbox claiming
**File:** `packages/core/src/harness/v1/harness.test.ts`

Extended the channel diagnostics test to assert that the outbox row remains claimable after diagnostics operations. The test now verifies post-diagnostics outbox claiming via `storage.claimChannelOutbox` with a short TTL and validates that the claimed outbox item is the expected one with the new `claimId`, proving diagnostics are read-only.

### Test: Pre-delivery claim-loss safety regression
**File:** `packages/core/src/harness/v1/harness.test.ts`

Added a regression test ensuring `dispatchOutbox` respects claim ownership and does not call the outbox provider nor mutate the outbox item once pre-delivery claim ownership is lost. The test:
- Forces `renewChannelOutboxClaim` to throw a claim-conflict error (simulating a competing claim taking ownership)
- Asserts the dispatched item is recorded as a failed terminal outcome with the specific error message
- Verifies the outbox row is retained by the competing claim without any sent/failed fields written
- Confirms that early recovery claims return empty until TTL expiry and then succeed (row is recoverable)

### Test: Outbox deduplication conflicts for operation kind and delivery semantics
**File:** `packages/core/src/storage/domains/harness/inmemory.test.ts`

Added two new outbox deduplication conflict test cases in the in-memory harness channel outbox ledger:
- One for `operationKind: 'message-edit'`
- One for `deliverySemantics: 'at-least-once'`

Both assertions expect the enqueued outbox item to be marked as duplicate and conflict while retaining the original `outboxItemId: 'outbox-1'`.

## Testing & Validation

- Multiple package builds (pnpm) across internal packages and SDKs
- Test suite run via vitest on harness and in-memory storage tests (180s timeout)
- ESLint and typecheck validation (pnpm --filter ./packages/core check)
- git diff --check
- Two local Codex review passes after fixing claim-loss simulation
- CodeRabbit CLI: no findings

**Note:** Tests-only change; no changeset included as there is no runtime or package behavior change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->