### PR TITLE
[PF-586] Add workspace journal request path filters

### DIFF
--- a/.changeset/pf-586-workspace-journal-filters.md
+++ b/.changeset/pf-586-workspace-journal-filters.md
@@ -1,0 +1,26 @@
+---
+"@mastra/core": patch
+"@mastra/libsql": patch
+"@mastra/pg": patch
+---
+
+Added request and affected-path filters when listing Harness workspace action journal entries. Developers can now narrow journal reads to a specific request or exact filesystem path, and can opt in to matching rename or move destinations.
+
+```ts
+const requestEntries = await harness.listWorkspaceActionJournalEntries({
+  sessionId: "session-1",
+  resourceId: "resource-1",
+  requestId: "request-1",
+  limit: 50,
+});
+
+const pathEntries = await harness.listWorkspaceActionJournalEntries({
+  sessionId: "session-1",
+  resourceId: "resource-1",
+  affectedPath: {
+    path: "/workspace/src/renamed.ts",
+    includeToPath: true,
+  },
+  limit: 50,
+});
+```

--- a/packages/core/src/storage/domains/harness/inmemory.test.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.test.ts
@@ -556,6 +556,100 @@ describe('InMemoryHarness admission storage contract', () => {
     await expect(listIds({ harnessName: 'other-harness' })).resolves.toEqual(['other-namespace']);
   });
 
