### PR TITLE
[PF-338] Validate wakeup channel bindings

### DIFF
--- a/.changeset/pf-338-wakeup-channel-binding.md
+++ b/.changeset/pf-338-wakeup-channel-binding.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Harness v1 channel wakeups now record `channel_binding_closed` and stop instead of running with stale or mismatched channel binding context.

--- a/.changeset/pf-338-wakeup-channel-binding.md
+++ b/.changeset/pf-338-wakeup-channel-binding.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Harness v1 channel wakeups now record `channel_binding_closed` and stop instead of running with stale or mismatched channel binding context.
+Fixed channel wakeups with stale or mismatched bindings: they now stop before admission and are marked as `channel_binding_closed`.

--- a/packages/core/src/worker/worker.test.ts
+++ b/packages/core/src/worker/worker.test.ts
@@ -581,6 +581,150 @@ describe('HarnessWakeupWorker', () => {
     );
   });
 
+  it('admits channel wakeups when the registered binding matches the persisted snapshot', async () => {
+    const item = sampleWakeup({ requestContext: sampleWakeupChannelContext() });
+    const storage = createWakeupStorage([item]);
+    const admit = vi.fn().mockResolvedValue({ accepted: true, queuedItemId: 'queued-channel', duplicate: false });
+    const worker = new HarnessWakeupWorker();
+    const deps = createMockDeps();
+    deps._storage.getStore.mockResolvedValue(storage);
+    deps.mastra = {
+      getHarnesses: () => ({
+        default: {
+          _internalGetSessionStorage: () => storage,
+          getChannelBinding: vi.fn().mockReturnValue(sampleWakeupChannelBinding()),
+          session: vi.fn().mockResolvedValue({
+            resourceId: item.resourceId,
+            threadId: item.threadId,
+            _admitWakeupQueue: admit,
+          }),
+        },
+      }),
+    } as any;
+
+    await worker.init(deps);
+    await worker.runOnce();
+
+    expect(admit).toHaveBeenCalledWith(item);
+    expect(storage.updateHarnessWakeupItem).toHaveBeenCalledWith(
+      expect.objectContaining({ id: item.id, status: 'queued', queuedItemId: 'queued-channel' }),
+      { claimId: item.claimId },
+    );
+  });
+
+  it('fails closed when a channel wakeup binding is missing', async () => {
+    const item = sampleWakeup({ requestContext: sampleWakeupChannelContext() });
+    const storage = createWakeupStorage([item]);
+    const session = vi.fn().mockResolvedValue({
+      resourceId: item.resourceId,
+      threadId: item.threadId,
+      _admitWakeupQueue: vi.fn(),
+    });
+    const getChannelBinding = vi.fn().mockReturnValue(undefined);
+    const worker = new HarnessWakeupWorker();
+    const deps = createMockDeps();
+    deps._storage.getStore.mockResolvedValue(storage);
+    deps.mastra = {
+      getHarnesses: () => ({
+        default: {
+          _internalGetSessionStorage: () => storage,
+          getChannelBinding,
+          session,
+        },
+      }),
+    } as any;
+
+    await worker.init(deps);
+    await worker.runOnce();
+
+    expect(getChannelBinding).toHaveBeenCalledWith('support');
+    expect(session).not.toHaveBeenCalled();
+    expect(storage.updateHarnessWakeupItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: item.id,
+        status: 'dead',
+        lastError: expect.objectContaining({ code: 'channel_binding_closed', retryable: false }),
+      }),
+      { claimId: item.claimId },
+    );
+  });
+
+  it('fails closed when a channel wakeup lacks a binding snapshot', async () => {
+    const item = sampleWakeup({
+      requestContext: sampleWakeupChannelContext({
+        bindingId: undefined,
+      }),
+    });
+    const storage = createWakeupStorage([item]);
+    const session = vi.fn().mockResolvedValue({
+      resourceId: item.resourceId,
+      threadId: item.threadId,
+      _admitWakeupQueue: vi.fn(),
+    });
+    const getChannelBinding = vi.fn().mockReturnValue(sampleWakeupChannelBinding());
+    const worker = new HarnessWakeupWorker();
+    const deps = createMockDeps();
+    deps._storage.getStore.mockResolvedValue(storage);
+    deps.mastra = {
+      getHarnesses: () => ({
+        default: {
+          _internalGetSessionStorage: () => storage,
+          getChannelBinding,
+          session,
+        },
+      }),
+    } as any;
+
+    await worker.init(deps);
+    await worker.runOnce();
+
+    expect(getChannelBinding).not.toHaveBeenCalled();
+    expect(session).not.toHaveBeenCalled();
+    expect(storage.updateHarnessWakeupItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: item.id,
+        status: 'dead',
+        lastError: expect.objectContaining({ code: 'channel_binding_closed', retryable: false }),
+      }),
+      { claimId: item.claimId },
+    );
+  });
+
+  it('fails closed when a channel wakeup binding snapshot is stale', async () => {
+    const item = sampleWakeup({ requestContext: sampleWakeupChannelContext() });
+    const storage = createWakeupStorage([item]);
+    const admit = vi.fn();
+    const worker = new HarnessWakeupWorker();
+    const deps = createMockDeps();
+    deps._storage.getStore.mockResolvedValue(storage);
+    deps.mastra = {
+      getHarnesses: () => ({
+        default: {
+          _internalGetSessionStorage: () => storage,
+          getChannelBinding: vi.fn().mockReturnValue(sampleWakeupChannelBinding({ bindingId: 'support-binding-2' })),
+          session: vi.fn().mockResolvedValue({
+            resourceId: item.resourceId,
+            threadId: item.threadId,
+            _admitWakeupQueue: admit,
+          }),
+        },
+      }),
+    } as any;
+
+    await worker.init(deps);
+    await worker.runOnce();
+
+    expect(admit).not.toHaveBeenCalled();
+    expect(storage.updateHarnessWakeupItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: item.id,
+        status: 'dead',
+        lastError: expect.objectContaining({ code: 'channel_binding_closed', retryable: false }),
+      }),
+      { claimId: item.claimId },
+    );
+  });
+
   it('marks retryable failures failed with a later retry time', async () => {
     const item = sampleWakeup({ attempts: 2 });
     const storage = createWakeupStorage([item]);
@@ -1008,6 +1152,56 @@ function sampleWakeup(overrides: Partial<HarnessWakeupItem> = {}): HarnessWakeup
     requestContext: { metadata: { source: 'test' } },
     content: 'scheduled work',
     attachments: [],
+    ...overrides,
+  };
+}
+
+function sampleWakeupChannelContext(
+  overrides: Partial<{
+    origin: 'inbound' | 'binding';
+    harnessName: string;
+    channelId: string;
+    providerId: string;
+    platform: string;
+    externalThreadId: string;
+    externalMessageId: string;
+    bindingId: string;
+  }> = {},
+) {
+  return {
+    channel: {
+      origin: 'inbound' as const,
+      harnessName: 'default',
+      channelId: 'support',
+      providerId: 'slack-provider',
+      platform: 'slack',
+      externalThreadId: 'thread-ext-1',
+      externalMessageId: 'message-ext-1',
+      bindingId: 'support-binding',
+      ...overrides,
+    },
+  };
+}
+
+function sampleWakeupChannelBinding(
+  overrides: Partial<{
+    harnessName: string;
+    channelId: string;
+    bindingId: string;
+    providerId: string;
+    platform: string;
+    callbackTarget: string;
+    durableId: string;
+  }> = {},
+) {
+  return {
+    harnessName: 'default',
+    channelId: 'support',
+    bindingId: 'support-binding',
+    providerId: 'slack-provider',
+    platform: 'slack',
+    callbackTarget: 'https://channels.example.test/slack',
+    durableId: 'default:support:support-binding',
     ...overrides,
   };
 }

