### PR TITLE
[PF-545] Fail closed agent network FGA ownership

### DIFF
--- a/.changeset/pf-545-agent-network-fga.md
+++ b/.changeset/pf-545-agent-network-fga.md
@@ -3,9 +3,9 @@
 "@mastra/server": patch
 ---
 
-Agent network execution now fails closed when Fine-Grained Authorization (FGA) is enabled.
+Agent network execution now fails closed when Fine-Grained Authorization is enabled.
 
-When FGA is enabled, `agent.network()` calls must include a trusted resource id in `requestContext`. Calls without that resource id are denied. If FGA is disabled, no caller changes are required.
+When Fine-Grained Authorization is enabled, `agent.network()` calls must include a trusted resource id in `requestContext`. Calls without that resource id are denied. If Fine-Grained Authorization is disabled, no caller changes are required.
 
 ```ts
 import { MASTRA_RESOURCE_ID_KEY, RequestContext } from '@mastra/core/request-context';

--- a/.changeset/pf-545-agent-network-fga.md
+++ b/.changeset/pf-545-agent-network-fga.md
@@ -1,0 +1,22 @@
+---
+"@mastra/core": patch
+"@mastra/server": patch
+---
+
+Agent network execution now fails closed when Fine-Grained Authorization (FGA) is enabled.
+
+When FGA is enabled, `agent.network()` calls must include a trusted resource id in `requestContext`. Calls without that resource id are denied. If FGA is disabled, no caller changes are required.
+
+```ts
+import { MASTRA_RESOURCE_ID_KEY, RequestContext } from '@mastra/core/request-context';
+
+const requestContext = new RequestContext();
+requestContext.set('user', { id: 'user-123' });
+requestContext.set(MASTRA_RESOURCE_ID_KEY, 'resource-456');
+
+await agent.network('Research this request', {
+  requestContext,
+});
+```
+
+Network resume and network tool-call approval routes now use the same request context ownership checks.

--- a/packages/core/src/agent/__tests__/agent-fga.test.ts
+++ b/packages/core/src/agent/__tests__/agent-fga.test.ts
@@ -343,6 +343,40 @@ describe('Agent FGA checks', () => {
       expect(getMemory).not.toHaveBeenCalled();
       expect(fgaProvider.require).not.toHaveBeenCalled();
     });
+
+    it('should authorize merged streamUntilIdle options when caller memory overrides defaults', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'default-user', organizationMembershipId: 'default-om' });
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: {} as any,
+        defaultOptions: {
+          requestContext: requestContext as any,
+          memory: { resource: 'default-resource', thread: 'default-thread' },
+        },
+      });
+      (agent as any).__registerMastra(mastra);
+
+      try {
+        await agent.streamUntilIdle('test', {
+          memory: { resource: 'caller-resource', thread: 'caller-thread' },
+        });
+      } catch {
+        // Expected to fail due to no real model.
+      }
+
+      expect(fgaProvider.require).toHaveBeenCalledTimes(1);
+      expectAgentExecutionRequire(
+        fgaProvider,
+        { id: 'default-user', organizationMembershipId: 'default-om' },
+        { resourceId: 'caller-resource' },
+      );
+    });
   });
 
   describe('stream()', () => {
@@ -1402,6 +1436,41 @@ describe('Agent FGA checks', () => {
       expectAgentExecutionRequire(fgaProvider, { id: 'default-user', organizationMembershipId: 'default-om' }, {
         runId: 'missing-run-id',
       });
+    });
+
+    it('should authorize merged resumeStreamUntilIdle options when caller memory overrides defaults', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'default-user', organizationMembershipId: 'default-om' });
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: {} as any,
+        defaultOptions: {
+          requestContext: requestContext as any,
+          memory: { resource: 'default-resource', thread: 'default-thread' },
+        },
+      });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(
+        agent.resumeStreamUntilIdle(
+          { approved: true },
+          { runId: 'missing-run-id', memory: { resource: 'caller-resource', thread: 'caller-thread' } },
+        ),
+      ).rejects.toMatchObject({
+        id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND',
+      });
+
+      expect(fgaProvider.require).toHaveBeenCalledTimes(1);
+      expectAgentExecutionRequire(
+        fgaProvider,
+        { id: 'default-user', organizationMembershipId: 'default-om' },
+        { resourceId: 'caller-resource', runId: 'missing-run-id' },
+      );
     });
 
     it('should enforce run owner checks through resumeStreamUntilIdle', async () => {

--- a/packages/core/src/agent/__tests__/agent-fga.test.ts
+++ b/packages/core/src/agent/__tests__/agent-fga.test.ts
@@ -121,6 +121,29 @@ function expectNoResumeOwnerError(error: unknown) {
   }
 }
 
+function expectAgentExecutionRequire(
+  fgaProvider: IFGAProvider,
+  user: unknown,
+  options: { requestContext?: unknown; resourceId?: string; runId?: string } = {},
+) {
+  expect(fgaProvider.require).toHaveBeenCalledWith(
+    user,
+    expect.objectContaining({
+      resource: { type: 'agent', id: 'test-agent' },
+      permission: 'agents:execute',
+      context: expect.objectContaining({
+        requestContext: options.requestContext ?? expect.any(RequestContext),
+        resourceId: options.resourceId,
+        metadata: expect.objectContaining({
+          agentId: 'test-agent',
+          agentName: 'test-agent',
+          ...(options.runId === undefined ? {} : { runId: options.runId }),
+        }),
+      }),
+    }),
+  );
+}
+
 describe('Agent FGA checks', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -136,6 +159,7 @@ describe('Agent FGA checks', () => {
 
       const requestContext = new RequestContext();
       requestContext.set('user', { id: 'user-1', organizationMembershipId: 'om-1' });
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'resource-a');
 
       try {
         await agent.generate('test', { requestContext: requestContext as any });
@@ -145,7 +169,15 @@ describe('Agent FGA checks', () => {
 
       expect(fgaProvider.require).toHaveBeenCalledWith(
         { id: 'user-1', organizationMembershipId: 'om-1' },
-        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+        expect.objectContaining({
+          resource: { type: 'agent', id: 'test-agent' },
+          permission: 'agents:execute',
+          context: expect.objectContaining({
+            requestContext,
+            resourceId: 'resource-a',
+            metadata: expect.objectContaining({ agentId: 'test-agent', agentName: 'test-agent' }),
+          }),
+        }),
       );
     });
 
@@ -228,6 +260,7 @@ describe('Agent FGA checks', () => {
       const mastra = createMockMastra(fgaProvider);
       const requestContext = new RequestContext();
       requestContext.set('user', { id: 'default-user', organizationMembershipId: 'default-om' });
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'resource-a');
 
       const agent = new Agent({
         id: 'test-agent',
@@ -246,7 +279,15 @@ describe('Agent FGA checks', () => {
 
       expect(fgaProvider.require).toHaveBeenCalledWith(
         { id: 'default-user', organizationMembershipId: 'default-om' },
-        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+        expect.objectContaining({
+          resource: { type: 'agent', id: 'test-agent' },
+          permission: 'agents:execute',
+          context: expect.objectContaining({
+            requestContext: expect.any(RequestContext),
+            resourceId: 'resource-a',
+            metadata: expect.objectContaining({ agentId: 'test-agent', agentName: 'test-agent' }),
+          }),
+        }),
       );
       expect(fgaProvider.require).toHaveBeenCalledTimes(1);
     });
@@ -321,10 +362,7 @@ describe('Agent FGA checks', () => {
         // Expected to fail due to no real model
       }
 
-      expect(fgaProvider.require).toHaveBeenCalledWith(
-        { id: 'user-1', organizationMembershipId: 'om-1' },
-        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
-      );
+      expectAgentExecutionRequire(fgaProvider, { id: 'user-1', organizationMembershipId: 'om-1' }, { requestContext });
     });
 
     it('should throw FGADeniedError when FGA check fails in stream', async () => {
@@ -386,10 +424,7 @@ describe('Agent FGA checks', () => {
         // Expected to fail due to no real model.
       }
 
-      expect(fgaProvider.require).toHaveBeenCalledWith(
-        { id: 'default-user', organizationMembershipId: 'default-om' },
-        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
-      );
+      expectAgentExecutionRequire(fgaProvider, { id: 'default-user', organizationMembershipId: 'default-om' });
     });
 
     it('should reject default request contexts without users when FGA is configured', async () => {
@@ -445,10 +480,7 @@ describe('Agent FGA checks', () => {
 
       await agent.generateLegacy('test', { requestContext: requestContext as any });
 
-      expect(fgaProvider.require).toHaveBeenCalledWith(
-        { id: 'user-1', organizationMembershipId: 'om-1' },
-        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
-      );
+      expectAgentExecutionRequire(fgaProvider, { id: 'user-1', organizationMembershipId: 'om-1' }, { requestContext });
     });
 
     it('should fail closed when FGA is configured and no user is present in requestContext', async () => {
@@ -550,9 +582,10 @@ describe('Agent FGA checks', () => {
 
       await agent.generateLegacy('test', { requestContext: explicitRequestContext as any });
 
-      expect(fgaProvider.require).toHaveBeenCalledWith(
+      expectAgentExecutionRequire(
+        fgaProvider,
         { id: 'explicit-user', organizationMembershipId: 'explicit-om' },
-        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+        { requestContext: explicitRequestContext },
       );
       expect(fgaProvider.require).toHaveBeenCalledTimes(1);
     });
@@ -574,10 +607,7 @@ describe('Agent FGA checks', () => {
 
       await agent.generateLegacy('test');
 
-      expect(fgaProvider.require).toHaveBeenCalledWith(
-        { id: 'default-user', organizationMembershipId: 'default-om' },
-        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
-      );
+      expectAgentExecutionRequire(fgaProvider, { id: 'default-user', organizationMembershipId: 'default-om' });
       expect(fgaProvider.require).toHaveBeenCalledTimes(1);
     });
 
@@ -632,10 +662,7 @@ describe('Agent FGA checks', () => {
       const stream = await agent.streamLegacy('test', { requestContext: requestContext as any });
       await stream.consumeStream();
 
-      expect(fgaProvider.require).toHaveBeenCalledWith(
-        { id: 'user-1', organizationMembershipId: 'om-1' },
-        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
-      );
+      expectAgentExecutionRequire(fgaProvider, { id: 'user-1', organizationMembershipId: 'om-1' }, { requestContext });
     });
 
     it('should fail closed when FGA is configured and no user is present in requestContext', async () => {
@@ -688,9 +715,10 @@ describe('Agent FGA checks', () => {
       const stream = await agent.streamLegacy('test', { requestContext: explicitRequestContext as any });
       await stream.consumeStream();
 
-      expect(fgaProvider.require).toHaveBeenCalledWith(
+      expectAgentExecutionRequire(
+        fgaProvider,
         { id: 'explicit-user', organizationMembershipId: 'explicit-om' },
-        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+        { requestContext: explicitRequestContext },
       );
       expect(fgaProvider.require).toHaveBeenCalledTimes(1);
     });
@@ -713,10 +741,7 @@ describe('Agent FGA checks', () => {
       const stream = await agent.streamLegacy('test');
       await stream.consumeStream();
 
-      expect(fgaProvider.require).toHaveBeenCalledWith(
-        { id: 'default-user', organizationMembershipId: 'default-om' },
-        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
-      );
+      expectAgentExecutionRequire(fgaProvider, { id: 'default-user', organizationMembershipId: 'default-om' });
       expect(fgaProvider.require).toHaveBeenCalledTimes(1);
     });
 
@@ -753,6 +778,329 @@ describe('Agent FGA checks', () => {
     });
   });
 
+  describe('network()', () => {
+    it('should reject missing users when FGA is configured', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const model = createMockModel();
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.network('test')).rejects.toThrow(FGADeniedError);
+      expect(fgaProvider.require).not.toHaveBeenCalled();
+      expect(model.doGenerateCalls).toHaveLength(0);
+    });
+
+    it('should call FGA provider when request context user is provided', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1', organizationMembershipId: 'om-1' });
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'resource-a');
+
+      try {
+        await agent.network('test', { requestContext: requestContext as any });
+      } catch {
+        // Expected to fail due to no real model.
+      }
+
+      expect(fgaProvider.require).toHaveBeenCalledWith(
+        { id: 'user-1', organizationMembershipId: 'om-1' },
+        expect.objectContaining({
+          resource: { type: 'agent', id: 'test-agent' },
+          permission: 'agents:execute',
+          context: expect.objectContaining({
+            requestContext,
+            resourceId: 'resource-a',
+            metadata: expect.objectContaining({ agentId: 'test-agent', agentName: 'test-agent' }),
+          }),
+        }),
+      );
+    });
+
+    it('should authorize the effective request context from default network options', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'default-user', organizationMembershipId: 'default-om' });
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'resource-a');
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: {} as any,
+        defaultNetworkOptions: { requestContext: requestContext as any },
+      });
+      (agent as any).__registerMastra(mastra);
+
+      try {
+        await agent.network('test');
+      } catch {
+        // Expected to fail due to no real model.
+      }
+
+      expect(fgaProvider.require).toHaveBeenCalledWith(
+        { id: 'default-user', organizationMembershipId: 'default-om' },
+        expect.objectContaining({
+          resource: { type: 'agent', id: 'test-agent' },
+          permission: 'agents:execute',
+          context: expect.objectContaining({
+            requestContext: expect.any(RequestContext),
+            resourceId: 'resource-a',
+            metadata: expect.objectContaining({ agentId: 'test-agent', agentName: 'test-agent' }),
+          }),
+        }),
+      );
+      expect(fgaProvider.require).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fail closed before starting a network run when FGA cannot verify a resource owner', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1', organizationMembershipId: 'om-1' });
+
+      await expect(agent.network('test', { requestContext: requestContext as any })).rejects.toMatchObject({
+        id: 'AGENT_NETWORK_OWNER_UNVERIFIED',
+      });
+      expect(fgaProvider.require).not.toHaveBeenCalled();
+    });
+
+    it('should not treat caller-controlled network memory resource as a verified FGA owner', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1', organizationMembershipId: 'om-1' });
+
+      await expect(
+        agent.network('test', {
+          requestContext: requestContext as any,
+          memory: { resource: 'caller-controlled-resource', thread: 'thread-a' },
+        }),
+      ).rejects.toMatchObject({
+        id: 'AGENT_NETWORK_OWNER_UNVERIFIED',
+      });
+      expect(fgaProvider.require).not.toHaveBeenCalled();
+    });
+
+    it('should not use caller-controlled network memory thread when FGA has no trusted context thread', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const getThreadById = vi.fn(async ({ threadId }: { threadId: string }) => {
+        if (threadId === 'caller-thread') {
+          throw new Error('caller-controlled thread should not be used');
+        }
+        return null;
+      });
+      const memory = {
+        hasOwnStorage: true,
+        __registerMastra: vi.fn(),
+        getConfig: vi.fn(() => ({})),
+        getThreadById,
+        createThread: vi.fn(async ({ threadId, resourceId }: { threadId: string; resourceId: string }) => ({
+          id: threadId,
+          resourceId,
+          title: 'Network Thread',
+          metadata: {},
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        })),
+        saveMessages: vi.fn(async () => undefined),
+        getMergedThreadConfig: vi.fn(() => ({})),
+      };
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: {} as any,
+        memory: memory as any,
+      });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1', organizationMembershipId: 'om-1' });
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'resource-a');
+
+      await agent.network('test', {
+        requestContext: requestContext as any,
+        runId: 'caller-thread',
+        memory: { resource: 'resource-a', thread: 'caller-thread' },
+      });
+
+      expect(getThreadById).toHaveBeenCalledWith({ threadId: 'test-run-id' });
+      expect(getThreadById).not.toHaveBeenCalledWith({ threadId: 'caller-thread' });
+    });
+  });
+
+  describe('network resume helpers', () => {
+    it('should reject missing users in resumeNetwork before loading network resume state', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const getStorage = vi.fn(() => ({
+        getStore: vi.fn(() => ({
+          loadWorkflowSnapshot: vi.fn(),
+        })),
+      }));
+      const mastra = createMockMastra(fgaProvider, getStorage);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.resumeNetwork({ approved: true }, { runId: 'missing-run-id' })).rejects.toThrow(
+        FGADeniedError,
+      );
+      expect(getStorage).not.toHaveBeenCalled();
+      expect(fgaProvider.require).not.toHaveBeenCalled();
+    });
+
+    it('should reject missing users in network approval helpers when FGA is configured', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      await expect(agent.approveNetworkToolCall({ runId: 'missing-run-id' })).rejects.toThrow(FGADeniedError);
+      await expect(agent.declineNetworkToolCall({ runId: 'missing-run-id' })).rejects.toThrow(FGADeniedError);
+      expect(fgaProvider.require).not.toHaveBeenCalled();
+    });
+
+    it('should reject denied network resume users before loading network resume state', async () => {
+      const fgaProvider = createMockFGAProvider(false);
+      const getStorage = vi.fn(() => ({
+        getStore: vi.fn(() => ({
+          loadWorkflowSnapshot: vi.fn(),
+        })),
+      }));
+      const mastra = createMockMastra(fgaProvider, getStorage);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'resource-a');
+
+      await expect(
+        agent.resumeNetwork({ approved: true }, { runId: 'missing-run-id', requestContext: requestContext as any }),
+      ).rejects.toThrow(FGADeniedError);
+      expect(getStorage).not.toHaveBeenCalled();
+    });
+
+    it('should reject callers whose resource does not own the suspended network run', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const { getStorage, workflowsStore } = createWorkflowRunStorage({ resourceId: 'resource-b' });
+      const mastra = createMockMastra(fgaProvider, getStorage);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'resource-a');
+
+      await expect(
+        agent.resumeNetwork({ approved: true }, { runId: 'suspended-run-id', requestContext: requestContext as any }),
+      ).rejects.toMatchObject({ id: 'AGENT_RESUME_OWNER_MISMATCH' });
+      expect(workflowsStore.getWorkflowRunById).toHaveBeenCalledWith({
+        workflowName: 'agent-loop-main-workflow',
+        runId: 'suspended-run-id',
+      });
+    });
+
+    it('should fail closed when FGA is configured and caller resource is missing for an owned network run', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const { getStorage } = createWorkflowRunStorage({ resourceId: 'resource-b' });
+      const mastra = createMockMastra(fgaProvider, getStorage);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+
+      await expect(
+        agent.resumeNetwork({ approved: true }, { runId: 'suspended-run-id', requestContext: requestContext as any }),
+      ).rejects.toMatchObject({ id: 'AGENT_RESUME_OWNER_UNVERIFIED' });
+      expect(getStorage).not.toHaveBeenCalled();
+    });
+
+    it('should fail closed when FGA is configured and the persisted network run has no owner', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const { getStorage } = createWorkflowRunStorage({ resourceId: undefined });
+      const mastra = createMockMastra(fgaProvider, getStorage);
+
+      const agent = new Agent({ id: 'test-agent', name: 'test-agent', instructions: 'test', model: {} as any });
+      (agent as any).__registerMastra(mastra);
+
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'user-1' });
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'resource-a');
+
+      await expect(
+        agent.resumeNetwork({ approved: true }, { runId: 'suspended-run-id', requestContext: requestContext as any }),
+      ).rejects.toMatchObject({ id: 'AGENT_RESUME_PERSISTED_RUN_NO_OWNER' });
+    });
+
+    it('should authorize approval helpers with the default network request context', async () => {
+      const fgaProvider = createMockFGAProvider(true);
+      const mastra = createMockMastra(fgaProvider);
+      const requestContext = new RequestContext();
+      requestContext.set('user', { id: 'default-user', organizationMembershipId: 'default-om' });
+      requestContext.set(MASTRA_RESOURCE_ID_KEY, 'resource-a');
+
+      const agent = new Agent({
+        id: 'test-agent',
+        name: 'test-agent',
+        instructions: 'test',
+        model: {} as any,
+        defaultNetworkOptions: { requestContext: requestContext as any },
+      });
+      (agent as any).__registerMastra(mastra);
+
+      try {
+        await agent.approveNetworkToolCall({ runId: 'missing-run-id' });
+      } catch {
+        // Expected to fail after authorization because no suspended network state exists.
+      }
+
+      try {
+        await agent.declineNetworkToolCall({ runId: 'missing-run-id' });
+      } catch {
+        // Expected to fail after authorization because no suspended network state exists.
+      }
+
+      expect(fgaProvider.require).toHaveBeenCalledTimes(2);
+      expect(fgaProvider.require).toHaveBeenCalledWith(
+        { id: 'default-user', organizationMembershipId: 'default-om' },
+        expect.objectContaining({
+          resource: { type: 'agent', id: 'test-agent' },
+          permission: 'agents:execute',
+          context: expect.objectContaining({
+            requestContext: expect.any(RequestContext),
+            resourceId: 'resource-a',
+            metadata: expect.objectContaining({ agentId: 'test-agent', agentName: 'test-agent' }),
+          }),
+        }),
+      );
+      expect(requestContext.has('__mastra_networkToolApprovalResume')).toBe(false);
+    });
+  });
+
   describe('resumeStream()', () => {
     it('should call FGA provider before loading a persisted snapshot', async () => {
       const fgaProvider = createMockFGAProvider(true);
@@ -768,10 +1116,7 @@ describe('Agent FGA checks', () => {
         agent.resumeStream({ approved: true }, { runId: 'missing-run-id', requestContext: requestContext as any }),
       ).rejects.toMatchObject({ id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND' });
 
-      expect(fgaProvider.require).toHaveBeenCalledWith(
-        { id: 'user-1', organizationMembershipId: 'om-1' },
-        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
-      );
+      expectAgentExecutionRequire(fgaProvider, { id: 'user-1', organizationMembershipId: 'om-1' }, { requestContext });
     });
 
     it('should reject denied users before loading a persisted snapshot', async () => {
@@ -856,10 +1201,7 @@ describe('Agent FGA checks', () => {
         id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND',
       });
 
-      expect(fgaProvider.require).toHaveBeenCalledWith(
-        { id: 'default-user', organizationMembershipId: 'default-om' },
-        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
-      );
+      expectAgentExecutionRequire(fgaProvider, { id: 'default-user', organizationMembershipId: 'default-om' });
     });
 
     it('should reject callers whose resource does not own the suspended run', async () => {
@@ -1030,9 +1372,10 @@ describe('Agent FGA checks', () => {
       ).rejects.toMatchObject({ id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND' });
 
       expect(fgaProvider.require).toHaveBeenCalledTimes(1);
-      expect(fgaProvider.require).toHaveBeenCalledWith(
+      expectAgentExecutionRequire(
+        fgaProvider,
         { id: 'user-1', organizationMembershipId: 'om-1' },
-        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+        { requestContext, runId: 'missing-run-id' },
       );
     });
 
@@ -1056,10 +1399,9 @@ describe('Agent FGA checks', () => {
       });
 
       expect(fgaProvider.require).toHaveBeenCalledTimes(1);
-      expect(fgaProvider.require).toHaveBeenCalledWith(
-        { id: 'default-user', organizationMembershipId: 'default-om' },
-        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
-      );
+      expectAgentExecutionRequire(fgaProvider, { id: 'default-user', organizationMembershipId: 'default-om' }, {
+        runId: 'missing-run-id',
+      });
     });
 
     it('should enforce run owner checks through resumeStreamUntilIdle', async () => {
@@ -1098,9 +1440,10 @@ describe('Agent FGA checks', () => {
         agent.resumeGenerate({ approved: true }, { runId: 'missing-run-id', requestContext: requestContext as any }),
       ).rejects.toMatchObject({ id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND' });
 
-      expect(fgaProvider.require).toHaveBeenCalledWith(
+      expectAgentExecutionRequire(
+        fgaProvider,
         { id: 'user-1', organizationMembershipId: 'om-1' },
-        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
+        { requestContext, runId: 'missing-run-id' },
       );
     });
 
@@ -1163,10 +1506,9 @@ describe('Agent FGA checks', () => {
         id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND',
       });
 
-      expect(fgaProvider.require).toHaveBeenCalledWith(
-        { id: 'default-user', organizationMembershipId: 'default-om' },
-        { resource: { type: 'agent', id: 'test-agent' }, permission: 'agents:execute' },
-      );
+      expectAgentExecutionRequire(fgaProvider, { id: 'default-user', organizationMembershipId: 'default-om' }, {
+        runId: 'missing-run-id',
+      });
     });
 
     it('should reject callers whose resource does not own the suspended generate run', async () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -33,7 +33,6 @@ import type {
   StreamTextResult,
 } from '../llm/model/base.types';
 import { MastraLLMVNext } from '../llm/model/model.loop';
-import { mergeProviderOptions } from '../llm/model/provider-options';
 import type { ProviderOptions } from '../llm/model/provider-options';
 import { ModelRouterLanguageModel } from '../llm/model/router';
 import type { MastraLanguageModel, MastraLegacyLanguageModel, MastraModelConfig } from '../llm/model/shared.types';
@@ -929,11 +928,19 @@ export class Agent<
   /**
    * Enforces the request-context and FGA boundary shared by fresh and resumed agent execution.
    */
-  async #assertAgentExecutionPreflight(requestContext?: RequestContext) {
+  async #assertAgentExecutionPreflight(
+    requestContext?: RequestContext,
+    options?: {
+      authorize?: boolean;
+      memory?: AgentExecutionOptionsBase<any>['memory'];
+      runId?: string;
+      snapshotMemoryInfo?: AgentSnapshotMemoryInfo;
+    },
+  ) {
     const fgaProvider = this.#mastra?.getServer()?.fga;
     if (fgaProvider) {
       const user = requestContext?.get('user');
-      const { checkFGA, FGADeniedError } = await import(/* @vite-ignore */ '../auth/ee/fga-check');
+      const { FGADeniedError } = await import(/* @vite-ignore */ '../auth/ee/fga-check');
       if (!user) {
         throw new FGADeniedError(
           { id: 'unknown' },
@@ -944,11 +951,15 @@ export class Agent<
 
       await this.#validateRequestContext(requestContext);
 
-      await checkFGA({
-        fgaProvider,
-        user,
-        resource: { type: 'agent', id: this.id },
-        permission: MastraFGAPermissions.AGENTS_EXECUTE,
+      if (options?.authorize === false) {
+        return;
+      }
+
+      await this.#requireAgentExecutionFGA({
+        requestContext,
+        memory: options?.memory,
+        runId: options?.runId,
+        snapshotMemoryInfo: options?.snapshotMemoryInfo,
       });
       return;
     }
@@ -990,7 +1001,6 @@ export class Agent<
         throw mastraError;
       }
 
-      const pubsub = this.getPubSub();
       Object.entries(agents || {}).forEach(([_agentName, agent]) => {
         if (this.#mastra) {
           agent.__registerMastra?.(this.#mastra);
@@ -5509,18 +5519,26 @@ export class Agent<
    * Used by resumeStream and resumeGenerate to fail fast at the agent boundary.
    * @internal
    */
-  async #loadAgenticLoopSnapshotOrThrow({ runId, method }: { runId: string; method: string }) {
+  async #loadAgenticLoopSnapshotOrThrow({
+    runId,
+    method,
+    workflowName = 'agentic-loop',
+  }: {
+    runId: string;
+    method: string;
+    workflowName?: string;
+  }) {
     const workflowsStore = await this.#mastra?.getStorage()?.getStore('workflows');
     let workflowRun: { resourceId?: unknown; snapshot?: unknown } | null | undefined;
     if (typeof workflowsStore?.getWorkflowRunById === 'function') {
-      workflowRun = await workflowsStore.getWorkflowRunById({ workflowName: 'agentic-loop', runId });
+      workflowRun = await workflowsStore.getWorkflowRunById({ workflowName, runId });
     }
     const workflowRunSnapshot =
       workflowRun?.snapshot && typeof workflowRun.snapshot === 'object' ? workflowRun.snapshot : undefined;
     const existingSnapshot =
       workflowRunSnapshot ??
       (await workflowsStore?.loadWorkflowSnapshot({
-        workflowName: 'agentic-loop',
+        workflowName,
         runId,
       }));
 
@@ -6233,31 +6251,59 @@ export class Agent<
     options?: MultiPrimitiveExecutionOptions<OUTPUT>,
   ): Promise<MastraAgentNetworkStream<OUTPUT>>;
   async network<OUTPUT = undefined>(messages: MessageListInput, options?: MultiPrimitiveExecutionOptions<OUTPUT>) {
-    const requestContextToUse = options?.requestContext || new RequestContext();
+    const explicitRequestContext = options?.requestContext;
+    const requestContextForDefaults = explicitRequestContext || new RequestContext();
+    if (explicitRequestContext) {
+      await this.#assertAgentExecutionPreflight(explicitRequestContext, { authorize: false });
+    }
 
     // Merge default network options with call-specific options
-    const defaultNetworkOptions = await this.getDefaultNetworkOptions({ requestContext: requestContextToUse });
+    const defaultNetworkOptions = await this.getDefaultNetworkOptions({ requestContext: requestContextForDefaults });
     const mergedOptions = {
       ...defaultNetworkOptions,
       ...options,
       routing: { ...defaultNetworkOptions?.routing, ...options?.routing },
       completion: { ...defaultNetworkOptions?.completion, ...options?.completion },
     };
-
-    const runId = mergedOptions?.runId || this.#mastra?.generateId() || randomUUID();
+    const requestContextToUse = explicitRequestContext || mergedOptions.requestContext || requestContextForDefaults;
+    if (!explicitRequestContext) {
+      await this.#assertAgentExecutionPreflight(requestContextToUse, { authorize: false });
+    }
 
     // Reserved keys from requestContext take precedence for security.
     // This allows middleware to securely set resourceId/threadId based on authenticated user,
     // preventing attackers from hijacking another user's memory by passing different values in the body.
     const resourceIdFromContext = requestContextToUse.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
     const threadIdFromContext = requestContextToUse.get(MASTRA_THREAD_ID_KEY) as string | undefined;
+    const hasFga = Boolean(this.#mastra?.getServer()?.fga);
 
-    const threadId =
-      threadIdFromContext ||
-      (typeof mergedOptions?.memory?.thread === 'string'
+    const memoryThreadId =
+      typeof mergedOptions?.memory?.thread === 'string'
         ? mergedOptions?.memory?.thread
-        : mergedOptions?.memory?.thread?.id);
-    const resourceId = resourceIdFromContext || mergedOptions?.memory?.resource;
+        : mergedOptions?.memory?.thread?.id;
+    const threadId = hasFga ? threadIdFromContext : threadIdFromContext || memoryThreadId;
+    const resourceId = hasFga ? resourceIdFromContext : resourceIdFromContext || mergedOptions?.memory?.resource;
+
+    if (hasFga && !resourceId) {
+      throw new MastraError({
+        id: 'AGENT_NETWORK_OWNER_UNVERIFIED',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        text: `Agent "${this.name}" network() requires a verified resource id when FGA is configured.`,
+        details: {
+          agentName: this.name,
+        },
+      });
+    }
+
+    const runId = hasFga
+      ? this.#mastra?.generateId() || randomUUID()
+      : mergedOptions?.runId || this.#mastra?.generateId() || randomUUID();
+    await this.#requireAgentExecutionFGA({
+      requestContext: requestContextToUse,
+      memory: mergedOptions?.memory,
+      runId,
+    });
 
     return await networkLoop<OUTPUT>({
       networkName: this.name,
@@ -6310,16 +6356,61 @@ export class Agent<
    */
   async resumeNetwork(resumeData: any, options: Omit<MultiPrimitiveExecutionOptions, 'runId'> & { runId: string }) {
     const runId = options.runId;
-    const requestContextToUse = options?.requestContext || new RequestContext();
+    const explicitRequestContext = options.requestContext;
+    const requestContextForDefaults = explicitRequestContext || new RequestContext();
+    if (explicitRequestContext) {
+      await this.#assertAgentExecutionPreflight(explicitRequestContext, { authorize: false });
+    }
+    const isNetworkToolApprovalResume =
+      (options as { __mastraNetworkToolApprovalResume?: boolean }).__mastraNetworkToolApprovalResume === true;
 
     // Merge default network options with call-specific options
-    const defaultNetworkOptions = await this.getDefaultNetworkOptions({ requestContext: requestContextToUse });
+    const defaultNetworkOptions = await this.getDefaultNetworkOptions({ requestContext: requestContextForDefaults });
     const mergedOptions = {
       ...defaultNetworkOptions,
       ...options,
       routing: { ...defaultNetworkOptions?.routing, ...options?.routing },
       completion: { ...defaultNetworkOptions?.completion, ...options?.completion },
     };
+    let requestContextToUse = explicitRequestContext || mergedOptions.requestContext || requestContextForDefaults;
+    if (!explicitRequestContext) {
+      await this.#assertAgentExecutionPreflight(requestContextToUse, { authorize: false });
+    }
+    if (isNetworkToolApprovalResume) {
+      requestContextToUse = new RequestContext(requestContextToUse.entries());
+      requestContextToUse.set('__mastra_networkToolApprovalResume', true);
+    }
+    const hasFga = Boolean(this.#mastra?.getServer()?.fga);
+    const trustedResourceId = requestContextToUse.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
+    if (hasFga && !trustedResourceId) {
+      throw new MastraError({
+        id: 'AGENT_RESUME_OWNER_UNVERIFIED',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        text: `Agent "${this.name}" resumeNetwork() requires a matching resource id to resume runId "${runId}".`,
+        details: {
+          runId,
+          agentName: this.name,
+        },
+      });
+    }
+    await this.#requireAgentExecutionFGA({
+      requestContext: requestContextToUse,
+      memory: mergedOptions?.memory,
+      runId,
+    });
+    const { resourceId: runResourceId } = await this.#loadAgenticLoopSnapshotOrThrow({
+      runId,
+      method: 'resumeNetwork',
+      workflowName: 'agent-loop-main-workflow',
+    });
+    this.#assertAgenticLoopResumeOwnership({
+      method: 'resumeNetwork',
+      runId,
+      runResourceId,
+      requestContext: requestContextToUse,
+      options: { memory: mergedOptions?.memory },
+    });
 
     // Reserved keys from requestContext take precedence for security.
     // This allows middleware to securely set resourceId/threadId based on authenticated user,
@@ -6327,12 +6418,12 @@ export class Agent<
     const resourceIdFromContext = requestContextToUse.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
     const threadIdFromContext = requestContextToUse.get(MASTRA_THREAD_ID_KEY) as string | undefined;
 
-    const threadId =
-      threadIdFromContext ||
-      (typeof mergedOptions?.memory?.thread === 'string'
+    const memoryThreadId =
+      typeof mergedOptions?.memory?.thread === 'string'
         ? mergedOptions?.memory?.thread
-        : mergedOptions?.memory?.thread?.id);
-    const resourceId = resourceIdFromContext || mergedOptions?.memory?.resource;
+        : mergedOptions?.memory?.thread?.id;
+    const threadId = hasFga ? threadIdFromContext : threadIdFromContext || memoryThreadId;
+    const resourceId = hasFga ? resourceIdFromContext : resourceIdFromContext || mergedOptions?.memory?.resource;
 
     return await networkLoop({
       networkName: this.name,
@@ -6377,9 +6468,9 @@ export class Agent<
    * ```
    */
   async approveNetworkToolCall(options: Omit<MultiPrimitiveExecutionOptions, 'runId'> & { runId: string }) {
-    const requestContext = new RequestContext(options.requestContext?.entries());
-    requestContext.set('__mastra_networkToolApprovalResume', true);
-    return this.resumeNetwork({ approved: true }, { ...options, requestContext });
+    const resumeOptions = { ...options } as typeof options & { __mastraNetworkToolApprovalResume: true };
+    resumeOptions.__mastraNetworkToolApprovalResume = true;
+    return this.resumeNetwork({ approved: true }, resumeOptions);
   }
 
   /**
@@ -6398,9 +6489,9 @@ export class Agent<
    * ```
    */
   async declineNetworkToolCall(options: Omit<MultiPrimitiveExecutionOptions, 'runId'> & { runId: string }) {
-    const requestContext = new RequestContext(options.requestContext?.entries());
-    requestContext.set('__mastra_networkToolApprovalResume', true);
-    return this.resumeNetwork({ approved: false }, { ...options, requestContext });
+    const resumeOptions = { ...options } as typeof options & { __mastraNetworkToolApprovalResume: true };
+    resumeOptions.__mastraNetworkToolApprovalResume = true;
+    return this.resumeNetwork({ approved: false }, resumeOptions);
   }
 
   async generate<
