### PR TITLE
[PF-577] Capture runtime compatibility generation drift

### DIFF
--- a/.changeset/pf-577-runtime-compatibility-generation.md
+++ b/.changeset/pf-577-runtime-compatibility-generation.md
@@ -11,4 +11,4 @@ const harness = new Harness({
 });
 ```
 
-Change the `runtimeCompatibilityGeneration` value whenever existing non-terminal queued or suspended work should not resume on the new runtime surface.
+Change the `runtimeCompatibilityGeneration` value whenever in-progress queued or suspended work should not resume on the updated runtime.

--- a/.changeset/pf-577-runtime-compatibility-generation.md
+++ b/.changeset/pf-577-runtime-compatibility-generation.md
@@ -2,7 +2,7 @@
 "@mastra/core": patch
 ---
 
-Added runtime compatibility protection for Harness recovery. When you update agent implementations, prompts, tools, model bindings, MCP bindings, or other runtime dependencies, queued or suspended work from an older generation will be rejected during recovery instead of running against mismatched runtime state.
+Added runtime compatibility protection for Harness recovery. When you update agent code, prompts, tools, model settings, protocol bindings, or other runtime dependencies, queued or suspended work from an older generation will be rejected during recovery instead of running against mismatched runtime state.
 
 ```ts
 const harness = new Harness({

--- a/.changeset/pf-577-runtime-compatibility-generation.md
+++ b/.changeset/pf-577-runtime-compatibility-generation.md
@@ -1,0 +1,14 @@
+---
+"@mastra/core": patch
+---
+
+Added runtime compatibility protection for Harness recovery. When you update agent implementations, prompts, tools, model bindings, MCP bindings, or other runtime dependencies, queued or suspended work from an older generation will be rejected during recovery instead of running against mismatched runtime state.
+
+```ts
+const harness = new Harness({
+  runtimeCompatibilityGeneration: "agents-2026-05-21",
+  // ...other Harness config
+});
+```
+
+Change the `runtimeCompatibilityGeneration` value whenever existing non-terminal queued or suspended work should not resume on the new runtime surface.

--- a/packages/core/src/harness/v1/errors.ts
+++ b/packages/core/src/harness/v1/errors.ts
@@ -23,7 +23,7 @@ export class HarnessConfigError extends Error {
   }
 }
 
-export type HarnessRuntimeDependencyKind = 'mode' | 'agent' | 'workspace_provider';
+export type HarnessRuntimeDependencyKind = 'mode' | 'agent' | 'workspace_provider' | 'runtime_compatibility_generation';
 
 export class HarnessRuntimeDependencyDriftError extends Error {
   readonly name = 'HarnessRuntimeDependencyDriftError';

--- a/packages/core/src/harness/v1/harness.test.ts
+++ b/packages/core/src/harness/v1/harness.test.ts
@@ -1637,6 +1637,78 @@ describe('Harness v1 — construction', () => {
     ).toThrow(expect.objectContaining({ field: 'mastra', name: 'HarnessConfigError' }));
   });
 
+  it('captures and validates runtimeCompatibilityGeneration for recoverable runtime deps', () => {
+    expect(
+      () =>
+        new Harness({
+          agents: { default: makeAgent() },
+          modes: [{ id: 'default', agentId: 'default' }],
+          defaultModeId: 'default',
+          runtimeCompatibilityGeneration: '   ',
+          sessions: { storage: makeStorage() },
+        }),
+    ).toThrow(expect.objectContaining({ field: 'runtimeCompatibilityGeneration', name: 'HarnessConfigError' }));
+
+    const harness = new Harness({
+      agents: { default: makeAgent() },
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      runtimeCompatibilityGeneration: ' generation-a ',
+      sessions: { storage: makeStorage() },
+    });
+
+    expect(harness._runtimeDependenciesForMode('default')).toMatchObject({
+      modeId: 'default',
+      agentId: 'default',
+      runtimeCompatibilityGeneration: 'generation-a',
+    });
+
+    expect(() =>
+      harness._resolveAgentForRuntimeDependencies(
+        {
+          modeId: 'default',
+          agentId: 'default',
+          runtimeCompatibilityGeneration: 'generation-b',
+        },
+        'queued item recovery',
+      ),
+    ).toThrow(
+      expect.objectContaining({
+        code: 'harness.runtime_dependency_drifted',
+        dependencyKind: 'runtime_compatibility_generation',
+      }),
+    );
+
+    expect(
+      harness._resolveAgentForRuntimeDependencies({ modeId: 'default', agentId: 'default' }, 'legacy recovery'),
+    ).toMatchObject({
+      mode: { id: 'default', agentId: 'default' },
+    });
+
+    const unconfiguredHarness = new Harness({
+      agents: { default: makeAgent() },
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      sessions: { storage: makeStorage() },
+    });
+
+    expect(() =>
+      unconfiguredHarness._resolveAgentForRuntimeDependencies(
+        {
+          modeId: 'default',
+          agentId: 'default',
+          runtimeCompatibilityGeneration: 'generation-a',
+        },
+        'unset generation recovery',
+      ),
+    ).toThrow(
+      expect.objectContaining({
+        code: 'harness.runtime_dependency_drifted',
+        dependencyKind: 'runtime_compatibility_generation',
+      }),
+    );
+  });
+
   it('throws HarnessConfigError for duplicate mode ids', () => {
     expect(
       () =>

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -689,6 +689,7 @@ export class Harness {
   private readonly _modelAuthStatusResolver?: (modelId: string) => ModelAuthStatus | Promise<ModelAuthStatus>;
   private readonly _codeSkills: ReadonlyMap<string, HarnessSkill>;
   private readonly _channelRegistry: HarnessChannelRegistry;
+  private readonly _runtimeCompatibilityGeneration?: string;
   private readonly _emitter = new EventEmitter();
   /** Per-session unsubscribers so harness-level subscribers see session events too. */
   private readonly _sessionEventBridges = new Map<string, HarnessEventUnsubscribe>();
@@ -706,6 +707,14 @@ export class Harness {
 
   constructor(config: HarnessConfig) {
     this.ownerId = `harness-${randomUUID()}`;
+    const runtimeCompatibilityGeneration = config.runtimeCompatibilityGeneration;
+    if (
+      runtimeCompatibilityGeneration !== undefined &&
+      (typeof runtimeCompatibilityGeneration !== 'string' || runtimeCompatibilityGeneration.trim().length === 0)
+    ) {
+      throw new HarnessConfigError('runtimeCompatibilityGeneration', 'must be a non-empty string when provided');
+    }
+    this._runtimeCompatibilityGeneration = runtimeCompatibilityGeneration?.trim();
     this._leaseTtlMs = DEFAULT_LEASE_TTL_MS;
     this._storageOverride = config.sessions?.storage;
     this._maxQueueDepth = config.sessions?.maxQueueDepth ?? DEFAULT_MAX_QUEUE_DEPTH;
@@ -1257,6 +1266,9 @@ export class Harness {
     return {
       modeId,
       agentId: mode.agentId,
+      ...(this._runtimeCompatibilityGeneration
+        ? { runtimeCompatibilityGeneration: this._runtimeCompatibilityGeneration }
+        : {}),
       ...(modelId ? { modelId } : {}),
       workspaceProviderId: this._workspaceDependencyId(),
     };
@@ -1292,6 +1304,17 @@ export class Harness {
         'agent',
         agentId,
         'is not registered on this Mastra instance',
+        context,
+      );
+    }
+    if (
+      refs.runtimeCompatibilityGeneration !== undefined &&
+      refs.runtimeCompatibilityGeneration !== this._runtimeCompatibilityGeneration
+    ) {
+      throw new HarnessRuntimeDependencyDriftError(
+        'runtime_compatibility_generation',
+        refs.runtimeCompatibilityGeneration,
+        `was recorded, but the current generation is "${this._runtimeCompatibilityGeneration ?? 'unconfigured'}"`,
         context,
       );
     }

--- a/packages/core/src/harness/v1/session.queue.test.ts
+++ b/packages/core/src/harness/v1/session.queue.test.ts
@@ -1770,6 +1770,89 @@ describe('Session.queue() — crash replay', () => {
     });
   });
 
+  it('fails closed when queued work replays after runtime compatibility generation drift', async () => {
+    const storage = new InMemoryStore();
+    const harnessStore = await storage.getStore('harness');
+    if (!harnessStore) throw new Error('expected harness storage');
+    const sessionId = 'sess-queued-generation-drift';
+    const queuedItemId = 'q-queued-generation-drift';
+    const now = Date.now();
+    await harnessStore.saveSession(
+      {
+        harnessName: 'default',
+        id: sessionId,
+        resourceId: 'u',
+        threadId: 't-queued-generation-drift',
+        origin: 'top-level',
+        ownsThread: false,
+        modeId: 'default',
+        modelId: 'default',
+        subagentModelOverrides: {},
+        permissionRules: { categories: {}, tools: {} },
+        sessionGrants: { categories: [], tools: [] },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        pendingQueue: [
+          {
+            id: queuedItemId,
+            admissionId: 'queue-generation-drift',
+            admissionHash: 'hash-generation-drift',
+            enqueuedAt: now,
+            content: 'do not run after generation drift',
+            attachments: [],
+          },
+        ],
+        queueAdmissionReceipts: {
+          [queuedItemId]: {
+            admissionId: 'queue-generation-drift',
+            admissionHash: 'hash-generation-drift',
+            queuedItemId,
+            modeId: 'default',
+            runtimeDependencies: {
+              modeId: 'default',
+              agentId: 'default',
+              modelId: 'default',
+              runtimeCompatibilityGeneration: 'generation-a',
+            },
+            status: 'accepted',
+            runId: 'stale-run',
+            signalId: 'stale-signal',
+            attempts: 1,
+            enqueuedAt: now,
+            acceptedAt: now,
+            updatedAt: now,
+          },
+        },
+        state: undefined,
+        createdAt: now,
+        lastActivityAt: now,
+        version: 0,
+      },
+      { harnessName: 'default', ifVersion: 0 },
+    );
+
+    const replayAgent = new MockAgent({ id: 'default' });
+    const replayHarness = new Harness({
+      agents: { default: replayAgent } as any,
+      storage,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      runtimeCompatibilityGeneration: 'generation-b',
+    });
+
+    const replaySession = await replayHarness.session({ sessionId });
+    await replaySession.waitForIdle({ timeoutMs: 1000 });
+
+    expect(replayAgent.streamCalls).toHaveLength(0);
+    expect(replaySession.getRecord().pendingQueue).toEqual([]);
+    expect(replaySession.getRecord().queueAdmissionReceipts?.[queuedItemId]).toMatchObject({
+      status: 'failed',
+      error: {
+        code: 'harness.runtime_dependency_drifted',
+        message: expect.stringContaining('runtime_compatibility_generation "generation-a"'),
+      },
+    });
+  });
+
   it('replays an accepted receipt when pending signal evidence has no persisted memory signal', async () => {
     const storage = new InMemoryStore();
     const harnessStore = await storage.getStore('harness');

--- a/packages/core/src/harness/v1/session.suspend.test.ts
+++ b/packages/core/src/harness/v1/session.suspend.test.ts
@@ -567,6 +567,77 @@ describe('Session — respondToToolApproval / Suspension / Question / PlanApprov
     expect(session.getRecord().pendingResume?.resumedAt).toBeUndefined();
   });
 
+  it('fails closed when a recovered question resume observes runtime compatibility generation drift', async () => {
+    const storage = new InMemoryStore();
+    const harnessStore = await storage.getStore('harness');
+    if (!harnessStore) throw new Error('expected harness storage');
+    const sessionId = 'sess-question-generation-drift';
+    const requestedAt = Date.now();
+    await harnessStore.saveSession(
+      {
+        harnessName: 'default',
+        id: sessionId,
+        resourceId: 'u',
+        threadId: 't-question-generation-drift',
+        origin: 'top-level',
+        ownsThread: false,
+        modeId: 'default',
+        modelId: 'default',
+        subagentModelOverrides: {},
+        permissionRules: { categories: {}, tools: {} },
+        sessionGrants: { categories: [], tools: [] },
+        tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        pendingQueue: [],
+        pendingResume: {
+          kind: 'question',
+          itemId: 'question:tc-Q-generation',
+          runId: 'run-Q-generation',
+          toolCallId: 'tc-Q-generation',
+          toolName: 'ask_user',
+          source: 'parent',
+          requestedAt,
+          modeId: 'default',
+          runtimeDependencies: {
+            modeId: 'default',
+            agentId: 'default',
+            modelId: 'default',
+            runtimeCompatibilityGeneration: 'generation-a',
+          },
+          payload: { question: 'pick' },
+        },
+        state: undefined,
+        createdAt: requestedAt,
+        lastActivityAt: requestedAt,
+        version: 0,
+      },
+      { harnessName: 'default', ifVersion: 0 },
+    );
+    const agent = new FakeAgent();
+    const harness = new Harness({
+      agents: { default: agent } as any,
+      storage,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      runtimeCompatibilityGeneration: 'generation-b',
+    });
+
+    const session = await harness.session({ sessionId });
+    await expect(
+      session.respondToQuestion({ itemId: 'question:tc-Q-generation', responseId: 'answer-generation', answer: 'red' }),
+    ).rejects.toMatchObject({ code: 'harness.runtime_dependency_drifted' });
+
+    expect(agent.resumeCalls).toHaveLength(0);
+    expect(session.getRecord().inboxResponseReceipts?.['answer-generation']).toMatchObject({
+      status: 'failed',
+      error: {
+        code: 'harness.runtime_dependency_drifted',
+        message: expect.stringContaining('runtime_compatibility_generation "generation-a"'),
+      },
+    });
+    expect(session.getRecord().pendingResume).toMatchObject({ runId: 'run-Q-generation' });
+    expect(session.getRecord().pendingResume?.resumedAt).toBeUndefined();
+  });
+
   it('rejects an active question resume when the live session is marked deleted', async () => {
     const { harness, agent } = setup();
     agent.enqueueRun({

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -749,6 +749,20 @@ export type HarnessConfig = HarnessConfigCommon &
 
 export interface HarnessConfigCommon {
   /**
+   * Operator-managed compatibility token for the configured runtime surface:
+   * agents and prompts/tools, mode-to-agent bindings, model aliases, MCP
+   * bindings, workspace provider wiring, and wrappers that affect run
+   * semantics. Harness does not derive this value. Operators bump it when a
+   * change is incompatible with non-terminal persisted work.
+   *
+   * When set, recoverable work snapshots the token and later fails closed with
+   * `harness.runtime_dependency_drifted` if replay/resume observes a different
+   * current token, including when a previously configured token is later unset.
+   * Legacy rows without a snapshot continue ID-only validation.
+   */
+  runtimeCompatibilityGeneration?: string;
+
+  /**
    * Operating modes. Each mode pins a backing agent and may override or
    * extend its tool surface and instructions. Mode ids must be unique;
    * each mode's `agentId` must reference an agent visible to the harness

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -440,6 +440,12 @@ export interface HarnessRuntimeDependencyRefs {
   modeId: string;
   agentId?: string;
   /**
+   * Operator-managed compatibility token captured at admission/resume time.
+   * When present, recovered work must match the current Harness runtime
+   * generation before invoking agents. Omitted means legacy ID-only evidence.
+   */
+  runtimeCompatibilityGeneration?: string;
+  /**
    * Evidence-only selected model id. The current Harness model catalog is a
    * UX surface, not an execution registry, so recovery does not fail closed on
    * this field until a stable runtime model registry exists.


### PR DESCRIPTION
## Linear

PF-577

## Summary

- Add optional `runtimeCompatibilityGeneration` to Harness config and durable runtime dependency refs.
- Snapshot the normalized generation token for recoverable queued and pending-resume work.
- Reject recovered work with `harness.runtime_dependency_drifted` when the stored generation differs from the current Harness generation, including set-to-unset drift.
- Keep legacy rows without a captured generation on ID-only validation.

## Validation

- `pnpm --filter ./packages/core exec vitest run src/harness/v1/harness.test.ts src/harness/v1/session.queue.test.ts src/harness/v1/session.suspend.test.ts` — 3 files passed, 221 tests passed, 1 todo.
- `pnpm build:core` — passed, 11 tasks successful.
- `git diff --check` — passed.
- Isolated Docker PG check: started `pf-harness-pg-dev1-20260521-577b` on `127.0.0.1:55434`, ran `POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=55434 POSTGRES_DB=mastra POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres pnpm --filter @mastra/pg exec vitest run src/storage/domains/harness/index.test.ts` — 1 file passed, 12 tests passed; container stopped and removed, verified absent from `docker ps -a`.
- Claude council review — addressed missing changeset, legacy compatibility coverage, whitespace validation/doc notes.
- Local Codex review pass 1 — addressed whitespace-token footgun.
- Local Codex review pass 2 — addressed set-to-unset regression coverage and normalized token comparison.
- `coderabbit review --plain` — initial changeset wording finding fixed; rerun completed with no findings.

## Overlap

Open PR #162 touches Harness action catalog types and one nearby config/type area, but not runtime dependency recovery semantics. This PR can proceed independently; if #162 lands first, rebase normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a simple safety tag so the system can tell if paused or queued tasks were created for a different runtime version; if the saved tag doesn't match the current runtime, the task is rejected instead of running with potentially incompatible behavior.

## Changes Summary

**Core functionality**
- Add optional runtimeCompatibilityGeneration?: string to HarnessConfigCommon so operators can set a runtime compatibility token.
- Add optional runtimeCompatibilityGeneration?: string to HarnessRuntimeDependencyRefs to snapshot the token at admission/resume time.
- Extend HarnessRuntimeDependencyKind with 'runtime_compatibility_generation' so drift errors can identify this new check.

**Harness validation & recovery**
- Harness constructor validates provided runtimeCompatibilityGeneration as a non-empty, trimmed string.
- _runtimeDependenciesForMode includes runtimeCompatibilityGeneration when configured so the token is captured for queued/suspended work.
- _resolveAgentForRuntimeDependencies rejects recovered work (throws HarnessRuntimeDependencyDriftError with dependencyKind: 'runtime_compatibility_generation' and code harness.runtime_dependency_drifted) when the persisted generation differs from the harness's current generation, including set→unset and unset→set transitions.
- Legacy persisted rows that lack a captured generation continue to use ID-only validation to preserve backward compatibility.

**Tests added**
- Config validation test: rejects whitespace-only, trims valid strings, and checks resolution behavior for matching/mismatched/legacy cases.
- Crash-replay (queue) test: ensures queued items captured with one generation are rejected when the harness uses a different generation, that the item is removed from pendingQueue, and the admission receipt transitions to failed with harness.runtime_dependency_drifted.
- Resume test: ensures pending-resume items with a mismatched captured generation are rejected during respondToQuestion, leaving pendingResume.resumedAt unset and recording the drift error.

**Changesets & docs**
- .changeset/pf-577-runtime-compatibility-generation.md added for `@mastra/core` with example usage and guidance to update runtimeCompatibilityGeneration when operator changes should reject existing queued/suspended work.

## Validation & CI
- Unit tests: pnpm --filter ./packages/core exec vitest run — 221 tests passed, 1 todo.
- Build: pnpm build:core — 11 tasks successful.
- Code style: git diff --check passed.
- Isolated Docker Postgres: postgres-backed tests — 12 tests passed; container started and removed cleanly.
- Reviews: Addressed changeset, coverage, whitespace/token and regression coverage reviewer feedback.
- Overlap: PR `#162` touches related types but not recovery semantics; this PR can land independently (rebase if `#162` lands first).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->