### PR TITLE
[PF-359] Add Harness readiness lifecycle barrier

### DIFF
--- a/.changeset/pf-359-pg-harness-store.md
+++ b/.changeset/pf-359-pg-harness-store.md
@@ -1,0 +1,5 @@
+---
+'@mastra/pg': patch
+---
+
+Fixed the PostgreSQL adapter's Harness domain wiring so Harness schema exports and store composition load correctly.

--- a/.changeset/pf-359-server-readiness.md
+++ b/.changeset/pf-359-server-readiness.md
@@ -1,0 +1,10 @@
+---
+'@mastra/server': patch
+---
+
+Updated `MastraServer.init()` to call `Mastra.init()` before route registration, delaying server request handling until Harness readiness completes.
+
+```ts
+const server = new MastraServer({ app, mastra });
+await server.init();
+```

--- a/.changeset/pf-359-server-readiness.md
+++ b/.changeset/pf-359-server-readiness.md
@@ -2,7 +2,7 @@
 '@mastra/server': patch
 ---
 
-Updated `MastraServer.init()` to call `Mastra.init()` before route registration, delaying server request handling until Harness readiness completes.
+Server routes now wait for Harness and channel readiness before accepting traffic.
 
 ```ts
 const server = new MastraServer({ app, mastra });

--- a/.changeset/pf-359-server-readiness.md
+++ b/.changeset/pf-359-server-readiness.md
@@ -2,7 +2,7 @@
 '@mastra/server': patch
 ---
 
-Server routes now wait for Harness and channel readiness before accepting traffic.
+Fixed server startup readiness: routes now wait for Harness and channel readiness before accepting traffic.
 
 ```ts
 const server = new MastraServer({ app, mastra });

--- a/.changeset/puny-jeans-warn.md
+++ b/.changeset/puny-jeans-warn.md
@@ -1,0 +1,15 @@
+---
+'@mastra/core': patch
+---
+
+Added `Mastra.init()` as a Harness readiness lifecycle so callers can wait for channels and Harness initialization before accepting traffic or starting workers.
+
+Callers that start workers directly should initialize Mastra first:
+
+```ts
+const mastra = new Mastra({ harness });
+await mastra.init();
+await mastra.startWorkers();
+```
+
+Harness readiness means every registered Harness instance has completed its async initialization and is safe to accept traffic.

--- a/packages/core/src/channels/__tests__/integration.test.ts
+++ b/packages/core/src/channels/__tests__/integration.test.ts
@@ -1,5 +1,5 @@
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { Agent } from '../../agent';
 import { Mastra } from '../../mastra';