@@ -6433,7 +6524,7 @@ export class Agent<
   ): Promise<FullOutput<OUTPUT>> {
     const requestContextToUse = options?.requestContext;
     if (requestContextToUse) {
-      await this.#assertAgentExecutionPreflight(requestContextToUse);
+      await this.#assertAgentExecutionPreflight(requestContextToUse, { authorize: false });
     }
 
     const defaultOptions = await this.getDefaultOptions({
@@ -6446,7 +6537,7 @@ export class Agent<
     if (requestContextToUse) {
       mergedOptions.requestContext = requestContextToUse;
     } else {
-      await this.#assertAgentExecutionPreflight(mergedOptions.requestContext);
+      await this.#assertAgentExecutionPreflight(mergedOptions.requestContext, { authorize: false });
     }
 
     await this.#requireAgentExecutionFGA(mergedOptions);
@@ -6781,12 +6872,18 @@ export class Agent<
 
     try {
       if (!skipExecutionPreflight && requestContextToUse) {
-        await this.#assertAgentExecutionPreflight(requestContextToUse);
+        await this.#assertAgentExecutionPreflight(requestContextToUse, {
+          memory: streamOptionsWithRunId.memory,
+          runId: streamOptionsWithRunId.runId,
+        });
         preflightedRequestContext = requestContextToUse;
         hasPreflightedRequestContext = true;
         reserveAdmittedRun();
       } else if (!skipExecutionPreflight && staticDefaultOptions) {
-        await this.#assertAgentExecutionPreflight(staticDefaultOptions.requestContext);
+        await this.#assertAgentExecutionPreflight(staticDefaultOptions.requestContext, {
+          memory: staticDefaultOptions.memory,
+          runId: streamOptionsWithRunId.runId,
+        });
         preflightedRequestContext = staticDefaultOptions.requestContext;
         hasPreflightedRequestContext = true;
         reserveAdmittedRun();
@@ -6807,7 +6904,10 @@ export class Agent<
         hasExecutionPreflight &&
         (!hasPreflightedRequestContext || mergedOptions.requestContext !== preflightedRequestContext)
       ) {
-        await this.#assertAgentExecutionPreflight(mergedOptions.requestContext);
+        await this.#assertAgentExecutionPreflight(mergedOptions.requestContext, {
+          memory: mergedOptions.memory,
+          runId: mergedOptions.runId,
+        });
       }
 
       const mergedThreadTarget = this.#getThreadTarget(mergedOptions);
