### PR TITLE
[PF-578] Harden workspace action journal filter parity

### DIFF
--- a/packages/core/src/storage/domains/harness/inmemory.test.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.test.ts
@@ -471,6 +471,91 @@ describe('InMemoryHarness admission storage contract', () => {
     ).resolves.toEqual([]);
   });
 
+  it('filters workspace action journal rows by thread, kind, operation, and policy decision', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    await storage.saveSession(sampleSession(), { ownerId: 'h-1', ifVersion: 0 });
+    await storage.saveSession(sampleSession({ harnessName: 'other-harness' }), { ownerId: 'h-1', ifVersion: 0 });
+
+    await expect(
+      storage.appendWorkspaceActionJournalEntry(
+        sampleWorkspaceActionJournalEntry({ id: 'wrong-thread', threadId: 'thread-2' }),
+      ),
+    ).resolves.toEqual({ created: false });
+    await storage.appendWorkspaceActionJournalEntry(sampleWorkspaceActionJournalEntry({ id: 'a', createdAt: 1000 }));
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'b',
+        operation: 'read',
+        action: { kind: 'file', operation: 'read', path: 'notes.md' },
+        policyDecision: 'allow',
+        createdAt: 1000,
+      }),
+    );
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'c',
+        actionKind: 'command',
+        operation: 'run',
+        action: { kind: 'command', operation: 'run', command: 'pnpm test' },
+        policyDecision: 'deny',
+        path: undefined,
+        createdAt: 1100,
+      }),
+    );
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'd',
+        actionKind: 'mcp',
+        operation: 'call',
+        action: { kind: 'mcp', operation: 'call', serverKey: 'filesystem' },
+        policyDecision: 'allow',
+        path: undefined,
+        createdAt: 1200,
+      }),
+    );
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'e',
+        actionKind: 'network',
+        operation: 'fetch',
+        action: { kind: 'network', operation: 'fetch', url: 'https://example.test' },
+        path: undefined,
+        createdAt: 1300,
+      }),
+    );
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        harnessName: 'other-harness',
+        id: 'other-namespace',
+        createdAt: 900,
+      }),
+    );
+
+    const listIds = async (
+      overrides: Partial<Parameters<typeof storage.listWorkspaceActionJournalEntries>[0]>,
+    ): Promise<string[]> =>
+      (
+        await storage.listWorkspaceActionJournalEntries({
+          sessionId: 'session-1',
+          resourceId: 'resource-1',
+          limit: 10,
+          ...overrides,
+        })
+      ).map(entry => entry.id);
+
+    await expect(listIds({ threadId: 'thread-1' })).resolves.toEqual(['a', 'b', 'c', 'd', 'e']);
+    await expect(listIds({ threadId: 'thread-2' })).resolves.toEqual([]);
+    await expect(listIds({ sessionId: 'other-session' })).resolves.toEqual([]);
+    await expect(listIds({ resourceId: 'other-resource' })).resolves.toEqual([]);
+    await expect(listIds({ actionKind: 'file' })).resolves.toEqual(['a', 'b']);
+    await expect(listIds({ operation: 'write' })).resolves.toEqual(['a']);
+    await expect(listIds({ policyDecision: 'ask' })).resolves.toEqual(['a', 'e']);
+    await expect(listIds({ actionKind: 'mcp', policyDecision: 'allow' })).resolves.toEqual(['d']);
+    await expect(listIds({ actionKind: 'command', operation: 'run', policyDecision: 'deny' })).resolves.toEqual(['c']);
+    await expect(listIds({ actionKind: 'file', after: { createdAt: 1000, id: 'a' } })).resolves.toEqual(['b']);
+    await expect(listIds({ harnessName: 'other-harness' })).resolves.toEqual(['other-namespace']);
+  });
+
   it('ignores duplicate or mismatched workspace action journal appends and deletes rows with the session', async () => {
     const storage = new InMemoryHarness({ db: new InMemoryDB() });
     await storage.saveSession(sampleSession({ closedAt: 2000, lastActivityAt: 2000 }), {

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -16,7 +16,6 @@ import {
   TABLE_HARNESS_SESSIONS,
   TABLE_HARNESS_THREAD_DELETE_FENCES,
   TABLE_HARNESS_WAKEUPS,
-  TABLE_HARNESS_WORKSPACE_ACTIONS,
   HarnessStorageAttachmentInUseError,
   HarnessStorageAttachmentUnavailableError,
   HarnessStorageChannelActionClaimConflictError,
@@ -591,6 +590,90 @@ describe('HarnessLibSQL active session admission', () => {
         limit: -1,
       }),
     ).resolves.toEqual([]);
+  });
+
+  it('filters workspace action journal rows by thread, kind, operation, and policy decision', async () => {
+    await storage.saveSession(sampleSession(), { ownerId: 'h-1', ifVersion: 0 });
+    await storage.saveSession(sampleSession({ harnessName: 'other-harness' }), { ownerId: 'h-1', ifVersion: 0 });
+
+    await expect(
+      storage.appendWorkspaceActionJournalEntry(
+        sampleWorkspaceActionJournalEntry({ id: 'wrong-thread', threadId: 'thread-2' }),
+      ),
+    ).resolves.toEqual({ created: false });
+    await storage.appendWorkspaceActionJournalEntry(sampleWorkspaceActionJournalEntry({ id: 'a', createdAt: 1000 }));
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'b',
+        operation: 'read',
+        action: { kind: 'file', operation: 'read', path: 'notes.md' },
+        policyDecision: 'allow',
+        createdAt: 1000,
+      }),
+    );
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'c',
+        actionKind: 'command',
+        operation: 'run',
+        action: { kind: 'command', operation: 'run', command: 'pnpm test' },
+        policyDecision: 'deny',
+        path: undefined,
+        createdAt: 1100,
+      }),
+    );
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'd',
+        actionKind: 'mcp',
+        operation: 'call',
+        action: { kind: 'mcp', operation: 'call', serverKey: 'filesystem' },
+        policyDecision: 'allow',
+        path: undefined,
+        createdAt: 1200,
+      }),
+    );
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'e',
+        actionKind: 'network',
+        operation: 'fetch',
+        action: { kind: 'network', operation: 'fetch', url: 'https://example.test' },
+        path: undefined,
+        createdAt: 1300,
+      }),
+    );
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        harnessName: 'other-harness',
+        id: 'other-namespace',
+        createdAt: 900,
+      }),
+    );
+
+    const listIds = async (
+      overrides: Partial<Parameters<typeof storage.listWorkspaceActionJournalEntries>[0]>,
+    ): Promise<string[]> =>
+      (
+        await storage.listWorkspaceActionJournalEntries({
+          sessionId: 'session-1',
+          resourceId: 'resource-1',
+          limit: 10,
+          ...overrides,
+        })
+      ).map(entry => entry.id);
+
+    await expect(listIds({ threadId: 'thread-1' })).resolves.toEqual(['a', 'b', 'c', 'd', 'e']);
+    await expect(listIds({ threadId: 'thread-2' })).resolves.toEqual([]);
+    await expect(listIds({ sessionId: 'other-session' })).resolves.toEqual([]);
+    await expect(listIds({ resourceId: 'other-resource' })).resolves.toEqual([]);
+    await expect(listIds({ actionKind: 'file' })).resolves.toEqual(['a', 'b']);
+    await expect(listIds({ operation: 'write' })).resolves.toEqual(['a']);
+    await expect(listIds({ policyDecision: 'ask' })).resolves.toEqual(['a', 'e']);
+    await expect(listIds({ actionKind: 'mcp', policyDecision: 'allow' })).resolves.toEqual(['d']);
+    await expect(listIds({ actionKind: 'command', operation: 'run', policyDecision: 'deny' })).resolves.toEqual(['c']);
+    await expect(listIds({ actionKind: 'file', after: { createdAt: 1000, id: 'a' } })).resolves.toEqual(['b']);
+    await expect(listIds({ harnessName: 'other-harness' })).resolves.toEqual(['other-namespace']);
   });
 
   it('ignores duplicate or mismatched workspace action journal appends and deletes rows with the session', async () => {

--- a/stores/pg/src/storage/domains/harness/index.test.ts
+++ b/stores/pg/src/storage/domains/harness/index.test.ts
@@ -295,6 +295,96 @@ describe('HarnessPG', () => {
     ).resolves.toEqual([]);
   });
 
+  it('filters workspace action journal rows by thread, kind, operation, and policy decision', async () => {
+    const harness = store.stores.harness;
+    expect(harness).toBeDefined();
+
+    await harness!.saveSession(createSampleSessionRecord(), { ownerId: 'h-1', ifVersion: 0 });
+    await harness!.saveSession(createSampleSessionRecord({ harnessName: 'other-harness' }), {
+      ownerId: 'h-1',
+      ifVersion: 0,
+    });
+
+    await expect(
+      harness!.appendWorkspaceActionJournalEntry(
+        sampleWorkspaceActionJournalEntry({ id: 'wrong-thread', threadId: 'thread-2' }),
+      ),
+    ).resolves.toEqual({ created: false });
+    await harness!.appendWorkspaceActionJournalEntry(sampleWorkspaceActionJournalEntry({ id: 'a', createdAt: 1000 }));
+    await harness!.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'b',
+        operation: 'read',
+        action: { kind: 'file', operation: 'read', path: 'notes.md' },
+        policyDecision: 'allow',
+        createdAt: 1000,
+      }),
+    );
+    await harness!.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'c',
+        actionKind: 'command',
+        operation: 'run',
+        action: { kind: 'command', operation: 'run', command: 'pnpm test' },
+        policyDecision: 'deny',
+        path: undefined,
+        createdAt: 1100,
+      }),
+    );
+    await harness!.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'd',
+        actionKind: 'mcp',
+        operation: 'call',
+        action: { kind: 'mcp', operation: 'call', serverKey: 'filesystem' },
+        policyDecision: 'allow',
+        path: undefined,
+        createdAt: 1200,
+      }),
+    );
+    await harness!.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'e',
+        actionKind: 'network',
+        operation: 'fetch',
+        action: { kind: 'network', operation: 'fetch', url: 'https://example.test' },
+        path: undefined,
+        createdAt: 1300,
+      }),
+    );
+    await harness!.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        harnessName: 'other-harness',
+        id: 'other-namespace',
+        createdAt: 900,
+      }),
+    );
+
+    const listIds = async (
+      overrides: Partial<Parameters<typeof harness.listWorkspaceActionJournalEntries>[0]>,
+    ): Promise<string[]> =>
+      (
+        await harness!.listWorkspaceActionJournalEntries({
+          sessionId: 'session-1',
+          resourceId: 'resource-1',
+          limit: 10,
+          ...overrides,
+        })
+      ).map(entry => entry.id);
+
+    await expect(listIds({ threadId: 'thread-1' })).resolves.toEqual(['a', 'b', 'c', 'd', 'e']);
+    await expect(listIds({ threadId: 'thread-2' })).resolves.toEqual([]);
+    await expect(listIds({ sessionId: 'other-session' })).resolves.toEqual([]);
+    await expect(listIds({ resourceId: 'other-resource' })).resolves.toEqual([]);
+    await expect(listIds({ actionKind: 'file' })).resolves.toEqual(['a', 'b']);
+    await expect(listIds({ operation: 'write' })).resolves.toEqual(['a']);
+    await expect(listIds({ policyDecision: 'ask' })).resolves.toEqual(['a', 'e']);
+    await expect(listIds({ actionKind: 'mcp', policyDecision: 'allow' })).resolves.toEqual(['d']);
+    await expect(listIds({ actionKind: 'command', operation: 'run', policyDecision: 'deny' })).resolves.toEqual(['c']);
+    await expect(listIds({ actionKind: 'file', after: { createdAt: 1000, id: 'a' } })).resolves.toEqual(['b']);
+    await expect(listIds({ harnessName: 'other-harness' })).resolves.toEqual(['other-namespace']);
+  });
+
   it('ignores duplicate or mismatched workspace action journal appends and deletes rows with the session', async () => {
     const harness = store.stores.harness;
     expect(harness).toBeDefined();


### PR DESCRIPTION
## Summary
- Add workspace action journal filter parity coverage for InMemory, LibSQL, and Postgres adapters.
- Cover thread/session/resource fences, harness namespace isolation, action kind, operation, policy decision, and stable `(createdAt, id)` cursor ordering.
- Keep scope test-only; no public API, storage schema, runtime, server, SDK, Docker, Convex, release, or production behavior changes.

Linear: PF-578

## Validation
- `pnpm build:core`
- `pnpm --filter @internal/llm-recorder build`
- `pnpm --filter @mastra/core build:lib`
- `pnpm --filter @internal/test-utils build`
- `pnpm --filter ./stores/libsql build:lib`
- `pnpm --filter ./stores/pg build:lib`
- `pnpm exec prettier --check packages/core/src/storage/domains/harness/inmemory.test.ts stores/libsql/src/storage/domains/harness/index.test.ts stores/pg/src/storage/domains/harness/index.test.ts`
- `git diff --check`
- `pnpm --filter @mastra/core exec eslint src/storage/domains/harness/inmemory.test.ts`
- `pnpm --filter @mastra/libsql exec eslint src/storage/domains/harness/index.test.ts`
- `pnpm --filter @mastra/pg exec eslint src/storage/domains/harness/index.test.ts`
- `pnpm --filter ./packages/core run test:unit src/storage/domains/harness/inmemory.test.ts`
- `timeout 180 pnpm --filter @mastra/libsql run test src/storage/domains/harness/index.test.ts`
- isolated Postgres: `docker run -d --name pf-harness-pg-dev1-20260521-578c -e POSTGRES_DB=mastra -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -p 127.0.0.1:55438:5432 postgres:16-alpine`; then `POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=55438 POSTGRES_DB=mastra POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres pnpm --filter @mastra/pg exec vitest run src/storage/domains/harness/index.test.ts`; passed 13 tests; container stopped/removed; no `pf-harness-pg-dev1*` or `pg-test-db` containers remained.
- Two local Codex review passes: no findings after final patch.
- `coderabbit review --plain --type uncommitted`: no findings.

## Notes
- No changeset: test-only coverage hardening with no package contract or runtime behavior change.
- I avoided the package PG test script for final validation because it starts the repository default compose service; final PG evidence used a unique container name and high localhost port to avoid interfering with other work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR adds tests to make sure that three different database systems (InMemory, LibSQL, and Postgres) all filter workspace action journal entries the same way. Think of it like checking that a filing system works correctly no matter which storage cabinet you use—the tests verify that filtering by thread, action type, and policy decision works consistently across all three storage options.

## Changes

Added comprehensive test coverage for `listWorkspaceActionJournalEntries` filtering behavior across all three harness storage adapters:

### InMemory Adapter
- New test case verifying filtering by thread, action kind, operation, policy decision, and pagination
- Tests cursor-based pagination using `createdAt` + `id`
- Validates multiple journal entries across different threads and harness namespaces

### LibSQL Adapter  
- New test case with expanded scope covering thread, harness namespace, session/resource scoping, action kind, operation, and policy decision
- Confirms cursor-based pagination behavior
- Seeds diverse workspace action journal rows to verify filter combination accuracy

### Postgres Adapter
- New test case validating the same filtering dimensions as LibSQL
- Tests with entries from wrong threads and different harnesses to ensure isolation
- Verifies cursor pagination with createdAt + id ordering

All three test suites assert that only expected entry IDs are returned for each filter combination, ensuring parity across adapters.

## Scope
- Test-only changes with no impact to public APIs, storage schemas, runtime behavior, or production code
- No changeset required

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->