### PR TITLE
[PF-564] Add workspace action journal storage

### DIFF
--- a/.changeset/pf-564-workspace-action-journal.md
+++ b/.changeset/pf-564-workspace-action-journal.md
@@ -23,4 +23,4 @@ await storage.appendWorkspaceActionJournalEntry({
 });
 ```
 
-LibSQL and Postgres adapters can now return ordered journal pages for reconnectable desktop audit views.
+Improved: LibSQL and Postgres adapters now return ordered journal pages for reconnectable desktop audit views.

--- a/.changeset/pf-564-workspace-action-journal.md
+++ b/.changeset/pf-564-workspace-action-journal.md
@@ -1,0 +1,26 @@
+---
+"@mastra/core": patch
+"@mastra/libsql": patch
+"@mastra/pg": patch
+---
+
+Added: Harness storage can now persist workspace action journal rows for desktop policy and action audits.
+
+```ts
+await storage.appendWorkspaceActionJournalEntry({
+  id: 'workspace-action-1',
+  harnessName: 'default',
+  sessionId: 'session-1',
+  resourceId: 'resource-1',
+  threadId: 'thread-1',
+  actionKind: 'file',
+  operation: 'write',
+  action: { kind: 'file', operation: 'write', path: 'notes.md' },
+  policyDecision: 'ask',
+  policyReasons: ['workspace.default_ask'],
+  matchedRules: [],
+  createdAt: Date.now(),
+});
+```
+
+LibSQL and Postgres adapters can now return ordered journal pages for reconnectable desktop audit views.

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -59,6 +59,7 @@ export const TABLE_HARNESS_CHANNEL_ACTION_TOKENS = 'mastra_harness_channel_actio
 export const TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS = 'mastra_harness_channel_action_receipts';
 export const TABLE_HARNESS_CHANNEL_OUTBOX = 'mastra_harness_channel_outbox';
 export const TABLE_HARNESS_WAKEUPS = 'mastra_harness_wakeups';
+export const TABLE_HARNESS_WORKSPACE_ACTIONS = 'mastra_harness_workspace_actions';
 
 /** Union of all core table name constants. */
 export type TABLE_NAMES =
@@ -107,7 +108,8 @@ export type TABLE_NAMES =
   | typeof TABLE_HARNESS_CHANNEL_ACTION_TOKENS
   | typeof TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS
   | typeof TABLE_HARNESS_CHANNEL_OUTBOX
-  | typeof TABLE_HARNESS_WAKEUPS;
+  | typeof TABLE_HARNESS_WAKEUPS
+  | typeof TABLE_HARNESS_WORKSPACE_ACTIONS;
 
 export const SCORERS_SCHEMA: Record<string, StorageColumn> = {
   id: { type: 'text', nullable: false, primaryKey: true },
@@ -967,6 +969,26 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
     result: { type: 'jsonb', nullable: true },
     last_error: { type: 'jsonb', nullable: true },
   },
+  [TABLE_HARNESS_WORKSPACE_ACTIONS]: {
+    id: { type: 'text', nullable: false },
+    harness_name: { type: 'text', nullable: false },
+    session_id: { type: 'text', nullable: false },
+    resource_id: { type: 'text', nullable: false },
+    thread_id: { type: 'text', nullable: false },
+    action_kind: { type: 'text', nullable: false },
+    operation: { type: 'text', nullable: true },
+    action: { type: 'jsonb', nullable: false },
+    policy_decision: { type: 'text', nullable: false },
+    policy_reasons: { type: 'jsonb', nullable: false },
+    matched_rules: { type: 'jsonb', nullable: false },
+    path: { type: 'jsonb', nullable: true },
+    to_path: { type: 'jsonb', nullable: true },
+    cwd: { type: 'jsonb', nullable: true },
+    actor: { type: 'jsonb', nullable: true },
+    request_id: { type: 'text', nullable: true },
+    result: { type: 'jsonb', nullable: true },
+    created_at: { type: 'bigint', nullable: false },
+  },
 };
 
 /**
@@ -1018,6 +1040,10 @@ export const TABLE_CONFIGS: Partial<Record<TABLE_NAMES, StorageTableConfig>> = {
   },
   [TABLE_HARNESS_WAKEUPS]: {
     columns: TABLE_SCHEMAS[TABLE_HARNESS_WAKEUPS],
+  },
+  [TABLE_HARNESS_WORKSPACE_ACTIONS]: {
+    columns: TABLE_SCHEMAS[TABLE_HARNESS_WORKSPACE_ACTIONS],
+    compositePrimaryKey: ['harness_name', 'session_id', 'id'],
   },
 };
 

--- a/packages/core/src/storage/domains/harness/base.ts
+++ b/packages/core/src/storage/domains/harness/base.ts
@@ -3,6 +3,7 @@ import type {
   AcquireSessionLeaseInput,
   AgentSignalResultEvidence,
   AgentSignalResultStatus,
+  AppendWorkspaceActionJournalEntryResult,
   AttachmentReference,
   AttachmentRecord,
   ChannelActionInitialClaim,
@@ -32,6 +33,7 @@ import type {
   ListChannelDiagnosticsInput,
   ListSessionsByThreadInput,
   ListSessionsInput,
+  ListWorkspaceActionJournalInput,
   LoadedAttachment,
   OperationAdmissionEvidence,
   OperationAdmissionTombstone,
@@ -50,6 +52,7 @@ import type {
   SessionSummary,
   ThreadDeleteFenceLease,
   WithThreadDeleteFenceInput,
+  WorkspaceActionJournalEntry,
 } from './types';
 
 export interface WriteMessageResultEvidenceResult {
@@ -201,6 +204,14 @@ export class HarnessStorageSessionEventReplayUnsupportedError extends Error {
   readonly code = 'harness.storage.session_event_replay_unsupported' as const;
   constructor() {
     super('HarnessStorage session event replay must be implemented by this storage adapter');
+  }
+}
+
+export class HarnessStorageWorkspaceActionJournalUnsupportedError extends Error {
+  readonly name = 'HarnessStorageWorkspaceActionJournalUnsupportedError';
+  readonly code = 'harness.storage.workspace_action_journal_unsupported' as const;
+  constructor() {
+    super('HarnessStorage workspace action journal must be implemented by this storage adapter');
   }
 }
 
@@ -726,6 +737,31 @@ export abstract class HarnessStorage extends StorageDomain {
     limit: number;
   }): Promise<HarnessSessionEventRecord[]> {
     throw new HarnessStorageSessionEventReplayUnsupportedError();
+  }
+
+  // -------------------------------------------------------------------------
+  // Workspace action journal
+  // -------------------------------------------------------------------------
+
+  /**
+   * Append one immutable workspace policy/action audit row.
+   *
+   * Implementations return `{ created: false }` without mutating when the
+   * owning session is missing, the `(resourceId, threadId)` fence does not
+   * match the session, or the same `(harnessName, sessionId, id)` was already
+   * written. Existing rows are never updated; callers that need multi-phase
+   * evidence should append a separate row per phase.
+   */
+  async appendWorkspaceActionJournalEntry(
+    _record: WorkspaceActionJournalEntry,
+  ): Promise<AppendWorkspaceActionJournalEntryResult> {
+    throw new HarnessStorageWorkspaceActionJournalUnsupportedError();
+  }
+
+  async listWorkspaceActionJournalEntries(
+    _opts: ListWorkspaceActionJournalInput,
+  ): Promise<WorkspaceActionJournalEntry[]> {
+    throw new HarnessStorageWorkspaceActionJournalUnsupportedError();
   }
 
   // -------------------------------------------------------------------------

--- a/packages/core/src/storage/domains/harness/inmemory.test.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.test.ts
@@ -27,6 +27,7 @@ import type {
   HarnessProviderCallbackBinding,
   HarnessWakeupItem,
   SessionRecord,
+  WorkspaceActionJournalEntry,
 } from './types';
 
 describe('InMemoryHarness admission storage contract', () => {
@@ -422,6 +423,94 @@ describe('InMemoryHarness admission storage contract', () => {
         threadId: 'thread-1',
       }),
     ).resolves.toBeNull();
+  });
+
+  it('appends and pages workspace action journal rows by session/resource', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    await storage.saveSession(sampleSession(), { ownerId: 'h-1', ifVersion: 0 });
+    await storage.saveSession(sampleSession({ id: 'other-session', resourceId: 'other-resource' }), {
+      ownerId: 'h-1',
+      ifVersion: 0,
+    });
+
+    await storage.appendWorkspaceActionJournalEntry(sampleWorkspaceActionJournalEntry({ id: 'b', createdAt: 1000 }));
+    await storage.appendWorkspaceActionJournalEntry(sampleWorkspaceActionJournalEntry({ id: 'a', createdAt: 1000 }));
+    await storage.appendWorkspaceActionJournalEntry(sampleWorkspaceActionJournalEntry({ id: 'c', createdAt: 1100 }));
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'other-resource-entry',
+        sessionId: 'other-session',
+        resourceId: 'other-resource',
+      }),
+    );
+
+    await expect(
+      storage.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        limit: 2,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({ id: 'a', actionKind: 'file' }),
+      expect.objectContaining({ id: 'b', actionKind: 'file' }),
+    ]);
+    await expect(
+      storage.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        after: { createdAt: 1000, id: 'b' },
+        limit: 10,
+      }),
+    ).resolves.toEqual([expect.objectContaining({ id: 'c' })]);
+    await expect(
+      storage.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        limit: -1,
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it('ignores duplicate or mismatched workspace action journal appends and deletes rows with the session', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    await storage.saveSession(sampleSession({ closedAt: 2000, lastActivityAt: 2000 }), {
+      ownerId: 'h-1',
+      ifVersion: 0,
+    });
+
+    await expect(
+      storage.appendWorkspaceActionJournalEntry(sampleWorkspaceActionJournalEntry({ id: 'entry-1' })),
+    ).resolves.toEqual({ created: true });
+    await expect(
+      storage.appendWorkspaceActionJournalEntry(
+        sampleWorkspaceActionJournalEntry({ id: 'entry-1', result: { status: 'changed' } }),
+      ),
+    ).resolves.toEqual({ created: false });
+    await expect(
+      storage.appendWorkspaceActionJournalEntry(
+        sampleWorkspaceActionJournalEntry({ id: 'wrong-resource', resourceId: 'other-resource' }),
+      ),
+    ).resolves.toEqual({ created: false });
+
+    await expect(
+      storage.listWorkspaceActionJournalEntries({ sessionId: 'session-1', resourceId: 'resource-1', limit: 10 }),
+    ).resolves.toEqual([expect.objectContaining({ id: 'entry-1', result: { status: 'ok' } })]);
+
+    const closed = await storage.loadSession({ sessionId: 'session-1' });
+    if (!closed) throw new Error('expected closed session');
+    await storage.deleteSession({
+      sessionId: 'session-1',
+      ifVersion: closed.version,
+      expectedResourceId: closed.resourceId,
+      expectedThreadId: closed.threadId,
+      expectedParentSessionId: closed.parentSessionId ?? null,
+      expectedCreatedAt: closed.createdAt,
+      requireClosed: true,
+    });
+
+    await expect(
+      storage.listWorkspaceActionJournalEntries({ sessionId: 'session-1', resourceId: 'resource-1', limit: 10 }),
+    ).resolves.toEqual([]);
   });
 
   it('lists sessions by exact resource/thread and can include closed records', async () => {
@@ -2285,6 +2374,35 @@ function sampleSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
     createdAt: 1000,
     lastActivityAt: 1000,
     version: 0,
+    ...overrides,
+  };
+}
+
+function sampleWorkspaceActionJournalEntry(
+  overrides: Partial<WorkspaceActionJournalEntry> = {},
+): WorkspaceActionJournalEntry {
+  return {
+    id: 'workspace-action-1',
+    harnessName: 'default',
+    sessionId: 'session-1',
+    resourceId: 'resource-1',
+    threadId: 'thread-1',
+    actionKind: 'file',
+    operation: 'write',
+    action: { kind: 'file', operation: 'write', path: 'notes.md' },
+    policyDecision: 'ask',
+    policyReasons: ['workspace.default_ask'],
+    matchedRules: [],
+    path: {
+      rootId: 'project',
+      rootPath: '/workspace',
+      path: '/workspace/notes.md',
+      relativePath: 'notes.md',
+    },
+    actor: { type: 'user', id: 'user-1' },
+    requestId: 'request-1',
+    result: { status: 'ok' },
+    createdAt: 1000,
     ...overrides,
   };
 }

--- a/packages/core/src/storage/domains/harness/inmemory.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.ts
@@ -28,6 +28,7 @@ import type {
   AcquireSessionLeaseInput,
   AgentSignalResultEvidence,
   AgentSignalResultStatus,
+  AppendWorkspaceActionJournalEntryResult,
   AttachmentReference,
   AttachmentRecord,
   AttachmentSemanticMetadata,
@@ -53,6 +54,7 @@ import type {
   ListChannelDiagnosticsInput,
   ListSessionsByThreadInput,
   ListSessionsInput,
+  ListWorkspaceActionJournalInput,
   LoadedAttachment,
   JsonValue,
   OperationAdmissionEvidence,
@@ -72,6 +74,7 @@ import type {
   SessionSummary,
   ThreadDeleteFenceLease,
   WithThreadDeleteFenceInput,
+  WorkspaceActionJournalEntry,
 } from './types';
 
 /**
@@ -435,6 +438,11 @@ export class InMemoryHarness extends HarnessStorage {
     for (const [key, event] of this.db.harnessSessionEvents) {
       if (event.harnessName === namespace && event.sessionId === sessionId) {
         this.db.harnessSessionEvents.delete(key);
+      }
+    }
+    for (const [key, entry] of this.db.harnessWorkspaceActionJournal) {
+      if (entry.harnessName === namespace && entry.sessionId === sessionId) {
+        this.db.harnessWorkspaceActionJournal.delete(key);
       }
     }
     const refPrefix = `${namespace}\u0000${sessionId}\u0000`;
@@ -1040,6 +1048,50 @@ export class InMemoryHarness extends HarnessStorage {
         event.sequence > afterSequence,
     );
     rows.sort((a, b) => a.sequence - b.sequence);
+    return rows.slice(0, limit).map(row => cloneJson(row));
+  }
+
+  async appendWorkspaceActionJournalEntry(
+    record: WorkspaceActionJournalEntry,
+  ): Promise<AppendWorkspaceActionJournalEntryResult> {
+    assertWorkspaceActionKindMatches(record);
+    const namespaced = { ...record, harnessName: resolveHarnessName(record.harnessName, this.harnessName) };
+    const session = this.db.harnessSessions.get(sessionKey(namespaced.harnessName, namespaced.sessionId));
+    if (!session || session.resourceId !== namespaced.resourceId || session.threadId !== namespaced.threadId) {
+      return { created: false };
+    }
+    const key = workspaceActionJournalKey(namespaced.harnessName, namespaced.sessionId, namespaced.id);
+    if (!this.db.harnessWorkspaceActionJournal.has(key)) {
+      this.db.harnessWorkspaceActionJournal.set(key, cloneJson(namespaced));
+      return { created: true };
+    }
+    return { created: false };
+  }
+
+  async listWorkspaceActionJournalEntries({
+    harnessName,
+    sessionId,
+    resourceId,
+    threadId,
+    actionKind,
+    operation,
+    policyDecision,
+    after,
+    limit,
+  }: ListWorkspaceActionJournalInput): Promise<WorkspaceActionJournalEntry[]> {
+    if (limit <= 0) return [];
+    const namespace = resolveHarnessName(harnessName, this.harnessName);
+    const rows = Array.from(this.db.harnessWorkspaceActionJournal.values()).filter(entry => {
+      if (entry.harnessName !== namespace) return false;
+      if (entry.sessionId !== sessionId || entry.resourceId !== resourceId) return false;
+      if (threadId !== undefined && entry.threadId !== threadId) return false;
+      if (actionKind !== undefined && entry.actionKind !== actionKind) return false;
+      if (operation !== undefined && entry.operation !== operation) return false;
+      if (policyDecision !== undefined && entry.policyDecision !== policyDecision) return false;
+      if (after !== undefined && compareWorkspaceActionJournalCursor(entry, after) <= 0) return false;
+      return true;
+    });
+    rows.sort(compareWorkspaceActionJournalOrder);
     return rows.slice(0, limit).map(row => cloneJson(row));
   }
 
@@ -2357,6 +2409,7 @@ export class InMemoryHarness extends HarnessStorage {
     this.db.harnessMessageResultEvidence.clear();
     this.db.harnessOperationTombstones.clear();
     this.db.harnessSessionEvents.clear();
+    this.db.harnessWorkspaceActionJournal.clear();
     this.db.harnessChannelInbox.clear();
     this.db.harnessProviderCallbackBindings.clear();
     this.db.harnessChannelActionTokens.clear();
@@ -2406,6 +2459,10 @@ function sessionEventKey(
   record: Pick<HarnessSessionEventRecord, 'harnessName' | 'sessionId' | 'epoch' | 'sequence'>,
 ): string {
   return `${record.harnessName}\u0000${record.sessionId}\u0000${record.epoch}\u0000${record.sequence}`;
+}
+
+function workspaceActionJournalKey(harnessName: string, sessionId: string, id: string): string {
+  return `${harnessName}\u0000${sessionId}\u0000${id}`;
 }
 
 function channelInboxKey(_harnessName: string, inboxItemId: string): string {
@@ -3411,6 +3468,32 @@ function attachmentSemantic(record: AttachmentRecord): AttachmentSemanticMetadat
     ...(record.metadata ? { metadata: cloneJsonRecord(record.metadata) } : {}),
     ...(record.object ? { object: { ...record.object } } : {}),
   };
+}
+
+function compareWorkspaceActionJournalOrder(a: WorkspaceActionJournalEntry, b: WorkspaceActionJournalEntry): number {
+  return a.createdAt - b.createdAt || compareWorkspaceActionJournalId(a.id, b.id);
+}
+
+function compareWorkspaceActionJournalCursor(
+  entry: WorkspaceActionJournalEntry,
+  cursor: NonNullable<ListWorkspaceActionJournalInput['after']>,
+): number {
+  return entry.createdAt - cursor.createdAt || compareWorkspaceActionJournalId(entry.id, cursor.id);
+}
+
+function compareWorkspaceActionJournalId(a: string, b: string): number {
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
+function assertWorkspaceActionKindMatches(record: WorkspaceActionJournalEntry): void {
+  const action = record.action;
+  if (action && typeof action === 'object' && !Array.isArray(action) && 'kind' in action) {
+    const actionKind = (action as { kind?: unknown }).kind;
+    if (actionKind !== undefined && actionKind !== record.actionKind) {
+      throw new Error(`Workspace action journal kind mismatch: ${String(actionKind)} != ${record.actionKind}`);
+    }
+  }
 }
 
 function cloneJsonRecord(value: Record<string, JsonValue>): Record<string, JsonValue> {

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -474,6 +474,59 @@ export interface HarnessSessionEventReplayState {
   newestSequence: number;
 }
 
+export interface WorkspaceActionJournalPath {
+  rootId: string;
+  rootPath: string;
+  path: string;
+  relativePath: string;
+}
+
+export interface WorkspaceActionJournalEntry {
+  id: string;
+  harnessName: string;
+  sessionId: string;
+  resourceId: string;
+  threadId: string;
+  actionKind: 'file' | 'command' | 'network' | 'mcp';
+  operation?: string;
+  action: JsonValue;
+  policyDecision: 'allow' | 'ask' | 'deny';
+  policyReasons: string[];
+  matchedRules: JsonValue[];
+  path?: WorkspaceActionJournalPath;
+  toPath?: WorkspaceActionJournalPath;
+  cwd?: WorkspaceActionJournalPath;
+  actor?: JsonValue;
+  requestId?: string;
+  result?: JsonValue;
+  createdAt: number;
+}
+
+export interface AppendWorkspaceActionJournalEntryResult {
+  created: boolean;
+}
+
+/**
+ * Session-scoped workspace action journal query. `resourceId` is required as a
+ * tenant/resource isolation fence; `threadId` narrows the session's observed
+ * thread when the caller wants that exact committed identity. Pagination is a
+ * stable `(createdAt, id)` cursor in ascending order.
+ */
+export interface ListWorkspaceActionJournalInput {
+  harnessName?: string;
+  sessionId: string;
+  resourceId: string;
+  threadId?: string;
+  actionKind?: WorkspaceActionJournalEntry['actionKind'];
+  operation?: string;
+  policyDecision?: WorkspaceActionJournalEntry['policyDecision'];
+  after?: {
+    createdAt: number;
+    id: string;
+  };
+  limit: number;
+}
+
 export interface InboxResponseReceipt {
   responseId: string;
   responseHash: string;

--- a/packages/core/src/storage/domains/inmemory-db.ts
+++ b/packages/core/src/storage/domains/inmemory-db.ts
@@ -32,6 +32,7 @@ import type {
   HarnessProviderCallbackBinding,
   HarnessWakeupItem,
   HarnessSessionEventRecord,
+  WorkspaceActionJournalEntry,
   OperationAdmissionTombstone,
   SessionRecord,
 } from './harness/types';
@@ -121,6 +122,7 @@ export class InMemoryDB {
   readonly harnessMessageResultEvidence = new Map<string, AgentSignalResultEvidence>();
   readonly harnessOperationTombstones = new Map<string, OperationAdmissionTombstone>();
   readonly harnessSessionEvents = new Map<string, HarnessSessionEventRecord>();
+  readonly harnessWorkspaceActionJournal = new Map<string, WorkspaceActionJournalEntry>();
   readonly harnessChannelInbox = new Map<string, ChannelInboxItem>();
   readonly harnessProviderCallbackBindings = new Map<string, HarnessProviderCallbackBinding>();
   readonly harnessChannelActionTokens = new Map<string, ChannelActionToken>();
@@ -185,6 +187,7 @@ export class InMemoryDB {
     this.harnessMessageResultEvidence.clear();
     this.harnessOperationTombstones.clear();
     this.harnessSessionEvents.clear();
+    this.harnessWorkspaceActionJournal.clear();
     this.harnessChannelInbox.clear();
     this.harnessProviderCallbackBindings.clear();
     this.harnessChannelActionTokens.clear();

--- a/packages/core/src/storage/domains/operations/inmemory.ts
+++ b/packages/core/src/storage/domains/operations/inmemory.ts
@@ -59,6 +59,7 @@ export class StoreOperationsInMemory extends StoreOperations {
       mastra_harness_channel_outbox: new Map(),
       mastra_harness_provider_callback_bindings: new Map(),
       mastra_harness_wakeups: new Map(),
+      mastra_harness_workspace_actions: new Map(),
     };
   }
 

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -16,6 +16,7 @@ import {
   TABLE_HARNESS_SESSIONS,
   TABLE_HARNESS_THREAD_DELETE_FENCES,
   TABLE_HARNESS_WAKEUPS,
+  TABLE_HARNESS_WORKSPACE_ACTIONS,
   HarnessStorageAttachmentInUseError,
   HarnessStorageAttachmentUnavailableError,
   HarnessStorageChannelActionClaimConflictError,
@@ -39,6 +40,7 @@ import type {
   HarnessProviderCallbackBinding,
   HarnessWakeupItem,
   SessionRecord,
+  WorkspaceActionJournalEntry,
   HarnessStorageParentSessionUnavailableError,
 } from '@mastra/core/storage';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -544,6 +546,92 @@ describe('HarnessLibSQL active session admission', () => {
         threadId: 'thread-1',
       }),
     ).resolves.toBeNull();
+  });
+
+  it('appends and pages workspace action journal rows by session/resource', async () => {
+    await storage.saveSession(sampleSession(), { ownerId: 'h-1', ifVersion: 0 });
+    await storage.saveSession(sampleSession({ id: 'other-session', resourceId: 'other-resource' }), {
+      ownerId: 'h-1',
+      ifVersion: 0,
+    });
+
+    await storage.appendWorkspaceActionJournalEntry(sampleWorkspaceActionJournalEntry({ id: 'b', createdAt: 1000 }));
+    await storage.appendWorkspaceActionJournalEntry(sampleWorkspaceActionJournalEntry({ id: 'a', createdAt: 1000 }));
+    await storage.appendWorkspaceActionJournalEntry(sampleWorkspaceActionJournalEntry({ id: 'c', createdAt: 1100 }));
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'other-resource-entry',
+        sessionId: 'other-session',
+        resourceId: 'other-resource',
+      }),
+    );
+
+    await expect(
+      storage.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        limit: 2,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({ id: 'a', actionKind: 'file', path: expect.objectContaining({ rootId: 'project' }) }),
+      expect.objectContaining({ id: 'b', actionKind: 'file' }),
+    ]);
+    await expect(
+      storage.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        after: { createdAt: 1000, id: 'b' },
+        limit: 10,
+      }),
+    ).resolves.toEqual([expect.objectContaining({ id: 'c' })]);
+    await expect(
+      storage.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        limit: -1,
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it('ignores duplicate or mismatched workspace action journal appends and deletes rows with the session', async () => {
+    await storage.saveSession(sampleSession({ closedAt: 2000, lastActivityAt: 2000 }), {
+      ownerId: 'h-1',
+      ifVersion: 0,
+    });
+
+    await expect(
+      storage.appendWorkspaceActionJournalEntry(sampleWorkspaceActionJournalEntry({ id: 'entry-1' })),
+    ).resolves.toEqual({ created: true });
+    await expect(
+      storage.appendWorkspaceActionJournalEntry(
+        sampleWorkspaceActionJournalEntry({ id: 'entry-1', result: { status: 'changed' } }),
+      ),
+    ).resolves.toEqual({ created: false });
+    await expect(
+      storage.appendWorkspaceActionJournalEntry(
+        sampleWorkspaceActionJournalEntry({ id: 'wrong-resource', resourceId: 'other-resource' }),
+      ),
+    ).resolves.toEqual({ created: false });
+
+    await expect(
+      storage.listWorkspaceActionJournalEntries({ sessionId: 'session-1', resourceId: 'resource-1', limit: 10 }),
+    ).resolves.toEqual([expect.objectContaining({ id: 'entry-1', result: { status: 'ok' } })]);
+
+    const closed = await storage.loadSession({ sessionId: 'session-1' });
+    if (!closed) throw new Error('expected closed session');
+    await storage.deleteSession({
+      sessionId: 'session-1',
+      ifVersion: closed.version,
+      expectedResourceId: closed.resourceId,
+      expectedThreadId: closed.threadId,
+      expectedParentSessionId: closed.parentSessionId ?? null,
+      expectedCreatedAt: closed.createdAt,
+      requireClosed: true,
+    });
+
+    await expect(
+      storage.listWorkspaceActionJournalEntries({ sessionId: 'session-1', resourceId: 'resource-1', limit: 10 }),
+    ).resolves.toEqual([]);
   });
 
   it('lists sessions by exact resource/thread and can include closed records', async () => {
@@ -2943,6 +3031,35 @@ function sampleSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
     createdAt: 1000,
     lastActivityAt: 1000,
     version: 0,
+    ...overrides,
+  };
+}
+
+function sampleWorkspaceActionJournalEntry(
+  overrides: Partial<WorkspaceActionJournalEntry> = {},
+): WorkspaceActionJournalEntry {
+  return {
+    id: 'workspace-action-1',
+    harnessName: 'default',
+    sessionId: 'session-1',
+    resourceId: 'resource-1',
+    threadId: 'thread-1',
+    actionKind: 'file',
+    operation: 'write',
+    action: { kind: 'file', operation: 'write', path: 'notes.md' },
+    policyDecision: 'ask',
+    policyReasons: ['workspace.default_ask'],
+    matchedRules: [],
+    path: {
+      rootId: 'project',
+      rootPath: '/workspace',
+      path: '/workspace/notes.md',
+      relativePath: 'notes.md',
+    },
+    actor: { type: 'user', id: 'user-1' },
+    requestId: 'request-1',
+    result: { status: 'ok' },
+    createdAt: 1000,
     ...overrides,
   };
 }

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -36,6 +36,7 @@ import {
   TABLE_HARNESS_SESSIONS,
   TABLE_HARNESS_THREAD_DELETE_FENCES,
   TABLE_HARNESS_WAKEUPS,
+  TABLE_HARNESS_WORKSPACE_ACTIONS,
   TABLE_SCHEMAS,
   getSqlType,
 } from '@mastra/core/storage';
@@ -43,6 +44,7 @@ import type {
   AcquireSessionLeaseInput,
   AgentSignalResultEvidence,
   AgentSignalResultStatus,
+  AppendWorkspaceActionJournalEntryResult,
   AttachmentReference,
   AttachmentRecord,
   AttachmentSemanticMetadata,
@@ -67,6 +69,7 @@ import type {
   ListChannelDiagnosticsInput,
   ListSessionsByThreadInput,
   ListSessionsInput,
+  ListWorkspaceActionJournalInput,
   LoadedAttachment,
   JsonValue,
   OperationAdmissionEvidence,
@@ -87,6 +90,7 @@ import type {
   StorageColumn,
   ThreadDeleteFenceLease,
   WithThreadDeleteFenceInput,
+  WorkspaceActionJournalEntry,
   WriteMessageResultEvidenceResult,
 } from '@mastra/core/storage';
 import { LibSQLDB, resolveClient } from '../../db';
@@ -113,6 +117,7 @@ export class HarnessLibSQL extends HarnessStorage {
   #harnessName: string;
   #compactionLocks = new Map<string, Promise<void>>();
   #sessionEventsReady: Promise<void> | undefined;
+  #workspaceActionsReady: Promise<void> | undefined;
   #providerCallbackBindingIndexesReady: Promise<void> | undefined;
   #channelInboxIndexesReady: Promise<void> | undefined;
   #channelActionIndexesReady: Promise<void> | undefined;
@@ -153,6 +158,7 @@ export class HarnessLibSQL extends HarnessStorage {
     });
     await this.#ensureMessageResultsTable();
     await this.#ensureSessionEventsTable();
+    await this.#ensureWorkspaceActionsTable();
     const tombstonesConfig = TABLE_CONFIGS[TABLE_HARNESS_OPERATION_TOMBSTONES];
     await this.#db.createTable({
       tableName: TABLE_HARNESS_OPERATION_TOMBSTONES,
@@ -241,6 +247,7 @@ export class HarnessLibSQL extends HarnessStorage {
     await this.#ensureMessageResultsTable();
     await this.#ensureOperationTombstonesTable();
     await this.#ensureSessionEventsTable();
+    await this.#ensureWorkspaceActionsTable();
     await this.#ensureThreadDeleteFencesTable();
     await this.#ensureChannelInboxTable();
     await this.#ensureProviderCallbackBindingsTable();
@@ -253,6 +260,7 @@ export class HarnessLibSQL extends HarnessStorage {
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_MESSAGE_RESULTS}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_OPERATION_TOMBSTONES}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_SESSION_EVENTS}`);
+    await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_WORKSPACE_ACTIONS}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_CHANNEL_INBOX}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_PROVIDER_CALLBACK_BINDINGS}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}`);
@@ -835,6 +843,7 @@ export class HarnessLibSQL extends HarnessStorage {
     await this.#ensureMessageResultsTable();
     await this.#ensureOperationTombstonesTable();
     await this.#ensureSessionEventsTable();
+    await this.#ensureWorkspaceActionsTable();
     const tx = await this.#client.transaction('write');
     const deleteCandidates = new Map<
       string,
@@ -893,6 +902,11 @@ export class HarnessLibSQL extends HarnessStorage {
         });
         await tx.execute({
           sql: `DELETE FROM ${TABLE_HARNESS_SESSION_EVENTS}
