### PR TITLE
[PF-560] Add Harness desktop workspace policy evaluator

### DIFF
--- a/.changeset/upset-corners-join.md
+++ b/.changeset/upset-corners-join.md
@@ -2,9 +2,12 @@
 '@mastra/core': patch
 ---
 
-Added Harness desktop workspace policy evaluation for desktop hosts and other constrained executors.
+Added workspace policy evaluation for desktop hosts and other constrained runtimes.
 
-Apps can now enforce file, command, network, and MCP access rules before starting work. The evaluator resolves file paths and command working directories against declared workspace roots, rejects path traversal and read-only root writes, applies deterministic `deny > ask > allow` precedence, and returns the matched rules and resolved paths for audit or approval UI.
+**What changed**
+- Added pre-run checks for file, command, network, and Model Context Protocol (MCP) access.
+- Added consistent decision order: `deny` before `ask`, and `ask` before `allow`.
+- Added resolved paths and matched rules in results for approval screens and audit logs.
 
 ```ts
 import { evaluateWorkspacePolicy } from '@mastra/core/harness/v1';
@@ -18,7 +21,9 @@ const result = evaluateWorkspacePolicy(
   { kind: 'file', operation: 'write', path: 'src/index.ts', rootId: 'project' },
 );
 
-if (result.decision === 'deny') {
-  throw new Error(result.reasons.join(', '));
+if (result.decision !== 'allow') {
+  throw new Error(
+    result.decision === 'ask' ? `Approval required: ${result.reasons.join(', ')}` : result.reasons.join(', '),
+  );
 }
 ```

--- a/.changeset/upset-corners-join.md
+++ b/.changeset/upset-corners-join.md
@@ -1,0 +1,24 @@
+---
+'@mastra/core': patch
+---
+
+Added Harness desktop workspace policy evaluation for desktop hosts and other constrained executors.
+
+Apps can now enforce file, command, network, and MCP access rules before starting work. The evaluator resolves file paths and command working directories against declared workspace roots, rejects path traversal and read-only root writes, applies deterministic `deny > ask > allow` precedence, and returns the matched rules and resolved paths for audit or approval UI.
+
+```ts
+import { evaluateWorkspacePolicy } from '@mastra/core/harness/v1';
+
+const result = evaluateWorkspacePolicy(
+  {
+    roots: [{ id: 'project', path: '/workspace/project', writable: true }],
+    defaultDecision: 'deny',
+    rules: [{ kind: 'file', rootId: 'project', operation: 'write', decision: 'ask' }],
+  },
+  { kind: 'file', operation: 'write', path: 'src/index.ts', rootId: 'project' },
+);
+
+if (result.decision === 'deny') {
+  throw new Error(result.reasons.join(', '));
+}
+```

