### PR TITLE
[PF-377] Add client attachment admission acceptance

### DIFF
--- a/.changeset/sharp-baths-shop.md
+++ b/.changeset/sharp-baths-shop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Harness client preserves file, primitive, and element attachment references when admitting messages and queued work.

--- a/.changeset/sharp-baths-shop.md
+++ b/.changeset/sharp-baths-shop.md
@@ -2,4 +2,4 @@
 '@mastra/client-js': patch
 ---
 
-Harness client preserves file, primitive, and element attachment references when admitting messages and queued work.
+Improved Harness client attachment admission to preserve file, primitive, and element references for messages and queued work.

--- a/client-sdks/client-js/src/resources/harness.test.ts
+++ b/client-sdks/client-js/src/resources/harness.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MastraClient } from '../client';
-import { RemoteHarnessOperationError, RemoteHarnessUnsupportedError } from './harness';
+import { RemoteHarnessOperationError, RemoteHarnessUnsupportedError, type AttachmentRef } from './harness';
 
 global.fetch = vi.fn();
 
@@ -225,6 +225,83 @@ describe('Harness Resource', () => {
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({ content: 'later', admissionId: 'queue-admission-1' }),
+      }),
+    );
+  });
+
+  it('passes file, primitive, and element attachment refs through message and queue admissions', async () => {
+    const attachments: AttachmentRef[] = [
+      {
+        attachmentId: 'file-attachment-1',
+        resourceId: 'resource-1',
+        ownerSessionId: 'session-1',
+        source: 'preupload',
+        kind: 'file',
+        name: 'paper.pdf',
+        mimeType: 'application/pdf',
+        bytes: 1234,
+        sha256: '0'.repeat(64),
+      },
+      {
+        attachmentId: 'primitive-attachment-1',
+        resourceId: 'resource-1',
+        ownerSessionId: 'session-1',
+        source: 'preupload',
+        kind: 'primitive',
+        primitiveType: 'table',
+        schemaId: 'schema:table:v1',
+        object: {
+          providerId: 'cloudflare-r2',
+          objectKey: 'harness/resource-1/session-1/primitives/primitive-attachment-1.json',
+          etag: 'primitive-etag-1',
+          storageClass: 'standard',
+        },
+      },
+      {
+        attachmentId: 'element-attachment-1',
+        resourceId: 'resource-1',
+        ownerSessionId: 'session-1',
+        source: 'preupload',
+        kind: 'element',
+        elementType: 'chart',
+        renderer: { type: 'vega-lite' },
+        metadata: { cloudStorage: 'r2' },
+      },
+    ];
+    mockJson({ session: makeSnapshot() });
+    mockJson({ accepted: true, signalId: 'signal-1', runId: 'run-1', duplicate: false });
+    mockJson({ accepted: true, queuedItemId: 'queue-1', duplicate: false });
+
+    const session = await client.getHarness().session();
+    await expect(
+      session.admitMessage({ content: 'summarize attachments', admissionId: 'message-admission-1', attachments }),
+    ).resolves.toEqual({ accepted: true, signalId: 'signal-1', runId: 'run-1', duplicate: false });
+    await expect(
+      session.admitQueue({ content: 'process attachments later', admissionId: 'queue-admission-1', attachments }),
+    ).resolves.toEqual({ accepted: true, queuedItemId: 'queue-1', duplicate: false });
+
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      'http://localhost:4111/api/harness/default/sessions/session-1/messages',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          content: 'summarize attachments',
+          admissionId: 'message-admission-1',
+          attachments,
+        }),
+      }),
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      3,
+      'http://localhost:4111/api/harness/default/sessions/session-1/queue',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          content: 'process attachments later',
+          admissionId: 'queue-admission-1',
+          attachments,
+        }),
       }),
     );
   });


### PR DESCRIPTION
## Summary
- add client-js Harness acceptance coverage for message and queue admissions with file, primitive, and element attachment refs
- include a Cloudflare R2-style object pointer fixture for primitive attachments so the SDK contract covers object-backed primitives/elements
- add a client-js changeset for the preserved attachment-reference admission contract

## Linear
- PF-377

## Validation
- pnpm install --offline --ignore-scripts
- pnpm --filter @internal/ai-sdk-v4 build
- pnpm --filter @internal/ai-sdk-v5 build
- pnpm --filter @internal/ai-v6 build
- pnpm --filter @internal/core build:lib
- pnpm --filter @mastra/schema-compat build
- pnpm --filter @mastra/client-js test:unit src/resources/harness.test.ts (1 file, 28 tests passed)
- local Codex review pass 1: one changeset NITPICK reviewed and kept because package rules require changeset workflow
- local Codex review pass 2: fixed primitive fixture object pointer realism
- coderabbit review --plain: first run found changeset wording issue, fixed; second run reported no findings

## Note
- Attempted pnpm --filter @mastra/core build:lib before all local prerequisites were built; it failed during type generation with existing unrelated type/module-resolution errors. After building the narrower prerequisites, the targeted client-js test passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a test to make sure the JavaScript client for the Harness correctly forwards attachment references (files, data primitives, and UI elements) when sending messages or queuing work, so attachments stay intact end-to-end.

## Changes

### Test Coverage for Attachment Handling
- Added a new test in client-sdks/client-js/src/resources/harness.test.ts that verifies session.admitMessage and session.admitQueue preserve and forward attachment references of kinds: file, primitive, and element.
  - Constructs representative AttachmentRef objects, including a Cloudflare R2–style object pointer for object-backed primitive attachments.
  - Asserts both admitMessage and admitQueue resolve with expected acceptance responses.
  - Validates that the POST request bodies include an attachments array exactly matching the provided attachment refs.

### Documentation / Release Notes
- Added a changeset (.changeset/sharp-baths-shop.md) for `@mastra/client-js` at patch level documenting that the Harness client preserves file, primitive, and element attachment references during message and queue admissions.

## Validation
- Local build/test commands exercised across packages (pnpm builds for ai-sdk v4/v5, ai-v6, core build:lib after narrower prerequisites, schema-compat build).
- Unit tests: 1 file updated, 28 tests passed for `@mastra/client-js` (harness.test.ts).
- Local reviews: two Codex review passes (one NITPICK retained; one fixture realism fix) and coderabbit review fixing changeset wording.
- Note: Initial attempt to run `@mastra/core` build:lib failed due to unrelated type/module-resolution errors; after building narrower prerequisites, the targeted client-js test passed.

## Stats
- Files modified: 2 (.changeset entry + client-sdks/client-js/src/resources/harness.test.ts)
- Lines added: 83 (78 in test file + 5 in changeset)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->