+                WHERE harness_name = ? AND session_id = ?`,
+          args: [namespace, sessionId],
+        });
+        await tx.execute({
+          sql: `DELETE FROM ${TABLE_HARNESS_WORKSPACE_ACTIONS}
                 WHERE harness_name = ? AND session_id = ?`,
           args: [namespace, sessionId],
         });
@@ -1506,6 +1520,97 @@ export class HarnessLibSQL extends HarnessStorage {
       args: [namespace, sessionId, resourceId, threadId, epoch, afterSequence, limit],
     });
     return result.rows.map(row => rowToSessionEvent(row as Record<string, unknown>));
+  }
+
+  async appendWorkspaceActionJournalEntry(
+    record: WorkspaceActionJournalEntry,
+  ): Promise<AppendWorkspaceActionJournalEntryResult> {
+    assertWorkspaceActionKindMatches(record);
+    const namespace = this.#resolveHarnessName(record.harnessName);
+    await this.#ensureWorkspaceActionsTable();
+    const result = await this.#client.execute({
+      sql: `INSERT INTO ${TABLE_HARNESS_WORKSPACE_ACTIONS}
+            (id, harness_name, session_id, resource_id, thread_id, action_kind, operation, action,
+             policy_decision, policy_reasons, matched_rules, path, to_path, cwd, actor, request_id, result, created_at)
+            SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            WHERE EXISTS (
+              SELECT 1 FROM ${TABLE_HARNESS_SESSIONS}
+              WHERE harness_name = ? AND id = ? AND resource_id = ? AND thread_id = ?
+            )
+            ON CONFLICT(harness_name, session_id, id) DO NOTHING`,
+      args: [
+        record.id,
+        namespace,
+        record.sessionId,
+        record.resourceId,
+        record.threadId,
+        record.actionKind,
+        record.operation ?? null,
+        JSON.stringify(record.action),
+        record.policyDecision,
+        JSON.stringify(record.policyReasons),
+        JSON.stringify(record.matchedRules),
+        record.path === undefined ? null : JSON.stringify(record.path),
+        record.toPath === undefined ? null : JSON.stringify(record.toPath),
+        record.cwd === undefined ? null : JSON.stringify(record.cwd),
+        record.actor === undefined ? null : JSON.stringify(record.actor),
+        record.requestId ?? null,
+        record.result === undefined ? null : JSON.stringify(record.result),
+        record.createdAt,
+        namespace,
+        record.sessionId,
+        record.resourceId,
+        record.threadId,
+      ],
+    });
+    return { created: result.rowsAffected > 0 };
+  }
+
+  async listWorkspaceActionJournalEntries({
+    harnessName,
+    sessionId,
+    resourceId,
+    threadId,
+    actionKind,
+    operation,
+    policyDecision,
+    after,
+    limit,
+  }: ListWorkspaceActionJournalInput): Promise<WorkspaceActionJournalEntry[]> {
+    if (limit <= 0) return [];
+    const namespace = this.#resolveHarnessName(harnessName);
+    await this.#ensureWorkspaceActionsTable();
+    const conditions = ['harness_name = ?', 'session_id = ?', 'resource_id = ?'];
+    const args: (string | number)[] = [namespace, sessionId, resourceId];
+    if (threadId !== undefined) {
+      conditions.push('thread_id = ?');
+      args.push(threadId);
+    }
+    if (actionKind !== undefined) {
+      conditions.push('action_kind = ?');
+      args.push(actionKind);
+    }
+    if (operation !== undefined) {
+      conditions.push('operation = ?');
+      args.push(operation);
+    }
+    if (policyDecision !== undefined) {
+      conditions.push('policy_decision = ?');
+      args.push(policyDecision);
+    }
+    if (after !== undefined) {
+      conditions.push('(created_at > ? OR (created_at = ? AND id > ?))');
+      args.push(after.createdAt, after.createdAt, after.id);
+    }
+    args.push(limit);
+    const result = await this.#client.execute({
+      sql: `SELECT * FROM ${TABLE_HARNESS_WORKSPACE_ACTIONS}
+            WHERE ${conditions.join(' AND ')}
+            ORDER BY created_at ASC, id ASC
+            LIMIT ?`,
+      args,
+    });
+    return result.rows.map(row => rowToWorkspaceActionJournalEntry(row as Record<string, unknown>));
   }
 
   async resolveOperationAdmissionEvidence({
@@ -3732,6 +3837,34 @@ export class HarnessLibSQL extends HarnessStorage {
     return this.#sessionEventsReady;
   }
 
+  async #ensureWorkspaceActionsTable(): Promise<void> {
+    if (this.#workspaceActionsReady !== undefined) {
+      return this.#workspaceActionsReady;
+    }
+    this.#workspaceActionsReady = (async () => {
+      const workspaceActionsConfig = TABLE_CONFIGS[TABLE_HARNESS_WORKSPACE_ACTIONS];
+      await this.#db.createTable({
+        tableName: TABLE_HARNESS_WORKSPACE_ACTIONS,
+        schema: TABLE_SCHEMAS[TABLE_HARNESS_WORKSPACE_ACTIONS],
+        compositePrimaryKey: workspaceActionsConfig?.compositePrimaryKey,
+      });
+      await this.#client.execute({
+        sql: `CREATE INDEX IF NOT EXISTS idx_harness_workspace_actions_session
+              ON "${TABLE_HARNESS_WORKSPACE_ACTIONS}" ("harness_name", "session_id", "resource_id", "thread_id", "created_at", "id")`,
+        args: [],
+      });
+      await this.#client.execute({
+        sql: `CREATE INDEX IF NOT EXISTS idx_harness_workspace_actions_page
+              ON "${TABLE_HARNESS_WORKSPACE_ACTIONS}" ("harness_name", "session_id", "resource_id", "created_at", "id")`,
+        args: [],
+      });
+    })().catch(error => {
+      this.#workspaceActionsReady = undefined;
+      throw error;
+    });
+    return this.#workspaceActionsReady;
+  }
+
   async #ensureThreadDeleteFencesTable(): Promise<void> {
     const threadDeleteFencesConfig = TABLE_CONFIGS[TABLE_HARNESS_THREAD_DELETE_FENCES];
     await this.#db.createTable({
@@ -4969,6 +5102,41 @@ function rowToSessionEvent(row: Record<string, unknown>): HarnessSessionEventRec
     emittedAt: Number(row.emitted_at),
     storedAt: Number(row.stored_at),
   };
+}
+
+function rowToWorkspaceActionJournalEntry(row: Record<string, unknown>): WorkspaceActionJournalEntry {
+  const entry: WorkspaceActionJournalEntry = {
+    id: String(row.id),
+    harnessName: String(row.harness_name),
+    sessionId: String(row.session_id),
+    resourceId: String(row.resource_id),
+    threadId: String(row.thread_id),
+    actionKind: String(row.action_kind) as WorkspaceActionJournalEntry['actionKind'],
+    ...(row.operation == null ? {} : { operation: String(row.operation) }),
+    action: parseJson(row.action) as JsonValue,
+    policyDecision: String(row.policy_decision) as WorkspaceActionJournalEntry['policyDecision'],
+    policyReasons: (parseJson(row.policy_reasons) ?? []) as string[],
+    matchedRules: (parseJson(row.matched_rules) ?? []) as JsonValue[],
+    ...(row.path == null ? {} : { path: parseJson(row.path) as WorkspaceActionJournalEntry['path'] }),
+    ...(row.to_path == null ? {} : { toPath: parseJson(row.to_path) as WorkspaceActionJournalEntry['toPath'] }),
+    ...(row.cwd == null ? {} : { cwd: parseJson(row.cwd) as WorkspaceActionJournalEntry['cwd'] }),
+    ...(row.actor == null ? {} : { actor: parseJson(row.actor) as JsonValue }),
+    ...(row.request_id == null ? {} : { requestId: String(row.request_id) }),
+    ...(row.result == null ? {} : { result: parseJson(row.result) as JsonValue }),
+    createdAt: Number(row.created_at),
+  };
+  assertWorkspaceActionKindMatches(entry);
+  return entry;
+}
+
+function assertWorkspaceActionKindMatches(record: WorkspaceActionJournalEntry): void {
+  const action = record.action;
+  if (action && typeof action === 'object' && !Array.isArray(action) && 'kind' in action) {
+    const actionKind = (action as { kind?: unknown }).kind;
+    if (actionKind !== undefined && actionKind !== record.actionKind) {
+      throw new Error(`Workspace action journal kind mismatch: ${String(actionKind)} != ${record.actionKind}`);
+    }
+  }
 }
 
 function rowToMessageResultEvidence(row: Record<string, unknown>): AgentSignalResultEvidence {

--- a/stores/pg/src/storage/domains/harness/index.test.ts
+++ b/stores/pg/src/storage/domains/harness/index.test.ts
@@ -6,7 +6,9 @@ import {
   HarnessStorageAttachmentUnavailableError,
   HarnessStorageThreadDeleteFenceConflictError,
   TABLE_HARNESS_SESSION_EVENTS,
+  TABLE_HARNESS_WORKSPACE_ACTIONS,
 } from '@mastra/core/storage';
+import type { WorkspaceActionJournalEntry } from '@mastra/core/storage';
 import { describe, expect, it, beforeAll, beforeEach, afterAll, vi } from 'vitest';
 
 import { exportSchemas, HarnessPG, PostgresStore } from '../..';
@@ -38,8 +40,11 @@ describe('HarnessPG', () => {
     expect(ddl).toContain('mastra_harness_channel_inbox');
     expect(ddl).toContain('mastra_harness_wakeups');
     expect(ddl).toContain(TABLE_HARNESS_SESSION_EVENTS);
+    expect(ddl).toContain(TABLE_HARNESS_WORKSPACE_ACTIONS);
     expect(ddl).toContain('idx_harness_sessions_active_key');
     expect(ddl).toContain('idx_harness_session_events_replay');
+    expect(ddl).toContain('idx_harness_workspace_actions_page');
+    expect(ddl).toContain('idx_harness_workspace_actions_session');
     expect(ddl).toContain('idx_harness_channel_outbox_idempotency');
 
     const indexes = await store.db.manyOrNone<{ indexname: string }>(
@@ -54,6 +59,8 @@ describe('HarnessPG', () => {
           'idx_harness_channel_outbox_idempotency',
           'idx_harness_session_events_replay',
           'idx_harness_wakeups_idempotency',
+          'idx_harness_workspace_actions_page',
+          'idx_harness_workspace_actions_session',
         ],
       ],
     );
@@ -63,6 +70,8 @@ describe('HarnessPG', () => {
       'idx_harness_session_events_replay',
       'idx_harness_sessions_active_key',
       'idx_harness_wakeups_idempotency',
+      'idx_harness_workspace_actions_page',
+      'idx_harness_workspace_actions_session',
     ]);
   });
 
@@ -236,6 +245,98 @@ describe('HarnessPG', () => {
       renderer: { id: 'citation-card', version: '2' },
       metadata: { doi: '10.1234/example' },
     });
+  });
+
+  it('appends and pages workspace action journal rows by session/resource', async () => {
+    const harness = store.stores.harness;
+    expect(harness).toBeDefined();
+
+    await harness!.saveSession(createSampleSessionRecord(), { ownerId: 'h-1', ifVersion: 0 });
+    await harness!.saveSession(createSampleSessionRecord({ id: 'other-session', resourceId: 'other-resource' }), {
+      ownerId: 'h-1',
+      ifVersion: 0,
+    });
+
+    await harness!.appendWorkspaceActionJournalEntry(sampleWorkspaceActionJournalEntry({ id: 'b', createdAt: 1000 }));
+    await harness!.appendWorkspaceActionJournalEntry(sampleWorkspaceActionJournalEntry({ id: 'a', createdAt: 1000 }));
+    await harness!.appendWorkspaceActionJournalEntry(sampleWorkspaceActionJournalEntry({ id: 'c', createdAt: 1100 }));
+    await harness!.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'other-resource-entry',
+        sessionId: 'other-session',
+        resourceId: 'other-resource',
+      }),
+    );
+
+    await expect(
+      harness!.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        limit: 2,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({ id: 'a', actionKind: 'file', path: expect.objectContaining({ rootId: 'project' }) }),
+      expect.objectContaining({ id: 'b', actionKind: 'file' }),
+    ]);
+    await expect(
+      harness!.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        after: { createdAt: 1000, id: 'b' },
+        limit: 10,
+      }),
+    ).resolves.toEqual([expect.objectContaining({ id: 'c' })]);
+    await expect(
+      harness!.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        limit: -1,
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it('ignores duplicate or mismatched workspace action journal appends and deletes rows with the session', async () => {
+    const harness = store.stores.harness;
+    expect(harness).toBeDefined();
+
+    await harness!.saveSession(createSampleSessionRecord({ closedAt: 2000, lastActivityAt: 2000 }), {
+      ownerId: 'h-1',
+      ifVersion: 0,
+    });
+
+    await expect(
+      harness!.appendWorkspaceActionJournalEntry(sampleWorkspaceActionJournalEntry({ id: 'entry-1' })),
+    ).resolves.toEqual({ created: true });
+    await expect(
+      harness!.appendWorkspaceActionJournalEntry(
+        sampleWorkspaceActionJournalEntry({ id: 'entry-1', result: { status: 'changed' } }),
+      ),
+    ).resolves.toEqual({ created: false });
+    await expect(
+      harness!.appendWorkspaceActionJournalEntry(
+        sampleWorkspaceActionJournalEntry({ id: 'wrong-resource', resourceId: 'other-resource' }),
+      ),
+    ).resolves.toEqual({ created: false });
+
+    await expect(
+      harness!.listWorkspaceActionJournalEntries({ sessionId: 'session-1', resourceId: 'resource-1', limit: 10 }),
+    ).resolves.toEqual([expect.objectContaining({ id: 'entry-1', result: { status: 'ok' } })]);
+
+    const closed = await harness!.loadSession({ sessionId: 'session-1' });
+    if (!closed) throw new Error('expected closed session');
+    await harness!.deleteSession({
+      sessionId: 'session-1',
+      ifVersion: closed.version,
+      expectedResourceId: closed.resourceId,
+      expectedThreadId: closed.threadId,
+      expectedParentSessionId: closed.parentSessionId ?? null,
+      expectedCreatedAt: closed.createdAt,
+      requireClosed: true,
+    });
+
+    await expect(
+      harness!.listWorkspaceActionJournalEntries({ sessionId: 'session-1', resourceId: 'resource-1', limit: 10 }),
+    ).resolves.toEqual([]);
   });
 
   it('keeps §15 attachment-reference admission atomic and delete-guarded', async () => {
@@ -545,3 +646,32 @@ describe('HarnessPG', () => {
     ).resolves.toEqual({ inbox: [], actionTokens: [], actionReceipts: [], outbox: [] });
   });
 });
+
+function sampleWorkspaceActionJournalEntry(
+  overrides: Partial<WorkspaceActionJournalEntry> = {},
+): WorkspaceActionJournalEntry {
+  return {
+    id: 'workspace-action-1',
+    harnessName: 'default',
+    sessionId: 'session-1',
+    resourceId: 'resource-1',
+    threadId: 'thread-1',
+    actionKind: 'file',
+    operation: 'write',
+    action: { kind: 'file', operation: 'write', path: 'notes.md' },
+    policyDecision: 'ask',
+    policyReasons: ['workspace.default_ask'],
+    matchedRules: [],
+    path: {
+      rootId: 'project',
+      rootPath: '/workspace',
+      path: '/workspace/notes.md',
+      relativePath: 'notes.md',
+    },
+    actor: { type: 'user', id: 'user-1' },
+    requestId: 'request-1',
+    result: { status: 'ok' },
+    createdAt: 1000,
+    ...overrides,
+  };
+}

--- a/stores/pg/src/storage/domains/harness/index.ts
+++ b/stores/pg/src/storage/domains/harness/index.ts
@@ -33,12 +33,14 @@ import {
   TABLE_HARNESS_SESSIONS,
   TABLE_HARNESS_THREAD_DELETE_FENCES,
   TABLE_HARNESS_WAKEUPS,
+  TABLE_HARNESS_WORKSPACE_ACTIONS,
   TABLE_SCHEMAS,
 } from '@mastra/core/storage';
 import type {
   AcquireSessionLeaseInput,
   AgentSignalResultEvidence,
   AgentSignalResultStatus,
+  AppendWorkspaceActionJournalEntryResult,
   AttachmentReference,
   AttachmentRecord,
   AttachmentSemanticMetadata,
@@ -63,6 +65,7 @@ import type {
   ListChannelDiagnosticsInput,
   ListSessionsByThreadInput,
   ListSessionsInput,
+  ListWorkspaceActionJournalInput,
   LoadedAttachment,
   JsonValue,
   OperationAdmissionEvidence,
@@ -80,6 +83,7 @@ import type {
   SessionSummary,
   ThreadDeleteFenceLease,
   WithThreadDeleteFenceInput,
+  WorkspaceActionJournalEntry,
   WriteMessageResultEvidenceResult,
 } from '@mastra/core/storage';
 import { parseSqlIdentifier } from '@mastra/core/utils';
@@ -106,6 +110,7 @@ const HARNESS_TABLE_NAMES = [
   TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS,
   TABLE_HARNESS_CHANNEL_OUTBOX,
   TABLE_HARNESS_WAKEUPS,
+  TABLE_HARNESS_WORKSPACE_ACTIONS,
 ] as const;
 
 class PgHarnessClient {
@@ -255,6 +260,16 @@ function harnessIndexDefs(schemaPrefix: string): CreateIndexOptions[] {
       columns: ['harness_name', 'session_id', 'resource_id', 'thread_id', 'epoch', 'sequence'],
     },
     {
+      name: harnessIndexName(schemaPrefix, 'idx_harness_workspace_actions_session'),
+      table: TABLE_HARNESS_WORKSPACE_ACTIONS,
+      columns: ['harness_name', 'session_id', 'resource_id', 'thread_id', 'created_at', 'id'],
+    },
+    {
+      name: harnessIndexName(schemaPrefix, 'idx_harness_workspace_actions_page'),
+      table: TABLE_HARNESS_WORKSPACE_ACTIONS,
+      columns: ['harness_name', 'session_id', 'resource_id', 'created_at', 'id'],
+    },
+    {
       name: harnessIndexName(schemaPrefix, 'idx_harness_channel_inbox_idempotency'),
       table: TABLE_HARNESS_CHANNEL_INBOX,
       columns: ['harness_name', 'channel_id', 'idempotency_key'],
@@ -369,6 +384,7 @@ export class HarnessPG extends HarnessStorage {
   #skipDefaultIndexes?: boolean;
   #indexes?: CreateIndexOptions[];
   #sessionEventsReady: Promise<void> | undefined;
+  #workspaceActionsReady: Promise<void> | undefined;
   #compactionLocks = new Map<string, Promise<void>>();
   #channelInboxIndexesReady: Promise<void> | undefined;
   #channelActionIndexesReady: Promise<void> | undefined;
@@ -389,6 +405,7 @@ export class HarnessPG extends HarnessStorage {
     TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS,
     TABLE_HARNESS_CHANNEL_OUTBOX,
     TABLE_HARNESS_WAKEUPS,
+    TABLE_HARNESS_WORKSPACE_ACTIONS,
   ] as const;
 
   constructor(config: PgDomainConfig & { harnessName?: string }) {
@@ -450,6 +467,7 @@ export class HarnessPG extends HarnessStorage {
     });
     await this.#ensureMessageResultsTable();
     await this.#ensureSessionEventsTable();
+    await this.#ensureWorkspaceActionsTable();
     const tombstonesConfig = TABLE_CONFIGS[TABLE_HARNESS_OPERATION_TOMBSTONES];
     await this.#db.createTable({
       tableName: TABLE_HARNESS_OPERATION_TOMBSTONES,
@@ -538,6 +556,7 @@ export class HarnessPG extends HarnessStorage {
     await this.#ensureMessageResultsTable();
     await this.#ensureOperationTombstonesTable();
     await this.#ensureSessionEventsTable();
+    await this.#ensureWorkspaceActionsTable();
     await this.#ensureThreadDeleteFencesTable();
     await this.#ensureChannelInboxTable();
     await this.#ensureChannelActionTables();
@@ -549,6 +568,7 @@ export class HarnessPG extends HarnessStorage {
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_MESSAGE_RESULTS}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_OPERATION_TOMBSTONES}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_SESSION_EVENTS}`);
+    await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_WORKSPACE_ACTIONS}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_CHANNEL_INBOX}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_CHANNEL_ACTION_RECEIPTS}`);
     await this.#client.execute(`DELETE FROM ${TABLE_HARNESS_CHANNEL_ACTION_TOKENS}`);
@@ -1144,6 +1164,7 @@ export class HarnessPG extends HarnessStorage {
     await this.#ensureMessageResultsTable();
     await this.#ensureOperationTombstonesTable();
     await this.#ensureSessionEventsTable();
+    await this.#ensureWorkspaceActionsTable();
     const tx = await this.#client.transaction('write');
     const deleteCandidates = new Map<
       string,
@@ -1203,6 +1224,11 @@ export class HarnessPG extends HarnessStorage {
         });
         await tx.execute({
           sql: `DELETE FROM ${TABLE_HARNESS_SESSION_EVENTS}