--- a/packages/core/src/harness/v1/index.ts
+++ b/packages/core/src/harness/v1/index.ts
@@ -81,6 +81,22 @@ export {
 
 export { nonDurableProvider } from './workspace-provider';
 export type { WorkspaceOwnershipKind, WorkspaceProvider, WorkspaceProviderContext } from './workspace-provider';
+export { evaluateWorkspacePolicy, resolveWorkspacePath } from './workspace-policy';
+export type {
+  WorkspaceCommandPolicyAction,
+  WorkspaceFileOperation,
+  WorkspaceFilePolicyAction,
+  WorkspaceMcpPolicyAction,
+  WorkspaceNetworkPolicyAction,
+  WorkspacePolicy,
+  WorkspacePolicyAction,
+  WorkspacePolicyActionKind,
+  WorkspacePolicyEvaluation,
+  WorkspacePolicyMatchedRule,
+  WorkspacePolicyRule,
+  WorkspaceResolvedPath,
+  WorkspaceRootDescriptor,
+} from './workspace-policy';
 
 /**
  * `HarnessMessage` and `HarnessMessageContent` are stable cross-version

--- a/packages/core/src/harness/v1/workspace-policy.test.ts
+++ b/packages/core/src/harness/v1/workspace-policy.test.ts
@@ -61,6 +61,16 @@ describe('workspace policy evaluator', () => {
     });
   });
 
+  it('keeps backslashes as literal path characters for POSIX roots', () => {
+    const resolved = resolveWorkspacePath(roots, '..\\secret.txt', 'project');
+
+    expect(resolved).toMatchObject({
+      root: { id: 'project' },
+      normalizedPath: '/workspace/project/..\\secret.txt',
+      relativePath: '..\\secret.txt',
+    });
+  });
+
   it('keeps lexical path containment segment-aware', () => {
     const resolved = resolveWorkspacePath(
       [{ id: 'project', path: '/workspace/project' }],

--- a/packages/core/src/harness/v1/workspace-policy.test.ts
+++ b/packages/core/src/harness/v1/workspace-policy.test.ts
@@ -21,10 +21,38 @@ describe('workspace policy evaluator', () => {
     });
   });
 
+  it('resolves Windows-style absolute paths against workspace roots', () => {
+    const windowsRoots = [
+      { id: 'project', path: 'C:\\workspace\\project', writable: true },
+    ] satisfies WorkspacePolicy['roots'];
+
+    expect(resolveWorkspacePath(windowsRoots, 'C:\\workspace\\project\\src\\index.ts')).toMatchObject({
+      root: { id: 'project', path: 'C:\\workspace\\project' },
+      normalizedPath: 'C:\\workspace\\project\\src\\index.ts',
+      relativePath: 'src\\index.ts',
+    });
+  });
+
   it('denies traversal outside an explicit workspace root', () => {
     const evaluation = evaluateWorkspacePolicy(
       { roots, defaultDecision: 'allow' },
       { kind: 'file', operation: 'read', path: '../secret.txt', rootId: 'project' },
+    );
+
+    expect(evaluation).toMatchObject({
+      decision: 'deny',
+      reasons: ['workspace.path_outside_roots'],
+    });
+  });
+
+  it('denies Windows-style traversal outside an explicit workspace root', () => {
+    const windowsRoots = [
+      { id: 'project', path: 'C:\\workspace\\project', writable: true },
+    ] satisfies WorkspacePolicy['roots'];
+
+    const evaluation = evaluateWorkspacePolicy(
+      { roots: windowsRoots, defaultDecision: 'allow' },
+      { kind: 'file', operation: 'read', path: '..\\secret.txt', rootId: 'project' },
     );
 
     expect(evaluation).toMatchObject({
@@ -78,6 +106,39 @@ describe('workspace policy evaluator', () => {
       decision: 'deny',
       reasons: ['workspace.root_readonly:readonly'],
       path: { root: { id: 'readonly' }, normalizedPath: '/workspace/docs/notes.md' },
+    });
+  });
+
+  it('treats roots as writable when writable is omitted', () => {
+    const implicitWritableRoots = [
+      { id: 'project', path: '/workspace/project' },
+      { id: 'scratch', path: '/workspace/scratch' },
+    ] satisfies WorkspacePolicy['roots'];
+
+    const writeEvaluation = evaluateWorkspacePolicy(
+      { roots: implicitWritableRoots, defaultDecision: 'allow' },
+      { kind: 'file', operation: 'write', path: 'src/index.ts', rootId: 'project' },
+    );
+    const renameEvaluation = evaluateWorkspacePolicy(
+      { roots: implicitWritableRoots, defaultDecision: 'allow' },
+      {
+        kind: 'file',
+        operation: 'rename',
+        path: '/workspace/project/src/index.ts',
+        toPath: '/workspace/scratch/index.ts',
+      },
+    );
+
+    expect(writeEvaluation).toMatchObject({
+      decision: 'allow',
+      reasons: ['workspace.default_allow'],
+      path: { root: { id: 'project' } },
+    });
+    expect(renameEvaluation).toMatchObject({
+      decision: 'allow',
+      reasons: ['workspace.default_allow'],
+      path: { root: { id: 'project' } },
+      toPath: { root: { id: 'scratch' } },
     });
   });
 

--- a/packages/core/src/harness/v1/workspace-policy.test.ts
+++ b/packages/core/src/harness/v1/workspace-policy.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it } from 'vitest';
+
+import { evaluateWorkspacePolicy, resolveWorkspacePath } from './workspace-policy';
+import type { WorkspacePolicy } from './workspace-policy';
+
+const roots = [
+  { id: 'project', path: '/workspace/project', writable: true },
+  { id: 'nested', path: '/workspace/project/packages/app', writable: true },
+  { id: 'readonly', path: '/workspace/docs', writable: false },
+  { id: 'scratch', path: '/workspace/scratch', writable: true },
+] satisfies WorkspacePolicy['roots'];
+
+describe('workspace policy evaluator', () => {
+  it('resolves paths against the most specific workspace root', () => {
+    const resolved = resolveWorkspacePath(roots, '/workspace/project/packages/app/src/index.ts');
+
+    expect(resolved).toMatchObject({
+      root: { id: 'nested', path: '/workspace/project/packages/app' },
+      normalizedPath: '/workspace/project/packages/app/src/index.ts',
+      relativePath: 'src/index.ts',
+    });
+  });
+
+  it('denies traversal outside an explicit workspace root', () => {
+    const evaluation = evaluateWorkspacePolicy(
+      { roots, defaultDecision: 'allow' },
+      { kind: 'file', operation: 'read', path: '../secret.txt', rootId: 'project' },
+    );
+
+    expect(evaluation).toMatchObject({
+      decision: 'deny',
+      reasons: ['workspace.path_outside_roots'],
+    });
+  });
+
+  it('keeps lexical path containment segment-aware', () => {
+    const resolved = resolveWorkspacePath(
+      [{ id: 'project', path: '/workspace/project' }],
+      '..files/cache.txt',
+      'project',
+    );
+
+    expect(resolved).toMatchObject({
+      normalizedPath: '/workspace/project/..files/cache.txt',
+      relativePath: '..files/cache.txt',
+    });
+  });
+
+  it('denies file moves whose target leaves the selected root', () => {
+    const evaluation = evaluateWorkspacePolicy(
+      { roots, defaultDecision: 'allow' },
+      {
+        kind: 'file',
+        operation: 'rename',
+        path: 'src/index.ts',
+        toPath: '../other/index.ts',
+        rootId: 'project',
+      },
+    );
+
+    expect(evaluation).toMatchObject({
+      decision: 'deny',
+      reasons: ['workspace.target_path_outside_roots'],
+    });
+  });
+
+  it('denies mutating operations inside read-only roots before rules are applied', () => {
+    const evaluation = evaluateWorkspacePolicy(
+      {
+        roots,
+        defaultDecision: 'ask',
+        rules: [{ id: 'allow-docs', kind: 'file', rootId: 'readonly', operation: 'write', decision: 'allow' }],
+      },
+      { kind: 'file', operation: 'write', path: 'notes.md', rootId: 'readonly' },
+    );
+
+    expect(evaluation).toMatchObject({
+      decision: 'deny',
+      reasons: ['workspace.root_readonly:readonly'],
+      path: { root: { id: 'readonly' }, normalizedPath: '/workspace/docs/notes.md' },
+    });
+  });
+
+  it('enforces the most specific root even when callers provide a broader root id', () => {
+    const evaluation = evaluateWorkspacePolicy(
+      {
+        roots: [
+          { id: 'project', path: '/workspace/project', writable: true },
+          { id: 'generated', path: '/workspace/project/generated', writable: false },
+        ],
+        defaultDecision: 'allow',
+      },
+      { kind: 'file', operation: 'write', path: 'generated/index.ts', rootId: 'project' },
+    );
+
+    expect(evaluation).toMatchObject({
+      decision: 'deny',
+      reasons: ['workspace.root_readonly:generated'],
+      path: { root: { id: 'generated' }, normalizedPath: '/workspace/project/generated/index.ts' },
+    });
+  });
+
+  it('uses deny over ask and allow when multiple rules match', () => {
+    const evaluation = evaluateWorkspacePolicy(
+      {
+        roots,
+        defaultDecision: 'allow',
+        rules: [
+          { id: 'allow-project', kind: 'file', rootId: 'project', operation: 'write', decision: 'allow' },
+          { id: 'ask-write', kind: 'file', operation: 'write', decision: 'ask' },
+          { id: 'deny-lock', kind: 'file', rootId: 'project', operation: 'write', decision: 'deny' },
+        ],
+      },
+      { kind: 'file', operation: 'write', path: 'src/index.ts', rootId: 'project' },
+    );
+
+    expect(evaluation.decision).toBe('deny');
+    expect(evaluation.matchedRules.map(rule => rule.id)).toEqual(['allow-project', 'ask-write', 'deny-lock']);
+  });
+
+  it('applies file root rules to rename targets as well as sources', () => {
+    const evaluation = evaluateWorkspacePolicy(
+      {
+        roots,
+        defaultDecision: 'deny',
+        rules: [
+          { id: 'allow-project-rename', kind: 'file', rootId: 'project', operation: 'rename', decision: 'allow' },
+          { id: 'deny-scratch-rename', kind: 'file', rootId: 'scratch', operation: 'rename', decision: 'deny' },
+        ],
+      },
+      {
+        kind: 'file',
+        operation: 'rename',
+        path: '/workspace/project/src/index.ts',
+        toPath: '/workspace/scratch/index.ts',
+      },
+    );
+
+    expect(evaluation.decision).toBe('deny');
+    expect(evaluation.matchedRules.map(rule => rule.id)).toEqual(['deny-scratch-rename']);
+    expect(evaluation).toMatchObject({
+      path: { root: { id: 'project' } },
+      toPath: { root: { id: 'scratch' } },
+    });
+  });
+
+  it('does not let a source-root allow authorize an unallowed rename target root', () => {
+    const evaluation = evaluateWorkspacePolicy(
+      {
+        roots,
+        defaultDecision: 'deny',
+        rules: [
+          { id: 'allow-project-rename', kind: 'file', rootId: 'project', operation: 'rename', decision: 'allow' },
+        ],
+      },
+      {
+        kind: 'file',
+        operation: 'rename',
+        path: '/workspace/project/src/index.ts',
+        toPath: '/workspace/scratch/index.ts',
+      },
+    );
+
+    expect(evaluation).toMatchObject({
+      decision: 'deny',
+      matchedRules: [],
+      reasons: ['workspace.default_deny'],
+    });
+  });
+
+  it('uses ask over allow and falls back to the default decision when no rules match', () => {
+    const askEvaluation = evaluateWorkspacePolicy(
+      {
+        roots,
+        defaultDecision: 'deny',
+        rules: [
+          { id: 'allow-project', kind: 'file', rootId: 'project', operation: 'read', decision: 'allow' },
+          { id: 'ask-project', kind: 'file', rootId: 'project', operation: 'read', decision: 'ask' },
+        ],
+      },
+      { kind: 'file', operation: 'read', path: 'README.md', rootId: 'project' },
+    );
+
+    expect(askEvaluation.decision).toBe('ask');
+
+    const defaultEvaluation = evaluateWorkspacePolicy(
+      {
+        roots,
+        defaultDecision: 'deny',
+        rules: [{ id: 'allow-command', kind: 'command', command: 'pnpm', decision: 'allow' }],
+      },
+      { kind: 'network', host: 'example.com', protocol: 'https' },
+    );
+
+    expect(defaultEvaluation).toMatchObject({
+      decision: 'deny',
+      matchedRules: [],
+      reasons: ['workspace.default_deny'],
+    });
+  });
+
+  it('matches command, network, and MCP selectors only on their own action kinds', () => {
+    const policy: WorkspacePolicy = {
+      roots,
+      defaultDecision: 'deny',
+      rules: [
+        { id: 'pnpm', kind: 'command', command: 'pnpm', decision: 'allow' },
+        {
+          id: 'api',
+          kind: 'network',
+          networkHost: ['api.example.test'],
+          networkPort: 443,
+          networkProtocol: 'https',
+          decision: 'ask',
+        },
+        { id: 'linear', kind: 'mcp', mcpServerId: 'linear', mcpToolName: 'createComment', decision: 'allow' },
+        { id: 'bad-cross-kind', kind: 'command', mcpServerId: 'linear', decision: 'allow' },
+      ],
+    };
+
+    expect(evaluateWorkspacePolicy(policy, { kind: 'command', command: 'pnpm', args: ['test'] })).toMatchObject({
+      decision: 'allow',
+      matchedRules: [{ id: 'pnpm' }],
+    });
+    expect(
+      evaluateWorkspacePolicy(policy, { kind: 'network', host: 'api.example.test', port: 443, protocol: 'https' }),
+    ).toMatchObject({
+      decision: 'ask',
+      matchedRules: [{ id: 'api' }],
+    });
+    expect(
+      evaluateWorkspacePolicy(policy, { kind: 'network', host: 'api.example.test', port: 80, protocol: 'http' }),
+    ).toMatchObject({
+      decision: 'deny',
+      matchedRules: [],
+    });
+    expect(
+      evaluateWorkspacePolicy(policy, { kind: 'mcp', serverId: 'linear', toolName: 'createComment' }),
+    ).toMatchObject({
+      decision: 'allow',
+      matchedRules: [{ id: 'linear' }],
+    });
+    expect(
+      evaluateWorkspacePolicy(policy, { kind: 'mcp', serverId: 'linear', toolName: 'archiveIssue' }),
+    ).toMatchObject({
+      decision: 'deny',
+      matchedRules: [],
+    });
+  });
+
+  it('contains command cwd and lets command rules target the cwd root', () => {
+    const policy: WorkspacePolicy = {
+      roots,
+      defaultDecision: 'deny',
+      rules: [{ id: 'pnpm-project', kind: 'command', rootId: 'project', command: 'pnpm', decision: 'allow' }],
+    };
+
+    expect(
+      evaluateWorkspacePolicy(policy, { kind: 'command', command: 'pnpm', cwd: '/workspace/project', args: ['test'] }),
+    ).toMatchObject({
+      decision: 'allow',
+      matchedRules: [{ id: 'pnpm-project' }],
+      cwd: { root: { id: 'project' }, normalizedPath: '/workspace/project' },
+    });
+    expect(
+      evaluateWorkspacePolicy(
+        {
+          roots,
+          defaultDecision: 'allow',
+          rules: [{ id: 'pnpm', kind: 'command', command: 'pnpm', decision: 'allow' }],
+        },
+        { kind: 'command', command: 'pnpm', cwd: '/etc' },
+      ),
+    ).toMatchObject({
+      decision: 'deny',
+      reasons: ['workspace.cwd_outside_roots'],
+    });
+  });
+
+  it('lets command rootId select a workspace root without a cwd', () => {
+    const policy: WorkspacePolicy = {
+      roots,
+      defaultDecision: 'deny',
+      rules: [{ id: 'pnpm-project', kind: 'command', rootId: 'project', command: 'pnpm', decision: 'allow' }],
+    };
+
+    expect(evaluateWorkspacePolicy(policy, { kind: 'command', command: 'pnpm', rootId: 'project' })).toMatchObject({
+      decision: 'allow',
+      matchedRules: [{ id: 'pnpm-project' }],
+    });
+    expect(evaluateWorkspacePolicy(policy, { kind: 'command', command: 'pnpm', rootId: 'missing' })).toMatchObject({
+      decision: 'deny',
+      reasons: ['workspace.root_not_found'],
+    });
+  });
+});

--- a/packages/core/src/harness/v1/workspace-policy.test.ts
+++ b/packages/core/src/harness/v1/workspace-policy.test.ts
@@ -1,3 +1,7 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import { evaluateWorkspacePolicy, resolveWorkspacePath } from './workspace-policy';
@@ -102,6 +106,18 @@ describe('workspace policy evaluator', () => {
     });
   });
 
+  it('denies rename actions that omit the target path', () => {
+    const evaluation = evaluateWorkspacePolicy(
+      { roots, defaultDecision: 'allow' },
+      { kind: 'file', operation: 'rename', path: 'src/index.ts', rootId: 'project' },
+    );
+
+    expect(evaluation).toMatchObject({
+      decision: 'deny',
+      reasons: ['workspace.target_path_required'],
+    });
+  });
+
   it('denies mutating operations inside read-only roots before rules are applied', () => {
     const evaluation = evaluateWorkspacePolicy(
       {
@@ -149,6 +165,24 @@ describe('workspace policy evaluator', () => {
       reasons: ['workspace.default_allow'],
       path: { root: { id: 'project' } },
       toPath: { root: { id: 'scratch' } },
+    });
+  });
+
+  it('preserves an explicitly selected root id when another root shares the same path', () => {
+    const duplicatePathRoots = [
+      { id: 'writable', path: '/workspace/project', writable: true },
+      { id: 'readonly', path: '/workspace/project', writable: false },
+    ] satisfies WorkspacePolicy['roots'];
+
+    const evaluation = evaluateWorkspacePolicy(
+      { roots: duplicatePathRoots, defaultDecision: 'allow' },
+      { kind: 'file', operation: 'write', path: 'notes.md', rootId: 'readonly' },
+    );
+
+    expect(evaluation).toMatchObject({
+      decision: 'deny',
+      reasons: ['workspace.root_readonly:readonly'],
+      path: { root: { id: 'readonly' } },
     });
   });
 
@@ -294,7 +328,7 @@ describe('workspace policy evaluator', () => {
       matchedRules: [{ id: 'pnpm' }],
     });
     expect(
-      evaluateWorkspacePolicy(policy, { kind: 'network', host: 'api.example.test', port: 443, protocol: 'https' }),
+      evaluateWorkspacePolicy(policy, { kind: 'network', host: 'API.EXAMPLE.TEST', port: 443, protocol: 'https:' }),
     ).toMatchObject({
       decision: 'ask',
       matchedRules: [{ id: 'api' }],
@@ -317,6 +351,30 @@ describe('workspace policy evaluator', () => {
       decision: 'deny',
       matchedRules: [],
     });
+  });
+
+  it('denies paths that escape a workspace root through an existing symlink', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mastra-workspace-policy-'));
+    const rootDir = path.join(tempDir, 'root');
+    const outsideDir = path.join(tempDir, 'outside');
+
+    try {
+      fs.mkdirSync(rootDir);
+      fs.mkdirSync(outsideDir);
+      fs.symlinkSync(outsideDir, path.join(rootDir, 'linked-outside'), 'dir');
+
+      const evaluation = evaluateWorkspacePolicy(
+        { roots: [{ id: 'project', path: rootDir, writable: true }], defaultDecision: 'allow' },
+        { kind: 'file', operation: 'write', path: 'linked-outside/created.txt', rootId: 'project' },
+      );
+
+      expect(evaluation).toMatchObject({
+        decision: 'deny',
+        reasons: ['workspace.path_outside_roots'],
+      });
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('contains command cwd and lets command rules target the cwd root', () => {

--- a/packages/core/src/harness/v1/workspace-policy.ts
+++ b/packages/core/src/harness/v1/workspace-policy.ts
@@ -1,0 +1,366 @@
+import path from 'node:path';
+
+import type { PermissionPolicy } from './types';
+
+export type WorkspacePolicyActionKind = 'file' | 'command' | 'network' | 'mcp';
+export type WorkspaceFileOperation = 'read' | 'write' | 'delete' | 'rename' | 'patch';
+
+export interface WorkspaceRootDescriptor {
+  id: string;
+  path: string;
+  label?: string;
+  writable?: boolean;
+  metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface WorkspaceFilePolicyAction {
+  kind: 'file';
+  operation: WorkspaceFileOperation;
+  path: string;
+  rootId?: string;
+  toPath?: string;
+}
+
+export interface WorkspaceCommandPolicyAction {
+  kind: 'command';
+  command: string;
+  rootId?: string;
+  cwd?: string;
+  args?: readonly string[];
+}
+
+export interface WorkspaceNetworkPolicyAction {
+  kind: 'network';
+  host: string;
+  port?: number;
+  protocol?: string;
+}
+
+export interface WorkspaceMcpPolicyAction {
+  kind: 'mcp';
+  serverId: string;
+  toolName?: string;
+}
+
+export type WorkspacePolicyAction =
+  | WorkspaceFilePolicyAction
+  | WorkspaceCommandPolicyAction
+  | WorkspaceNetworkPolicyAction
+  | WorkspaceMcpPolicyAction;
+
+export interface WorkspacePolicyRule {
+  id?: string;
+  kind?: WorkspacePolicyActionKind | readonly WorkspacePolicyActionKind[];
+  operation?: WorkspaceFileOperation | readonly WorkspaceFileOperation[];
+  rootId?: string | readonly string[];
+  command?: string | readonly string[];
+  networkHost?: string | readonly string[];
+  networkPort?: number | readonly number[];
+  networkProtocol?: string | readonly string[];
+  mcpServerId?: string | readonly string[];
+  mcpToolName?: string | readonly string[];
+  decision: PermissionPolicy;
+  reason?: string;
+}
+
+export interface WorkspacePolicy {
+  roots: readonly WorkspaceRootDescriptor[];
+  defaultDecision?: PermissionPolicy;
+  rules?: readonly WorkspacePolicyRule[];
+}
+
+export interface WorkspaceResolvedPath {
+  root: WorkspaceRootDescriptor;
+  normalizedPath: string;
+  relativePath: string;
+}
+
+export interface WorkspacePolicyMatchedRule {
+  id?: string;
+  decision: PermissionPolicy;
+  reason?: string;
+}
+
+export interface WorkspacePolicyEvaluation {
+  decision: PermissionPolicy;
+  reasons: string[];
+  matchedRules: WorkspacePolicyMatchedRule[];
+  path?: WorkspaceResolvedPath;
+  toPath?: WorkspaceResolvedPath;
+  cwd?: WorkspaceResolvedPath;
+}
+
+const MUTATING_FILE_OPERATIONS = new Set<WorkspaceFileOperation>(['write', 'delete', 'rename', 'patch']);
+
+export function evaluateWorkspacePolicy(
+  policy: WorkspacePolicy,
+  action: WorkspacePolicyAction,
+): WorkspacePolicyEvaluation {
+  const reasons: string[] = [];
+  let resolvedPath: WorkspaceResolvedPath | undefined;
+  let resolvedToPath: WorkspaceResolvedPath | undefined;
+  let resolvedCwd: WorkspaceResolvedPath | undefined;
+  let commandRootId: string | undefined;
+
+  if (action.kind === 'file') {
+    const resolved = resolveWorkspaceFileAction(policy.roots, action);
+    if (resolved.status === 'denied') {
+      return {
+        decision: 'deny',
+        reasons: [resolved.reason],
+        matchedRules: [],
+      };
+    }
+    resolvedPath = resolved.path;
+    resolvedToPath = resolved.toPath;
+    if (isMutatingFileOperation(action.operation)) {
+      const readOnlyRoot = [resolvedPath.root, resolvedToPath?.root].find(root => root?.writable === false);
+      if (readOnlyRoot) {
+        return {
+          decision: 'deny',
+          reasons: [`workspace.root_readonly:${readOnlyRoot.id}`],
+          matchedRules: [],
+          path: resolvedPath,
+          ...(resolvedToPath ? { toPath: resolvedToPath } : {}),
+        };
+      }
+    }
+  } else if (action.kind === 'command' && (action.cwd !== undefined || action.rootId !== undefined)) {
+    const commandContext =
+      action.cwd !== undefined
+        ? resolveWorkspaceActionPath(policy.roots, action.cwd, action.rootId)
+        : resolveWorkspaceCommandRoot(policy.roots, action.rootId);
+    if (!commandContext) {
+      return {
+        decision: 'deny',
+        reasons: [action.cwd !== undefined ? 'workspace.cwd_outside_roots' : 'workspace.root_not_found'],
+        matchedRules: [],
+      };
+    }
+    resolvedCwd = action.cwd !== undefined ? commandContext : undefined;
+    commandRootId = commandContext.root.id;
+  }
+
+  const matchedRules = (policy.rules ?? [])
+    .filter(rule => ruleMatches(rule, action, resolvedPath, resolvedToPath, commandRootId))
+    .map(rule => ({
+      id: rule.id,
+      decision: rule.decision,
+      reason: rule.reason,
+    }));
+
+  for (const rule of matchedRules) {
+    if (rule.reason) reasons.push(rule.reason);
+  }
+
+  const decision = strongestDecision(
+    matchedRules.map(rule => rule.decision),
+    policy.defaultDecision ?? 'ask',
+  );
+  if (matchedRules.length === 0) reasons.push(`workspace.default_${decision}`);
+
+  return {
+    decision,
+    reasons,
+    matchedRules,
+    ...(resolvedPath ? { path: resolvedPath } : {}),
+    ...(resolvedToPath ? { toPath: resolvedToPath } : {}),
+    ...(resolvedCwd ? { cwd: resolvedCwd } : {}),
+  };
+}
+
+function resolveWorkspaceFileAction(
+  roots: readonly WorkspaceRootDescriptor[],
+  action: WorkspaceFilePolicyAction,
+):
+  | { status: 'allowed'; path: WorkspaceResolvedPath; toPath?: WorkspaceResolvedPath }
+  | { status: 'denied'; reason: string } {
+  const resolvedPath = resolveWorkspaceActionPath(roots, action.path, action.rootId);
+  if (!resolvedPath) {
+    return { status: 'denied', reason: 'workspace.path_outside_roots' };
+  }
+
+  if (action.toPath === undefined) {
+    return { status: 'allowed', path: resolvedPath };
+  }
+
+  const resolvedToPath = resolveWorkspaceActionPath(roots, action.toPath, action.rootId);
+  if (!resolvedToPath) {
+    return { status: 'denied', reason: 'workspace.target_path_outside_roots' };
+  }
+
+  return { status: 'allowed', path: resolvedPath, toPath: resolvedToPath };
+}
+
+function resolveWorkspaceActionPath(
+  roots: readonly WorkspaceRootDescriptor[],
+  inputPath: string,
+  rootId?: string,
+): WorkspaceResolvedPath | null {
+  const requestedPath = resolveWorkspacePath(roots, inputPath, rootId);
+  if (!requestedPath) return null;
+
+  return resolveWorkspacePath(roots, requestedPath.normalizedPath) ?? requestedPath;
+}
+
+function resolveWorkspaceCommandRoot(
+  roots: readonly WorkspaceRootDescriptor[],
+  rootId: string | undefined,
+): WorkspaceResolvedPath | null {
+  if (rootId === undefined) return null;
+  const root = roots.find(candidate => candidate.id === rootId);
+  if (!root) return null;
+  return resolveWorkspacePath(roots, '.', rootId);
+}
+
+export function resolveWorkspacePath(
+  roots: readonly WorkspaceRootDescriptor[],
+  inputPath: string,
+  rootId?: string,
+): WorkspaceResolvedPath | null {
+  if (!isUsablePath(inputPath)) return null;
+
+  const candidateRoots = rootId === undefined ? roots : roots.filter(root => root.id === rootId);
+  if (candidateRoots.length === 0) return null;
+
+  const resolved = candidateRoots
+    .map(root => resolveAgainstRoot(root, inputPath))
+    .filter((item): item is WorkspaceResolvedPath => item !== null)
+    .sort((left, right) => right.root.path.length - left.root.path.length);
+
+  return resolved[0] ?? null;
+}
+
+function resolveAgainstRoot(root: WorkspaceRootDescriptor, inputPath: string): WorkspaceResolvedPath | null {
+  if (!isUsablePath(root.id) || !isUsablePath(root.path)) return null;
+
+  const flavor = pathFlavorFor(root.path, inputPath);
+  const pathApi = flavor === 'win32' ? path.win32 : path.posix;
+  const normalizedRoot = normalizeAbsolutePath(root.path, pathApi);
+  if (!normalizedRoot) return null;
+
+  const normalizedPath = pathApi.isAbsolute(inputPath)
+    ? pathApi.normalize(inputPath)
+    : pathApi.resolve(normalizedRoot, inputPath);
+  const relativePath = pathApi.relative(normalizedRoot, normalizedPath);
+
+  if (relativePath === '') {
+    return { root: { ...root, path: normalizedRoot }, normalizedPath, relativePath: '.' };
+  }
+  if (isOutsideRelativePath(relativePath, pathApi)) return null;
+
+  return { root: { ...root, path: normalizedRoot }, normalizedPath, relativePath };
+}
+
+function normalizeAbsolutePath(value: string, pathApi: typeof path.posix | typeof path.win32): string | null {
+  if (!isUsablePath(value)) return null;
+  const normalized = pathApi.normalize(value);
+  return pathApi.isAbsolute(normalized) ? normalized : null;
+}
+
+function isOutsideRelativePath(relativePath: string, pathApi: typeof path.posix | typeof path.win32): boolean {
+  return relativePath === '..' || relativePath.startsWith(`..${pathApi.sep}`) || pathApi.isAbsolute(relativePath);
+}
+
+function pathFlavorFor(...values: string[]): 'posix' | 'win32' {
+  return values.some(value => /^[a-zA-Z]:[\\/]/.test(value) || value.startsWith('\\\\')) ? 'win32' : 'posix';
+}
+
+function isUsablePath(value: string): boolean {
+  return value.length > 0 && !value.includes('\0');
+}
+
+function ruleMatches(
+  rule: WorkspacePolicyRule,
+  action: WorkspacePolicyAction,
+  resolvedPath: WorkspaceResolvedPath | undefined,
+  resolvedToPath: WorkspaceResolvedPath | undefined,
+  commandRootId: string | undefined,
+): boolean {
+  if (!matchesValue(rule.kind, action.kind)) return false;
+
+  if (action.kind === 'file') {
+    return (
+      matchesValue(rule.operation, action.operation) &&
+      matchesFileRootSelector(rule, [resolvedPath?.root.id, resolvedToPath?.root.id]) &&
+      rule.command === undefined &&
+      rule.networkHost === undefined &&
+      rule.networkPort === undefined &&
+      rule.networkProtocol === undefined &&
+      rule.mcpServerId === undefined &&
+      rule.mcpToolName === undefined
+    );
+  }
+  if (rule.operation !== undefined) return false;
+
+  if (action.kind === 'command') {
+    return (
+      matchesValue(rule.command, action.command) &&
+      matchesValue(rule.rootId, commandRootId) &&
+      rule.networkHost === undefined &&
+      rule.networkPort === undefined &&
+      rule.networkProtocol === undefined &&
+      rule.mcpServerId === undefined &&
+      rule.mcpToolName === undefined
+    );
+  }
+  if (rule.rootId !== undefined) return false;
+
+  if (action.kind === 'network') {
+    return (
+      matchesValue(rule.networkHost, action.host) &&
+      matchesValue(rule.networkPort, action.port) &&
+      matchesValue(rule.networkProtocol, action.protocol) &&
+      rule.command === undefined &&
+      rule.mcpServerId === undefined &&
+      rule.mcpToolName === undefined
+    );
+  }
+  return (
+    matchesValue(rule.mcpServerId, action.serverId) &&
+    matchesValue(rule.mcpToolName, action.toolName) &&
+    rule.command === undefined &&
+    rule.networkHost === undefined &&
+    rule.networkPort === undefined &&
+    rule.networkProtocol === undefined
+  );
+}
+
+function matchesValue<T extends number | string>(
+  expected: T | readonly T[] | undefined,
+  actual: T | undefined,
+): boolean {
+  if (expected === undefined) return true;
+  if (actual === undefined) return false;
+  return Array.isArray(expected) ? expected.includes(actual) : expected === actual;
+}
+
+function matchesAnyValue<T extends string>(
+  expected: T | readonly T[] | undefined,
+  actualValues: readonly (T | undefined)[],
+): boolean {
+  if (expected === undefined) return true;
+  return actualValues.some(actual => matchesValue(expected, actual));
+}
+
+function matchesFileRootSelector(rule: WorkspacePolicyRule, rootIds: readonly (string | undefined)[]): boolean {
+  if (rule.rootId === undefined) return true;
+  const actualRootIds = rootIds.filter((rootId): rootId is string => rootId !== undefined);
+  if (actualRootIds.length === 0) return false;
+
+  if (rule.decision === 'allow') {
+    return actualRootIds.every(rootId => matchesValue(rule.rootId, rootId));
+  }
+  return matchesAnyValue(rule.rootId, actualRootIds);
+}
+
+function strongestDecision(decisions: readonly PermissionPolicy[], fallback: PermissionPolicy): PermissionPolicy {
+  if (decisions.includes('deny')) return 'deny';
+  if (decisions.includes('ask')) return 'ask';
+  if (decisions.includes('allow')) return 'allow';
+  return fallback;
+}
+
+function isMutatingFileOperation(operation: WorkspaceFileOperation): boolean {
+  return MUTATING_FILE_OPERATIONS.has(operation);
+}

--- a/packages/core/src/harness/v1/workspace-policy.ts
+++ b/packages/core/src/harness/v1/workspace-policy.ts
@@ -9,6 +9,9 @@ export interface WorkspaceRootDescriptor {
   id: string;
   path: string;
   label?: string;
+  /**
+   * When omitted, the root is treated as writable. Set to false to deny mutating file operations before rules run.
+   */
   writable?: boolean;
   metadata?: Readonly<Record<string, unknown>>;
 }