@@ -7129,7 +7229,10 @@ export class Agent<
       _pubsub: pubsub,
     };
     if (streamOptionsWithPubSub.requestContext) {
-      await this.#assertAgentExecutionPreflight(streamOptionsWithPubSub.requestContext);
+      await this.#assertAgentExecutionPreflight(streamOptionsWithPubSub.requestContext, {
+        memory: streamOptionsWithPubSub.memory,
+        runId: streamOptionsWithPubSub.runId,
+      });
       streamOptionsWithPubSub = {
         ...streamOptionsWithPubSub,
         [SKIP_AGENT_EXECUTION_PREFLIGHT]: true,
@@ -7138,7 +7241,10 @@ export class Agent<
       const defaultOptions = await this.getDefaultOptions({
         requestContext: streamOptionsWithPubSub.requestContext,
       });
-      await this.#assertAgentExecutionPreflight(defaultOptions.requestContext);
+      await this.#assertAgentExecutionPreflight(defaultOptions.requestContext, {
+        memory: defaultOptions.memory,
+        runId: streamOptionsWithPubSub.runId,
+      });
       streamOptionsWithPubSub = {
         ...streamOptionsWithPubSub,
         [STREAM_UNTIL_IDLE_DEFAULT_OPTIONS]: defaultOptions,
@@ -7226,12 +7332,18 @@ export class Agent<
     };
     if (streamOptionsWithPubSub.requestContext) {
       // Preflight before idle-wrapper setup, which can resolve defaults and memory before delegating to resumeStream().
-      await this.#assertAgentExecutionPreflight(streamOptionsWithPubSub.requestContext);
+      await this.#assertAgentExecutionPreflight(streamOptionsWithPubSub.requestContext, {
+        memory: streamOptionsWithPubSub.memory,
+        runId: streamOptionsWithPubSub.runId,
+      });
     } else {
       const defaultOptions = await this.getDefaultOptions({
         requestContext: streamOptionsWithPubSub.requestContext,
       });
-      await this.#assertAgentExecutionPreflight(defaultOptions.requestContext);
+      await this.#assertAgentExecutionPreflight(defaultOptions.requestContext, {
+        memory: defaultOptions.memory,
+        runId: streamOptionsWithPubSub.runId,
+      });
       streamOptionsWithPubSub = {
         ...streamOptionsWithPubSub,
         _pubsub: pubsub,
@@ -7306,12 +7418,18 @@ export class Agent<
     if (!streamOptionsWithPubSub?.[SKIP_AGENT_EXECUTION_PREFLIGHT]) {
       if (requestContextToUse) {
         // Keep explicit-context resume preflight before snapshot loading/reservation so denied callers cannot touch persisted runs.
-        await this.#assertAgentExecutionPreflight(requestContextToUse);
+        await this.#assertAgentExecutionPreflight(requestContextToUse, {
+          memory: streamOptionsWithPubSub.memory,
+          runId,
+        });
       } else if (this.#requestContextSchema || this.#mastra?.getServer()?.fga) {
         defaultOptions = (await this.getDefaultOptions({
           requestContext: requestContextToUse,
         })) as AgentExecutionOptions<TOutput>;
-        await this.#assertAgentExecutionPreflight(defaultOptions.requestContext);
+        await this.#assertAgentExecutionPreflight(defaultOptions.requestContext, {
+          memory: defaultOptions.memory,
+          runId,
+        });
       }
     }
     const { resourceId: runResourceId, snapshot: existingSnapshot } = await this.#loadAgenticLoopSnapshotOrThrow({