+                WHERE harness_name = ? AND session_id = ?`,
+          args: [namespace, sessionId],
+        });
+        await tx.execute({
+          sql: `DELETE FROM ${TABLE_HARNESS_WORKSPACE_ACTIONS}
                 WHERE harness_name = ? AND session_id = ?`,
           args: [namespace, sessionId],
         });
@@ -1835,6 +1861,96 @@ export class HarnessPG extends HarnessStorage {
       args: [namespace, sessionId, resourceId, threadId, epoch, afterSequence, limit],
     });
     return result.rows.map(row => rowToSessionEvent(row as Record<string, unknown>));
+  }
+
+  async appendWorkspaceActionJournalEntry(
+    record: WorkspaceActionJournalEntry,
+  ): Promise<AppendWorkspaceActionJournalEntryResult> {
+    assertWorkspaceActionKindMatches(record);
+    const namespace = this.#resolveHarnessName(record.harnessName);
+    await this.#ensureWorkspaceActionsTable();
+    const result = await this.#client.execute({
+      sql: `INSERT INTO ${TABLE_HARNESS_WORKSPACE_ACTIONS}
+            (id, harness_name, session_id, resource_id, thread_id, action_kind, operation, action,
+             policy_decision, policy_reasons, matched_rules, path, to_path, cwd, actor, request_id, result, created_at)
+            SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            FROM ${TABLE_HARNESS_SESSIONS}
+            WHERE harness_name = ? AND id = ? AND resource_id = ? AND thread_id = ?
+            FOR KEY SHARE
+            ON CONFLICT (harness_name, session_id, id) DO NOTHING`,
+      args: [
+        record.id,
+        namespace,
+        record.sessionId,
+        record.resourceId,
+        record.threadId,
+        record.actionKind,
+        record.operation ?? null,
+        JSON.stringify(record.action),
+        record.policyDecision,
+        JSON.stringify(record.policyReasons),
+        JSON.stringify(record.matchedRules),
+        record.path === undefined ? null : JSON.stringify(record.path),
+        record.toPath === undefined ? null : JSON.stringify(record.toPath),
+        record.cwd === undefined ? null : JSON.stringify(record.cwd),
+        record.actor === undefined ? null : JSON.stringify(record.actor),
+        record.requestId ?? null,
+        record.result === undefined ? null : JSON.stringify(record.result),
+        record.createdAt,
+        namespace,
+        record.sessionId,
+        record.resourceId,
+        record.threadId,
+      ],
+    });
+    return { created: result.rowsAffected > 0 };
+  }
+
+  async listWorkspaceActionJournalEntries({
+    harnessName,
+    sessionId,
+    resourceId,
+    threadId,
+    actionKind,
+    operation,
+    policyDecision,
+    after,
+    limit,
+  }: ListWorkspaceActionJournalInput): Promise<WorkspaceActionJournalEntry[]> {
+    if (limit <= 0) return [];
+    const namespace = this.#resolveHarnessName(harnessName);
+    await this.#ensureWorkspaceActionsTable();
+    const conditions = ['harness_name = ?', 'session_id = ?', 'resource_id = ?'];
+    const args: QueryValues = [namespace, sessionId, resourceId];
+    if (threadId !== undefined) {
+      conditions.push('thread_id = ?');
+      args.push(threadId);
+    }
+    if (actionKind !== undefined) {
+      conditions.push('action_kind = ?');
+      args.push(actionKind);
+    }
+    if (operation !== undefined) {
+      conditions.push('operation = ?');
+      args.push(operation);
+    }
+    if (policyDecision !== undefined) {
+      conditions.push('policy_decision = ?');
+      args.push(policyDecision);
+    }
+    if (after !== undefined) {
+      conditions.push('(created_at > ? OR (created_at = ? AND id > ?))');
+      args.push(after.createdAt, after.createdAt, after.id);
+    }
+    args.push(limit);
+    const result = await this.#client.execute({
+      sql: `SELECT * FROM ${TABLE_HARNESS_WORKSPACE_ACTIONS}
+            WHERE ${conditions.join(' AND ')}
+            ORDER BY created_at ASC, id ASC
+            LIMIT ?`,
+      args,
+    });
+    return result.rows.map(row => rowToWorkspaceActionJournalEntry(row as Record<string, unknown>));
   }
 
   async resolveOperationAdmissionEvidence({
@@ -3632,6 +3748,26 @@ export class HarnessPG extends HarnessStorage {
     return this.#sessionEventsReady;
   }
 
+  async #ensureWorkspaceActionsTable(): Promise<void> {
+    if (this.#workspaceActionsReady !== undefined) {
+      return this.#workspaceActionsReady;
+    }
+    this.#workspaceActionsReady = (async () => {
+      const workspaceActionsConfig = TABLE_CONFIGS[TABLE_HARNESS_WORKSPACE_ACTIONS];
+      await this.#db.createTable({
+        tableName: TABLE_HARNESS_WORKSPACE_ACTIONS,
+        schema: TABLE_SCHEMAS[TABLE_HARNESS_WORKSPACE_ACTIONS],
+        compositePrimaryKey: workspaceActionsConfig?.compositePrimaryKey,
+      });
+      await this.#createDefaultIndexes(['idx_harness_workspace_actions_session']);
+      await this.#createDefaultIndexes(['idx_harness_workspace_actions_page']);
+    })().catch(error => {
+      this.#workspaceActionsReady = undefined;
+      throw error;
+    });
+    return this.#workspaceActionsReady;
+  }
+
   async #ensureThreadDeleteFencesTable(): Promise<void> {
     const threadDeleteFencesConfig = TABLE_CONFIGS[TABLE_HARNESS_THREAD_DELETE_FENCES];
     await this.#db.createTable({
@@ -4661,6 +4797,41 @@ function rowToSessionEvent(row: Record<string, unknown>): HarnessSessionEventRec
     emittedAt: Number(row.emitted_at),
     storedAt: Number(row.stored_at),
   };
+}
+
+function rowToWorkspaceActionJournalEntry(row: Record<string, unknown>): WorkspaceActionJournalEntry {
+  const entry: WorkspaceActionJournalEntry = {
+    id: String(row.id),
+    harnessName: String(row.harness_name),
+    sessionId: String(row.session_id),
+    resourceId: String(row.resource_id),
+    threadId: String(row.thread_id),
+    actionKind: String(row.action_kind) as WorkspaceActionJournalEntry['actionKind'],
+    ...(row.operation == null ? {} : { operation: String(row.operation) }),
+    action: parseJson(row.action) as JsonValue,
+    policyDecision: String(row.policy_decision) as WorkspaceActionJournalEntry['policyDecision'],
+    policyReasons: (parseJson(row.policy_reasons) ?? []) as string[],
+    matchedRules: (parseJson(row.matched_rules) ?? []) as JsonValue[],
+    ...(row.path == null ? {} : { path: parseJson(row.path) as WorkspaceActionJournalEntry['path'] }),
+    ...(row.to_path == null ? {} : { toPath: parseJson(row.to_path) as WorkspaceActionJournalEntry['toPath'] }),
+    ...(row.cwd == null ? {} : { cwd: parseJson(row.cwd) as WorkspaceActionJournalEntry['cwd'] }),
+    ...(row.actor == null ? {} : { actor: parseJson(row.actor) as JsonValue }),
+    ...(row.request_id == null ? {} : { requestId: String(row.request_id) }),
+    ...(row.result == null ? {} : { result: parseJson(row.result) as JsonValue }),
+    createdAt: Number(row.created_at),
+  };
+  assertWorkspaceActionKindMatches(entry);
+  return entry;
+}
+
+function assertWorkspaceActionKindMatches(record: WorkspaceActionJournalEntry): void {
+  const action = record.action;
+  if (action && typeof action === 'object' && !Array.isArray(action) && 'kind' in action) {
+    const actionKind = (action as { kind?: unknown }).kind;
+    if (actionKind !== undefined && actionKind !== record.actionKind) {
+      throw new Error(`Workspace action journal kind mismatch: ${String(actionKind)} != ${record.actionKind}`);
+    }
+  }
 }
 
 function rowToMessageResultEvidence(row: Record<string, unknown>): AgentSignalResultEvidence {


### PR DESCRIPTION
[PF-564](https://linear.app/papersflow/issue/PF-564/harness-v1desktop-workspace-action-audit-and-change-journal-storage)

## Summary
- Adds the Harness workspace action journal storage contract and exported types.
- Persists session/resource/thread-scoped journal rows in in-memory, LibSQL, and PG adapters.
- Adds stable `(createdAt, id)` pagination, duplicate-safe append results, SQL indexes for scoped reads, delete cleanup, and package changeset coverage.

## Validation
- `pnpm --filter ./packages/core test:unit src/storage/domains/harness/inmemory.test.ts`
- `pnpm build:core`
- `pnpm --filter @mastra/libsql test src/storage/domains/harness/index.test.ts`
- `pnpm --filter @mastra/libsql build:lib`
- `pnpm --filter @mastra/pg build:lib`
- Isolated Docker PG run, no shared compose hooks:
  - `docker run --name pf564-harness-pg-postreview --rm -d -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=postgres -p 127.0.0.1:55464:5432 --tmpfs /var/lib/postgresql/data:rw postgres:16-alpine`
  - `POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=55464 POSTGRES_DB=postgres POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres pnpm --filter @mastra/pg exec vitest run src/storage/domains/harness/index.test.ts`
  - `docker stop pf564-harness-pg-postreview`
- `git diff --check`
- Codex local review pass 1: fixed PG managed-table export and LibSQL init coverage.
- Codex local review pass 2: fixed LibSQL targeted conflict handling, non-positive limit handling, no-thread pagination index, and changeset coverage.
- CodeRabbit CLI pass 1: fixed changeset wording and SQL read-path invariant validation.
- CodeRabbit CLI pass 2: no findings.

## Scope notes
- Storage contract only. No workspace tool execution, OS sandboxing, server routes, client SDKs, or UI behavior.
- PG validation used a one-off container on `127.0.0.1:55464` and was stopped after the run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a safe, queryable "diary" for workspace actions: it records important events in a workspace and lets you read them back with filters and stable pagination. The journal is supported in-memory, in LibSQL, and in PostgreSQL, and avoids duplicate writes while cleaning up entries when sessions are deleted.

## Overview

Adds workspace action journal storage across the harness storage domain, including types, storage constants, adapter contract methods, and implementations for InMemory, LibSQL, and PostgreSQL adapters. Supports session/resource isolation, stable (createdAt, id) pagination, duplicate-safe appends, scoped read indexes, and cleanup on session deletion.

## Key Changes

### Core Storage Types & Constants
- New constant: TABLE_HARNESS_WORKSPACE_ACTIONS (composite primary key) in packages/core/src/storage/constants.ts
- New types in packages/core/src/storage/domains/harness/types.ts:
  - WorkspaceActionJournalPath
  - WorkspaceActionJournalEntry
  - ListWorkspaceActionJournalInput (filters: resourceId, sessionId, threadId, actionKind, operation, policyDecision; cursor via (createdAt, id); limit)
  - AppendWorkspaceActionJournalEntryResult

### Harness Storage Base
- Added methods to abstract HarnessStorage:
  - appendWorkspaceActionJournalEntry(record): Promise<AppendWorkspaceActionJournalEntryResult>
  - listWorkspaceActionJournalEntries(opts): Promise<WorkspaceActionJournalEntry[]>
- New adapter error: HarnessStorageWorkspaceActionJournalUnsupportedError (thrown by base implementations)

### In-Memory Implementation
- InMemoryHarness: idempotent append (skips duplicates by id/resource), list with stable (createdAt,id) ordering and cursor support, kind validation for action payload vs actionKind.
- InMemoryDB now stores harnessWorkspaceActionJournal and clears it on reset.
- Session deletion cascades to remove associated journal entries.

### LibSQL Adapter
- Adds workspace actions table with lazy initialization and indexes; ensured during init, clear, and delete flows.
- appendWorkspaceActionJournalEntry uses INSERT ... ON CONFLICT DO NOTHING for duplicate-safety.
- listWorkspaceActionJournalEntries implements scoped filtering, stable pagination, and runtime validation of action kind.
- Clears workspace action rows during session deletion and dangerouslyClearAll.

### PostgreSQL Adapter
- Adds workspace actions table and two indexes:
  - idx_harness_workspace_actions_page (pagination)
  - idx_harness_workspace_actions_session (session-scoped reads)
- Ensures table and indexes during init, clear, and delete flows (cached readiness).
- appendWorkspaceActionJournalEntry queries session metadata, INSERT ... ON CONFLICT DO NOTHING, returns created flag.
- listWorkspaceActionJournalEntries supports filters and orders by (created_at, id); maps rows to WorkspaceActionJournalEntry with JSON parsing and kind validation.
- Deletes journal rows for removed sessions.

### Testing
- New/updated tests in core (in-memory), stores/libsql, and stores/pg:
  - Append/list behavior with session/resource scoping and pagination (limit, after)
  - Non-positive limit returns empty result
  - Duplicate/mismatched appends ignored
  - Cascading deletion of session removes journal rows
  - Export/schema/index verification for Postgres
- Added sampleWorkspaceActionJournalEntry fixture helper across tests.

## Technical Details & Behavioural Notes
- Stable pagination: ordered by (createdAt, id) to remain deterministic with concurrent writes.
- Duplicate detection is resource-scoped (prevents same action record being added twice for same session/resource).
- Adapters validate that embedded action payload kind matches the journal entry's actionKind.
- Session deletion removes associated journal entries.
- limit <= 0 returns an empty list.

## Validation Performed
- Unit tests and builds: core (inmemory), LibSQL, and Postgres builds/tests executed.
- PostgreSQL validated in isolated Docker (postgres:16-alpine) running pg tests against 127.0.0.1:55464.
- Additional checks: git diff --check, multiple local review passes (PG managed-table export, LibSQL init/conflict handling, non-positive limit, pagination index concerns, changeset wording/coverage), and CodeRabbit CLI final pass with no findings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->