@@ -348,6 +351,7 @@ function matchesFileRootSelector(rule: WorkspacePolicyRule, rootIds: readonly (s
   const actualRootIds = rootIds.filter((rootId): rootId is string => rootId !== undefined);
   if (actualRootIds.length === 0) return false;
 
+  // Allow rules must approve every involved root, while deny/ask rules block when any involved root matches.
   if (rule.decision === 'allow') {
     return actualRootIds.every(rootId => matchesValue(rule.rootId, rootId));
   }

--- a/packages/core/src/harness/v1/workspace-policy.ts
+++ b/packages/core/src/harness/v1/workspace-policy.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 
 import type { PermissionPolicy } from './types';
@@ -183,6 +184,10 @@ function resolveWorkspaceFileAction(
     return { status: 'denied', reason: 'workspace.path_outside_roots' };
   }
 
+  if (action.operation === 'rename' && action.toPath === undefined) {
+    return { status: 'denied', reason: 'workspace.target_path_required' };
+  }
+
   if (action.toPath === undefined) {
     return { status: 'allowed', path: resolvedPath };
   }
@@ -203,7 +208,18 @@ function resolveWorkspaceActionPath(
   const requestedPath = resolveWorkspacePath(roots, inputPath, rootId);
   if (!requestedPath) return null;
 
-  return resolveWorkspacePath(roots, requestedPath.normalizedPath) ?? requestedPath;
+  const canonicalPath = resolveWorkspacePath(roots, requestedPath.normalizedPath);
+  if (!canonicalPath) return requestedPath;
+
+  if (
+    rootId !== undefined &&
+    canonicalPath.root.id !== requestedPath.root.id &&
+    canonicalPath.root.path === requestedPath.root.path
+  ) {
+    return requestedPath;
+  }
+
+  return canonicalPath;
 }
 
 function resolveWorkspaceCommandRoot(
@@ -251,6 +267,7 @@ function resolveAgainstRoot(root: WorkspaceRootDescriptor, inputPath: string): W
     return { root: { ...root, path: normalizedRoot }, normalizedPath, relativePath: '.' };
   }
   if (isOutsideRelativePath(relativePath, pathApi)) return null;
+  if (escapesRootByRealpath(normalizedRoot, normalizedPath, pathApi)) return null;
 
   return { root: { ...root, path: normalizedRoot }, normalizedPath, relativePath };
 }
@@ -263,6 +280,43 @@ function normalizeAbsolutePath(value: string, pathApi: typeof path.posix | typeo
 
 function isOutsideRelativePath(relativePath: string, pathApi: typeof path.posix | typeof path.win32): boolean {
   return relativePath === '..' || relativePath.startsWith(`..${pathApi.sep}`) || pathApi.isAbsolute(relativePath);
+}
+
+function escapesRootByRealpath(
+  normalizedRoot: string,
+  normalizedPath: string,
+  pathApi: typeof path.posix | typeof path.win32,
+): boolean {
+  const realRoot = realpathIfExists(normalizedRoot);
+  if (!realRoot) return false;
+
+  const nearestRealPath =
+    realpathIfExists(normalizedPath) ?? realpathIfExists(nearestExistingPath(normalizedPath, pathApi));
+  if (!nearestRealPath) return false;
+
+  const relativeRealPath = pathApi.relative(realRoot, nearestRealPath);
+  return isOutsideRelativePath(relativeRealPath, pathApi);
+}
+
+function realpathIfExists(value: string | null): string | null {
+  if (!value) return null;
+
+  try {
+    return fs.realpathSync.native(value);
+  } catch {
+    return null;
+  }
+}
+
+function nearestExistingPath(inputPath: string, pathApi: typeof path.posix | typeof path.win32): string | null {
+  let current = inputPath;
+
+  while (current !== pathApi.dirname(current)) {
+    if (fs.existsSync(current)) return current;
+    current = pathApi.dirname(current);
+  }
+
+  return fs.existsSync(current) ? current : null;
 }
 
 function pathFlavorFor(...values: string[]): 'posix' | 'win32' {
@@ -311,9 +365,9 @@ function ruleMatches(
 
   if (action.kind === 'network') {
     return (
-      matchesValue(rule.networkHost, action.host) &&
+      matchesNetworkHost(rule.networkHost, action.host) &&
       matchesValue(rule.networkPort, action.port) &&
-      matchesValue(rule.networkProtocol, action.protocol) &&
+      matchesNetworkProtocol(rule.networkProtocol, action.protocol) &&
       rule.command === undefined &&
       rule.mcpServerId === undefined &&
       rule.mcpToolName === undefined
@@ -344,6 +398,37 @@ function matchesAnyValue<T extends string>(
 ): boolean {
   if (expected === undefined) return true;
   return actualValues.some(actual => matchesValue(expected, actual));
+}
+
+function matchesNetworkHost(expected: string | readonly string[] | undefined, actual: string | undefined): boolean {
+  return matchesValue(normalizeExpectedStringSelector(expected, normalizeNetworkHost), normalizeNetworkHost(actual));
+}
+
+function matchesNetworkProtocol(expected: string | readonly string[] | undefined, actual: string | undefined): boolean {
+  return matchesValue(
+    normalizeExpectedStringSelector(expected, normalizeNetworkProtocol),
+    normalizeNetworkProtocol(actual),
+  );
+}
+
+function normalizeExpectedStringSelector(
+  expected: string | readonly string[] | undefined,
+  normalize: (value: string | undefined) => string | undefined,
+): string | readonly string[] | undefined {
+  if (expected === undefined) return undefined;
+  if (Array.isArray(expected)) {
+    return expected.map(value => normalize(value) ?? value);
+  }
+  if (typeof expected !== 'string') return expected;
+  return normalize(expected) ?? expected;
+}
+
+function normalizeNetworkHost(value: string | undefined): string | undefined {
+  return value?.toLowerCase();
+}
+
+function normalizeNetworkProtocol(value: string | undefined): string | undefined {
+  return value?.replace(/:$/, '').toLowerCase();
 }
 
 function matchesFileRootSelector(rule: WorkspacePolicyRule, rootIds: readonly (string | undefined)[]): boolean {

--- a/packages/core/src/harness/v1/workspace-policy.ts
+++ b/packages/core/src/harness/v1/workspace-policy.ts
@@ -304,6 +304,7 @@ function realpathIfExists(value: string | null): string | null {
   try {
     return fs.realpathSync.native(value);
   } catch {
+    // Missing or inaccessible paths fall back to lexical containment checks above.
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- Add a public Harness v1 workspace policy evaluator for desktop hosts and constrained executors.
- Resolve file paths and command cwd/root context against declared workspace roots.
- Enforce traversal denial, read-only root mutation denial, deterministic deny > ask > allow precedence, cross-root rename safety, command cwd/root scoping, and network/MCP selector matching.
- Export the evaluator/types from @mastra/core/harness/v1 and add a patch changeset with a public usage example.

## Scope
- PF-560 child of PF-551.
- Local core contract only: no server routes, no storage schema, no OS sandboxing, no production actions.
- Open PR overlap check before create: none open in mbenhamd/mastra.
- Rebased onto latest origin/main before opening: d176682677e40873e7a415136960534a56cede0a.

## Validation
- pnpm install --frozen-lockfile (needed because this worktree had no node_modules; completed with existing ignored-build-script warnings)
- pnpm build:core (needed to populate @internal/test-utils setup after initial focused test could not resolve it)
- pnpm --filter ./packages/core test:unit src/harness/v1/workspace-policy.test.ts
- pnpm --filter ./packages/core check
- pnpm prettier --check packages/core/src/harness/v1/workspace-policy.ts packages/core/src/harness/v1/workspace-policy.test.ts packages/core/src/harness/v1/index.ts .changeset/upset-corners-join.md
- git diff --check
- Local Codex review pass 1: fixed target-root rename, nested read-only root, and command cwd findings
- Local Codex review pass 2: fixed command rootId and network/MCP selector API findings
- coderabbit review --plain: fixed changeset description finding; rerun completed with no findings

## Follow-up
- Later PF-551 slices should wire this evaluator into concrete desktop host file/command/network/MCP execution surfaces, audit journal, and restore flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a simple safety checker that, before desktop or constrained executors touch files, run commands, use the network, or call AI tools, verifies those actions against workspace rules (with "deny" taking priority) and returns resolved paths plus rule reasons for approvals and audit.

## Overview

Adds a public Harness v1 workspace policy evaluator to `@mastra/core` that:
- Resolves action paths against declared workspace roots (POSIX and Windows-aware) and selects the most-specific root.
- Enforces no-traversal outside configured roots (including symlink escape detection), denies mutating ops on read-only roots, and enforces cross-root rename safety.
- Scopes selectors to action kinds (file, command, network, MCP) and enforces command cwd/root scoping.
- Produces deterministic decisions with precedence deny > ask > allow, falling back to policy.defaultDecision (defaults to ask).
- Returns enriched evaluation results including resolved path / toPath / cwd / root and matched rule reasons for approval screens and audit logs.

Scope: core contract only (no server routes, storage schema, OS sandboxing, or runtime wiring).

## Changes

- packages/core/src/harness/v1/workspace-policy.ts
  - New evaluator and helpers:
    - resolveWorkspacePath(roots, inputPath, rootId?) — Windows/POSIX handling, normalization, containment checks, and most-specific-root selection.
    - evaluateWorkspacePolicy(policy, action) — resolves path/toPath/cwd, enforces writable-root restrictions for mutating ops, matches rules by action kind and selectors (file root, command root/cwd, network host/port/protocol, MCP server/tool), aggregates matched reasons, applies deterministic decision precedence, and handles rename/source-target validation and symlink escapes.
  - New exported types/interfaces: WorkspacePolicy, WorkspacePolicyRule, WorkspacePolicyAction (and per-kind variants), WorkspaceResolvedPath, WorkspacePolicyEvaluation, WorkspacePolicyMatchedRule, WorkspaceRootDescriptor, WorkspaceFileOperation, WorkspacePolicyActionKind, etc.

- packages/core/src/harness/v1/index.ts
  - Re-exports evaluateWorkspacePolicy, resolveWorkspacePath, and workspace-policy types from ./workspace-policy.

- packages/core/src/harness/v1/workspace-policy.test.ts
  - New Vitest suite covering:
    - Most-specific-root selection (including Windows absolute paths).
    - Path traversal prevention (POSIX and Windows separators), segment-aware containment, and symlink escape denial.
    - Preservation of literal backslashes for POSIX roots and mixed-separator edge cases.
    - Read-only root denial for mutating ops and writable defaulting behavior.
    - Rename safety across roots, rule application to source vs. target, and missing-target checks.
    - Rule precedence (deny > ask > allow), ask vs allow resolution, and defaultDecision fallback.
    - Selector scoping per action kind and negative cross-kind cases.
    - Command cwd containment and rootId scoping/validation (including workspace.root_not_found).

- .changeset/upset-corners-join.md
  - Patch release note documenting the new workspace policy evaluation capability and a usage example showing evaluateWorkspacePolicy and throwing on non-allow decisions (including reasons).

- packages/core/src/harness/v1/index.ts
  - Re-exports added for evaluateWorkspacePolicy, resolveWorkspacePath, and related types.

## Validation & Reviews

- Local validation performed: pnpm install --frozen-lockfile; pnpm build:core; unit tests for workspace-policy.test.ts; pnpm --filter ./packages/core check; prettier checks on specified files; git diff --check.
- Two Codex review passes and a coderabbit review completed with fixes applied.
- Branch rebased onto origin/main commit d176682677e40873e7a415136960534a56cede0a. PR PF-560 is a child of PF-551.

## Follow-up Work

Wire the evaluator into desktop host file/command/network/MCP execution surfaces, audit journal, and restore flows in later PF-551 slices.

## Notes for reviewers

- Implementation intentionally focuses on core policy evaluation (no runtime integrations or sandboxing).
- Tests include mixed path-separator and Windows/POSIX edge cases added after review.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->