@@ -7334,7 +7452,10 @@ export class Agent<
       !preflightedDefaultOptions &&
       (this.#requestContextSchema || this.#mastra?.getServer()?.fga)
     ) {
-      await this.#assertAgentExecutionPreflight(ownershipOptions.requestContext);
+      await this.#assertAgentExecutionPreflight(ownershipOptions.requestContext, {
+        memory: ownershipOptions.memory,
+        runId,
+      });
     }
     this.#assertAgenticLoopResumeOwnership({
       method: 'resumeStream',
@@ -7663,12 +7784,15 @@ export class Agent<
     let defaultOptions: AgentExecutionOptions<TOutput> | undefined;
     if (requestContextToUse) {
       // Keep explicit-context resume preflight before snapshot loading/model resolution so denied callers cannot touch persisted runs.
-      await this.#assertAgentExecutionPreflight(requestContextToUse);
+      await this.#assertAgentExecutionPreflight(requestContextToUse, { memory: options?.memory, runId: options?.runId });
     } else if (this.#requestContextSchema || this.#mastra?.getServer()?.fga) {
       defaultOptions = (await this.getDefaultOptions({
         requestContext: requestContextToUse,
       })) as AgentExecutionOptions<TOutput>;
-      await this.#assertAgentExecutionPreflight(defaultOptions.requestContext);
+      await this.#assertAgentExecutionPreflight(defaultOptions.requestContext, {
+        memory: defaultOptions.memory,
+        runId: options?.runId,
+      });
     }
 
     const runId = options?.runId ?? '';

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -7241,13 +7241,17 @@ export class Agent<
       const defaultOptions = await this.getDefaultOptions({
         requestContext: streamOptionsWithPubSub.requestContext,
       });