@@ -104,6 +104,26 @@ describe('Mastra Channel Integration', () => {
 
       const channels = mastra.getChannels();
       expect(Object.keys(channels)).toEqual(['agent1', 'agent2']);
+    });
+
+    it('surfaces and retries agent channel initialization through Mastra init', async () => {
+      const agent = createTestAgent('agent1', {
+        channels: { adapters: { discord: createMockAdapter('discord') } },
+      });
+      const initialize = vi
+        .spyOn(agent.getChannels()!, 'initialize')
+        .mockRejectedValueOnce(new Error('agent channel readiness failed'))
+        .mockResolvedValueOnce(undefined);
+      const mastra = new Mastra({
+        logger: false,
+        agents: { agent },
+        storage: new InMemoryStore(),
+      });
+
+      await expect(mastra.init()).rejects.toThrow('agent channel readiness failed');
+      await mastra.init();
+
+      expect(initialize).toHaveBeenCalledTimes(2);
     });
 
     it('returns empty when no agents have channels', () => {

--- a/packages/core/src/channels/__tests__/integration.test.ts
+++ b/packages/core/src/channels/__tests__/integration.test.ts
@@ -120,6 +120,7 @@ describe('Mastra Channel Integration', () => {
         storage: new InMemoryStore(),
       });
 
+      expect(initialize).not.toHaveBeenCalled();
       await expect(mastra.init()).rejects.toThrow('agent channel readiness failed');
       await mastra.init();
 

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -698,7 +698,10 @@ export class Harness {
   readonly _workspaceRegistry: WorkspaceRegistry;
   /** Snapshot of the workspace kind for fast read paths. `undefined` when not configured. */
   readonly _workspaceKind?: 'shared' | 'per-resource' | 'per-session';
+  private readonly _workspaceEager: boolean;
 
+  private _initialized = false;
+  private _initPromise?: Promise<void>;
   private _shutdown = false;
 
   constructor(config: HarnessConfig) {
@@ -892,19 +895,11 @@ export class Harness {
     // Workspace (§2.7). Three ownership models; registry handles lifecycle.
     // Cross-checks against the subagent registry happen below.
     this._workspaceKind = config.workspace?.kind;
+    this._workspaceEager = Boolean(config.workspace?.eager);
     this._workspaceRegistry = new WorkspaceRegistry({
       config: config.workspace,
       emitter: this._emitter,
     });
-
-    // Eager provisioning for `kind: 'shared'`. Per-resource and per-session
-    // are eagerly provisioned at session creation when `eager: true`
-    // (handled in Session._resolve / Session._construct).
-    if (config.workspace?.kind === 'shared' && config.workspace.eager) {
-      void this._workspaceRegistry.acquireShared().catch(() => {
-        // Errors surface through the workspace_error event; swallow here.
-      });
-    }
 
     // Subagent `workspace: 'fresh'` is only valid under `per-session`. Validate
     // at config time so misconfigurations don't reach the runtime spawn path.
@@ -999,6 +994,54 @@ export class Harness {
       );
     }
     return this._mastra;
+  }
+
+  /**
+   * Mastra lifecycle readiness hook. Validates that the harness is bound and
+   * materializes eager shared workspace dependencies before server routes are
+   * admitted.
+   */
+  async init(): Promise<void> {
+    if (this._shutdown) {
+      throw new HarnessConfigError('shutdown', 'harness cannot be initialized after shutdown');
+    }
+    if (this._initialized) return;
+    if (this._initPromise) return this._initPromise;
+
+    this._initPromise = this._initOnce();
+    try {
+      await this._initPromise;
+    } catch (error) {
+      this._initPromise = undefined;
+      throw error;
+    }
+  }
+
+  private async _initOnce(): Promise<void> {
+    // Accessor intentionally provides the existing bound-Mastra error shape.
+    this.mastra;
+
+    let acquiredSharedWorkspace = false;
+    if (this._workspaceKind === 'shared' && this._workspaceEager) {
+      try {
+        await this._workspaceRegistry.acquireShared();
+      } catch (error) {
+        if (this._shutdown) {
+          throw new HarnessConfigError('shutdown', 'harness cannot be initialized after shutdown');
+        }
+        throw error;
+      }
+      acquiredSharedWorkspace = true;
+    }
+
+    if (this._shutdown) {
+      if (acquiredSharedWorkspace) {
+        await this._workspaceRegistry.destroyShared();
+      }
+      throw new HarnessConfigError('shutdown', 'harness cannot be initialized after shutdown');
+    }
+
+    this._initialized = true;
   }
 
   /**
@@ -2852,6 +2895,11 @@ export class Harness {
     } catch {
       // No storage bound — nothing to release. Idempotent.
       this._liveSessions.clear();
+      try {
+        await this._workspaceRegistry.shutdown();
+      } catch {
+        // Best-effort: errors surface through the workspace_error event.
+      }
       this._untrackBoundStorage();
       return;
     }

--- a/packages/core/src/harness/v1/workspace-registry.test.ts
+++ b/packages/core/src/harness/v1/workspace-registry.test.ts
@@ -8,7 +8,7 @@
  * `HarnessWorkspaceLostError`).
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { Agent } from '../../agent';
 import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
@@ -86,16 +86,74 @@ describe('WorkspaceRegistry — shared', () => {
     expect(calls).toBe(1);
   });
 
-  it('eager: true provisions the workspace synchronously from the Harness constructor', async () => {
+  it('eager: true provisions the shared workspace from Harness init', async () => {
     let constructed = 0;
     const factory = () => {
       constructed++;
       return makeWorkspace('eager');
     };
-    new Harness(baseConfig({ workspace: { kind: 'shared' as const, workspace: factory, eager: true } }));
-    // Constructor fires acquireShared() — give the microtask a tick to land.
+    const harness = new Harness(
+      baseConfig({ workspace: { kind: 'shared' as const, workspace: factory, eager: true } }),
+    );
+
     await new Promise(r => setImmediate(r));
+    expect(constructed).toBe(0);
+
+    await harness.init();
     expect(constructed).toBe(1);
+  });
+
+  it('deduplicates concurrent shared workspace teardown', async () => {
+    let releaseDestroy!: () => void;
+    const destroy = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          releaseDestroy = resolve;
+        }),
+    );
+    const workspace = { ...makeWorkspace('shared'), destroy } as unknown as Workspace;
+    const harness = new Harness(baseConfig({ workspace: { kind: 'shared' as const, workspace, eager: true } }));
+
+    await harness.init();
+    const firstDestroy = harness._workspaceRegistry.destroyShared();
+    const secondDestroy = harness._workspaceRegistry.destroyShared();
+    releaseDestroy();
+    await Promise.all([firstDestroy, secondDestroy]);
+
+    expect(destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not recreate the shared workspace while shutdown is destroying it', async () => {
+    let releaseDestroy!: () => void;
+    const destroy = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          releaseDestroy = resolve;
+        }),
+    );
+    let calls = 0;
+    const workspace = { ...makeWorkspace('shared'), destroy } as unknown as Workspace;
+    const harness = new Harness(
+      baseConfig({
+        workspace: {
+          kind: 'shared' as const,
+          eager: true,
+          workspace: () => {
+            calls++;
+            return workspace;
+          },
+        },
+      }),
+    );
+
+    await harness.init();
+    const shutdown = harness._workspaceRegistry.shutdown();
+    await expect(harness.getWorkspace()).rejects.toThrow('workspace registry is shut down');
+    releaseDestroy();
+    await shutdown;
+
+    expect(calls).toBe(1);
+    expect(destroy).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/core/src/harness/v1/workspace-registry.ts
+++ b/packages/core/src/harness/v1/workspace-registry.ts
@@ -28,6 +28,7 @@ import type { WorkspaceProvider, WorkspaceProviderContext } from './workspace-pr
 interface SharedEntry {
   workspace?: Workspace;
   resolving?: Promise<Workspace>;
+  destroying?: Promise<void>;
   initialized: boolean;
 }
 
@@ -80,6 +81,7 @@ export class WorkspaceRegistry {
   private readonly _perResource = new Map<string, PerResourceEntry>();
   private readonly _perSession = new Map<string, PerSessionEntry>();
   private readonly _resolvedProvider?: WorkspaceProvider;
+  private _closed = false;
 
   constructor(opts: { config?: HarnessWorkspaceConfig; emitter: EventEmitter }) {
     this._config = opts.config;
@@ -149,6 +151,11 @@ export class WorkspaceRegistry {
     if (!this._shared || !this._config || this._config.kind !== 'shared') {
       throw new HarnessConfigError('workspace', 'no shared workspace configured');
     }
+    this._assertOpen();
+    if (this._shared.destroying) {
+      await this._shared.destroying;
+      this._assertOpen();
+    }
     if (this._shared.workspace) {
       return this._shared.workspace;
     }
@@ -174,6 +181,11 @@ export class WorkspaceRegistry {
         await ws.init();
         this._shared!.initialized = true;
       }
+      if (this._closed) {
+        await this._destroyWorkspace(ws);
+        this._shared!.initialized = false;
+        throw new HarnessConfigError('workspace', 'workspace registry is shut down');
+      }
       this._shared!.workspace = ws;
       this._emitStatus({ status: 'ready' });
       return ws;
@@ -188,16 +200,27 @@ export class WorkspaceRegistry {
   }
 
   async destroyShared(): Promise<void> {
+    if (!this._shared) return;
+    if (this._shared.destroying) return this._shared.destroying;
+    if (!this._shared.workspace) return;
+    const destroy = this._destroySharedOnce();
+    this._shared.destroying = destroy;
+    try {
+      await destroy;
+    } finally {
+      if (this._shared.destroying === destroy) {
+        this._shared.destroying = undefined;
+      }
+    }
+  }
+
+  private async _destroySharedOnce(): Promise<void> {
     if (!this._shared || !this._shared.workspace) return;
     const ws = this._shared.workspace;
-    this._emitStatus({ status: 'destroying' });
-    try {
-      await ws.destroy();
-    } catch (err) {
-      this._emitError({ err });
-    }
     this._shared.workspace = undefined;
     this._shared.initialized = false;
+    this._emitStatus({ status: 'destroying' });
+    await this._destroyWorkspace(ws);
     this._emitStatus({ status: 'destroyed' });
   }
 
@@ -207,6 +230,7 @@ export class WorkspaceRegistry {
 
   async acquirePerResource(opts: AcquirePerResourceOpts): Promise<Workspace> {
     this._assertKind('per-resource');
+    this._assertOpen();
     const existing = this._perResource.get(opts.resourceId);
     if (existing) {
       existing.refCount += 1;
@@ -274,6 +298,7 @@ export class WorkspaceRegistry {
 
   async acquirePerSession(opts: AcquirePerSessionOpts): Promise<Workspace> {
     this._assertKind('per-session');
+    this._assertOpen();
     const existing = this._perSession.get(opts.sessionId);
     if (existing) {
       existing.refCount += 1;
@@ -329,6 +354,7 @@ export class WorkspaceRegistry {
 
   inheritPerSession(opts: InheritPerSessionOpts): Workspace {
     this._assertKind('per-session');
+    this._assertOpen();
     const parent = this._perSession.get(opts.parentSessionId);
     if (!parent) {
       throw new HarnessConfigError(
@@ -383,6 +409,7 @@ export class WorkspaceRegistry {
   // -------------------------------------------------------------------------
 
   async shutdown(): Promise<void> {
+    this._closed = true;
     // Iterate over unique per-session entries (multiple ids can point to the
     // same physical entry under `inherit`). De-dup via Set on object identity.
     const seenSessionEntries = new Set<PerSessionEntry>();
@@ -432,6 +459,20 @@ export class WorkspaceRegistry {
         'workspace.kind',
         `expected "${expected}", got "${this._config?.kind ?? 'unconfigured'}"`,
       );
+    }
+  }
+
+  private _assertOpen(): void {
+    if (this._closed) {
+      throw new HarnessConfigError('workspace', 'workspace registry is shut down');
+    }
+  }
+
+  private async _destroyWorkspace(workspace: Workspace): Promise<void> {
+    try {
+      await workspace.destroy();
+    } catch (err) {
+      this._emitError({ err });
     }
   }
 

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1337,12 +1337,7 @@ export class Mastra<
       this.#ensureScheduler();
     }
 
-    // Initialize channels asynchronously (auto-provision apps, etc.).
-    // Harness-enabled servers await this promise in init() so channel-bound
-    // harnesses cannot accept traffic before channel providers are ready.
-    if (this.#channels) {
-      this.#startChannelInitialization();
-    }
+    // Channel initialization is deferred to init() so readiness owns startup side effects.
   }
 
   #startChannelInitialization(): void {
@@ -2074,7 +2069,9 @@ export class Mastra<
         };
       }
       this.#agentChannelInstances.set(String(agentKey), agentChannelsInstance);
-      this.#startAgentChannelInitialization(String(agentKey), agentChannelsInstance);
+      if (this.#lifecycleState === 'ready') {
+        this.#startAgentChannelInitialization(String(agentKey), agentChannelsInstance);
+      }
     }
   }
 
@@ -4294,6 +4291,10 @@ export class Mastra<
    * user-defined event listeners.
    */
   public async startWorkers(name?: string): Promise<void> {
+    if (this.#lifecycleState === 'constructed' || this.#lifecycleState === 'starting') {
+      await this.init();
+    }
+
     if (
       this.#shutdownStarted ||
       this.#lifecycleState === 'failed' ||

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -618,6 +618,11 @@ export class Mastra<
   #hasScheduledWorkflow = false;
   #gateways?: Record<string, MastraModelGateway>;
   #channels?: TChannels;
+  #channelInitializationPromise?: Promise<void>;
+  #channelInitializationError?: unknown;
+  #agentChannelInstances = new Map<string, AgentChannels>();
+  #agentChannelInitializationPromises = new Map<string, Promise<void>>();
+  #agentChannelInitializationErrors = new Map<string, unknown>();
   #environment?: string;
   #harnesses: Record<string, HarnessV1> = {};
   #toolPayloadTransform?: ToolPayloadTransformPolicy;
@@ -630,6 +635,10 @@ export class Mastra<
   #workerStartSequence = 0;
   #allWorkersStartPromise?: Promise<void>;
   #workersStopPromise?: Promise<void>;
+  #initPromise?: Promise<void>;
+  #shutdownPromise?: Promise<void>;
+  #shutdownStarted = false;
+  #lifecycleState: 'constructed' | 'starting' | 'ready' | 'stopping' | 'stopped' | 'failed' = 'constructed';
   #pendingWorkerStarts = new Set<PendingWorkerStart>();
   #workerStartPromises = new WeakMap<MastraWorker, Promise<void>>();
   #latestWorkerStartTokens = new WeakMap<MastraWorker, number>();
@@ -1328,20 +1337,65 @@ export class Mastra<
       this.#ensureScheduler();
     }
 
-    // Initialize channels asynchronously (auto-provision apps, etc.)
-    // This runs after all agents are registered so configs are available
+    // Initialize channels asynchronously (auto-provision apps, etc.).
+    // Harness-enabled servers await this promise in init() so channel-bound
+    // harnesses cannot accept traffic before channel providers are ready.
     if (this.#channels) {
-      void Promise.resolve().then(async () => {
-        for (const [key, channel] of Object.entries(this.#channels ?? {})) {
-          if (channel.initialize) {
-            try {
-              await channel.initialize();
-            } catch (err) {
-              console.error(`[Mastra] Failed to initialize channel "${key}":`, err);
-            }
-          }
-        }
-      });
+      this.#startChannelInitialization();
+    }
+  }
+
+  #startChannelInitialization(): void {
+    this.#channelInitializationError = undefined;
+    this.#channelInitializationPromise = this.#initializeChannels().catch(error => {
+      this.#channelInitializationError = error;
+    });
+  }
+
+  async #initializeChannels(): Promise<void> {
+    for (const [key, channel] of Object.entries(this.#channels ?? {})) {
+      if (!channel?.initialize) continue;
+      try {
+        await channel.initialize();
+      } catch (err) {
+        this.#logger?.error(`[Mastra] Failed to initialize channel "${key}"`, err);
+        throw err;
+      }
+    }
+  }
+
+  #startAgentChannelInitialization(agentKey: string, agentChannelsInstance: AgentChannels): void {
+    this.#agentChannelInitializationErrors.delete(agentKey);
+    const init = agentChannelsInstance.initialize(this).catch(error => {
+      this.#logger?.error(`[Mastra] Failed to initialize agent channels "${agentKey}"`, error);
+      this.#agentChannelInitializationErrors.set(agentKey, error);
+    });
+    this.#agentChannelInitializationPromises.set(agentKey, init);
+  }
+
+  #deleteAgentChannelInitialization(agentKey: string): void {
+    this.#agentChannelInstances.delete(agentKey);
+    this.#agentChannelInitializationPromises.delete(agentKey);
+    this.#agentChannelInitializationErrors.delete(agentKey);
+  }
+
+  async #awaitAgentChannelInitialization(): Promise<void> {
+    for (const [agentKey, agentChannelsInstance] of this.#agentChannelInstances) {
+      if (
+        !this.#agentChannelInitializationPromises.has(agentKey) ||
+        this.#agentChannelInitializationErrors.has(agentKey)
+      ) {
+        this.#startAgentChannelInitialization(agentKey, agentChannelsInstance);
+      }
+    }
+
+    for (const [agentKey, init] of this.#agentChannelInitializationPromises) {
+      await init;
+      this.#assertInitNotInterrupted();
+      const error = this.#agentChannelInitializationErrors.get(agentKey);
+      if (error) {
+        throw error;
+      }
     }
   }
 
