### PR TITLE
[PF-563] Add provider callback binding storage

### DIFF
--- a/.changeset/pf-563-provider-callback-binding.md
+++ b/.changeset/pf-563-provider-callback-binding.md
@@ -1,0 +1,23 @@
+---
+"@mastra/core": patch
+"@mastra/libsql": patch
+---
+
+Added: You can now route provider callbacks in Harness channels.
+
+```ts
+await storage.resolveProviderCallbackBinding({
+  id: 'slack-installation-team-1',
+  providerId: 'slack',
+  selectorKind: 'installation',
+  selectorValue: 'team-1',
+  harnessName: 'support',
+  channelId: 'support-slack',
+  status: 'active',
+  origin: { route: 'slack/events' },
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+});
+```
+
+The storage contract also keeps callback binding resolution idempotent and reports selector conflicts for implementers.

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -54,6 +54,7 @@ export const TABLE_HARNESS_OPERATION_TOMBSTONES = 'mastra_harness_operation_tomb
 export const TABLE_HARNESS_SESSION_EVENTS = 'mastra_harness_session_events';
 export const TABLE_HARNESS_THREAD_DELETE_FENCES = 'mastra_harness_thread_delete_fences';
 export const TABLE_HARNESS_CHANNEL_INBOX = 'mastra_harness_channel_inbox';
+export const TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS = 'mastra_harness_provider_callback_bindings';
 export const TABLE_HARNESS_CHANNEL_ACTION_TOKENS = 'mastra_harness_channel_action_tokens';
 export const TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS = 'mastra_harness_channel_action_receipts';
 export const TABLE_HARNESS_CHANNEL_OUTBOX = 'mastra_harness_channel_outbox';
@@ -102,6 +103,7 @@ export type TABLE_NAMES =
   | typeof TABLE_HARNESS_SESSION_EVENTS
   | typeof TABLE_HARNESS_THREAD_DELETE_FENCES
   | typeof TABLE_HARNESS_CHANNEL_INBOX
+  | typeof TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS
   | typeof TABLE_HARNESS_CHANNEL_ACTION_TOKENS
   | typeof TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS
   | typeof TABLE_HARNESS_CHANNEL_OUTBOX
@@ -820,6 +822,21 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
     attachments: { type: 'jsonb', nullable: false },
     last_error: { type: 'jsonb', nullable: true },
   },
+  [TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS]: {
+    id: { type: 'text', nullable: false, primaryKey: true },
+    provider_id: { type: 'text', nullable: false },
+    selector_kind: { type: 'text', nullable: false },
+    selector_value: { type: 'text', nullable: false },
+    harness_name: { type: 'text', nullable: false },
+    channel_id: { type: 'text', nullable: false },
+    origin: { type: 'jsonb', nullable: false },
+    status: { type: 'text', nullable: false },
+    created_at: { type: 'bigint', nullable: false },
+    updated_at: { type: 'bigint', nullable: false },
+    replaced_at: { type: 'bigint', nullable: true },
+    replaced_by_binding_id: { type: 'text', nullable: true },
+    last_error: { type: 'jsonb', nullable: true },
+  },
   [TABLE_HARNESS_CHANNEL_ACTION_TOKENS]: {
     action_token_id: { type: 'text', nullable: false },
     harness_name: { type: 'text', nullable: false },
@@ -985,6 +1002,9 @@ export const TABLE_CONFIGS: Partial<Record<TABLE_NAMES, StorageTableConfig>> = {
   },
   [TABLE_HARNESS_CHANNEL_INBOX]: {
     columns: TABLE_SCHEMAS[TABLE_HARNESS_CHANNEL_INBOX],
+  },
+  [TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS]: {
+    columns: TABLE_SCHEMAS[TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS],
   },
   [TABLE_HARNESS_CHANNEL_ACTION_TOKENS]: {
     columns: TABLE_SCHEMAS[TABLE_HARNESS_CHANNEL_ACTION_TOKENS],

--- a/packages/core/src/storage/domains/harness/base.ts
+++ b/packages/core/src/storage/domains/harness/base.ts
@@ -11,6 +11,7 @@ import type {
   ChannelDiagnosticsRows,
   ChannelOutboxItem,
   ChannelProviderDeliveryReceipt,
+  HarnessProviderCallbackBinding,
   ChannelInboxInitialClaim,
   ChannelInboxItem,
   CreateOrLoadChannelActionReceiptResult,
@@ -34,8 +35,10 @@ import type {
   LoadedAttachment,
   OperationAdmissionEvidence,
   OperationAdmissionTombstone,
+  ProviderCallbackSelectorKind,
   QueueAdmissionReceipt,
   ReleaseSessionLeaseInput,
+  ResolveProviderCallbackBindingResult,
   RenewSessionLeaseInput,
   SaveAttachmentInput,
   SaveAttachmentReferenceInput,
@@ -206,6 +209,29 @@ export class HarnessStorageChannelDiagnosticsUnsupportedError extends Error {
   readonly code = 'harness.storage.channel_diagnostics_unsupported' as const;
   constructor() {
     super('HarnessStorage channel diagnostics must be implemented by this storage adapter');
+  }
+}
+
+export class HarnessStorageProviderCallbackBindingUnsupportedError extends Error {
+  readonly name = 'HarnessStorageProviderCallbackBindingUnsupportedError';
+  readonly code = 'harness.storage.provider_callback_binding_unsupported' as const;
+  constructor() {
+    super('HarnessStorage provider callback bindings must be implemented by this storage adapter');
+  }
+}
+
+export class HarnessStorageProviderCallbackBindingTransitionError extends Error {
+  readonly name = 'HarnessStorageProviderCallbackBindingTransitionError';
+  readonly code = 'harness.storage.provider_callback_binding_transition_invalid' as const;
+  constructor(
+    public readonly bindingId: string,
+    public readonly fromStatus: HarnessProviderCallbackBinding['status'] | undefined,
+    public readonly toStatus: HarnessProviderCallbackBinding['status'],
+    reason: string,
+  ) {
+    super(
+      `Provider callback binding "${bindingId}" cannot transition from "${fromStatus ?? '<missing>'}" to "${toStatus}": ${reason}`,
+    );
   }
 }
 
@@ -700,6 +726,34 @@ export abstract class HarnessStorage extends StorageDomain {
     limit: number;
   }): Promise<HarnessSessionEventRecord[]> {
     throw new HarnessStorageSessionEventReplayUnsupportedError();
+  }
+
+  // -------------------------------------------------------------------------
+  // Provider callback binding ledger
+  // -------------------------------------------------------------------------
+
+  async resolveProviderCallbackBinding(
+    _record: HarnessProviderCallbackBinding,
+    _opts?: { replaceBindingId?: string },
+  ): Promise<ResolveProviderCallbackBindingResult> {
+    throw new HarnessStorageProviderCallbackBindingUnsupportedError();
+  }
+
+  async loadProviderCallbackBindingBySelector(_opts: {
+    providerId: string;
+    selectorKind: ProviderCallbackSelectorKind;
+    selectorValue: string;
+  }): Promise<HarnessProviderCallbackBinding | null> {
+    throw new HarnessStorageProviderCallbackBindingUnsupportedError();
+  }
+
+  async markProviderCallbackBindingStatus(_opts: {
+    bindingId: string;
+    status: Extract<HarnessProviderCallbackBinding['status'], 'active' | 'disabled' | 'undeliverable'>;
+    updatedAt?: number;
+    lastError?: HarnessProviderCallbackBinding['lastError'];
+  }): Promise<HarnessProviderCallbackBinding> {
+    throw new HarnessStorageProviderCallbackBindingUnsupportedError();
   }
 
   // -------------------------------------------------------------------------

--- a/packages/core/src/storage/domains/harness/inmemory.test.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.test.ts
@@ -12,6 +12,7 @@ import {
   HarnessStorageChannelOutboxClaimConflictError,
   HarnessStorageChannelOutboxTransitionError,
   HarnessStorageDeleteGuardConflictError,
+  HarnessStorageProviderCallbackBindingTransitionError,
   HarnessStorageThreadDeleteFenceConflictError,
   HarnessStorageVersionConflictError,
   HarnessStorageWakeupClaimConflictError,
@@ -23,6 +24,7 @@ import type {
   ChannelActionToken,
   ChannelInboxItem,
   ChannelOutboxItem,
+  HarnessProviderCallbackBinding,
   HarnessWakeupItem,
   SessionRecord,
 } from './types';
@@ -818,6 +820,153 @@ describe('InMemoryHarness admission storage contract', () => {
         signalId: 'signal-2',
       }),
     ).resolves.toMatchObject({ status: 'completed', result: { text: 'new' } });
+  });
+});
+
+describe('InMemoryHarness provider callback binding ledger', () => {
+  it('dedupes exact active selector bindings and preserves the first target', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+
+    await expect(storage.resolveProviderCallbackBinding(sampleProviderCallbackBinding())).resolves.toMatchObject({
+      duplicate: false,
+      conflict: false,
+      binding: { id: 'callback-binding-1', status: 'active' },
+    });
+    await expect(
+      storage.resolveProviderCallbackBinding(sampleProviderCallbackBinding({ id: 'callback-binding-retry' })),
+    ).resolves.toMatchObject({
+      duplicate: true,
+      conflict: false,
+      binding: { id: 'callback-binding-1' },
+    });
+  });
+
+  it('reports same selector with a different target as a conflict without retargeting', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    await storage.resolveProviderCallbackBinding(sampleProviderCallbackBinding());
+
+    await expect(
+      storage.resolveProviderCallbackBinding(
+        sampleProviderCallbackBinding({
+          id: 'callback-binding-2',
+          channelId: 'sales',
+          origin: { route: 'sales-events' },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      duplicate: true,
+      conflict: true,
+      binding: { id: 'callback-binding-1', channelId: 'support' },
+    });
+    await expect(
+      storage.loadProviderCallbackBindingBySelector({
+        providerId: 'slack',
+        selectorKind: 'installation',
+        selectorValue: 'installation-1',
+      }),
+    ).resolves.toMatchObject({ id: 'callback-binding-1', channelId: 'support' });
+  });
+
+  it('replaces active selector bindings and keeps replaced rows terminal', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    await storage.resolveProviderCallbackBinding(sampleProviderCallbackBinding());
+
+    await expect(
+      storage.resolveProviderCallbackBinding(sampleProviderCallbackBinding(), {
+        replaceBindingId: 'callback-binding-1',
+      }),
+    ).rejects.toBeInstanceOf(HarnessStorageProviderCallbackBindingTransitionError);
+    await expect(
+      storage.resolveProviderCallbackBinding(
+        sampleProviderCallbackBinding({
+          id: 'callback-binding-disabled',
+          status: 'disabled',
+          harnessName: 'support-disabled',
+          channelId: 'support-disabled',
+          createdAt: 1500,
+          updatedAt: 1500,
+          origin: { route: 'support-events-disabled' },
+        }),
+        { replaceBindingId: 'callback-binding-1' },
+      ),
+    ).rejects.toBeInstanceOf(HarnessStorageProviderCallbackBindingTransitionError);
+    await expect(
+      storage.loadProviderCallbackBindingBySelector({
+        providerId: 'slack',
+        selectorKind: 'installation',
+        selectorValue: 'installation-1',
+      }),
+    ).resolves.toMatchObject({ id: 'callback-binding-1', status: 'active' });
+    await expect(
+      storage.resolveProviderCallbackBinding(
+        sampleProviderCallbackBinding({
+          id: 'callback-binding-2',
+          harnessName: 'support-v2',
+          channelId: 'support-v2',
+          createdAt: 2000,
+          updatedAt: 2000,
+          origin: { route: 'support-events-v2' },
+        }),
+        { replaceBindingId: 'callback-binding-1' },
+      ),
+    ).resolves.toMatchObject({
+      duplicate: false,
+      conflict: false,
+      replacedBindingId: 'callback-binding-1',
+      binding: { id: 'callback-binding-2', harnessName: 'support-v2', status: 'active' },
+    });
+    await expect(
+      storage.loadProviderCallbackBindingBySelector({
+        providerId: 'slack',
+        selectorKind: 'installation',
+        selectorValue: 'installation-1',
+      }),
+    ).resolves.toMatchObject({ id: 'callback-binding-2' });
+    await expect(
+      storage.resolveProviderCallbackBinding(
+        sampleProviderCallbackBinding({
+          id: 'callback-binding-2',
+          harnessName: 'support-v2',
+          channelId: 'support-v2',
+          createdAt: 2000,
+          updatedAt: 2000,
+          origin: { route: 'support-events-v2' },
+        }),
+        { replaceBindingId: 'callback-binding-1' },
+      ),
+    ).resolves.toMatchObject({
+      duplicate: true,
+      conflict: false,
+      replacedBindingId: 'callback-binding-1',
+      binding: { id: 'callback-binding-2', status: 'active' },
+    });
+    await expect(
+      storage.markProviderCallbackBindingStatus({ bindingId: 'callback-binding-1', status: 'active', updatedAt: 3000 }),
+    ).rejects.toBeInstanceOf(HarnessStorageProviderCallbackBindingTransitionError);
+  });
+
+  it('allows disabled or undeliverable bindings to reactivate when no active selector owner exists', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    await storage.resolveProviderCallbackBinding(sampleProviderCallbackBinding());
+
+    await expect(
+      storage.markProviderCallbackBindingStatus({
+        bindingId: 'callback-binding-1',
+        status: 'undeliverable',
+        updatedAt: 2000,
+        lastError: { code: 'worker_unavailable', message: 'provider missing', retryable: true },
+      }),
+    ).resolves.toMatchObject({ status: 'undeliverable', lastError: { code: 'worker_unavailable' } });
+    await expect(
+      storage.loadProviderCallbackBindingBySelector({
+        providerId: 'slack',
+        selectorKind: 'installation',
+        selectorValue: 'installation-1',
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      storage.markProviderCallbackBindingStatus({ bindingId: 'callback-binding-1', status: 'active', updatedAt: 3000 }),
+    ).resolves.toMatchObject({ status: 'active', lastError: undefined });
   });
 });
 