-      await this.#assertAgentExecutionPreflight(defaultOptions.requestContext, {
-        memory: defaultOptions.memory,
-        runId: streamOptionsWithPubSub.runId,
+      const preflightOptions = deepMerge(
+        defaultOptions as Record<string, unknown>,
+        streamOptionsWithPubSub as Record<string, unknown>,
+      ) as AgentExecutionOptionsBase<any> & { requestContext?: RequestContext; runId?: string };
+      await this.#assertAgentExecutionPreflight(preflightOptions.requestContext, {
+        memory: preflightOptions.memory,
+        runId: preflightOptions.runId,
       });
       streamOptionsWithPubSub = {
         ...streamOptionsWithPubSub,
-        [STREAM_UNTIL_IDLE_DEFAULT_OPTIONS]: defaultOptions,
+        [STREAM_UNTIL_IDLE_DEFAULT_OPTIONS]: preflightOptions as AgentExecutionOptions<any>,
         [SKIP_AGENT_EXECUTION_PREFLIGHT]: true,
       };
     }
@@ -7340,14 +7344,18 @@ export class Agent<
       const defaultOptions = await this.getDefaultOptions({
         requestContext: streamOptionsWithPubSub.requestContext,
       });
-      await this.#assertAgentExecutionPreflight(defaultOptions.requestContext, {
-        memory: defaultOptions.memory,
-        runId: streamOptionsWithPubSub.runId,
+      const preflightOptions = deepMerge(
+        defaultOptions as Record<string, unknown>,
+        streamOptionsWithPubSub as Record<string, unknown>,
+      ) as AgentExecutionOptionsBase<any> & { requestContext?: RequestContext; runId?: string };
+      await this.#assertAgentExecutionPreflight(preflightOptions.requestContext, {
+        memory: preflightOptions.memory,
+        runId: preflightOptions.runId,
       });
       streamOptionsWithPubSub = {
         ...streamOptionsWithPubSub,
         _pubsub: pubsub,
-        [STREAM_UNTIL_IDLE_DEFAULT_OPTIONS]: defaultOptions,
+        [STREAM_UNTIL_IDLE_DEFAULT_OPTIONS]: preflightOptions as AgentExecutionOptions<TOutput>,
         [SKIP_AGENT_EXECUTION_PREFLIGHT]: true,
       };
     }