@@ -2019,7 +2073,8 @@ export class Mastra<
           apiRoutes: [...(this.#server?.apiRoutes ?? []), ...channelRoutes],
         };
       }
-      void agentChannelsInstance.initialize(this);
+      this.#agentChannelInstances.set(String(agentKey), agentChannelsInstance);
+      this.#startAgentChannelInitialization(String(agentKey), agentChannelsInstance);
     }
   }
 
@@ -2046,6 +2101,7 @@ export class Mastra<
     if (agents[keyOrId]) {
       const agentId = agents[keyOrId]?.id;
       delete agents[keyOrId];
+      this.#deleteAgentChannelInitialization(keyOrId);
       // Clear from stored agents cache to prevent stale data
       if (agentId) {
         this.#storedAgentsCache.delete(agentId);
@@ -2058,6 +2114,7 @@ export class Mastra<
     if (key) {
       const agentId = agents[key]?.id;
       delete agents[key];
+      this.#deleteAgentChannelInitialization(key);
       // Clear from stored agents cache to prevent stale data
       if (agentId) {
         this.#storedAgentsCache.delete(agentId);
@@ -2473,6 +2530,90 @@ export class Mastra<
    */
   public getHarnesses(): Record<string, HarnessV1> {
     return { ...this.#harnesses };
+  }
+
+  #createInitAfterShutdownError(): MastraError {
+    return new MastraError({
+      id: 'MASTRA_INIT_AFTER_SHUTDOWN',
+      domain: ErrorDomain.MASTRA,
+      category: ErrorCategory.USER,
+      text: 'Mastra cannot be initialized after shutdown has started',
+    });
+  }
+
+  #assertInitNotInterrupted(): void {
+    if (this.#shutdownStarted || this.#lifecycleState === 'stopping' || this.#lifecycleState === 'stopped') {
+      throw this.#createInitAfterShutdownError();
+    }
+  }
+
+  /**
+   * Initialize Mastra runtime dependencies that must be ready before a server
+   * accepts Harness traffic.
+   */
+  public async init(): Promise<void> {
+    this.#assertInitNotInterrupted();
+
+    const init = this.#initPromise ?? this.#init();
+    this.#initPromise = init;
+    try {
+      await init;
+    } catch (error) {
+      if (this.#initPromise === init && !this.#shutdownStarted) {
+        this.#initPromise = undefined;
+      }
+      throw error;
+    }
+  }
+
+  async #init(): Promise<void> {
+    this.#lifecycleState = 'starting';
+    const hasHarnesses = Object.keys(this.#harnesses).length > 0;
+
+    try {
+      if (this.#channels && (!this.#channelInitializationPromise || this.#channelInitializationError)) {
+        this.#startChannelInitialization();
+      }
+
+      if (this.#channelInitializationPromise) {
+        await this.#channelInitializationPromise;
+        this.#assertInitNotInterrupted();
+        if (this.#channelInitializationError) {
+          throw this.#channelInitializationError;
+        }
+      }
+
+      await this.#awaitAgentChannelInitialization();
+
+      if (hasHarnesses) {
+        for (const harness of Object.values(this.#harnesses)) {
+          await harness.init();
+          this.#assertInitNotInterrupted();
+        }
+      }
+
+      this.#lifecycleState = 'ready';
+    } catch (error) {
+      if (!['stopping', 'stopped'].includes(this.#lifecycleState)) {
+        this.#lifecycleState = 'failed';
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Current Mastra lifecycle status for server and diagnostic readiness checks.
+   */
+  public getLifecycleStatus(): 'constructed' | 'starting' | 'ready' | 'stopping' | 'stopped' | 'failed' {
+    return this.#lifecycleState;
+  }
+
+  /**
+   * Returns true only when the named Harness exists and the Mastra lifecycle is
+   * ready to accept Harness traffic.
+   */
+  public isHarnessReady(name = 'default'): boolean {
+    return this.#lifecycleState === 'ready' && this.#harnesses[name] !== undefined;
   }
 
   __registerInternalWorkflow(workflow: Workflow) {
@@ -4153,6 +4294,20 @@ export class Mastra<
    * user-defined event listeners.
    */
   public async startWorkers(name?: string): Promise<void> {
+    if (
+      this.#shutdownStarted ||
+      this.#lifecycleState === 'failed' ||
+      this.#lifecycleState === 'stopping' ||
+      this.#lifecycleState === 'stopped'
+    ) {
+      throw new MastraError({
+        id: 'MASTRA_START_WORKERS_AFTER_SHUTDOWN',
+        domain: ErrorDomain.MASTRA,
+        category: ErrorCategory.USER,
+        text: 'Mastra workers cannot be started after shutdown has started or readiness failed',
+      });
+    }
+
     if (this.#workersStopPromise) {
       await this.#workersStopPromise;
     }
@@ -4994,6 +5149,25 @@ export class Mastra<
    * ```
    */
   async shutdown(): Promise<void> {
+    this.#shutdownStarted = true;
+    if (this.#shutdownPromise) {
+      return this.#shutdownPromise;
+    }
+
+    const shutdown = this.#shutdown();
+    this.#shutdownPromise = shutdown;
+    try {
+      await shutdown;
+    } catch (error) {
+      if (this.#shutdownPromise === shutdown) {
+        this.#shutdownPromise = undefined;
+      }
+      throw error;
+    }
+  }
+
+  async #shutdown(): Promise<void> {
+    this.#lifecycleState = 'stopping';
     // Stop legacy scheduler if it was started via #ensureScheduler
     if (this.#schedulerInitPromise) {
       try {
@@ -5054,18 +5228,23 @@ export class Mastra<
       this.#logger?.error('Failed to shutdown observability', error);
     }
     if (hasStopWorkersError) {
+      this.#lifecycleState = 'failed';
       throw stopWorkersError;
     }
     if (hasBackgroundTaskShutdownError) {
+      this.#lifecycleState = 'failed';
       throw backgroundTaskShutdownError;
     }
     if (hasHarnessShutdownError) {
+      this.#lifecycleState = 'failed';
       throw harnessShutdownError;
     }
     if (hasObservabilityShutdownError) {
+      this.#lifecycleState = 'failed';
       throw observabilityShutdownError;
     }
 
+    this.#lifecycleState = 'stopped';
     this.#logger?.info('Mastra shutdown completed');
   }
 

--- a/packages/core/src/mastra/workers-filter.test.ts
+++ b/packages/core/src/mastra/workers-filter.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ChannelProvider } from '../channels';
 import { PubSub } from '../events/pubsub';
 import type { Event, EventCallback, SubscribeOptions } from '../events/types';
 import { Harness } from '../harness/v1/harness';
@@ -7,6 +8,8 @@ import { InMemoryDB } from '../storage/domains/inmemory-db';
 import { MockStore } from '../storage/mock';
 import { HarnessWakeupWorker, MastraWorker } from '../worker';
 import type { WorkerDeps } from '../worker';
+import { Workspace } from '../workspace';
+import type { WorkspaceSandbox } from '../workspace/sandbox/sandbox';
 import { Mastra } from './index';
 
 const ORIGINAL_ENV = process.env.MASTRA_WORKERS;
@@ -1294,6 +1297,259 @@ describe('Mastra workers filter (MASTRA_WORKERS env)', () => {
     await expect(starting).rejects.toThrow('worker startup failed during stop');
     await expect(stopping).rejects.toThrow('worker startup failed during stop');
     expect(firstRunning).toBe(false);
+  });
+
+  it('uses Mastra init and shutdown as the Harness readiness lifecycle without implicit worker startup', async () => {
+    const harness = new Harness({
+      modes: [],
+      sessions: { storage: new InMemoryHarness({ db: new InMemoryDB() }) },
+    });
+    const harnessInit = vi.spyOn(harness, 'init');
+    const harnessShutdown = vi.spyOn(harness, 'shutdown');
+    const worker = new ControllableWorker();
+    const mastra = new Mastra({
+      harness,
+      workers: [worker],
+      logger: false,
+    });
+
+    expect(mastra.getLifecycleStatus()).toBe('constructed');
+    expect(mastra.isHarnessReady()).toBe(false);
+    expect(worker.startCalls).toBe(0);
+
+    await mastra.init();
+
+    expect(harnessInit).toHaveBeenCalledTimes(1);
+    expect(worker.initCalls).toBe(0);
+    expect(worker.startCalls).toBe(0);
+    expect(mastra.getLifecycleStatus()).toBe('ready');
+    expect(mastra.isHarnessReady()).toBe(true);
+
+    await mastra.startWorkers();
+
+    expect(worker.initCalls).toBe(1);
+    expect(worker.startCalls).toBe(1);
+
+    await mastra.shutdown();
+
+    expect(worker.stopCalls).toBeGreaterThanOrEqual(1);
+    expect(harnessShutdown).toHaveBeenCalledTimes(1);
+    expect(mastra.getLifecycleStatus()).toBe('stopped');
+    expect(mastra.isHarnessReady()).toBe(false);
+    await expect(mastra.startWorkers()).rejects.toThrow('Mastra workers cannot be started after shutdown has started');
+  });
+
+  it('keeps shutdown as a terminal lifecycle boundary when shutdown fails', async () => {
+    const harness = new Harness({
+      modes: [],
+      sessions: { storage: new InMemoryHarness({ db: new InMemoryDB() }) },
+    });
+    vi.spyOn(harness, 'shutdown').mockRejectedValueOnce(new Error('harness shutdown failed'));
+    const mastra = new Mastra({
+      harness,
+      logger: false,
+    });
+
+    await mastra.init();
+    await expect(mastra.shutdown()).rejects.toThrow('harness shutdown failed');
+
+    expect(mastra.getLifecycleStatus()).toBe('failed');
+    expect(mastra.isHarnessReady()).toBe(false);
+    await expect(mastra.init()).rejects.toThrow('Mastra cannot be initialized after shutdown has started');
+    await expect(mastra.startWorkers()).rejects.toThrow('Mastra workers cannot be started after shutdown has started');
+  });
+
+  it('allows Mastra init retry after a transient Harness readiness failure', async () => {
+    const harness = new Harness({
+      modes: [],
+      sessions: { storage: new InMemoryHarness({ db: new InMemoryDB() }) },
+    });
+    const harnessInit = vi
+      .spyOn(harness, 'init')
+      .mockRejectedValueOnce(new Error('transient readiness failed'))
+      .mockResolvedValueOnce(undefined);
+    const mastra = new Mastra({ harness, logger: false });
+
+    await expect(mastra.init()).rejects.toThrow('transient readiness failed');
+    expect(mastra.getLifecycleStatus()).toBe('failed');
+    await expect(mastra.startWorkers()).rejects.toThrow('readiness failed');
+
+    await mastra.init();
+
+    expect(harnessInit).toHaveBeenCalledTimes(2);
+    expect(mastra.getLifecycleStatus()).toBe('ready');
+    expect(mastra.isHarnessReady()).toBe(true);
+  });
+
+  it('does not mark Harness ready when shutdown interrupts init', async () => {
+    let resolveChannel!: () => void;
+    const channel: ChannelProvider = {
+      id: 'slow-channel',
+      getRoutes: () => [],
+      initialize: () =>
+        new Promise<void>(resolve => {
+          resolveChannel = resolve;
+        }),
+    };
+    const harness = new Harness({
+      modes: [],
+      sessions: { storage: new InMemoryHarness({ db: new InMemoryDB() }) },
+    });
+    const harnessInit = vi.spyOn(harness, 'init');
+    const worker = new ControllableWorker();
+    const mastra = new Mastra({
+      harness,
+      channels: { slow: channel },
+      workers: [worker],
+      logger: false,
+    });
+
+    const init = mastra.init();
+    expect(mastra.getLifecycleStatus()).toBe('starting');
+    const shutdown = mastra.shutdown();
+    resolveChannel();
+
+    await expect(init).rejects.toThrow('Mastra cannot be initialized after shutdown has started');
+    await shutdown;
+
+    expect(harnessInit).not.toHaveBeenCalled();
+    expect(worker.startCalls).toBe(0);
+    expect(mastra.getLifecycleStatus()).toBe('stopped');
+    expect(mastra.isHarnessReady()).toBe(false);
+  });
+
+  it('destroys eager shared workspace acquired after shutdown interrupts Harness init', async () => {
+    let resolveWorkspaceInit!: () => void;
+    const sandboxStart = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          resolveWorkspaceInit = resolve;
+        }),
+    );
+    const sandboxDestroy = vi.fn().mockResolvedValue(undefined);
+    const sandbox: WorkspaceSandbox = {
+      id: 'slow-sandbox',
+      name: 'Slow Sandbox',
+      provider: 'test',
+      start: sandboxStart,
+      destroy: sandboxDestroy,
+    };
+    const workspace = new Workspace({ id: 'slow-shared-workspace', sandbox });
+    const mastra = new Mastra({
+      harness: new Harness({
+        modes: [],
+        sessions: { storage: new InMemoryHarness({ db: new InMemoryDB() }) },
+        workspace: { kind: 'shared', eager: true, workspace },
+      }),
+      logger: false,
+    });
+
+    const init = mastra.init();
+    await vi.waitFor(() => {
+      expect(sandboxStart).toHaveBeenCalledTimes(1);
+    });
+    await mastra.shutdown();
+    resolveWorkspaceInit();
+
+    await expect(init).rejects.toThrow('harness cannot be initialized after shutdown');
+    expect(sandboxDestroy).toHaveBeenCalledTimes(1);
+    expect(mastra.getLifecycleStatus()).toBe('stopped');
+    expect(mastra.isHarnessReady()).toBe(false);
+  });
+
+  it('destroys eager shared workspace on shutdown when Harness has no storage', async () => {
+    const sandboxStart = vi.fn().mockResolvedValue(undefined);
+    const sandboxDestroy = vi.fn().mockResolvedValue(undefined);
+    const sandbox: WorkspaceSandbox = {
+      id: 'storage-free-sandbox',
+      name: 'Storage-free Sandbox',
+      provider: 'test',
+      start: sandboxStart,
+      destroy: sandboxDestroy,
+    };
+    const mastra = new Mastra({
+      harness: new Harness({
+        modes: [],
+        workspace: { kind: 'shared', eager: true, workspace: new Workspace({ id: 'storage-free-workspace', sandbox }) },
+      }),
+      logger: false,
+    });
+
+    await mastra.init();
+    await mastra.shutdown();
+
+    expect(sandboxStart).toHaveBeenCalledTimes(1);
+    expect(sandboxDestroy).toHaveBeenCalledTimes(1);
+    expect(mastra.getLifecycleStatus()).toBe('stopped');
+    expect(mastra.isHarnessReady()).toBe(false);
+  });
+
+  it('surfaces Harness channel initialization failures through Mastra init', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const channel: ChannelProvider = {
+      id: 'failing-channel',
+      getRoutes: () => [],
+      initialize: vi.fn().mockRejectedValue(new Error('channel init failed')),
+    };
+    const mastra = new Mastra({
+      harness: new Harness({
+        modes: [],
+        sessions: { storage: new InMemoryHarness({ db: new InMemoryDB() }) },
+      }),
+      channels: { failing: channel },
+      logger: false,
+    });
+
+    await expect(mastra.init()).rejects.toThrow('channel init failed');
+    expect(mastra.getLifecycleStatus()).toBe('failed');
+    expect(mastra.isHarnessReady()).toBe(false);
+  });
+
+  it('retries channel initialization after a transient readiness failure', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const initialize = vi.fn().mockRejectedValueOnce(new Error('channel not ready')).mockResolvedValueOnce(undefined);
+    const channel: ChannelProvider = {
+      id: 'retry-channel',
+      getRoutes: () => [],
+      initialize,
+    };
+    const mastra = new Mastra({
+      harness: new Harness({
+        modes: [],
+        sessions: { storage: new InMemoryHarness({ db: new InMemoryDB() }) },
+      }),
+      channels: { retry: channel },
+      logger: false,
+    });
+
+    await expect(mastra.init()).rejects.toThrow('channel not ready');
+    expect(mastra.getLifecycleStatus()).toBe('failed');
+
+    await mastra.init();
+
+    expect(initialize).toHaveBeenCalledTimes(2);
+    expect(mastra.getLifecycleStatus()).toBe('ready');
+    expect(mastra.isHarnessReady()).toBe(true);
+  });
+
+  it('does not start workers during Harness init when workers are disabled', async () => {
+    const pubsub = new StartupCleanupPubSub();
+    const mastra = new Mastra({
+      harness: new Harness({
+        modes: [],
+        sessions: { storage: new InMemoryHarness({ db: new InMemoryDB() }) },
+      }),
+      workers: false,
+      pubsub,
+      logger: false,
+    });
+
+    await mastra.init();
+
+    expect(mastra.workers).toEqual([]);
+    expect(pubsub.subscribeCalls).toEqual([]);
+    expect(mastra.getLifecycleStatus()).toBe('ready');
+    expect(mastra.isHarnessReady()).toBe(true);
   });
 
   it('registers harness wakeup worker for harness session storage without top-level storage', () => {

--- a/packages/core/src/mastra/workers-filter.test.ts
+++ b/packages/core/src/mastra/workers-filter.test.ts
@@ -1339,6 +1339,44 @@ describe('Mastra workers filter (MASTRA_WORKERS env)', () => {
     await expect(mastra.startWorkers()).rejects.toThrow('Mastra workers cannot be started after shutdown has started');
   });
 
+  it('waits for Harness readiness when workers are started before Mastra init completes', async () => {
+    const harness = new Harness({
+      modes: [],
+      sessions: { storage: new InMemoryHarness({ db: new InMemoryDB() }) },
+    });
+    let resolveHarnessInit!: () => void;
+    const harnessInit = vi.spyOn(harness, 'init').mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveHarnessInit = resolve;
+        }),
+    );
+    const worker = new ControllableWorker();
+    const mastra = new Mastra({
+      harness,
+      workers: [worker],
+      logger: false,
+    });
+
+    const starting = mastra.startWorkers();
+    await vi.waitFor(() => {
+      expect(harnessInit).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mastra.getLifecycleStatus()).toBe('starting');
+    expect(worker.initCalls).toBe(0);
+    expect(worker.startCalls).toBe(0);
+
+    resolveHarnessInit();
+    await starting;
+
+    expect(mastra.getLifecycleStatus()).toBe('ready');
+    expect(worker.initCalls).toBe(1);
+    expect(worker.startCalls).toBe(1);
+
+    await mastra.shutdown();
+  });
+
   it('keeps shutdown as a terminal lifecycle boundary when shutdown fails', async () => {
     const harness = new Harness({
       modes: [],
@@ -1500,6 +1538,7 @@ describe('Mastra workers filter (MASTRA_WORKERS env)', () => {
       logger: false,
     });
 
+    expect(channel.initialize).not.toHaveBeenCalled();
     await expect(mastra.init()).rejects.toThrow('channel init failed');
     expect(mastra.getLifecycleStatus()).toBe('failed');
     expect(mastra.isHarnessReady()).toBe(false);
@@ -1522,6 +1561,7 @@ describe('Mastra workers filter (MASTRA_WORKERS env)', () => {
       logger: false,
     });
 
+    expect(initialize).not.toHaveBeenCalled();
     await expect(mastra.init()).rejects.toThrow('channel not ready');
     expect(mastra.getLifecycleStatus()).toBe('failed');
 

--- a/packages/server/src/server/server-adapter/index.test.ts
+++ b/packages/server/src/server/server-adapter/index.test.ts
@@ -2,6 +2,7 @@
  * @license Mastra Enterprise License - see ee/LICENSE
  */
 import type { IFGAProvider } from '@mastra/core/auth/ee';
+import type { ChannelProvider } from '@mastra/core/channels';
 import { Mastra } from '@mastra/core/mastra';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MastraServer } from './index';
@@ -77,6 +78,69 @@ describe('custom route forwarding', () => {
       deleted: '123',
       reason: 'no longer needed',
     });
+  });
+});
+
+describe('server init readiness', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('awaits Mastra init before registering routes', async () => {
+    const events: string[] = [];
+    const mastra = new Mastra({ logger: false });
+    vi.spyOn(mastra, 'init').mockImplementation(async () => {
+      events.push('mastra:init');
+    });
+    const adapter = new TestMastraServer({ app: {}, mastra });
+    vi.spyOn(adapter, 'registerCustomApiRoutes').mockImplementation(async () => {
+      events.push('custom-routes');
+    });
+    vi.spyOn(adapter, 'registerRoutes').mockImplementation(async () => {
+      events.push('routes');
+    });
+
+    await adapter.init();
+
+    expect(events).toEqual(['mastra:init', 'custom-routes', 'routes']);
+  });
+
+  it('does not register routes when Mastra init fails', async () => {
+    const mastra = new Mastra({ logger: false });
+    vi.spyOn(mastra, 'init').mockRejectedValue(new Error('harness readiness failed'));
+    const adapter = new TestMastraServer({ app: {}, mastra });
+    const registerCustomApiRoutes = vi.spyOn(adapter, 'registerCustomApiRoutes');
+    const registerRoutes = vi.spyOn(adapter, 'registerRoutes');
+
+    await expect(adapter.init()).rejects.toThrow('harness readiness failed');
+
+    expect(registerCustomApiRoutes).not.toHaveBeenCalled();
+    expect(registerRoutes).not.toHaveBeenCalled();
+  });
+
+  it('does not register channel routes when channel initialization fails without Harness', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const channel: ChannelProvider = {
+      id: 'failing-channel',
+      getRoutes: () => [
+        {
+          path: '/channels/failing/webhook',
+          method: 'POST',
+          handler: vi.fn(),
+        },
+      ],
+      initialize: vi.fn().mockRejectedValue(new Error('channel readiness failed')),
+    };
+    const mastra = new Mastra({
+      channels: { failing: channel },
+      logger: false,
+    });
+    const adapter = new TestMastraServer({ app: {}, mastra });
+    const registerRoutes = vi.spyOn(adapter, 'registerRoutes');
+
+    await expect(adapter.init()).rejects.toThrow('channel readiness failed');
+
+    expect(registerRoutes).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -659,6 +659,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     await this.validateEELicense();
     await this.validateAgentBuilderLicense();
     await this.validateFGAPolicyCoverage();
+    await this.mastra.init();
     await this.registerCustomApiRoutes();
     await this.registerRoutes();
   }

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -22,6 +22,7 @@ import { ChannelsPG } from './domains/channels';
 import { DatasetsPG } from './domains/datasets';
 import { ExperimentsPG } from './domains/experiments';
 import { FavoritesPG } from './domains/favorites';
+import { HarnessPG } from './domains/harness';
 import { MCPClientsPG } from './domains/mcp-clients';
 import { MCPServersPG } from './domains/mcp-servers';
 import { MemoryPG } from './domains/memory';


### PR DESCRIPTION
## Summary
- add explicit Mastra readiness lifecycle that awaits global channels, agent channels, and Harness init before readiness
- harden Harness eager workspace initialization and WorkspaceRegistry shutdown/destroy races
- make MastraServer init await readiness before registering routes
- wire HarnessPG into the PostgreSQL store so Harness schema/domain composition loads correctly

## Linear
PF-359

## Open PR overlap
Rechecked before push: only open PR is #159 ([PF-559] upstream sync). It touches changesets, playground UI/workspace UI, and pnpm-lock only; no overlap with this PR's core Harness/Mastra lifecycle, server adapter, or pg storage files.

## Validation
- pnpm --dir packages/core exec vitest run src/channels/__tests__/integration.test.ts src/harness/v1/workspace-registry.test.ts src/mastra/workers-filter.test.ts (74 passed, no type errors)
- pnpm --dir packages/server exec vitest run src/server/server-adapter/index.test.ts (33 passed)
- Isolated Docker PostgreSQL Harness test: container pf359-harness-pg-final, port 55436, tmpfs data dir, env-scoped PG settings; pnpm --dir stores/pg exec vitest run src/storage/domains/harness/index.test.ts (10 passed), container removed afterward
- pnpm --filter ./packages/core check
- pnpm build:core
- pnpm --filter ./packages/server check:core-imports
- pnpm turbo build --filter ./packages/server --force (15 tasks successful; bypassed stale local Turbo cache artifact that made plain pnpm build:server restore a corrupted generated core declaration)
- pnpm exec prettier --check <touched files>
- pnpm exec eslint <touched files>
- git diff --check
- two local Codex review passes, findings patched
- coderabbit review --plain (no findings)

## Safety
No production Convex, production Docker, secrets, signing, or release/publish actions touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes Mastra wait until its internal pieces (channels, harnesses, and shared workspaces) finish initializing before the server accepts traffic, preventing requests from hitting unready components and avoiding related race conditions.

## Summary

This PR introduces an explicit readiness lifecycle across Mastra, hardens workspace lifecycle handling, changes server init ordering to await readiness, and fixes PostgreSQL Harness wiring so Harness schema/domain composition loads correctly.

### Core Changes

- Mastra readiness lifecycle (packages/core/src/mastra/index.ts)
  - Added Mastra.init() to orchestrate channel provisioning and Harness initialization.
  - Tracks lifecycle states: constructed, starting, ready, stopping, stopped, failed.
  - Agent channel initialization is started/lazy-tracked and awaited in init().
  - Added getLifecycleStatus() and isHarnessReady().
  - startWorkers() auto-calls init() when needed; shutdown is idempotent and marks lifecycle failed on errors.

- Harness initialization (packages/core/src/harness/v1/harness.ts)
  - Added Harness.init(): an explicit, idempotent, concurrency-safe async init hook.
  - Deferred eager shared workspace acquisition from constructor into init().
  - Init aborts cleanly with HarnessConfigError if shutdown occurs; shutdown now best-effort closes WorkspaceRegistry when no storage is bound.

- WorkspaceRegistry hardening (packages/core/src/harness/v1/workspace-registry.ts)
  - Tracks closed/shutdown state and prevents acquisitions after shutdown begins.
  - Adds concurrency-safe shared-destroy handling (deduplicated destroying promise).
  - Ensures in-progress initialization is torn down if shutdown begins; centralizes workspace destroy error emission.

### Server & Storage

- Server init ordering (packages/server/src/server/server-adapter/index.ts)
  - MastraServer.init() now awaits this.mastra.init() before registerCustomApiRoutes() and registerRoutes(), so routes are only registered after readiness completes.

- PostgreSQL store wiring (stores/pg/src/storage/index.ts)
  - Added the missing HarnessPG import so Harness domain is included in the domain list and store composition loads correctly.

### Tests & Validation

- Tests updated/added to cover readiness and workspace behavior:
  - Channel integration test: ensures mastra.init() surfaces channel initialize failures and retries.
  - WorkspaceRegistry tests: shared workspace provisioning during init(), concurrent destroy dedupe, and shutdown semantics.
  - Mastra lifecycle tests: lifecycle transitions, init/shutdown interactions, worker-start constraints, and teardown on interrupted init.
  - Server adapter tests: adapter.init() awaits mastra.init() and skips route registration on init rejection.
- Validation performed locally:
  - Core tests: 74 passing (vitest) for listed core tests.
  - Server adapter tests: 33 passing.
  - Isolated Docker PostgreSQL Harness test: 10 passing tests using container pf359-harness-pg-final (container removed after tests).
  - pnpm checks/builds, turbo rebuild to bypass cache, prettier and eslint checks, git diff --check.
  - Two Codex reviews and a coderabbit review with findings addressed or none.

### Release Notes / Changesets

- `@mastra/core`: patch — introduces Mastra.init() and Harness readiness lifecycle.
- `@mastra/server`: patch — delays route registration until Mastra.init() completes.
- `@mastra/pg`: patch — fixes PostgreSQL adapter Harness domain wiring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->