@@ -2167,6 +2316,24 @@ function sampleChannelInbox(overrides: Partial<ChannelInboxItem> = {}): ChannelI
     },
     content: 'hello',
     attachments: [],
+    ...overrides,
+  };
+}
+
+function sampleProviderCallbackBinding(
+  overrides: Partial<HarnessProviderCallbackBinding> = {},
+): HarnessProviderCallbackBinding {
+  return {
+    id: 'callback-binding-1',
+    providerId: 'slack',
+    selectorKind: 'installation',
+    selectorValue: 'installation-1',
+    harnessName: 'default',
+    channelId: 'support',
+    origin: { route: 'support-events' },
+    status: 'active',
+    createdAt: 1000,
+    updatedAt: 1000,
     ...overrides,
   };
 }

--- a/packages/core/src/storage/domains/harness/inmemory.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.ts
@@ -16,6 +16,7 @@ import {
   HarnessStorageDeleteGuardConflictError,
   HarnessStorageLeaseConflictError,
   HarnessStorageParentSessionUnavailableError,
+  HarnessStorageProviderCallbackBindingTransitionError,
   HarnessStorageSessionNotFoundError,
   HarnessStorageThreadDeleteFenceConflictError,
   HarnessStorageVersionConflictError,
@@ -36,6 +37,7 @@ import type {
   ChannelInboxItem,
   ChannelOutboxItem,
   ChannelProviderDeliveryReceipt,
+  HarnessProviderCallbackBinding,
   CreateOrLoadActiveSessionOptions,
   CreateOrLoadChannelActionReceiptResult,
   CreateOrLoadChannelActionTokenResult,
@@ -55,9 +57,11 @@ import type {
   JsonValue,
   OperationAdmissionEvidence,
   OperationAdmissionTombstone,
+  ProviderCallbackSelectorKind,
   QueueAdmissionReceipt,
   ReleaseSessionLeaseInput,
   RenewSessionLeaseInput,
+  ResolveProviderCallbackBindingResult,
   SaveAttachmentReferenceInput,
   SaveAttachmentInput,
   SaveAttachmentResult,
@@ -1040,6 +1044,177 @@ export class InMemoryHarness extends HarnessStorage {
   }
 
   // -------------------------------------------------------------------------
+  // Provider callback binding ledger
+  // -------------------------------------------------------------------------
+
+  async resolveProviderCallbackBinding(
+    record: HarnessProviderCallbackBinding,
+    opts?: { replaceBindingId?: string },
+  ): Promise<ResolveProviderCallbackBindingResult> {
+    const incoming: HarnessProviderCallbackBinding = {
+      ...record,
+      harnessName: resolveHarnessName(record.harnessName, this.harnessName),
+    };
+    assertValidProviderCallbackBindingState(incoming);
+    const active = this.findActiveProviderCallbackBindingBySelector({
+      providerId: incoming.providerId,
+      selectorKind: incoming.selectorKind,
+      selectorValue: incoming.selectorValue,
+    });
+
+    if (opts?.replaceBindingId !== undefined) {
+      if (opts.replaceBindingId === incoming.id) {
+        throw new HarnessStorageProviderCallbackBindingTransitionError(
+          incoming.id,
+          incoming.status,
+          'replaced',
+          'replacement target must be different from the incoming binding',
+        );
+      }
+      if (incoming.status !== 'active') {
+        throw new HarnessStorageProviderCallbackBindingTransitionError(
+          incoming.id,
+          incoming.status,
+          'active',
+          'replacement binding must be active',
+        );
+      }
+      const existingById = this.findProviderCallbackBindingById(incoming.id);
+      if (existingById && !providerCallbackBindingsEqual(existingById, incoming)) {
+        throw new HarnessStorageProviderCallbackBindingTransitionError(
+          incoming.id,
+          existingById.status,
+          incoming.status,
+          'id is already owned by another provider callback binding',
+        );
+      }
+      const previous = this.findProviderCallbackBindingById(opts.replaceBindingId);
+      if (
+        previous?.status === 'replaced' &&
+        previous.replacedByBindingId === incoming.id &&
+        existingById &&
+        providerCallbackBindingsEqual(existingById, incoming)
+      ) {
+        return {
+          binding: existingById,
+          duplicate: true,
+          conflict: false,
+          replacedBindingId: previous.id,
+        };
+      }
+      if (
+        !previous ||
+        previous.status !== 'active' ||
+        previous.providerId !== incoming.providerId ||
+        previous.selectorKind !== incoming.selectorKind ||
+        previous.selectorValue !== incoming.selectorValue
+      ) {
+        throw new HarnessStorageProviderCallbackBindingTransitionError(
+          opts.replaceBindingId,
+          previous?.status,
+          'replaced',
+          'replacement target is missing, inactive, or owns a different selector',
+        );
+      }
+      if (active && active.id !== previous.id) {
+        if (existingById && providerCallbackBindingsEqual(existingById, incoming)) {
+          return { binding: existingById, duplicate: true, conflict: false, replacedBindingId: previous.id };
+        }
+        return { binding: active, duplicate: true, conflict: true };
+      }
+      const replacedAt = incoming.createdAt;
+      const replacedPrevious: HarnessProviderCallbackBinding = {
+        ...previous,
+        status: 'replaced',
+        replacedAt,
+        replacedByBindingId: incoming.id,
+        updatedAt: replacedAt,
+      };
+      this.db.harnessProviderCallbackBindings.set(previous.id, cloneJson(replacedPrevious));
+      this.db.harnessProviderCallbackBindings.set(incoming.id, cloneJson(incoming));
+      return { binding: cloneJson(incoming), duplicate: false, conflict: false, replacedBindingId: previous.id };
+    }
+
+    if (active) {
+      return {
+        binding: active,
+        duplicate: true,
+        conflict: !sameProviderCallbackBindingTarget(active, incoming),
+      };
+    }
+    const existingById = this.findProviderCallbackBindingById(incoming.id);
+    if (existingById) {
+      if (providerCallbackBindingsEqual(existingById, incoming)) {
+        return { binding: existingById, duplicate: true, conflict: false };
+      }
+      throw new HarnessStorageProviderCallbackBindingTransitionError(
+        incoming.id,
+        existingById.status,
+        incoming.status,
+        'id is already owned by another provider callback binding',
+      );
+    }
+    this.db.harnessProviderCallbackBindings.set(incoming.id, cloneJson(incoming));
+    return { binding: cloneJson(incoming), duplicate: false, conflict: false };
+  }
+
+  async loadProviderCallbackBindingBySelector(opts: {
+    providerId: string;
+    selectorKind: ProviderCallbackSelectorKind;
+    selectorValue: string;
+  }): Promise<HarnessProviderCallbackBinding | null> {
+    return this.findActiveProviderCallbackBindingBySelector(opts);
+  }
+
+  async markProviderCallbackBindingStatus(opts: {
+    bindingId: string;
+    status: Extract<HarnessProviderCallbackBinding['status'], 'active' | 'disabled' | 'undeliverable'>;
+    updatedAt?: number;
+    lastError?: HarnessProviderCallbackBinding['lastError'];
+  }): Promise<HarnessProviderCallbackBinding> {
+    const current = this.findProviderCallbackBindingById(opts.bindingId);
+    if (!current) {
+      throw new HarnessStorageProviderCallbackBindingTransitionError(
+        opts.bindingId,
+        undefined,
+        opts.status,
+        'binding was not found',
+      );
+    }
+    if (current.status === 'replaced') {
+      throw new HarnessStorageProviderCallbackBindingTransitionError(
+        current.id,
+        current.status,
+        opts.status,
+        'replaced bindings are terminal',
+      );
+    }
+    const updatedAt = opts.updatedAt ?? Date.now();
+    const active = this.findActiveProviderCallbackBindingBySelector({
+      providerId: current.providerId,
+      selectorKind: current.selectorKind,
+      selectorValue: current.selectorValue,
+    });
+    if (opts.status === 'active' && active && active.id !== current.id) {
+      throw new HarnessStorageProviderCallbackBindingTransitionError(
+        current.id,
+        current.status,
+        opts.status,
+        'another active binding owns this selector',
+      );
+    }
+    const next: HarnessProviderCallbackBinding = {
+      ...current,
+      status: opts.status,
+      updatedAt,
+      lastError: opts.lastError,
+    };
+    assertValidProviderCallbackBindingState(next);
+    this.db.harnessProviderCallbackBindings.set(next.id, cloneJson(next));
+    return cloneJson(next);
+  }
+
+  // -------------------------------------------------------------------------
   // Channel inbox ledger
   // -------------------------------------------------------------------------
 
@@ -1926,6 +2101,33 @@ export class InMemoryHarness extends HarnessStorage {
     return null;
   }
 
+  private findProviderCallbackBindingById(bindingId: string): HarnessProviderCallbackBinding | null {
+    const binding = this.db.harnessProviderCallbackBindings.get(bindingId);
+    return binding ? cloneJson(binding) : null;
+  }
+
+  private findActiveProviderCallbackBindingBySelector({
+    providerId,
+    selectorKind,
+    selectorValue,
+  }: {
+    providerId: string;
+    selectorKind: ProviderCallbackSelectorKind;
+    selectorValue: string;
+  }): HarnessProviderCallbackBinding | null {
+    for (const binding of this.db.harnessProviderCallbackBindings.values()) {
+      if (
+        binding.status === 'active' &&
+        binding.providerId === providerId &&
+        binding.selectorKind === selectorKind &&
+        binding.selectorValue === selectorValue
+      ) {
+        return cloneJson(binding);
+      }
+    }
+    return null;
+  }
+
   private findChannelActionTokenById({
     harnessName,
     channelId,
@@ -2156,6 +2358,7 @@ export class InMemoryHarness extends HarnessStorage {
     this.db.harnessOperationTombstones.clear();
     this.db.harnessSessionEvents.clear();
     this.db.harnessChannelInbox.clear();
+    this.db.harnessProviderCallbackBindings.clear();
     this.db.harnessChannelActionTokens.clear();
     this.db.harnessChannelActionReceipts.clear();
     this.db.harnessChannelOutbox.clear();
@@ -3044,6 +3247,80 @@ function channelInboxComparableValues(record: ChannelInboxItem): unknown[] {
     stableJsonString(record.attachments),
     record.lastError ? stableJsonString(record.lastError) : undefined,
   ];
+}
+
+function providerCallbackBindingsEqual(a: HarnessProviderCallbackBinding, b: HarnessProviderCallbackBinding): boolean {
+  return (
+    stableJsonString(providerCallbackBindingComparableValues(a)) ===
+    stableJsonString(providerCallbackBindingComparableValues(b))
+  );
+}
+
+function sameProviderCallbackBindingTarget(
+  a: HarnessProviderCallbackBinding,
+  b: HarnessProviderCallbackBinding,
+): boolean {
+  return (
+    a.harnessName === b.harnessName &&
+    a.channelId === b.channelId &&
+    stableJsonString(a.origin) === stableJsonString(b.origin)
+  );
+}
+
+function providerCallbackBindingComparableValues(record: HarnessProviderCallbackBinding): unknown[] {
+  return [
+    record.id,
+    record.providerId,
+    record.selectorKind,
+    record.selectorValue,
+    record.harnessName,
+    record.channelId,
+    stableJsonString(record.origin),
+    record.status,
+    record.createdAt,
+    record.updatedAt,
+    record.replacedAt,
+    record.replacedByBindingId,
+    record.lastError ? stableJsonString(record.lastError) : undefined,
+  ];
+}
+
+function assertValidProviderCallbackBindingState(record: HarnessProviderCallbackBinding): void {
+  if (!['installation', 'route-key', 'external-tenant'].includes(record.selectorKind)) {
+    throw new HarnessStorageProviderCallbackBindingTransitionError(
+      record.id,
+      undefined,
+      record.status,
+      `invalid selector kind "${record.selectorKind}"`,
+    );
+  }
+  if (!['active', 'disabled', 'undeliverable', 'replaced'].includes(record.status)) {
+    throw new HarnessStorageProviderCallbackBindingTransitionError(
+      record.id,
+      undefined,
+      record.status,
+      `invalid status "${record.status}"`,
+    );
+  }
+  if (record.status === 'replaced') {
+    if (record.replacedAt === undefined || record.replacedByBindingId === undefined) {
+      throw new HarnessStorageProviderCallbackBindingTransitionError(
+        record.id,
+        undefined,
+        record.status,
+        'replaced bindings require replacedAt and replacedByBindingId',
+      );
+    }
+    return;
+  }
+  if (record.replacedAt !== undefined || record.replacedByBindingId !== undefined) {
+    throw new HarnessStorageProviderCallbackBindingTransitionError(
+      record.id,
+      undefined,
+      record.status,
+      'non-replaced bindings cannot carry replacement metadata',
+    );
+  }
 }
 
 function stableJsonString(value: unknown): string {

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -533,6 +533,31 @@ export interface PersistedRequestContextInput {
   metadata?: Record<string, JsonValue>;
 }
 
+export type ProviderCallbackSelectorKind = 'installation' | 'route-key' | 'external-tenant';
+
+export interface HarnessProviderCallbackBinding {
+  id: string;
+  providerId: string;
+  selectorKind: ProviderCallbackSelectorKind;
+  selectorValue: string;
+  harnessName: string;
+  channelId: string;
+  origin: JsonValue;
+  status: 'active' | 'disabled' | 'undeliverable' | 'replaced';
+  createdAt: number;
+  updatedAt: number;
+  replacedAt?: number;
+  replacedByBindingId?: string;
+  lastError?: { code: HarnessRowErrorCode; message: string; retryable?: boolean };
+}
+
+export interface ResolveProviderCallbackBindingResult {
+  binding: HarnessProviderCallbackBinding;
+  duplicate: boolean;
+  conflict: boolean;
+  replacedBindingId?: string;
+}
+
 export interface ChannelInboxItem {
   id: string;
   harnessName: string;

--- a/packages/core/src/storage/domains/inmemory-db.ts
+++ b/packages/core/src/storage/domains/inmemory-db.ts
@@ -29,6 +29,7 @@ import type {
   ChannelActionToken,
   ChannelInboxItem,
   ChannelOutboxItem,
+  HarnessProviderCallbackBinding,
   HarnessWakeupItem,
   HarnessSessionEventRecord,
   OperationAdmissionTombstone,
@@ -121,6 +122,7 @@ export class InMemoryDB {
   readonly harnessOperationTombstones = new Map<string, OperationAdmissionTombstone>();
   readonly harnessSessionEvents = new Map<string, HarnessSessionEventRecord>();
   readonly harnessChannelInbox = new Map<string, ChannelInboxItem>();
+  readonly harnessProviderCallbackBindings = new Map<string, HarnessProviderCallbackBinding>();
   readonly harnessChannelActionTokens = new Map<string, ChannelActionToken>();
   readonly harnessChannelActionReceipts = new Map<string, ChannelActionReceipt>();
   readonly harnessChannelOutbox = new Map<string, ChannelOutboxItem>();
@@ -184,6 +186,7 @@ export class InMemoryDB {
     this.harnessOperationTombstones.clear();
     this.harnessSessionEvents.clear();
     this.harnessChannelInbox.clear();
+    this.harnessProviderCallbackBindings.clear();
     this.harnessChannelActionTokens.clear();
     this.harnessChannelActionReceipts.clear();
     this.harnessChannelOutbox.clear();

--- a/packages/core/src/storage/domains/operations/inmemory.ts
+++ b/packages/core/src/storage/domains/operations/inmemory.ts
@@ -57,6 +57,7 @@ export class StoreOperationsInMemory extends StoreOperations {
       mastra_harness_channel_action_tokens: new Map(),
       mastra_harness_channel_action_receipts: new Map(),
       mastra_harness_channel_outbox: new Map(),
+      mastra_harness_provider_callback_bindings: new Map(),
       mastra_harness_wakeups: new Map(),
     };
   }

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -12,6 +12,7 @@ import {
   TABLE_HARNESS_CHANNEL_INBOX,
   TABLE_HARNESS_CHANNEL_OUTBOX,
   TABLE_HARNESS_MESSAGE_RESULTS,
+  TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS,
   TABLE_HARNESS_SESSIONS,
   TABLE_HARNESS_THREAD_DELETE_FENCES,
   TABLE_HARNESS_WAKEUPS,
@@ -24,6 +25,7 @@ import {
   HarnessStorageChannelOutboxClaimConflictError,
   HarnessStorageChannelOutboxTransitionError,
   HarnessStorageDeleteGuardConflictError,
+  HarnessStorageProviderCallbackBindingTransitionError,
   HarnessStorageThreadDeleteFenceConflictError,
   HarnessStorageVersionConflictError,
   HarnessStorageWakeupClaimConflictError,
@@ -34,6 +36,7 @@ import type {
   ChannelActionToken,
   ChannelInboxItem,
   ChannelOutboxItem,
+  HarnessProviderCallbackBinding,
   HarnessWakeupItem,
   SessionRecord,
   HarnessStorageParentSessionUnavailableError,
@@ -1043,6 +1046,275 @@ describe('HarnessLibSQL inbox response receipts', () => {
         },
       },
     });
+  });
+});
+
+describe('HarnessLibSQL provider callback binding ledger', () => {
+  let storage: HarnessLibSQL;
+  let client: Client;
+
+  beforeEach(async () => {
+    client = createHarnessTestClient();
+    storage = new HarnessLibSQL({ client });
+    await storage.init();
+  });
+
+  it('dedupes exact active selector bindings and creates active-selector indexes lazily', async () => {
+    const client = createHarnessTestClient();
+    const lazyStorage = new HarnessLibSQL({ client });
+    const executeSpy = vi.spyOn(client, 'execute');
+
+    await expect(lazyStorage.resolveProviderCallbackBinding(sampleProviderCallbackBinding())).resolves.toMatchObject({
+      duplicate: false,
+      conflict: false,
+      binding: { id: 'callback-binding-1', status: 'active' },
+    });
+    await expect(
+      lazyStorage.resolveProviderCallbackBinding(sampleProviderCallbackBinding({ id: 'callback-binding-retry' })),
+    ).resolves.toMatchObject({
+      duplicate: true,
+      conflict: false,
+      binding: { id: 'callback-binding-1' },
+    });
+    await expect(indexNames(client, TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS)).resolves.toEqual(
+      expect.arrayContaining([
+        'idx_harness_provider_callback_active_selector',
+        'idx_harness_provider_callback_selector_status',
+      ]),
+    );
+    expect(indexCreateStatements(executeSpy.mock.calls, 'idx_harness_provider_callback_')).toHaveLength(2);
+  });
+
+  it('reports same selector with a different target as a conflict without retargeting', async () => {
+    await storage.resolveProviderCallbackBinding(sampleProviderCallbackBinding());
+
+    await expect(
+      storage.resolveProviderCallbackBinding(
+        sampleProviderCallbackBinding({
+          id: 'callback-binding-2',
+          channelId: 'sales',
+          origin: { route: 'sales-events' },
+        }),
+      ),
+    ).resolves.toMatchObject({
+      duplicate: true,
+      conflict: true,
+      binding: { id: 'callback-binding-1', channelId: 'support' },
+    });
+    await expect(
+      storage.loadProviderCallbackBindingBySelector({
+        providerId: 'slack',
+        selectorKind: 'installation',
+        selectorValue: 'installation-1',
+      }),
+    ).resolves.toMatchObject({ id: 'callback-binding-1', channelId: 'support' });
+  });
+
+  it('replaces active selector bindings and keeps replaced rows terminal', async () => {
+    await storage.resolveProviderCallbackBinding(sampleProviderCallbackBinding());
+
+    await expect(
+      storage.resolveProviderCallbackBinding(sampleProviderCallbackBinding(), {
+        replaceBindingId: 'callback-binding-1',
+      }),
+    ).rejects.toBeInstanceOf(HarnessStorageProviderCallbackBindingTransitionError);
+    await expect(
+      storage.resolveProviderCallbackBinding(
+        sampleProviderCallbackBinding({
+          id: 'callback-binding-disabled',
+          status: 'disabled',
+          harnessName: 'support-disabled',
+          channelId: 'support-disabled',
+          createdAt: 1500,
+          updatedAt: 1500,
+          origin: { route: 'support-events-disabled' },
+        }),
+        { replaceBindingId: 'callback-binding-1' },
+      ),
+    ).rejects.toBeInstanceOf(HarnessStorageProviderCallbackBindingTransitionError);
+    await expect(
+      storage.loadProviderCallbackBindingBySelector({
+        providerId: 'slack',
+        selectorKind: 'installation',
+        selectorValue: 'installation-1',
+      }),
+    ).resolves.toMatchObject({ id: 'callback-binding-1', status: 'active' });
+    await expect(
+      storage.resolveProviderCallbackBinding(
+        sampleProviderCallbackBinding({
+          id: 'callback-binding-2',
+          harnessName: 'support-v2',
+          channelId: 'support-v2',
+          createdAt: 2000,
+          updatedAt: 2000,
+          origin: { route: 'support-events-v2' },
+        }),
+        { replaceBindingId: 'callback-binding-1' },
+      ),
+    ).resolves.toMatchObject({
+      duplicate: false,
+      conflict: false,
+      replacedBindingId: 'callback-binding-1',
+      binding: { id: 'callback-binding-2', harnessName: 'support-v2', status: 'active' },
+    });
+    await expect(
+      storage.loadProviderCallbackBindingBySelector({
+        providerId: 'slack',
+        selectorKind: 'installation',
+        selectorValue: 'installation-1',
+      }),
+    ).resolves.toMatchObject({ id: 'callback-binding-2' });
+    await expect(
+      storage.resolveProviderCallbackBinding(
+        sampleProviderCallbackBinding({
+          id: 'callback-binding-2',
+          harnessName: 'support-v2',
+          channelId: 'support-v2',
+          createdAt: 2000,
+          updatedAt: 2000,
+          origin: { route: 'support-events-v2' },
+        }),
+        { replaceBindingId: 'callback-binding-1' },
+      ),
+    ).resolves.toMatchObject({
+      duplicate: true,
+      conflict: false,
+      replacedBindingId: 'callback-binding-1',
+      binding: { id: 'callback-binding-2', status: 'active' },
+    });
+    await expect(
+      storage.markProviderCallbackBindingStatus({ bindingId: 'callback-binding-1', status: 'active', updatedAt: 3000 }),
+    ).rejects.toBeInstanceOf(HarnessStorageProviderCallbackBindingTransitionError);
+  });
+
+  it('rejects replacement retries when the previous owner was not replaced by the duplicate id', async () => {
+    await storage.resolveProviderCallbackBinding(sampleProviderCallbackBinding());
+    const stalledReplacement = sampleProviderCallbackBinding({
+      id: 'callback-binding-2',
+      status: 'disabled',
+      harnessName: 'support-v2',
+      channelId: 'support-v2',
+      createdAt: 2000,
+      updatedAt: 2000,
+      origin: { route: 'support-events-v2' },
+    });
+    await client.execute({
+      sql: `INSERT INTO ${TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS}
+            (id, provider_id, selector_kind, selector_value, harness_name, channel_id, origin, status,
+             created_at, updated_at, replaced_at, replaced_by_binding_id, last_error)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        stalledReplacement.id,
+        stalledReplacement.providerId,
+        stalledReplacement.selectorKind,
+        stalledReplacement.selectorValue,
+        stalledReplacement.harnessName,
+        stalledReplacement.channelId,
+        JSON.stringify(stalledReplacement.origin),
+        stalledReplacement.status,
+        stalledReplacement.createdAt,
+        stalledReplacement.updatedAt,
+        null,
+        null,
+        null,
+      ],
+    });
+
+    await expect(
+      storage.resolveProviderCallbackBinding(
+        sampleProviderCallbackBinding({
+          id: 'callback-binding-2',
+          harnessName: 'support-v2',
+          channelId: 'support-v2',
+          createdAt: 2000,
+          updatedAt: 2000,
+          origin: { route: 'support-events-v2' },
+        }),
+        { replaceBindingId: 'callback-binding-1' },
+      ),
+    ).rejects.toBeInstanceOf(HarnessStorageProviderCallbackBindingTransitionError);
+    await expect(
+      storage.loadProviderCallbackBindingBySelector({
+        providerId: 'slack',
+        selectorKind: 'installation',
+        selectorValue: 'installation-1',
+      }),
+    ).resolves.toMatchObject({ id: 'callback-binding-1', status: 'active' });
+  });
+
+  it('loads provider binding JSON columns when the driver returns parsed values', async () => {
+    await storage.resolveProviderCallbackBinding(sampleProviderCallbackBinding());
+    await storage.markProviderCallbackBindingStatus({
+      bindingId: 'callback-binding-1',
+      status: 'undeliverable',
+      updatedAt: 2000,
+      lastError: { code: 'worker_unavailable', message: 'provider missing', retryable: true },
+    });
+    const originalExecute = client.execute.bind(client);
+    vi.spyOn(client, 'execute').mockImplementation(async args => {
+      const result = await originalExecute(args as Parameters<typeof client.execute>[0]);
+      if (typeof args === 'object' && 'sql' in args && args.sql.includes(TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS)) {
+        return {
+          ...result,
+          rows: result.rows.map(row => ({
+            ...row,
+            origin: typeof row.origin === 'string' ? JSON.parse(row.origin) : row.origin,
+            last_error: typeof row.last_error === 'string' ? JSON.parse(row.last_error) : row.last_error,
+          })),
+        };
+      }
+      return result;
+    });
+
+    await expect(
+      storage.markProviderCallbackBindingStatus({ bindingId: 'callback-binding-1', status: 'active', updatedAt: 3000 }),
+    ).resolves.toMatchObject({
+      id: 'callback-binding-1',
+      origin: { route: 'support-events' },
+      status: 'active',
+      lastError: undefined,
+    });
+  });
+
+  it('allows disabled or undeliverable bindings to reactivate when no active selector owner exists', async () => {
+    await storage.resolveProviderCallbackBinding(sampleProviderCallbackBinding());
+
+    await expect(
+      storage.markProviderCallbackBindingStatus({
+        bindingId: 'callback-binding-1',
+        status: 'disabled',
+        updatedAt: 2000,
+        lastError: { code: 'worker_unavailable', message: 'provider disabled', retryable: true },
+      }),
+    ).resolves.toMatchObject({ status: 'disabled', lastError: { code: 'worker_unavailable' } });
+    await expect(
+      storage.loadProviderCallbackBindingBySelector({
+        providerId: 'slack',
+        selectorKind: 'installation',
+        selectorValue: 'installation-1',
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      storage.markProviderCallbackBindingStatus({ bindingId: 'callback-binding-1', status: 'active', updatedAt: 3000 }),
+    ).resolves.toMatchObject({ status: 'active', lastError: undefined });
+    await expect(
+      storage.markProviderCallbackBindingStatus({
+        bindingId: 'callback-binding-1',
+        status: 'undeliverable',
+        updatedAt: 4000,
+        lastError: { code: 'worker_unavailable', message: 'provider undeliverable', retryable: true },
+      }),
+    ).resolves.toMatchObject({ status: 'undeliverable', lastError: { code: 'worker_unavailable' } });
+    await expect(
+      storage.loadProviderCallbackBindingBySelector({
+        providerId: 'slack',
+        selectorKind: 'installation',
+        selectorValue: 'installation-1',
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      storage.markProviderCallbackBindingStatus({ bindingId: 'callback-binding-1', status: 'active', updatedAt: 5000 }),
+    ).resolves.toMatchObject({ status: 'active', lastError: undefined });
   });
 });
 
@@ -2702,6 +2974,24 @@ function sampleChannelInbox(overrides: Partial<ChannelInboxItem> = {}): ChannelI
     },
     content: 'hello',
     attachments: [],
+    ...overrides,
+  };
+}
+
+function sampleProviderCallbackBinding(
+  overrides: Partial<HarnessProviderCallbackBinding> = {},
+): HarnessProviderCallbackBinding {
+  return {
+    id: 'callback-binding-1',
+    providerId: 'slack',
+    selectorKind: 'installation',
+    selectorValue: 'installation-1',
+    harnessName: 'default',
+    channelId: 'support',
+    origin: { route: 'support-events' },
+    status: 'active',
+    createdAt: 1000,
+    updatedAt: 1000,
     ...overrides,
   };
 }

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -16,6 +16,7 @@ import {
   HarnessStorageDeleteGuardConflictError,
   HarnessStorageLeaseConflictError,
   HarnessStorageParentSessionUnavailableError,
+  HarnessStorageProviderCallbackBindingTransitionError,
   HarnessStorageSessionNotFoundError,
   HarnessStorageThreadDeleteFenceConflictError,
   HarnessStorageVersionConflictError,
@@ -30,6 +31,7 @@ import {
   TABLE_HARNESS_CHANNEL_OUTBOX,
   TABLE_HARNESS_MESSAGE_RESULTS,
   TABLE_HARNESS_OPERATION_TOMBSTONES,
+  TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS,
   TABLE_HARNESS_SESSION_EVENTS,
   TABLE_HARNESS_SESSIONS,
   TABLE_HARNESS_THREAD_DELETE_FENCES,
@@ -50,6 +52,7 @@ import type {
   ChannelInboxItem,
   ChannelOutboxItem,
   ChannelProviderDeliveryReceipt,
+  HarnessProviderCallbackBinding,
   CreateOrLoadActiveSessionOptions,
   CreateOrLoadActiveSessionResult,
   CreateOrLoadChannelActionReceiptResult,
@@ -68,8 +71,10 @@ import type {
   JsonValue,
   OperationAdmissionEvidence,
   OperationAdmissionTombstone,
+  ProviderCallbackSelectorKind,
   QueueAdmissionReceipt,
   ReleaseSessionLeaseInput,
+  ResolveProviderCallbackBindingResult,
   RenewSessionLeaseInput,
   SaveAttachmentReferenceInput,
   SaveAttachmentInput,
@@ -108,6 +113,7 @@ export class HarnessLibSQL extends HarnessStorage {
   #harnessName: string;
   #compactionLocks = new Map<string, Promise<void>>();
   #sessionEventsReady: Promise<void> | undefined;
+  #providerCallbackBindingIndexesReady: Promise<void> | undefined;
   #channelInboxIndexesReady: Promise<void> | undefined;
   #channelActionIndexesReady: Promise<void> | undefined;
   #channelOutboxIndexesReady: Promise<void> | undefined;
@@ -160,6 +166,7 @@ export class HarnessLibSQL extends HarnessStorage {
       compositePrimaryKey: threadDeleteFencesConfig?.compositePrimaryKey,
     });
     await this.#ensureChannelInboxTable();
+    await this.#ensureProviderCallbackBindingsTable();
     await this.#ensureChannelActionTables();
     await this.#ensureChannelOutboxTable();
     await this.#ensureWakeupTable();
@@ -236,6 +243,7 @@ export class HarnessLibSQL extends HarnessStorage {
     await this.#ensureSessionEventsTable();
     await this.#ensureThreadDeleteFencesTable();
     await this.#ensureChannelInboxTable();
+    await this.#ensureProviderCallbackBindingsTable();
     await this.#ensureChannelActionTables();
     await this.#ensureChannelOutboxTable();
     await this.#ensureWakeupTable();
@@ -246,6 +254,7 @@ export class HarnessLibSQL extends HarnessStorage {
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_OPERATION_TOMBSTONES}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_SESSION_EVENTS}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_CHANNEL_INBOX}`);
+    await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_CHANNEL_ACTION_TOKENS}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_CHANNEL_OUTBOX}`);
@@ -1784,6 +1793,239 @@ export class HarnessLibSQL extends HarnessStorage {
   }
 
   // -------------------------------------------------------------------------
+  // Provider callback binding ledger
+  // -------------------------------------------------------------------------
+
+  async resolveProviderCallbackBinding(
+    record: HarnessProviderCallbackBinding,
+    opts?: { replaceBindingId?: string },
+  ): Promise<ResolveProviderCallbackBindingResult> {
+    await this.#ensureProviderCallbackBindingsTable();
+    const incoming: HarnessProviderCallbackBinding = {
+      ...record,
+      harnessName: this.#resolveHarnessName(record.harnessName),
+    };
+    assertValidProviderCallbackBindingState(incoming);
+    const tx = await this.#client.transaction('write');
+    try {
+      const active = await this.#loadActiveProviderCallbackBindingBySelectorWithClient(tx, {
+        providerId: incoming.providerId,
+        selectorKind: incoming.selectorKind,
+        selectorValue: incoming.selectorValue,
+      });
+
+      if (opts?.replaceBindingId !== undefined) {
+        if (opts.replaceBindingId === incoming.id) {
+          throw new HarnessStorageProviderCallbackBindingTransitionError(
+            incoming.id,
+            incoming.status,
+            'replaced',
+            'replacement target must be different from the incoming binding',
+          );
+        }
+        if (incoming.status !== 'active') {
+          throw new HarnessStorageProviderCallbackBindingTransitionError(
+            incoming.id,
+            incoming.status,
+            'active',
+            'replacement binding must be active',
+          );
+        }
+        const existingById = await this.#loadProviderCallbackBindingByIdWithClient(tx, incoming.id);
+        if (existingById && !providerCallbackBindingsEqual(existingById, incoming)) {
+          throw new HarnessStorageProviderCallbackBindingTransitionError(
+            incoming.id,
+            existingById.status,
+            incoming.status,
+            'id is already owned by another provider callback binding',
+          );
+        }
+        const previous = await this.#loadProviderCallbackBindingByIdWithClient(tx, opts.replaceBindingId);
+        if (
+          previous?.status === 'replaced' &&
+          previous.replacedByBindingId === incoming.id &&
+          existingById &&
+          providerCallbackBindingsEqual(existingById, incoming)
+        ) {
+          await tx.commit();
+          return {
+            binding: existingById,
+            duplicate: true,
+            conflict: false,
+            replacedBindingId: previous.id,
+          };
+        }
+        if (existingById && providerCallbackBindingsEqual(existingById, incoming)) {
+          throw new HarnessStorageProviderCallbackBindingTransitionError(
+            incoming.id,
+            existingById.status,
+            incoming.status,
+            'id is already owned and replacement target has not transitioned',
+          );
+        }
+        if (
+          !previous ||
+          previous.status !== 'active' ||
+          previous.providerId !== incoming.providerId ||
+          previous.selectorKind !== incoming.selectorKind ||
+          previous.selectorValue !== incoming.selectorValue
+        ) {
+          throw new HarnessStorageProviderCallbackBindingTransitionError(
+            opts.replaceBindingId,
+            previous?.status,
+            'replaced',
+            'replacement target is missing, inactive, or owns a different selector',
+          );
+        }
+        if (active && active.id !== previous.id) {
+          if (existingById && providerCallbackBindingsEqual(existingById, incoming)) {
+            await tx.commit();
+            return { binding: existingById, duplicate: true, conflict: false, replacedBindingId: previous.id };
+          }
+          await tx.commit();
+          return { binding: active, duplicate: true, conflict: true };
+        }
+        const replacedAt = incoming.createdAt;
+        const replaceResult = await tx.execute({
+          sql: `UPDATE ${TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS}
+                SET status = 'replaced', replaced_at = ?, replaced_by_binding_id = ?, updated_at = ?
+                WHERE id = ? AND status = 'active'`,
+          args: [replacedAt, incoming.id, replacedAt, previous.id],
+        });
+        if (replaceResult.rowsAffected === 0) {
+          throw new HarnessStorageProviderCallbackBindingTransitionError(
+            previous.id,
+            previous.status,
+            'replaced',
+            'replacement target changed before it could be replaced',
+          );
+        }
+        await tx.execute(providerCallbackBindingInsertStatement(incoming));
+        await tx.commit();
+        return { binding: incoming, duplicate: false, conflict: false, replacedBindingId: previous.id };
+      }
+
+      if (active) {
+        await tx.commit();
+        return {
+          binding: active,
+          duplicate: true,
+          conflict: !sameProviderCallbackBindingTarget(active, incoming),
+        };
+      }
+      const existingById = await this.#loadProviderCallbackBindingByIdWithClient(tx, incoming.id);
+      if (existingById) {
+        if (providerCallbackBindingsEqual(existingById, incoming)) {
+          await tx.commit();
+          return { binding: existingById, duplicate: true, conflict: false };
+        }
+        throw new HarnessStorageProviderCallbackBindingTransitionError(
+          incoming.id,
+          existingById.status,
+          incoming.status,
+          'id is already owned by another provider callback binding',
+        );
+      }
+      await tx.execute(providerCallbackBindingInsertStatement(incoming));
+      await tx.commit();
+      return { binding: incoming, duplicate: false, conflict: false };
+    } catch (error) {
+      if (!tx.closed) await tx.rollback();
+      if (isUniqueConstraintError(error)) {
+        return this.#resolveProviderCallbackBindingUniqueConflict(incoming, opts);
+      }
+      throw error;
+    }
+  }
+
+  async loadProviderCallbackBindingBySelector(opts: {
+    providerId: string;
+    selectorKind: ProviderCallbackSelectorKind;
+    selectorValue: string;
+  }): Promise<HarnessProviderCallbackBinding | null> {
+    await this.#ensureProviderCallbackBindingsTable();
+    return this.#loadActiveProviderCallbackBindingBySelectorWithClient(this.#client, opts);
+  }
+
+  async markProviderCallbackBindingStatus(opts: {
+    bindingId: string;
+    status: Extract<HarnessProviderCallbackBinding['status'], 'active' | 'disabled' | 'undeliverable'>;
+    updatedAt?: number;
+    lastError?: HarnessProviderCallbackBinding['lastError'];
+  }): Promise<HarnessProviderCallbackBinding> {
+    await this.#ensureProviderCallbackBindingsTable();
+    const tx = await this.#client.transaction('write');
+    try {
+      const current = await this.#loadProviderCallbackBindingByIdWithClient(tx, opts.bindingId);
+      if (!current) {
+        throw new HarnessStorageProviderCallbackBindingTransitionError(
+          opts.bindingId,
+          undefined,
+          opts.status,
+          'binding was not found',
+        );
+      }
+      if (current.status === 'replaced') {
+        throw new HarnessStorageProviderCallbackBindingTransitionError(
+          current.id,
+          current.status,
+          opts.status,
+          'replaced bindings are terminal',
+        );
+      }
+      const active = await this.#loadActiveProviderCallbackBindingBySelectorWithClient(tx, {
+        providerId: current.providerId,
+        selectorKind: current.selectorKind,
+        selectorValue: current.selectorValue,
+      });
+      if (opts.status === 'active' && active && active.id !== current.id) {
+        throw new HarnessStorageProviderCallbackBindingTransitionError(
+          current.id,
+          current.status,
+          opts.status,
+          'another active binding owns this selector',
+        );
+      }
+      const updatedAt = opts.updatedAt ?? Date.now();
+      const next: HarnessProviderCallbackBinding = {
+        ...current,
+        status: opts.status,
+        updatedAt,
+        lastError: opts.lastError,
+      };
+      assertValidProviderCallbackBindingState(next);
+      const values = providerCallbackBindingColumnValues(next);
+      const currentValues = providerCallbackBindingColumnValues(current);
+      const expectedNames = currentValues.names.filter(name => name !== 'id');
+      const updateResult = await tx.execute({
+        sql: `UPDATE ${TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS}
+              SET ${values.names
+                .filter(name => name !== 'id')
+                .map(name => `${name} = ?`)
+                .join(', ')}
+              WHERE id = ? AND ${expectedNames.map(name => `${name} IS ?`).join(' AND ')}`,
+        args: [...values.values.slice(1), next.id, ...currentValues.values.slice(1)],
+      });
+      if (updateResult.rowsAffected === 0) {
+        throw new HarnessStorageProviderCallbackBindingTransitionError(
+          current.id,
+          current.status,
+          opts.status,
+          'binding changed before status update could be applied',
+        );
+      }
+      await tx.commit();
+      return next;
+    } catch (error) {
+      if (!tx.closed) await tx.rollback();
+      if (isUniqueConstraintError(error)) {
+        return this.#resolveProviderCallbackBindingStatusUniqueConflict(opts);
+      }
+      throw error;
+    }
+  }
+
+  // -------------------------------------------------------------------------
   // Channel inbox ledger
   // -------------------------------------------------------------------------
 
@@ -3192,6 +3434,136 @@ export class HarnessLibSQL extends HarnessStorage {
     }
   }
 
+  async #loadProviderCallbackBindingByIdWithClient(
+    client: Pick<Client, 'execute'>,
+    id: string,
+  ): Promise<HarnessProviderCallbackBinding | null> {
+    const result = await client.execute({
+      sql: `SELECT * FROM ${TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS}
+            WHERE id = ?
+            LIMIT 1`,
+      args: [id],
+    });
+    return result.rows[0] ? rowToProviderCallbackBinding(result.rows[0] as Record<string, unknown>) : null;
+  }
+
+  async #loadActiveProviderCallbackBindingBySelectorWithClient(
+    client: Pick<Client, 'execute'>,
+    opts: {
+      providerId: string;
+      selectorKind: ProviderCallbackSelectorKind;
+      selectorValue: string;
+    },
+  ): Promise<HarnessProviderCallbackBinding | null> {
+    const result = await client.execute({
+      sql: `SELECT * FROM ${TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS}
+            WHERE provider_id = ? AND selector_kind = ? AND selector_value = ? AND status = 'active'
+            LIMIT 1`,
+      args: [opts.providerId, opts.selectorKind, opts.selectorValue],
+    });
+    return result.rows[0] ? rowToProviderCallbackBinding(result.rows[0] as Record<string, unknown>) : null;
+  }
+
+  async #resolveProviderCallbackBindingUniqueConflict(
+    incoming: HarnessProviderCallbackBinding,
+    opts?: { replaceBindingId?: string },
+  ): Promise<ResolveProviderCallbackBindingResult> {
+    const [active, existingById] = await Promise.all([
+      this.#loadActiveProviderCallbackBindingBySelectorWithClient(this.#client, {
+        providerId: incoming.providerId,
+        selectorKind: incoming.selectorKind,
+        selectorValue: incoming.selectorValue,
+      }),
+      this.#loadProviderCallbackBindingByIdWithClient(this.#client, incoming.id),
+    ]);
+
+    if (existingById) {
+      if (!providerCallbackBindingsEqual(existingById, incoming)) {
+        throw new HarnessStorageProviderCallbackBindingTransitionError(
+          incoming.id,
+          existingById.status,
+          incoming.status,
+          'id is already owned by another provider callback binding',
+        );
+      }
+      if (opts?.replaceBindingId !== undefined) {
+        const previous = await this.#loadProviderCallbackBindingByIdWithClient(this.#client, opts.replaceBindingId);
+        if (previous?.status !== 'replaced' || previous.replacedByBindingId !== existingById.id) {
+          throw new HarnessStorageProviderCallbackBindingTransitionError(
+            incoming.id,
+            existingById.status,
+            incoming.status,
+            'id is already owned and replacement target has not transitioned',
+          );
+        }
+        return {
+          binding: existingById,
+          duplicate: true,
+          conflict: false,
+          replacedBindingId: previous.id,
+        };
+      }
+      return { binding: existingById, duplicate: true, conflict: false };
+    }
+
+    if (active) {
+      return {
+        binding: active,
+        duplicate: true,
+        conflict: !sameProviderCallbackBindingTarget(active, incoming),
+      };
+    }
+
+    throw new HarnessStorageProviderCallbackBindingTransitionError(
+      incoming.id,
+      undefined,
+      incoming.status,
+      'unique constraint conflict could not be resolved after provider callback binding insert',
+    );
+  }
+
+  async #resolveProviderCallbackBindingStatusUniqueConflict(opts: {
+    bindingId: string;
+    status: Extract<HarnessProviderCallbackBinding['status'], 'active' | 'disabled' | 'undeliverable'>;
+    updatedAt?: number;
+    lastError?: HarnessProviderCallbackBinding['lastError'];
+  }): Promise<HarnessProviderCallbackBinding> {
+    const current = await this.#loadProviderCallbackBindingByIdWithClient(this.#client, opts.bindingId);
+    if (!current) {
+      throw new HarnessStorageProviderCallbackBindingTransitionError(
+        opts.bindingId,
+        undefined,
+        opts.status,
+        'binding was not found',
+      );
+    }
+    const active = await this.#loadActiveProviderCallbackBindingBySelectorWithClient(this.#client, {
+      providerId: current.providerId,
+      selectorKind: current.selectorKind,
+      selectorValue: current.selectorValue,
+    });
+    if (opts.status === 'active' && active && active.id !== current.id) {
+      throw new HarnessStorageProviderCallbackBindingTransitionError(
+        current.id,
+        current.status,
+        opts.status,
+        'another active binding owns this selector',
+      );
+    }
+    if (
+      current.status === opts.status &&
+      (opts.lastError === undefined || stableJsonString(current.lastError) === stableJsonString(opts.lastError))
+    ) {
+      return current;
+    }
+    throw new HarnessStorageProviderCallbackBindingTransitionError(
+      current.id,
+      current.status,
+      opts.status,
+      'unique constraint conflict could not be resolved after provider callback binding status update',
+    );
+  }
+
   async #loadHarnessWakeupItemById(id: string, harnessName?: string): Promise<HarnessWakeupItem | null> {
     const conditions = ['id = ?'];
     const args: string[] = [id];
@@ -3404,6 +3776,41 @@ export class HarnessLibSQL extends HarnessStorage {
     await this.#client.execute({
       sql: `CREATE INDEX IF NOT EXISTS idx_harness_channel_inbox_claim
             ON "${TABLE_HARNESS_CHANNEL_INBOX}" ("harness_name", "channel_id", "status", "next_attempt_at", "claim_expires_at", "received_at")`,
+      args: [],
+    });
+  }
+
+  async #ensureProviderCallbackBindingsTable(): Promise<void> {
+    const config = TABLE_CONFIGS[TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS];
+    await this.#db.createTable({
+      tableName: TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS,
+      schema: TABLE_SCHEMAS[TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS],
+      compositePrimaryKey: config?.compositePrimaryKey,
+    });
+    await this.#ensureProviderCallbackBindingIndexes();
+  }
+
+  async #ensureProviderCallbackBindingIndexes(): Promise<void> {
+    if (this.#providerCallbackBindingIndexesReady !== undefined) {
+      return this.#providerCallbackBindingIndexesReady;
+    }
+    this.#providerCallbackBindingIndexesReady = this.#createProviderCallbackBindingIndexes().catch(error => {
+      this.#providerCallbackBindingIndexesReady = undefined;
+      throw error;
+    });
+    return this.#providerCallbackBindingIndexesReady;
+  }
+
+  async #createProviderCallbackBindingIndexes(): Promise<void> {
+    await this.#client.execute({
+      sql: `CREATE UNIQUE INDEX IF NOT EXISTS idx_harness_provider_callback_active_selector
+            ON "${TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS}" ("provider_id", "selector_kind", "selector_value")
+            WHERE "status" = 'active'`,
+      args: [],
+    });
+    await this.#client.execute({
+      sql: `CREATE INDEX IF NOT EXISTS idx_harness_provider_callback_selector_status
+            ON "${TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS}" ("provider_id", "selector_kind", "selector_value", "status")`,
       args: [],
     });
   }
@@ -3755,6 +4162,75 @@ function sessionColumnValues(record: SessionRecord, version: number): { names: s
     record.leaseExpiresAt ?? null,
   ];
   return { names: [...SESSION_COLUMN_NAMES], values };
+}
+
+const PROVIDER_CALLBACK_BINDING_COLUMN_NAMES = [
+  'id',
+  'provider_id',
+  'selector_kind',
+  'selector_value',
+  'harness_name',
+  'channel_id',
+  'origin',
+  'status',
+  'created_at',
+  'updated_at',
+  'replaced_at',
+  'replaced_by_binding_id',
+  'last_error',
+] as const;
+
+function providerCallbackBindingColumnValues(record: HarnessProviderCallbackBinding): {
+  names: string[];
+  values: any[];
+} {
+  return {
+    names: [...PROVIDER_CALLBACK_BINDING_COLUMN_NAMES],
+    values: [
+      record.id,
+      record.providerId,
+      record.selectorKind,
+      record.selectorValue,
+      record.harnessName,
+      record.channelId,
+      JSON.stringify(record.origin),
+      record.status,
+      record.createdAt,
+      record.updatedAt,
+      record.replacedAt ?? null,
+      record.replacedByBindingId ?? null,
+      record.lastError ? JSON.stringify(record.lastError) : null,
+    ],
+  };
+}
+
+function providerCallbackBindingInsertStatement(record: HarnessProviderCallbackBinding): { sql: string; args: any[] } {
+  const cols = providerCallbackBindingColumnValues(record);
+  return {
+    sql: `INSERT INTO ${TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS}
+          (${cols.names.join(', ')})
+          VALUES (${cols.names.map(() => '?').join(', ')})`,
+    args: cols.values,
+  };
+}
+
+function rowToProviderCallbackBinding(row: Record<string, unknown>): HarnessProviderCallbackBinding {
+  return {
+    id: String(row.id),
+    providerId: String(row.provider_id),
+    selectorKind: String(row.selector_kind) as ProviderCallbackSelectorKind,
+    selectorValue: String(row.selector_value),
+    harnessName: String(row.harness_name),
+    channelId: String(row.channel_id),
+    origin: parseJson(row.origin) as JsonValue,
+    status: String(row.status) as HarnessProviderCallbackBinding['status'],
+    createdAt: Number(row.created_at),
+    updatedAt: Number(row.updated_at),
+    replacedAt: row.replaced_at == null ? undefined : Number(row.replaced_at),
+    replacedByBindingId: row.replaced_by_binding_id == null ? undefined : String(row.replaced_by_binding_id),
+    lastError:
+      row.last_error == null ? undefined : (parseJson(row.last_error) as HarnessProviderCallbackBinding['lastError']),
+  };
 }
 
 const CHANNEL_INBOX_COLUMN_NAMES = [
@@ -5195,6 +5671,80 @@ function harnessWakeupItemsEquivalentForCreate(a: HarnessWakeupItem, b: HarnessW
     a.content === b.content &&
     stableJsonString(a.attachments) === stableJsonString(b.attachments)
   );
+}
+
+function providerCallbackBindingsEqual(a: HarnessProviderCallbackBinding, b: HarnessProviderCallbackBinding): boolean {
+  return (
+    stableJsonString(providerCallbackBindingComparableValues(a)) ===
+    stableJsonString(providerCallbackBindingComparableValues(b))
+  );
+}
+
+function sameProviderCallbackBindingTarget(
+  a: HarnessProviderCallbackBinding,
+  b: HarnessProviderCallbackBinding,
+): boolean {
+  return (
+    a.harnessName === b.harnessName &&
+    a.channelId === b.channelId &&
+    stableJsonString(a.origin) === stableJsonString(b.origin)
+  );
+}
+
+function providerCallbackBindingComparableValues(record: HarnessProviderCallbackBinding): unknown[] {
+  return [
+    record.id,
+    record.providerId,
+    record.selectorKind,
+    record.selectorValue,
+    record.harnessName,
+    record.channelId,
+    stableJsonString(record.origin),
+    record.status,
+    record.createdAt,
+    record.updatedAt,
+    record.replacedAt,
+    record.replacedByBindingId,
+    record.lastError ? stableJsonString(record.lastError) : undefined,
+  ];
+}
+
+function assertValidProviderCallbackBindingState(record: HarnessProviderCallbackBinding): void {
+  if (!['installation', 'route-key', 'external-tenant'].includes(record.selectorKind)) {
+    throw new HarnessStorageProviderCallbackBindingTransitionError(
+      record.id,
+      undefined,
+      record.status,
+      `invalid selector kind "${record.selectorKind}"`,
+    );
+  }
+  if (!['active', 'disabled', 'undeliverable', 'replaced'].includes(record.status)) {
+    throw new HarnessStorageProviderCallbackBindingTransitionError(
+      record.id,
+      undefined,
+      record.status,
+      `invalid status "${record.status}"`,
+    );
+  }
+  if (record.status === 'replaced') {
+    if (record.replacedAt === undefined || record.replacedByBindingId === undefined) {
+      throw new HarnessStorageProviderCallbackBindingTransitionError(
+        record.id,
+        undefined,
+        record.status,
+        'replaced bindings require replacedAt and replacedByBindingId',
+      );
+    }
+    return;
+  }
+  if (record.replacedAt !== undefined || record.replacedByBindingId !== undefined) {
+    throw new HarnessStorageProviderCallbackBindingTransitionError(
+      record.id,
+      undefined,
+      record.status,
+      'non-replaced bindings cannot carry replacement metadata',
+    );
+  }
 }
 
 function channelActionTokensEquivalent(a: ChannelActionToken, b: ChannelActionToken): boolean {

--- a/stores/libsql/src/storage/index.test.ts
+++ b/stores/libsql/src/storage/index.test.ts
@@ -35,12 +35,14 @@ const mastra = new Mastra({
 createTestSuite(mastra.getStorage()!);
 
 describe('LibSQLStore domain wiring', () => {
-  it('initializes the favorites domain exposed by the composite store', async () => {
-    const store = new LibSQLStore({ id: 'libsql-favorites-wiring', url: 'file::memory:?cache=shared' });
+  it('initializes domains exposed by the composite store', async () => {
+    const store = new LibSQLStore({ id: 'libsql-domain-wiring', url: 'file::memory:?cache=shared' });
     await store.init();
 
     expect(store.stores.favorites).toBeDefined();
     await expect(store.getStore('favorites')).resolves.toBe(store.stores.favorites);
+    expect(store.stores.harness).toBeDefined();
+    await expect(store.getStore('harness')).resolves.toBe(store.stores.harness);
   });
 });
 

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -10,6 +10,7 @@ import { ChannelsLibSQL } from './domains/channels';
 import { DatasetsLibSQL } from './domains/datasets';
 import { ExperimentsLibSQL } from './domains/experiments';
 import { FavoritesLibSQL } from './domains/favorites';
+import { HarnessLibSQL } from './domains/harness';
 import { MCPClientsLibSQL } from './domains/mcp-clients';
 import { MCPServersLibSQL } from './domains/mcp-servers';
 import { MemoryLibSQL } from './domains/memory';
@@ -201,6 +202,7 @@ export class LibSQLStore extends MastraCompositeStore {
     const blobs = new BlobsLibSQL(domainConfig);
     const backgroundTasks = new BackgroundTasksLibSQL(domainConfig);
     const schedules = new SchedulesLibSQL(domainConfig);
+    const harness = new HarnessLibSQL(domainConfig);
 
     this.stores = {
       scores,
@@ -221,6 +223,7 @@ export class LibSQLStore extends MastraCompositeStore {
       blobs,
       backgroundTasks,
       schedules,
+      harness,
     };
   }
 


### PR DESCRIPTION
## Summary
- add typed Harness provider callback binding records and storage APIs for idempotent selector resolution, replacement, status updates, and active binding lookup
- implement the contract in in-memory Harness storage and LibSQL with an active-selector unique index
- add parity coverage for duplicate resolution, conflict detection, replacement retries, terminal replaced rows, status reactivation, and lazy LibSQL indexes
- fix the latest-main LibSQL export gap by importing HarnessLibSQL where it is re-exported

## Linear
PF-563

## Validation
- pnpm install --offline
- pnpm --filter @internal/ai-sdk-v4 build
- pnpm --filter @internal/ai-sdk-v5 build
- pnpm --filter @internal/ai-v6 build
- pnpm --filter @internal/core build:lib
- pnpm --filter @internal/llm-recorder build
- pnpm --filter @internal/test-utils build
- pnpm --filter @mastra/schema-compat build
- pnpm --filter @internal/external-types build:lib
- pnpm --filter @internal/external-types build
- pnpm --filter ./packages/core build:lib
- pnpm vitest run packages/core/src/storage/domains/harness/inmemory.test.ts --project unit:packages/core
- pnpm vitest run stores/libsql/src/storage/domains/harness/index.test.ts --project e2e:stores/libsql
- pnpm --filter ./packages/core exec eslint src/storage/constants.ts src/storage/domains/harness/base.ts src/storage/domains/harness/inmemory.ts src/storage/domains/harness/inmemory.test.ts src/storage/domains/harness/types.ts src/storage/domains/inmemory-db.ts src/storage/domains/operations/inmemory.ts
- pnpm --filter ./stores/libsql exec eslint src/storage/index.ts src/storage/domains/harness/index.ts src/storage/domains/harness/index.test.ts
- pnpm --filter ./packages/core check
- pnpm --filter ./stores/libsql exec tsc --noEmit
- git diff --check

## Review Evidence
- CodeRabbit CLI: ran locally; one minor changeset wording finding fixed.
- Local Codex review: attempted but blocked by CLI usage limit until May 26, 2026 8:36 PM; not claimed as run.
- Claude council: attempted earlier for PF-563 and blocked/hung; process was terminated and limitation recorded in Linear.

## Notes
- Branch was fast-forwarded to latest origin/main before final validation.
- No HTTP webhook routes, workers, client SDKs, UI, production systems, secrets, Docker, or release actions are touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

This PR teaches the system to remember and manage "provider callbacks" — instructions for where to send notifications from different providers. Think of it like a filing system that keeps track of which callback needs to go where, makes sure the same callback doesn't get stored twice, and can swap out old ones for new ones without losing track of what happened.

## Overview

Adds a complete typed storage layer for "provider callback bindings" — the routing rules that connect providers to Harness channels. The feature includes:

- **Type definitions** for provider callback bindings with status tracking (`active`, `disabled`, `undeliverable`, `replaced`), selector categories (`installation`, `route-key`, `external-tenant`), and replacement linkage
- **Dual implementations**: in-memory and LibSQL backends, both supporting the same API contract
- **Core operations**:
  - `resolveProviderCallbackBinding()` — register/upsert a binding with idempotent deduplication, conflict detection, and optional replacement of prior active bindings
  - `loadProviderCallbackBindingBySelector()` — lookup the active binding for a given provider/selector triple
  - `markProviderCallbackBindingStatus()` — transition a binding's status (`active` ↔ `disabled` ↔ `undeliverable`) with constraint validation

## Implementation Details

### Schema & Constants
- Added `TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS` table with columns for provider/selector identity, harness channel routing, origin (JSONB), status, timestamps, replacement tracking, and optional error details
- Defined `ProviderCallbackSelectorKind` union type for selector categories

### In-Memory Implementation (`InMemoryHarness`)
- Maintains a `Map<string, HarnessProviderCallbackBinding>` for bindings
- Validates binding state and enforces invariants: rejects self-replacement, prevents reactivation of `replaced` bindings, ensures single active binding per selector
- Distinguishes outcomes: `duplicate` (identical existing binding), `conflict` (different target for same selector), or successful resolution/replacement
- Supports lazy transitions for status updates and proper cleanup on replacement

### LibSQL Implementation (`HarnessLibSQL`)
- Persists bindings in a relational table with:
  - Unique constraint on `(provider_id, selector_kind, selector_value, status)` to enforce single `active` binding per selector
  - Secondary index on `(provider_id, selector_kind, status)` for efficient lookups
  - JSON parsing for `origin` and `last_error` JSONB fields
- Handles unique-constraint race conditions gracefully: rolls back, re-checks state, and returns domain-level error (`HarnessStorageProviderCallbackBindingTransitionError`) instead of leaking database constraint violations
- Implements CAS-style predicates on status transitions to detect mid-flight mutations

### Error Handling
- Added two new error types:
  - `HarnessStorageProviderCallbackBindingUnsupportedError` — thrown by base class if adapter doesn't support the feature
  - `HarnessStorageProviderCallbackBindingTransitionError` — thrown for invalid state transitions, conflicts, and deterministic race-condition outcomes

### Storage Wiring
- Registered `HarnessLibSQL` as a store domain in `LibSQLStore.stores` so `getStore("harness")` exposes the Harness binding operations

## Test Coverage

### In-Memory Tests
- Deduplication: identical active selector bindings keep first target, later identical requests return `duplicate: true`
- Conflict detection: same selector mapping to different target (without replacement) returns `conflict: true`
- Replacement semantics: replacing an active binding creates new active row, marks old row as `replaced` with terminal metadata
- Invalid transitions: rejecting reactivation of `replaced` bindings; allowing reactivation from `disabled`/`undeliverable` only if no active selector owner exists
- Self-replacement prevention: explicit rejection of `replaceBindingId === binding.id`

### LibSQL Tests
- Same coverage as in-memory plus:
- Lazy index creation during first resolution call (composite-store initialization test verifies harness domain availability)
- Unique-constraint race conditions during parallel resolution attempts (validates proper rollback and conflict detection)
- CAS-style mid-flight mutation detection for status transitions

## Validation Status

- Local ESLint and TypeScript checks passed for all modified/new files
- 77 tests passed for LibSQL harness domain; 65 tests passed for in-memory harness
- Composite-store wiring test confirms `harness` domain is registered and retrievable
- `git diff --check` validation passed
- Awaiting GitHub checks and CodeRabbit app review before merge

## Changesets

Added patch release note for `@mastra/core` and `@mastra/libsql` documenting that "provider callbacks can now be routed in Harness channels, and that provider callback binding resolution stays idempotent while reporting selector conflicts."

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->