+  it('filters workspace action journal rows by request and affected path', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    await storage.saveSession(sampleSession(), { ownerId: 'h-1', ifVersion: 0 });
+
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'write-readme',
+        requestId: 'turn-1',
+        path: {
+          rootId: 'project',
+          rootPath: '/workspace',
+          path: '/workspace/README.md',
+          relativePath: 'README.md',
+        },
+        action: { kind: 'file', operation: 'write', path: 'README.md' },
+        createdAt: 1000,
+      }),
+    );
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'rename-source',
+        requestId: 'turn-1',
+        operation: 'rename',
+        action: { kind: 'file', operation: 'rename', path: 'src/old.ts', toPath: 'src/new.ts' },
+        path: {
+          rootId: 'project',
+          rootPath: '/workspace',
+          path: '/workspace/src/old.ts',
+          relativePath: 'src/old.ts',
+        },
+        toPath: {
+          rootId: 'project',
+          rootPath: '/workspace',
+          path: '/workspace/src/new.ts',
+          relativePath: 'src/new.ts',
+        },
+        createdAt: 1100,
+      }),
+    );
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'write-docs-readme',
+        requestId: 'turn-2',
+        path: {
+          rootId: 'project',
+          rootPath: '/workspace',
+          path: '/workspace/docs/README.md',
+          relativePath: 'docs/README.md',
+        },
+        action: { kind: 'file', operation: 'write', path: 'docs/README.md' },
+        createdAt: 1200,
+      }),
+    );
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'run-command',
+        requestId: 'turn-1',
+        actionKind: 'command',
+        operation: 'run',
+        action: { kind: 'command', operation: 'run', command: 'pnpm test' },
+        path: undefined,
+        createdAt: 1300,
+      }),
+    );
+
+    const listIds = async (
+      overrides: Partial<Parameters<typeof storage.listWorkspaceActionJournalEntries>[0]>,
+    ): Promise<string[]> =>
+      (
+        await storage.listWorkspaceActionJournalEntries({
+          sessionId: 'session-1',
+          resourceId: 'resource-1',
+          limit: 10,
+          ...overrides,
+        })
+      ).map(entry => entry.id);
+
+    await expect(listIds({ requestId: 'turn-1' })).resolves.toEqual(['write-readme', 'rename-source', 'run-command']);
+    await expect(listIds({ requestId: 'turn-2', affectedPath: { relativePath: 'docs/README.md' } })).resolves.toEqual([
+      'write-docs-readme',
+    ]);
+    await expect(listIds({ affectedPath: { rootId: 'project', relativePath: 'README.md' } })).resolves.toEqual([
+      'write-readme',
+    ]);
+    await expect(listIds({ affectedPath: { path: '/workspace/src/old.ts' } })).resolves.toEqual(['rename-source']);
+    await expect(listIds({ affectedPath: { relativePath: 'src/new.ts' } })).resolves.toEqual([]);
+    await expect(listIds({ affectedPath: { relativePath: 'src/new.ts', includeToPath: true } })).resolves.toEqual([
+      'rename-source',
+    ]);
+    await expect(listIds({ affectedPath: { rootId: 'other', relativePath: 'README.md' } })).resolves.toEqual([]);
+    await expect(listIds({ affectedPath: {} })).resolves.toEqual([]);
+    await expect(listIds({ affectedPath: { includeToPath: true } })).resolves.toEqual([]);
+  });
+
   it('ignores duplicate or mismatched workspace action journal appends and deletes rows with the session', async () => {
     const storage = new InMemoryHarness({ db: new InMemoryDB() });
     await storage.saveSession(sampleSession({ closedAt: 2000, lastActivityAt: 2000 }), {

--- a/packages/core/src/storage/domains/harness/inmemory.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.ts
@@ -1076,6 +1076,8 @@ export class InMemoryHarness extends HarnessStorage {
     actionKind,
     operation,
     policyDecision,
+    requestId,
+    affectedPath,
     after,
     limit,
   }: ListWorkspaceActionJournalInput): Promise<WorkspaceActionJournalEntry[]> {
@@ -1088,6 +1090,8 @@ export class InMemoryHarness extends HarnessStorage {
       if (actionKind !== undefined && entry.actionKind !== actionKind) return false;
       if (operation !== undefined && entry.operation !== operation) return false;
       if (policyDecision !== undefined && entry.policyDecision !== policyDecision) return false;
+      if (requestId !== undefined && entry.requestId !== requestId) return false;
+      if (affectedPath !== undefined && !workspaceActionJournalEntryMatchesPath(entry, affectedPath)) return false;
       if (after !== undefined && compareWorkspaceActionJournalCursor(entry, after) <= 0) return false;
       return true;
     });
@@ -3484,6 +3488,34 @@ function compareWorkspaceActionJournalCursor(
 function compareWorkspaceActionJournalId(a: string, b: string): number {
   if (a === b) return 0;
   return a < b ? -1 : 1;
+}
+
+function workspaceActionJournalEntryMatchesPath(
+  entry: WorkspaceActionJournalEntry,
+  filter: NonNullable<ListWorkspaceActionJournalInput['affectedPath']>,
+): boolean {
+  if (!workspaceActionJournalPathFilterHasSelector(filter)) return false;
+  return (
+    workspaceActionJournalPathMatches(entry.path, filter) ||
+    (filter.includeToPath === true && workspaceActionJournalPathMatches(entry.toPath, filter))
+  );
+}
+
+function workspaceActionJournalPathMatches(
+  path: WorkspaceActionJournalEntry['path'],
+  filter: NonNullable<ListWorkspaceActionJournalInput['affectedPath']>,
+): boolean {
+  if (path === undefined) return false;
+  if (filter.rootId !== undefined && path.rootId !== filter.rootId) return false;
+  if (filter.path !== undefined && path.path !== filter.path) return false;
+  if (filter.relativePath !== undefined && path.relativePath !== filter.relativePath) return false;
+  return true;
+}
+
+function workspaceActionJournalPathFilterHasSelector(
+  filter: NonNullable<ListWorkspaceActionJournalInput['affectedPath']>,
+): boolean {
+  return filter.rootId !== undefined || filter.path !== undefined || filter.relativePath !== undefined;
 }
 
 function assertWorkspaceActionKindMatches(record: WorkspaceActionJournalEntry): void {

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -506,11 +506,22 @@ export interface AppendWorkspaceActionJournalEntryResult {
   created: boolean;
 }
 
+export interface WorkspaceActionJournalPathFilter {
+  rootId?: string;
+  path?: string;
+  relativePath?: string;
+  includeToPath?: boolean;
+}
+
 /**
  * Session-scoped workspace action journal query. `resourceId` is required as a
  * tenant/resource isolation fence; `threadId` narrows the session's observed
  * thread when the caller wants that exact committed identity. Pagination is a
- * stable `(createdAt, id)` cursor in ascending order.
+ * stable `(createdAt, id)` cursor in ascending order. `affectedPath` requires
+ * at least one concrete selector (`rootId`, `path`, or `relativePath`) and
+ * matches those selectors with AND semantics against the source `path` by
+ * default; set `includeToPath` when rename/move destinations should also be
+ * considered affected. Command `cwd` is not an affected path.
  */
 export interface ListWorkspaceActionJournalInput {
   harnessName?: string;
@@ -520,6 +531,8 @@ export interface ListWorkspaceActionJournalInput {
   actionKind?: WorkspaceActionJournalEntry['actionKind'];
   operation?: string;
   policyDecision?: WorkspaceActionJournalEntry['policyDecision'];
+  requestId?: string;
+  affectedPath?: WorkspaceActionJournalPathFilter;
   after?: {
     createdAt: number;
     id: string;

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -676,6 +676,99 @@ describe('HarnessLibSQL active session admission', () => {
     await expect(listIds({ harnessName: 'other-harness' })).resolves.toEqual(['other-namespace']);
   });
 
+  it('filters workspace action journal rows by request and affected path', async () => {
+    await storage.saveSession(sampleSession(), { ownerId: 'h-1', ifVersion: 0 });
+
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'write-readme',
+        requestId: 'turn-1',
+        path: {
+          rootId: 'project',
+          rootPath: '/workspace',
+          path: '/workspace/README.md',
+          relativePath: 'README.md',
+        },
+        action: { kind: 'file', operation: 'write', path: 'README.md' },
+        createdAt: 1000,
+      }),
+    );
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'rename-source',
+        requestId: 'turn-1',
+        operation: 'rename',
+        action: { kind: 'file', operation: 'rename', path: 'src/old.ts', toPath: 'src/new.ts' },
+        path: {
+          rootId: 'project',
+          rootPath: '/workspace',
+          path: '/workspace/src/old.ts',
+          relativePath: 'src/old.ts',
+        },
+        toPath: {
+          rootId: 'project',
+          rootPath: '/workspace',
+          path: '/workspace/src/new.ts',
+          relativePath: 'src/new.ts',
+        },
+        createdAt: 1100,
+      }),
+    );
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'write-docs-readme',
+        requestId: 'turn-2',
+        path: {
+          rootId: 'project',
+          rootPath: '/workspace',
+          path: '/workspace/docs/README.md',
+          relativePath: 'docs/README.md',
+        },
+        action: { kind: 'file', operation: 'write', path: 'docs/README.md' },
+        createdAt: 1200,
+      }),
+    );
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'run-command',
+        requestId: 'turn-1',
+        actionKind: 'command',
+        operation: 'run',
+        action: { kind: 'command', operation: 'run', command: 'pnpm test' },
+        path: undefined,
+        createdAt: 1300,
+      }),
+    );
+
+    const listIds = async (
+      overrides: Partial<Parameters<typeof storage.listWorkspaceActionJournalEntries>[0]>,
+    ): Promise<string[]> =>
+      (
+        await storage.listWorkspaceActionJournalEntries({
+          sessionId: 'session-1',
+          resourceId: 'resource-1',
+          limit: 10,
+          ...overrides,
+        })
+      ).map(entry => entry.id);
+
+    await expect(listIds({ requestId: 'turn-1' })).resolves.toEqual(['write-readme', 'rename-source', 'run-command']);
+    await expect(listIds({ requestId: 'turn-2', affectedPath: { relativePath: 'docs/README.md' } })).resolves.toEqual([
+      'write-docs-readme',
+    ]);
+    await expect(listIds({ affectedPath: { rootId: 'project', relativePath: 'README.md' } })).resolves.toEqual([
+      'write-readme',
+    ]);
+    await expect(listIds({ affectedPath: { path: '/workspace/src/old.ts' } })).resolves.toEqual(['rename-source']);
+    await expect(listIds({ affectedPath: { relativePath: 'src/new.ts' } })).resolves.toEqual([]);
+    await expect(listIds({ affectedPath: { relativePath: 'src/new.ts', includeToPath: true } })).resolves.toEqual([
+      'rename-source',
+    ]);
+    await expect(listIds({ affectedPath: { rootId: 'other', relativePath: 'README.md' } })).resolves.toEqual([]);
+    await expect(listIds({ affectedPath: {} })).resolves.toEqual([]);
+    await expect(listIds({ affectedPath: { includeToPath: true } })).resolves.toEqual([]);
+  });
+
   it('ignores duplicate or mismatched workspace action journal appends and deletes rows with the session', async () => {
     await storage.saveSession(sampleSession({ closedAt: 2000, lastActivityAt: 2000 }), {
       ownerId: 'h-1',

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -1574,6 +1574,8 @@ export class HarnessLibSQL extends HarnessStorage {
     actionKind,
     operation,
     policyDecision,
+    requestId,
+    affectedPath,
     after,
     limit,
   }: ListWorkspaceActionJournalInput): Promise<WorkspaceActionJournalEntry[]> {
@@ -1598,6 +1600,11 @@ export class HarnessLibSQL extends HarnessStorage {
       conditions.push('policy_decision = ?');
       args.push(policyDecision);
     }
+    if (requestId !== undefined) {
+      conditions.push('request_id = ?');
+      args.push(requestId);
+    }
+    addWorkspaceActionPathFilter(conditions, args, affectedPath);
     if (after !== undefined) {
       conditions.push('(created_at > ? OR (created_at = ? AND id > ?))');
       args.push(after.createdAt, after.createdAt, after.id);
@@ -5137,6 +5144,52 @@ function assertWorkspaceActionKindMatches(record: WorkspaceActionJournalEntry): 
       throw new Error(`Workspace action journal kind mismatch: ${String(actionKind)} != ${record.actionKind}`);
     }
   }
+}
+
+function addWorkspaceActionPathFilter(
+  conditions: string[],
+  args: (string | number)[],
+  filter: ListWorkspaceActionJournalInput['affectedPath'],
+): void {
+  if (filter === undefined) return;
+  if (!workspaceActionPathFilterHasSelector(filter)) {
+    conditions.push('1 = 0');
+    return;
+  }
+  const pathCondition = buildLibSqlWorkspaceActionPathCondition('path', filter, args);
+  if (filter.includeToPath === true) {
+    const toPathCondition = buildLibSqlWorkspaceActionPathCondition('to_path', filter, args);
+    conditions.push(`(${pathCondition} OR ${toPathCondition})`);
+    return;
+  }
+  conditions.push(pathCondition);
+}
+
+function buildLibSqlWorkspaceActionPathCondition(
+  column: 'path' | 'to_path',
+  filter: NonNullable<ListWorkspaceActionJournalInput['affectedPath']>,
+  args: (string | number)[],
+): string {
+  const predicates = [`${column} IS NOT NULL`];
+  if (filter.rootId !== undefined) {
+    predicates.push(`json_extract(${column}, '$.rootId') = ?`);
+    args.push(filter.rootId);
+  }
+  if (filter.path !== undefined) {
+    predicates.push(`json_extract(${column}, '$.path') = ?`);
+    args.push(filter.path);
+  }
+  if (filter.relativePath !== undefined) {
+    predicates.push(`json_extract(${column}, '$.relativePath') = ?`);
+    args.push(filter.relativePath);
+  }
+  return `(${predicates.join(' AND ')})`;
+}
+
+function workspaceActionPathFilterHasSelector(
+  filter: NonNullable<ListWorkspaceActionJournalInput['affectedPath']>,
+): boolean {
+  return filter.rootId !== undefined || filter.path !== undefined || filter.relativePath !== undefined;
 }
 
 function rowToMessageResultEvidence(row: Record<string, unknown>): AgentSignalResultEvidence {

--- a/stores/pg/src/storage/domains/harness/index.test.ts
+++ b/stores/pg/src/storage/domains/harness/index.test.ts
@@ -385,6 +385,101 @@ describe('HarnessPG', () => {
     await expect(listIds({ harnessName: 'other-harness' })).resolves.toEqual(['other-namespace']);
   });
 
+  it('filters workspace action journal rows by request and affected path', async () => {
+    const harness = store.stores.harness;
+    expect(harness).toBeDefined();
+
+    await harness!.saveSession(createSampleSessionRecord(), { ownerId: 'h-1', ifVersion: 0 });
+
+    await harness!.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'write-readme',
+        requestId: 'turn-1',
+        path: {
+          rootId: 'project',
+          rootPath: '/workspace',
+          path: '/workspace/README.md',
+          relativePath: 'README.md',
+        },
+        action: { kind: 'file', operation: 'write', path: 'README.md' },
+        createdAt: 1000,
+      }),
+    );
+    await harness!.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'rename-source',
+        requestId: 'turn-1',
+        operation: 'rename',
+        action: { kind: 'file', operation: 'rename', path: 'src/old.ts', toPath: 'src/new.ts' },
+        path: {
+          rootId: 'project',
+          rootPath: '/workspace',
+          path: '/workspace/src/old.ts',
+          relativePath: 'src/old.ts',
+        },
+        toPath: {
+          rootId: 'project',
+          rootPath: '/workspace',
+          path: '/workspace/src/new.ts',
+          relativePath: 'src/new.ts',
+        },
+        createdAt: 1100,
+      }),
+    );
+    await harness!.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'write-docs-readme',
+        requestId: 'turn-2',
+        path: {
+          rootId: 'project',
+          rootPath: '/workspace',
+          path: '/workspace/docs/README.md',
+          relativePath: 'docs/README.md',
+        },
+        action: { kind: 'file', operation: 'write', path: 'docs/README.md' },
+        createdAt: 1200,
+      }),
+    );
+    await harness!.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'run-command',
+        requestId: 'turn-1',
+        actionKind: 'command',
+        operation: 'run',
+        action: { kind: 'command', operation: 'run', command: 'pnpm test' },
+        path: undefined,
+        createdAt: 1300,
+      }),
+    );
+
+    type HarnessJournalListInput = Parameters<NonNullable<typeof harness>['listWorkspaceActionJournalEntries']>[0];
+    const listIds = async (overrides: Partial<HarnessJournalListInput>): Promise<string[]> =>
+      (
+        await harness!.listWorkspaceActionJournalEntries({
+          sessionId: 'session-1',
+          resourceId: 'resource-1',
+          limit: 10,
+          ...overrides,
+        })
+      ).map(entry => entry.id);
+
+    await expect(listIds({ requestId: 'turn-1' })).resolves.toEqual(['write-readme', 'rename-source', 'run-command']);
+    await expect(listIds({ requestId: 'turn-2', affectedPath: { relativePath: 'docs/README.md' } })).resolves.toEqual([
+      'write-docs-readme',
+    ]);
+    await expect(listIds({ affectedPath: { rootId: 'project', relativePath: 'README.md' } })).resolves.toEqual([
+      'write-readme',
+    ]);
+    await expect(listIds({ affectedPath: { path: '/workspace/src/old.ts' } })).resolves.toEqual(['rename-source']);
+    await expect(listIds({ affectedPath: { relativePath: 'src/new.ts' } })).resolves.toEqual([]);
+    await expect(listIds({ affectedPath: { relativePath: 'src/new.ts', includeToPath: true } })).resolves.toEqual([
+      'rename-source',
+    ]);
+    await expect(listIds({ affectedPath: { rootId: 'other', relativePath: 'README.md' } })).resolves.toEqual([]);
+    await expect(listIds({ affectedPath: {} })).resolves.toEqual([]);
+    await expect(listIds({ affectedPath: { includeToPath: true } })).resolves.toEqual([]);
+  });
+
   it('ignores duplicate or mismatched workspace action journal appends and deletes rows with the session', async () => {
     const harness = store.stores.harness;
     expect(harness).toBeDefined();

--- a/stores/pg/src/storage/domains/harness/index.ts
+++ b/stores/pg/src/storage/domains/harness/index.ts
@@ -1914,6 +1914,8 @@ export class HarnessPG extends HarnessStorage {
     actionKind,
     operation,
     policyDecision,
+    requestId,
+    affectedPath,
     after,
     limit,
   }: ListWorkspaceActionJournalInput): Promise<WorkspaceActionJournalEntry[]> {
@@ -1938,6 +1940,11 @@ export class HarnessPG extends HarnessStorage {
       conditions.push('policy_decision = ?');
       args.push(policyDecision);
     }
+    if (requestId !== undefined) {
+      conditions.push('request_id = ?');
+      args.push(requestId);
+    }
+    addWorkspaceActionPathFilter(conditions, args, affectedPath);
     if (after !== undefined) {
       conditions.push('(created_at > ? OR (created_at = ? AND id > ?))');
       args.push(after.createdAt, after.createdAt, after.id);
@@ -4832,6 +4839,52 @@ function assertWorkspaceActionKindMatches(record: WorkspaceActionJournalEntry): 
       throw new Error(`Workspace action journal kind mismatch: ${String(actionKind)} != ${record.actionKind}`);
     }
   }
+}
+
+function addWorkspaceActionPathFilter(
+  conditions: string[],
+  args: QueryValues,
+  filter: ListWorkspaceActionJournalInput['affectedPath'],
+): void {
+  if (filter === undefined) return;
+  if (!workspaceActionPathFilterHasSelector(filter)) {
+    conditions.push('1 = 0');
+    return;
+  }
+  const pathCondition = buildPgWorkspaceActionPathCondition('path', filter, args);
+  if (filter.includeToPath === true) {
+    const toPathCondition = buildPgWorkspaceActionPathCondition('to_path', filter, args);
+    conditions.push(`(${pathCondition} OR ${toPathCondition})`);
+    return;
+  }
+  conditions.push(pathCondition);
+}
+
+function buildPgWorkspaceActionPathCondition(
+  column: 'path' | 'to_path',
+  filter: NonNullable<ListWorkspaceActionJournalInput['affectedPath']>,
+  args: QueryValues,
+): string {
+  const predicates = [`${column} IS NOT NULL`];
+  if (filter.rootId !== undefined) {
+    predicates.push(`${column}->>'rootId' = ?`);
+    args.push(filter.rootId);
+  }
+  if (filter.path !== undefined) {
+    predicates.push(`${column}->>'path' = ?`);
+    args.push(filter.path);
+  }
+  if (filter.relativePath !== undefined) {
+    predicates.push(`${column}->>'relativePath' = ?`);
+    args.push(filter.relativePath);
+  }
+  return `(${predicates.join(' AND ')})`;
+}
+
+function workspaceActionPathFilterHasSelector(
+  filter: NonNullable<ListWorkspaceActionJournalInput['affectedPath']>,
+): boolean {
+  return filter.rootId !== undefined || filter.path !== undefined || filter.relativePath !== undefined;
 }
 
 function rowToMessageResultEvidence(row: Record<string, unknown>): AgentSignalResultEvidence {


### PR DESCRIPTION
## Linear

PF-586

## Summary

- Adds `requestId` and exact `affectedPath` filters to Harness workspace action journal listing.
- Implements the filters across in-memory, LibSQL, and PG storage adapters.
- Adds parity tests covering request filtering, source path matching, optional rename/move `toPath` matching, wrong root isolation, and empty path-filter no-match behavior.
- Adds a changeset for `@mastra/core`, `@mastra/libsql`, and `@mastra/pg`.

## Scope / Non-Goals

- Storage query surface only.
- No session/server/client route work.
- No restore/revert behavior.
- No OS sandboxing, R2/Cloudflare, Convex, production Docker, signing, release, or publish changes.

## Open PR overlap

- #164 / PF-578 changes adjacent workspace journal filter tests in the same three test files. A local `git merge-tree` simulation shows textual conflicts at the shared insertion points if either branch merges first without rebasing.
- #163 / PF-577 overlaps `packages/core/src/storage/domains/harness/types.ts` in a different area.
- #162 / PF-576 has no direct file overlap.

## Validation

- `pnpm install --offline --ignore-scripts`
- `pnpm build:core`
- `pnpm --filter ./stores/libsql build:lib`
- `pnpm --filter ./stores/pg build:lib`
- `pnpm exec prettier --check .changeset/pf-586-workspace-journal-filters.md packages/core/src/storage/domains/harness/types.ts packages/core/src/storage/domains/harness/inmemory.ts packages/core/src/storage/domains/harness/inmemory.test.ts stores/libsql/src/storage/domains/harness/index.ts stores/libsql/src/storage/domains/harness/index.test.ts stores/pg/src/storage/domains/harness/index.ts stores/pg/src/storage/domains/harness/index.test.ts`
- `pnpm --filter @mastra/core exec eslint src/storage/domains/harness/inmemory.ts src/storage/domains/harness/inmemory.test.ts src/storage/domains/harness/types.ts`
- `pnpm --filter @mastra/libsql exec eslint src/storage/domains/harness/index.ts src/storage/domains/harness/index.test.ts`
- `pnpm --filter @mastra/pg exec eslint src/storage/domains/harness/index.ts src/storage/domains/harness/index.test.ts`
- `pnpm --filter ./packages/core run test:unit src/storage/domains/harness/inmemory.test.ts`
- `timeout 360 pnpm --filter ./stores/libsql exec vitest run src/storage/domains/harness/index.test.ts`
- Isolated PG Docker run: container `pf-harness-pg-dev1-20260522-586d`, port `127.0.0.1:55442`, env `POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=55442 POSTGRES_DB=mastra POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres`, command `pnpm --filter @mastra/pg exec vitest run src/storage/domains/harness/index.test.ts`, result 13 passed. Container removed afterward and `docker ps -a` showed no PF-586 container and no `pg-test-db` leftover.
- `git diff --check`

Note: an earlier parallel validation batch ran store builds/tests while `build:core` was rewriting `packages/core/dist`, which produced transient unresolved-import/missing-dist failures. The affected checks were rerun serially after `build:core` and passed. One local Codex review command also used a 120s wrapper for the full LibSQL file and timed out; rerunning the same file with 360s passed.

## Review evidence

- Claude council review: no blockers. Empty `affectedPath` behavior and changeset/test-type nits were addressed before push.
- Local Codex review pass 1: no remaining findings after fixes.
- Local Codex review pass 2: recorded #164 textual test conflict and validation-wrapper caveat; final reruns above address the validation caveat.
- CodeRabbit CLI local review: no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR lets you narrow the workspace change log so you can find entries created by a specific request or that touched a specific file (and optionally matches rename/move destinations). It adds the filters to all storage adapters and tests to ensure they behave the same.

## Overview
Adds requestId and affectedPath filters to the Harness workspace action journal listing so callers can precisely query workspace changes. Implemented in the in-memory, LibSQL, and Postgres storage adapters with matching semantics and unit tests. Changes are limited to storage/query logic and associated tests and changesets.

## Changes

### Types
- Added WorkspaceActionJournalPathFilter with optional rootId, path, relativePath, and includeToPath.
- Updated ListWorkspaceActionJournalInput to include optional affectedPath and documented matching semantics (at least one selector required; matches source path by default; includeToPath toggles matching rename/move destinations).

### In-Memory
- InMemoryHarness.listWorkspaceActionJournalEntries now filters by requestId and affectedPath.
- Added helpers to evaluate matches against rootId, path, relativePath, and optionally toPath for rename/move entries.

### LibSQL
- listWorkspaceActionJournalEntries adds a request_id predicate when provided and applies affectedPath filtering using json_extract(...) predicates against stored path/to_path JSON.
- Introduced helper(s) to build the WHERE conditions; an affectedPath with no selectors results in a forced no-row condition.

### Postgres
- HarnessPG.listWorkspaceActionJournalEntries applies request_id and affectedPath filters using JSONB (->>) equality predicates against path and to_path.
- Helpers detect selector presence, build path/to_path predicates, and inject an always-false clause when affectedPath lacks selectors.

### Tests
- Added parallel Vitest tests for in-memory, LibSQL, and Postgres covering:
  - requestId filtering
  - exact path and relativePath matching
  - includeToPath behavior for rename/move destinations
  - root isolation (wrong-root no-match)
  - empty/insufficient affectedPath returns no matches
- Tests assert consistent entry-id results across adapters.

### Metadata & Validation
- Changeset added to patch `@mastra/core`, `@mastra/libsql`, and `@mastra/pg`.
- Local validation: build/lint/prettier checks; isolated Postgres Docker test run reported 13 passed in that run. Noted transient build-ordering reruns resolved and git diff --check performed.
- Review evidence: Claude council (no blockers), two Codex review passes addressing nits and noting potential textual test conflict with PR `#164`, and CodeRabbit CLI local review (no findings).

## Scope / Non-goals
- Changes limited to storage query surface. No session/server/client routes, no restore/revert behavior, and no infrastructure/release/publishing changes.

## Overlap
- Potential test-text conflict with `#164` (PF-578) at shared insertion points; `#163` (PF-577) overlaps a different types area; `#162` (PF-576) no direct overlap.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->