--- a/packages/core/src/worker/workers/harness-wakeup-worker.ts
+++ b/packages/core/src/worker/workers/harness-wakeup-worker.ts
@@ -18,8 +18,17 @@ type WakeupSession = {
   ) => Promise<{ accepted: true; queuedItemId: string; duplicate: boolean }>;
 };
 
+type WakeupChannelBinding = {
+  harnessName: string;
+  channelId: string;
+  bindingId: string;
+  providerId: string;
+  platform: string;
+};
+
 type WakeupHarness = {
   session(opts: { sessionId?: string; resourceId?: string; threadId?: string }): Promise<WakeupSession>;
+  getChannelBinding?: (channelId: string) => WakeupChannelBinding | undefined;
   _internalGetSessionStorage?: () => HarnessStorage | undefined;
 };
 
@@ -251,6 +260,7 @@ export class HarnessWakeupWorker extends MastraWorker {
         claimTtlMs: this.#config.claimTtlMs,
         claimRenewMs: this.#config.claimRenewMs,
         operation: async () => {
+          this.#assertWakeupChannelBinding(harness, item);
           const session = await this.#resolveSession(harness, storage, item);
           if (session._admitWakeupQueue) return session._admitWakeupQueue(item);
           throw Object.assign(new Error('Harness session does not expose wakeup queue admission'), {
@@ -275,6 +285,41 @@ export class HarnessWakeupWorker extends MastraWorker {
     }
 
     await this.#markWakeupQueued(storage, item, claimId, result.queuedItemId);
+  }
+
+  #assertWakeupChannelBinding(harness: WakeupHarness, item: HarnessWakeupItem): void {
+    const channel = item.requestContext?.channel;
+    if (!channel) return;
+
+    const failClosed = (message: string): never => {
+      throw Object.assign(new Error(message), {
+        code: 'channel_binding_closed',
+        retryable: false,
+      });
+    };
+
+    if (channel.harnessName !== item.harnessName) {
+      failClosed('Harness wakeup channel context does not match the wakeup harness');
+    }
+    if (channel.bindingId === undefined) {
+      failClosed('Harness wakeup channel context is missing a binding snapshot');
+    }
+
+    const binding = harness.getChannelBinding?.(channel.channelId);
+    if (binding !== undefined) {
+      if (
+        binding.harnessName !== item.harnessName ||
+        binding.channelId !== channel.channelId ||
+        binding.providerId !== channel.providerId ||
+        binding.platform !== channel.platform ||
+        binding.bindingId !== channel.bindingId
+      ) {
+        failClosed('Harness wakeup channel binding no longer matches the persisted channel snapshot');
+      }
+      return;
+    } else {
+      failClosed('Harness wakeup channel binding is unavailable');
+    }
   }
 
   async #markWakeupQueued(
@@ -523,6 +568,9 @@ function projectWakeupError(error: unknown): { code: HarnessRowErrorCode; messag
   }
   if (name === 'HarnessAdmissionConflictError') {
     return { code: 'channel_payload_conflict', message, retryable: false };
+  }
+  if (rawCode === 'channel_binding_closed') {
+    return { code: 'channel_binding_closed', message, retryable: false };
   }
   if (rawCode === 'harness.storage.wakeup_session_unavailable') {
     return { code: 'worker_unavailable', message, retryable: false };


### PR DESCRIPTION
## Summary
- Add PF-338 wakeup-worker validation for persisted channel wakeups before queue admission.
- Fail closed with `channel_binding_closed` when the channel context is missing a binding snapshot, the binding is unavailable, or the current binding no longer matches harness/channel/provider/platform/binding id.
- Add focused HarnessWakeupWorker tests for matching, missing, missing snapshot, and stale binding cases.

## Scope / coordination
- Linear: PF-338.
- Current open PR overlap checked before work:
  - #155 / PF-562 touches Harness MCP catalog paths; this PR does not touch those files.
  - #156 / PF-563 touches harness storage contracts/adapters; this PR intentionally avoids storage schema/status changes.
  - #157 / PF-559 is upstream sync/playground-only; no Harness overlap.
- No server routes, SDKs, storage schema/statuses, production Docker, Convex, secrets, or release/publish actions touched.

## Validation
- `git diff --check`
- `pnpm exec prettier --check .changeset/pf-338-wakeup-channel-binding.md packages/core/src/worker/workers/harness-wakeup-worker.ts packages/core/src/worker/worker.test.ts`
- `pnpm --filter @mastra/core exec eslint src/worker/workers/harness-wakeup-worker.ts src/worker/worker.test.ts`
- `pnpm --filter @mastra/core exec vitest run --exclude '**/tool-builder/**' src/worker/worker.test.ts` -> 35 passed

Local test setup note: this fresh worktree needed an offline `pnpm install --offline --ignore-scripts` plus local builds for `@internal/llm-recorder`, `@internal/test-utils`, `@internal/ai-sdk-v4`, `@internal/ai-sdk-v5`, `@internal/ai-v6`, `@internal/core build:lib`, and partial JS emit from `@mastra/schema-compat` before the focused core worker test could load package-local dist entries. `@mastra/schema-compat build` still reports unrelated DTS/type errors in schema/provider compat files.

## Reviews
- Gemini council review completed. One storage-enum concern was verified stale: `channel_binding_closed` already exists in `HarnessRowErrorCode`, and SQL adapters persist `last_error` as JSON/text. One batch-renewal nit was pre-existing and not changed in this storage-avoidant slice.
- CodeRabbit CLI local review completed; minor changeset wording finding addressed.
- Local Codex review could not run because the CLI hit usage limits; opencode review could not run because the configured provider did not expose the requested model.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes the worker check that a channel's saved configuration (binding) is current before processing a wakeup. If the binding is missing or doesn't match, the worker stops the wakeup with a clear, non-retryable error instead of proceeding.

---

## Summary

Implements PF-338: validate wakeup channel bindings before queue admission in HarnessWakeupWorker.

### Changes

- packages/core/src/worker/workers/harness-wakeup-worker.ts
  - Adds a WakeupChannelBinding type and an optional harness.getChannelBinding contract method.
  - Validates that a wakeup's channel context matches the persisted binding snapshot (harnessName, channelId, providerId, platform, bindingId).
  - Fails closed by throwing a non-retryable error (code: channel_binding_closed) when the snapshot is missing, unavailable, or stale/mismatched—before session resolution or queue admission.
  - Maps rawCode === 'channel_binding_closed' to the standardized non-retryable error projection.

- packages/core/src/worker/worker.test.ts
  - Adds focused HarnessWakeupWorker tests for:
    - Successful admission when binding snapshot matches.
    - Fail-closed cases: missing binding, missing snapshot on the wakeup, and stale/mismatched binding.
  - New test helpers sampleWakeupChannelContext and sampleWakeupChannelBinding.
  - Tests assert durable queue admission behavior and persisted wakeup updates (status, lastError including channel_binding_closed, queuedItemId).

- .changeset/pf-338-wakeup-channel-binding.md
  - Release note: Harness v1 channel wakeups with stale/mismatched bindings now stop and record channel_binding_closed.

### Validation & CI

- git diff --check: run.
- Prettier: passed for .changeset and specified files.
- ESLint: executed for the two core files as part of validation.
- Vitest: focused test run for the core worker tests reported 35 passed.
- Local build/testing required offline pnpm installs and local builds for internal packages; a separate schema/provider compat build still shows unrelated DTS/type issues.

### Scope & Coordination

- Linear: PF-338.
- Checked overlap with open PRs: `#155`, `#156`, `#157` — no conflicting changes in Harness for this PR.
- No changes to server routes, SDKs, storage schema/statuses, production Docker, Convex, secrets, or release/publish actions.

### Reviews & Notes

- Gemini council review: completed; storage-enum concern considered stale because channel_binding_closed already exists and adapters persist last_error.
- CodeRabbit CLI local review: completed; minor changeset wording adjusted.
- Commit messages: no additional intent beyond PR description (generic "Polish wakeup changeset").

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->