--- a/packages/core/src/auth/ee/interfaces/permissions.generated.ts
+++ b/packages/core/src/auth/ee/interfaces/permissions.generated.ts
@@ -13,6 +13,7 @@
  */
 export const RESOURCES = [
   'a2a',
+  'agent-builder',
   'agents',
   'auth',
   'background-tasks',
@@ -30,6 +31,7 @@ export const RESOURCES = [
   'processors',
   'schedules',
   'scores',
+  'stored',
   'stored-agents',
   'stored-mcp-clients',
   'stored-prompt-blocks',
@@ -89,6 +91,8 @@ export const PERMISSION_PATTERNS = {
   '*:write': '*:write',
   /** Full access to agent-to-agent communication */
   'a2a:*': 'a2a:*',
+  /** Full access to agent builder */
+  'agent-builder:*': 'agent-builder:*',
   /** Full access to agents */
   'agents:*': 'agents:*',
   /** Full access to auth */

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -2717,6 +2717,7 @@ export async function networkLoop<OUTPUT = undefined>({
 
   const run = await mainWorkflow.createRun({
     runId: runIdToUse,
+    resourceId,
   });
 
   const { thread } = await prepareMemoryStep({

--- a/packages/server/scripts/permission-generator.ts
+++ b/packages/server/scripts/permission-generator.ts
@@ -115,16 +115,10 @@ const COMPATIBILITY_PERMISSIONS = [
 ] as const;
 
 /**
- * Compound permission patterns supported by the RBAC matcher.
+ * Additional wildcard permission patterns supported by the RBAC matcher
+ * that are not derived from compatibility permissions or server routes.
  */
-const ADDITIONAL_PERMISSION_PATTERNS = [
-  'stored:*',
-  'stored:read',
-  'stored:write',
-  'stored:delete',
-  'stored-agents:share',
-  'stored-skills:share',
-];
+const ADDITIONAL_PERMISSION_PATTERNS = ['stored:*'];
 
 /**
  * Generates a human-readable description for a permission pattern.

--- a/packages/server/scripts/permission-generator.ts
+++ b/packages/server/scripts/permission-generator.ts
@@ -115,6 +115,18 @@ const COMPATIBILITY_PERMISSIONS = [
 ] as const;
 
 /**
+ * Compound permission patterns supported by the RBAC matcher.
+ */
+const ADDITIONAL_PERMISSION_PATTERNS = [
+  'stored:*',
+  'stored:read',
+  'stored:write',
+  'stored:delete',
+  'stored-agents:share',
+  'stored-skills:share',
+];
+
+/**
  * Generates a human-readable description for a permission pattern.
  */
 function getPermissionDescription(pattern: string): string {
@@ -204,9 +216,10 @@ export function generatePermissionFileContent(data: PermissionData): string {
     ...permissions, // Specific permissions
     ...ADDITIONAL_PERMISSION_PATTERNS, // Compound aliases
   ];
+  const uniquePatterns = [...new Set(allPatterns)];
 
   // Generate the PERMISSION_PATTERNS object entries with TSDoc comments
-  const patternEntries = allPatterns
+  const patternEntries = uniquePatterns
     .map(pattern => {
       const desc = getPermissionDescription(pattern);
       return `  /** ${desc} */\n  '${pattern}': '${pattern}'`;

--- a/packages/server/src/server/handlers/agents.test.ts
+++ b/packages/server/src/server/handlers/agents.test.ts
@@ -18,6 +18,9 @@ import {
   GET_AGENT_BY_ID_ROUTE,
   LIST_AGENTS_ROUTE,
   STREAM_GENERATE_ROUTE,
+  STREAM_NETWORK_ROUTE,
+  APPROVE_NETWORK_TOOL_CALL_ROUTE,
+  DECLINE_NETWORK_TOOL_CALL_ROUTE,
   RESUME_STREAM_ROUTE,
   SEND_AGENT_SIGNAL_ROUTE,
   SUBSCRIBE_AGENT_THREAD_ROUTE,
@@ -791,6 +794,65 @@ describe('Agent Routes Authorization', () => {
       // Verify requestContext was passed through
       expect(capturedOptions.requestContext).toBeDefined();
       expect(capturedOptions.requestContext.get('custom-key')).toBe('stream-value');
+    });
+
+    it('STREAM_NETWORK_ROUTE should pass requestContext to agent.network()', async () => {
+      const requestContext = createContextWithReservedKeys({ resourceId: 'user-a' });
+      requestContext.set('custom-key', 'network-value');
+
+      let capturedOptions: any;
+      vi.spyOn(mockAgent, 'network').mockImplementation(async (_messages, options) => {
+        capturedOptions = options;
+        return { fullStream: new ReadableStream() } as any;
+      });
+
+      await STREAM_NETWORK_ROUTE.handler({
+        mastra,
+        agentId: 'test-agent',
+        requestContext,
+        abortSignal: new AbortController().signal,
+        messages: [{ role: 'user', content: 'test' }],
+      } as any);
+
+      expect(capturedOptions.requestContext).toBe(requestContext);
+      expect(capturedOptions.requestContext.get('custom-key')).toBe('network-value');
+      expect(capturedOptions.requestContext.get(MASTRA_RESOURCE_ID_KEY)).toBe('user-a');
+    });
+
+    it('network tool-call routes should pass requestContext to approval helpers', async () => {
+      const requestContext = createContextWithReservedKeys({ resourceId: 'user-a' });
+      requestContext.set('custom-key', 'network-tool-value');
+
+      let capturedApproveOptions: any;
+      let capturedDeclineOptions: any;
+      vi.spyOn(mockAgent, 'approveNetworkToolCall').mockImplementation(async options => {
+        capturedApproveOptions = options;
+        return { fullStream: new ReadableStream() } as any;
+      });
+      vi.spyOn(mockAgent, 'declineNetworkToolCall').mockImplementation(async options => {
+        capturedDeclineOptions = options;
+        return { fullStream: new ReadableStream() } as any;
+      });
+
+      await APPROVE_NETWORK_TOOL_CALL_ROUTE.handler({
+        mastra,
+        agentId: 'test-agent',
+        requestContext,
+        abortSignal: new AbortController().signal,
+        runId: 'network-run-id',
+      } as any);
+      await DECLINE_NETWORK_TOOL_CALL_ROUTE.handler({
+        mastra,
+        agentId: 'test-agent',
+        requestContext,
+        abortSignal: new AbortController().signal,
+        runId: 'network-run-id',
+      } as any);
+
+      expect(capturedApproveOptions.requestContext).toBe(requestContext);
+      expect(capturedDeclineOptions.requestContext).toBe(requestContext);
+      expect(capturedApproveOptions.requestContext.get('custom-key')).toBe('network-tool-value');
+      expect(capturedDeclineOptions.requestContext.get(MASTRA_RESOURCE_ID_KEY)).toBe('user-a');
     });
   });
 

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -2392,6 +2392,7 @@ export const STREAM_NETWORK_ROUTE = createRoute({
 
       const streamResult = await agent.network(messages, {
         ...params,
+        requestContext,
       });
 
       return streamResult;
@@ -2431,6 +2432,7 @@ export const APPROVE_NETWORK_TOOL_CALL_ROUTE = createRoute({
 
       const streamResult = await agent.approveNetworkToolCall({
         ...params,
+        requestContext,
       });
 
       return streamResult;
@@ -2470,6 +2472,7 @@ export const DECLINE_NETWORK_TOOL_CALL_ROUTE = createRoute({
 
       const streamResult = await agent.declineNetworkToolCall({
         ...params,
+        requestContext,
       });
 
       return streamResult;

--- a/packages/server/src/server/server-adapter/routes/permissions.test.ts
+++ b/packages/server/src/server/server-adapter/routes/permissions.test.ts
@@ -636,6 +636,10 @@ describe('real route scenarios', () => {
       expect(derivePermission({ path: '/agents/:agentId/stream', method: 'POST' })).toBe('agents:execute');
     });
 
+    it('POST /agents/:agentId/network → agents:execute', () => {
+      expect(derivePermission({ path: '/agents/:agentId/network', method: 'POST' })).toBe('agents:execute');
+    });
+
     it('POST /agents/:agentId/approve-tool-call → agents:execute', () => {
       expect(derivePermission({ path: '/agents/:agentId/approve-tool-call', method: 'POST' })).toBe('agents:execute');
     });
@@ -722,6 +726,14 @@ describe('real route scenarios', () => {
 
     it('POST /memory/threads → memory:write', () => {
       expect(derivePermission({ path: '/memory/threads', method: 'POST' })).toBe('memory:write');
+    });
+
+    it('POST /memory/network/threads → memory:write', () => {
+      expect(derivePermission({ path: '/memory/network/threads', method: 'POST' })).toBe('memory:write');
+    });
+
+    it('POST /memory/network/save-messages → memory:write', () => {
+      expect(derivePermission({ path: '/memory/network/save-messages', method: 'POST' })).toBe('memory:write');
     });
 
     it('DELETE /memory/threads/:threadId → memory:delete', () => {

--- a/packages/server/src/server/server-adapter/routes/permissions.ts
+++ b/packages/server/src/server/server-adapter/routes/permissions.ts
@@ -30,6 +30,7 @@ const METHOD_TO_ACTION: Record<string, string> = {
 const EXECUTE_PATTERNS = [
   '/generate',
   '/stream',
+  '/agents/:agentId/network',
   '/execute',
   '/start',
   '/resume',


### PR DESCRIPTION
## Summary

- Enforces Fine-Grained Authorization fail-closed semantics for `agent.network()` and network resume/tool approval helpers.
- Requires a trusted `MASTRA_RESOURCE_ID_KEY` request-context owner under FGA before starting or resuming network work.
- Passes authenticated server request context into network routes and keeps the generated permissions map aligned.

## Coordination

- Linear: PF-545
- Parent: PF-531
- Related sibling: PF-546 is already Done.
- Open PR overlap checked before this PR:
  - #146 touches worker/Mastra index tests and changesets; no path overlap except `.changeset/`.
  - #148 touches Harness session/storage acceptance tests; no PF-545 path overlap.
  - #149 touches Harness channel/storage tests; no PF-545 path overlap.
- Branch is based on current `origin/main` at `dcf59d5d24cacbda7707042a1ee28385ec38d32b`.
- Official upstream was fetched separately; fork divergence is `142` ahead / `590` behind `mastra-ai/mastra:main`. Upstream sync is intentionally not folded into this PF-545 feature PR.

## Validation

- `timeout 180 pnpm --filter ./packages/core exec eslint src/agent/agent.ts src/agent/__tests__/agent-fga.test.ts src/loop/network/index.ts src/loop/network/index.test.ts`
- `timeout 180 pnpm --filter ./packages/server exec eslint src/server/handlers/agents.ts src/server/handlers/agents.test.ts src/server/server-adapter/routes/permissions.ts src/server/server-adapter/routes/permissions.test.ts scripts/permission-generator.ts`
- `timeout 180 pnpm --filter @mastra/core build:lib`
- `timeout 180 pnpm --filter ./packages/core exec vitest run src/agent/__tests__/agent-fga.test.ts src/loop/network/index.test.ts`
- `timeout 240 pnpm --filter ./packages/core check`
- `timeout 240 pnpm --filter ./packages/server generate:permissions`
- `timeout 240 pnpm --filter ./packages/server check:permissions`
- `timeout 240 pnpm --filter ./packages/server exec vitest run src/server/handlers/agents.test.ts src/server/server-adapter/routes/permissions.test.ts`
- `git diff --cached --check`

## Review Evidence

- Local Codex review pass 1: no findings on auth/security/data isolation.
- Local Codex review pass 2: found a valid permission-routing blocker where broad `/network` matching could classify `/memory/network/*` POST routes as execute. Fixed with a route-specific `/agents/:agentId/network` pattern and regression tests.
- CodeRabbit CLI: completed with one finding suggesting `memory.thread` and `memory.resource` should remain fallbacks under FGA. Reviewed and not applied because PF-545 intentionally treats caller-controlled memory owner/thread as untrusted under FGA; tests assert the fail-closed behavior and trusted request-context owner requirement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds an extra security check for agent network actions: before an agent can start or resume network work, the system requires trusted owner information in the request context. If that ownership info is missing when Fine-Grained Authorization (FGA) is enabled, the action is denied (fail-closed).

## Summary of Changes

Implements fail-closed FGA semantics for agent network execution and related flows, ensuring ownership in the request context (MASTRA_RESOURCE_ID_KEY) is required before starting or resuming network work or approving network tool calls.

### Core Authorization Logic
- Refactored Agent preflight checks: `#assertAgentExecutionPreflight` now accepts options ({ authorize, memory, runId, snapshotMemoryInfo }) and early-returns when authorize: false.
- Introduced `#requireAgentExecutionFGA` to centralize FGA checks; execution entrypoints call preflight with FGA-aware metadata (memory/runId) without re-authorizing.
- network() and resumeNetwork() compute threadId/resourceId with FGA-aware precedence, derive runId under FGA rules, and enforce ownership via `#requireAgentExecutionFGA`.
- resumeNetwork supports a "network tool approval resume" mode by cloning/re-tagging request context, loading snapshots via an optional workflowName, verifying resume ownership, then proceeding.
- Snapshot loader generalized: `#loadAgenticLoopSnapshotOrThrow` accepts an optional workflowName.

### Server & Routes
- Server routes now pass the authenticated RequestContext into agent.network, agent.approveNetworkToolCall, and agent.declineNetworkToolCall.
- Tightened route matching: added specific /agents/:agentId/network pattern so POST /agents/:agentId/network derives agents:execute (avoiding overly broad /network classification that defaulted to write).

### Permissions & Generator
- permission-generator deduplicates generated permission patterns (uses a Set) and includes additional stored:* patterns.
- Generated permissions updated to add agent-builder and a generic stored resource; PERMISSION_PATTERNS includes agent-builder:* and stored:* entries.

### Tests & Validation
- Added/updated tests:
  - New expectAgentExecutionRequire helper to assert full fgaProvider.require payloads.
  - Expanded FGA tests for generate/stream (legacy and vnext), network(), resume flows, and network resume/tool-approval helpers to verify resourceId and agent metadata in authorization payloads.
  - Server route tests ensure requestContext propagation through network and tool-approval routes.
  - Route permission tests validate /agents/:agentId/network and new memory network routes derive expected actions (agents:execute, memory:write).
- Validation performed: linting, builds, permission generation/checks, targeted vitest unit tests, and git diff --cached --check.

### Release Notes
- Changeset documents that when FGA is enabled, agent.network() (and related resume/approval flows) require a trusted resource ID in RequestContext; missing IDs are denied. No caller changes required when FGA is disabled.

### Coordination & Review
- Linear PF-545, parent PF-531, related PF-546 done; branch based on origin/main at commit dcf59d5...
- Review evidence: two local Codex review passes (one regression fixed) and an intentionally un-applied CodeRabbit CLI finding to preserve fail-closed semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->