### PR TITLE
[PF-591] Add remote-safe Harness display-state DTO

### DIFF
--- a/.changeset/pf-591-display-state-dto.md
+++ b/.changeset/pf-591-display-state-dto.md
@@ -1,0 +1,22 @@
+---
+'@mastra/core': minor
+'@mastra/server': minor
+'@mastra/client-js': minor
+---
+
+Harness v1 remote sessions now let developers reliably inspect remote session state through a versioned `displayState` snapshot (`version: 1`).
+
+The snapshot includes active tools, tool input buffers, active subagents, token usage, pending operations, queue state, and goal metadata without requiring local runtime objects.
+
+```ts
+const session = await client.getHarness('default').getSession('session-id');
+const snapshot = session.getDisplayState();
+
+if (snapshot?.version === 1) {
+  console.log(snapshot.activeTools);
+  console.log(snapshot.toolInputBuffers);
+  console.log(snapshot.activeSubagents);
+  console.log(snapshot.tokenUsage);
+  console.log(snapshot.pending);
+}
+```

--- a/.changeset/pf-591-display-state-dto.md
+++ b/.changeset/pf-591-display-state-dto.md
@@ -4,9 +4,9 @@
 '@mastra/client-js': minor
 ---
 
-Harness v1 remote sessions now let developers reliably inspect remote session state through a versioned `displayState` snapshot (`version: 1`).
+Added a versioned `displayState` snapshot (`version: 1`) for Harness v1 remote sessions through `session.getDisplayState()`.
 
-The snapshot includes active tools, tool input buffers, active subagents, token usage, pending operations, queue state, and goal metadata without requiring local runtime objects.
+Improved remote session inspection by exposing active tools, tool input buffers, active subagents, token usage, pending operations, queue state, and goal metadata without requiring local runtime objects.
 
 ```ts
 const session = await client.getHarness('default').getSession('session-id');

--- a/client-sdks/client-js/src/index.ts
+++ b/client-sdks/client-js/src/index.ts
@@ -9,6 +9,7 @@ export type {
   Goal,
   GoalBody,
   GoalResponse,
+  HarnessDisplayState,
   HarnessSessionSnapshot,
   HarnessSessionSummary,
   InboxResponseBody,

--- a/client-sdks/client-js/src/resources/harness.ts
+++ b/client-sdks/client-js/src/resources/harness.ts
@@ -1,5 +1,5 @@
 import { v4 as uuid } from '@lukeed/uuid';
-import type { HarnessEvent } from '@mastra/core/harness/v1';
+import type { HarnessDisplayStateSnapshotV1, HarnessEvent } from '@mastra/core/harness/v1';
 
 import type {
   GetHarnessNameSessions_Response,
@@ -14,7 +14,10 @@ import { MastraClientError } from '../types.js';
 import { BaseResource } from './base';
 
 type JsonObject = Record<string, unknown>;
-export type HarnessSessionSnapshot = GetHarnessNameSessionsSessionId_Response;
+export type HarnessSessionSnapshot = Omit<GetHarnessNameSessionsSessionId_Response, 'displayState'> & {
+  displayState?: HarnessDisplayStateSnapshotV1;
+};
+export type HarnessDisplayState = HarnessDisplayStateSnapshotV1;
 export type HarnessSessionSummary = GetHarnessNameSessions_Response['items'][number];
 export type ChannelDiagnostics = GetHarnessNameSessionsSessionIdChannelDiagnostics_Response;
 export type CreateHarnessSessionBody = PostHarnessNameSessions_Body;
@@ -250,7 +253,7 @@ export class RemoteSession extends BaseResource {
     return this.snapshot.summary;
   }
 
-  getDisplayState(): unknown {
+  getDisplayState(): HarnessDisplayStateSnapshotV1 | undefined {
     return this.snapshot.displayState;
   }
 

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -20225,7 +20225,73 @@ export type PostHarnessNameSessions_Response = {
       nextCursor?: string | undefined;
       sessionOwnedOnly: true;
     };
-    displayState?: unknown | undefined;
+    displayState?:
+      | {
+          version: 1;
+          sessionId: string;
+          threadId: string;
+          resourceId: string;
+          parentSessionId?: string | undefined;
+          lifecycleState: 'live' | 'closing' | 'closed' | 'deleted' | 'evicted';
+          modeId: string;
+          modelId: string;
+          createdAt: number;
+          lastActivityAt: number;
+          isRunning: boolean;
+          currentRunId?: string | undefined;
+          currentMessageId?: string | undefined;
+          currentTraceId?: string | undefined;
+          activeTools: {
+            [key: string]: {
+              toolCallId: string;
+              toolName: string;
+              args: PostHarnessNameSessions_Response_Auxiliary_10;
+              startedAt: number;
+              subagentSessionId?: string | undefined;
+            };
+          };
+          toolInputBuffers: {
+            [key: string]: {
+              toolName: string;
+              text: string;
+            };
+          };
+          activeSubagents: {
+            [key: string]: {
+              subagentSessionId: string;
+              agentType: string;
+              task: string;
+              parentToolCallId: string;
+              startedAt: number;
+            };
+          };
+          tokenUsage: {
+            promptTokens: number;
+            completionTokens: number;
+            totalTokens: number;
+          };
+          pending: {
+            kind: 'tool-approval' | 'tool-suspension' | 'question' | 'plan-approval';
+            itemId?: string | undefined;
+            runId: string;
+            toolCallId: string;
+            toolName?: string | undefined;
+            source: 'parent' | 'subagent';
+            subagentToolCallId?: string | undefined;
+            requestedAt: number;
+            queuedItemId?: string | undefined;
+            modeId?: string | undefined;
+            resumedAt?: number | undefined;
+            payload?: PostHarnessNameSessions_Response_Auxiliary_10 | undefined;
+            transitionModeId?: string | undefined;
+            approvedTransitionModeId?: string | undefined;
+            modeTransitionAppliedAt?: number | undefined;
+          } | null;
+          queueDepth: number;
+          currentQueuedItemId?: string | undefined;
+          goal?: PostHarnessNameSessions_Response_Auxiliary_10 | undefined;
+        }
+      | undefined;
     goal?: (unknown | null) | undefined;
     channelBindings: unknown[];
     tokenUsage: {
@@ -20364,7 +20430,73 @@ export type GetHarnessNameSessionsSessionId_Response = {
     nextCursor?: string | undefined;
     sessionOwnedOnly: true;
   };
-  displayState?: unknown | undefined;
+  displayState?:
+    | {
+        version: 1;
+        sessionId: string;
+        threadId: string;
+        resourceId: string;
+        parentSessionId?: string | undefined;
+        lifecycleState: 'live' | 'closing' | 'closed' | 'deleted' | 'evicted';
+        modeId: string;
+        modelId: string;
+        createdAt: number;
+        lastActivityAt: number;
+        isRunning: boolean;
+        currentRunId?: string | undefined;
+        currentMessageId?: string | undefined;
+        currentTraceId?: string | undefined;
+        activeTools: {
+          [key: string]: {
+            toolCallId: string;
+            toolName: string;
+            args: GetHarnessNameSessionsSessionId_Response_Auxiliary_9;
+            startedAt: number;
+            subagentSessionId?: string | undefined;
+          };
+        };
+        toolInputBuffers: {
+          [key: string]: {
+            toolName: string;
+            text: string;
+          };
+        };
+        activeSubagents: {
+          [key: string]: {
+            subagentSessionId: string;
+            agentType: string;
+            task: string;
+            parentToolCallId: string;
+            startedAt: number;
+          };
+        };
+        tokenUsage: {
+          promptTokens: number;
+          completionTokens: number;
+          totalTokens: number;
+        };
+        pending: {
+          kind: 'tool-approval' | 'tool-suspension' | 'question' | 'plan-approval';
+          itemId?: string | undefined;
+          runId: string;
+          toolCallId: string;
+          toolName?: string | undefined;
+          source: 'parent' | 'subagent';
+          subagentToolCallId?: string | undefined;
+          requestedAt: number;
+          queuedItemId?: string | undefined;
+          modeId?: string | undefined;
+          resumedAt?: number | undefined;
+          payload?: GetHarnessNameSessionsSessionId_Response_Auxiliary_9 | undefined;
+          transitionModeId?: string | undefined;
+          approvedTransitionModeId?: string | undefined;
+          modeTransitionAppliedAt?: number | undefined;
+        } | null;
+        queueDepth: number;
+        currentQueuedItemId?: string | undefined;
+        goal?: GetHarnessNameSessionsSessionId_Response_Auxiliary_9 | undefined;
+      }
+    | undefined;
   goal?: (unknown | null) | undefined;
   channelBindings: unknown[];
   tokenUsage: {

--- a/packages/core/src/harness/v1/display-state.test.ts
+++ b/packages/core/src/harness/v1/display-state.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+
+import { toHarnessDisplayStateSnapshotV1 } from './display-state';
+import type { SessionDisplayState } from './session';
+
+function makeDisplayState(overrides: Partial<SessionDisplayState> = {}): SessionDisplayState {
+  return {
+    sessionId: 'session-1',
+    threadId: 'thread-1',
+    resourceId: 'resource-1',
+    lifecycleState: 'live',
+    modeId: 'default',
+    modelId: '__GATEWAY_OPENAI_MODEL_BASE__',
+    createdAt: 1,
+    lastActivityAt: 2,
+    isRunning: false,
+    activeTools: {},
+    toolInputBuffers: {},
+    activeSubagents: {},
+    tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    pending: null,
+    queueDepth: 0,
+    ...overrides,
+  };
+}
+
+describe('toHarnessDisplayStateSnapshotV1', () => {
+  it('adds a versioned JSON-safe display-state envelope', () => {
+    const snapshot = toHarnessDisplayStateSnapshotV1(makeDisplayState());
+
+    expect(snapshot).toMatchObject({
+      version: 1,
+      sessionId: 'session-1',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      lifecycleState: 'live',
+      modeId: 'default',
+      modelId: '__GATEWAY_OPENAI_MODEL_BASE__',
+      isRunning: false,
+      activeTools: {},
+      toolInputBuffers: {},
+      activeSubagents: {},
+      pending: null,
+      queueDepth: 0,
+    });
+  });
+
+  it('serializes unknown active tool and pending payload values to JsonValue', () => {
+    const date = new Date('2026-05-23T05:00:00.000Z');
+    const circular: Record<string, unknown> = { ok: true };
+    circular.self = circular;
+    const protoKey = JSON.parse('{"__proto__":{"polluted":true}}') as Record<string, unknown>;
+    const serializable = {
+      toJSON() {
+        return { href: 'https://mastra.ai/harness' };
+      },
+    };
+
+    const snapshot = toHarnessDisplayStateSnapshotV1(
+      makeDisplayState({
+        activeTools: {
+          tool_1: {
+            toolCallId: 'tool_1',
+            toolName: 'inspect',
+            args: {
+              date,
+              count: 3n,
+              badNumber: Number.POSITIVE_INFINITY,
+              nested: circular,
+              protoKey,
+              serializable,
+              omitted: undefined,
+            },
+            startedAt: 11,
+          },
+        },
+        pending: {
+          kind: 'question',
+          itemId: 'question-1',
+          runId: 'run-1',
+          toolCallId: 'tool_1',
+          source: 'parent',
+          requestedAt: 12,
+          payload: {
+            question: 'Pick one',
+            requestedAt: date,
+            count: 4n,
+          },
+        } as SessionDisplayState['pending'],
+      }),
+    );
+
+    const args = snapshot.activeTools.tool_1?.args as Record<string, unknown>;
+    expect(args).toMatchObject({
+      date: '2026-05-23T05:00:00.000Z',
+      count: '3',
+      badNumber: null,
+      nested: { ok: true, self: null },
+      serializable: { href: 'https://mastra.ai/harness' },
+    });
+    expect(Object.prototype.hasOwnProperty.call(args, 'protoKey')).toBe(true);
+    const encodedProtoKey = args.protoKey as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(encodedProtoKey, '__proto__')).toBe(true);
+    expect(encodedProtoKey.__proto__).toEqual({ polluted: true });
+    expect((encodedProtoKey as any).polluted).toBeUndefined();
+    expect(snapshot.pending?.payload).toEqual({
+      question: 'Pick one',
+      requestedAt: '2026-05-23T05:00:00.000Z',
+      count: '4',
+    });
+    expect((snapshot.pending as unknown as Record<string, unknown>).runtimeDependencies).toBeUndefined();
+  });
+
+  it('preserves active subagents, tool buffers, token usage, queue, run, and goal fields', () => {
+    const snapshot = toHarnessDisplayStateSnapshotV1(
+      makeDisplayState({
+        parentSessionId: 'parent-1',
+        isRunning: true,
+        currentRunId: 'run-1',
+        currentMessageId: 'message-1',
+        currentTraceId: 'trace-1',
+        currentQueuedItemId: 'queue-1',
+        activeSubagents: {
+          tool_2: {
+            subagentSessionId: 'child-1',
+            agentType: 'research',
+            task: 'scan',
+            parentToolCallId: 'tool_2',
+            startedAt: 20,
+          },
+        },
+        toolInputBuffers: {
+          tool_1: { toolName: 'shell', text: 'npm test' },
+        },
+        tokenUsage: { promptTokens: 2, completionTokens: 3, totalTokens: 5 },
+        queueDepth: 1,
+        goal: {
+          id: 'goal-1',
+          objective: 'finish',
+          status: 'active',
+          turnsUsed: 1,
+          maxTurns: 4,
+          judgeModelId: '__GATEWAY_OPENAI_MODEL_MINI__',
+          createdAt: 30,
+        },
+      }),
+    );
+
+    expect(snapshot.parentSessionId).toBe('parent-1');
+    expect(snapshot.currentRunId).toBe('run-1');
+    expect(snapshot.currentMessageId).toBe('message-1');
+    expect(snapshot.currentTraceId).toBe('trace-1');
+    expect(snapshot.currentQueuedItemId).toBe('queue-1');
+    expect(snapshot.activeSubagents.tool_2).toEqual({
+      subagentSessionId: 'child-1',
+      agentType: 'research',
+      task: 'scan',
+      parentToolCallId: 'tool_2',
+      startedAt: 20,
+    });
+    expect(snapshot.toolInputBuffers.tool_1).toEqual({ toolName: 'shell', text: 'npm test' });
+    expect(snapshot.tokenUsage).toEqual({ promptTokens: 2, completionTokens: 3, totalTokens: 5 });
+    expect(snapshot.queueDepth).toBe(1);
+    expect(snapshot.goal).toMatchObject({ id: 'goal-1', status: 'active' });
+  });
+});

--- a/packages/core/src/harness/v1/display-state.ts
+++ b/packages/core/src/harness/v1/display-state.ts
@@ -59,6 +59,12 @@ export interface HarnessDisplayStateSnapshotV1 {
   goal?: HarnessDisplayJsonValue;
 }
 
+/**
+ * Converts unknown display-state payloads into JSON-safe values. Dates become
+ * ISO strings, bigints become strings, non-finite numbers/cycles/errors become
+ * null, and undefined/function/symbol object fields are omitted. Own
+ * `__proto__` keys are preserved as data properties to avoid prototype writes.
+ */
 function toHarnessDisplayJsonValue(value: unknown, seen = new WeakSet<object>()): HarnessDisplayJsonValue {
   if (value === null) return null;
 

--- a/packages/core/src/harness/v1/display-state.ts
+++ b/packages/core/src/harness/v1/display-state.ts
@@ -1,0 +1,183 @@
+import type { JsonValue } from '../../storage/domains/harness';
+import type {
+  ActiveSubagentState,
+  ActiveToolState,
+  SessionDisplayPending,
+  SessionDisplayState,
+  TokenUsage,
+} from './session';
+
+export type HarnessDisplayJsonValue = JsonValue;
+
+export interface HarnessDisplayActiveToolSnapshotV1 {
+  toolCallId: string;
+  toolName: string;
+  args: HarnessDisplayJsonValue;
+  startedAt: number;
+  subagentSessionId?: string;
+}
+
+export interface HarnessDisplayToolInputBufferSnapshotV1 {
+  toolName: string;
+  text: string;
+}
+
+export interface HarnessDisplayActiveSubagentSnapshotV1 {
+  subagentSessionId: string;
+  agentType: string;
+  task: string;
+  parentToolCallId: string;
+  startedAt: number;
+}
+
+export interface HarnessDisplayPendingSnapshotV1 extends Omit<SessionDisplayPending, 'payload'> {
+  payload?: HarnessDisplayJsonValue;
+}
+
+export interface HarnessDisplayStateSnapshotV1 {
+  version: 1;
+  sessionId: string;
+  threadId: string;
+  resourceId: string;
+  parentSessionId?: string;
+  lifecycleState: SessionDisplayState['lifecycleState'];
+  modeId: string;
+  modelId: string;
+  createdAt: number;
+  lastActivityAt: number;
+  isRunning: boolean;
+  currentRunId?: string;
+  currentMessageId?: string;
+  currentTraceId?: string;
+  activeTools: Record<string, HarnessDisplayActiveToolSnapshotV1>;
+  toolInputBuffers: Record<string, HarnessDisplayToolInputBufferSnapshotV1>;
+  activeSubagents: Record<string, HarnessDisplayActiveSubagentSnapshotV1>;
+  tokenUsage: TokenUsage;
+  pending: HarnessDisplayPendingSnapshotV1 | null;
+  queueDepth: number;
+  currentQueuedItemId?: string;
+  goal?: HarnessDisplayJsonValue;
+}
+
+function toHarnessDisplayJsonValue(value: unknown, seen = new WeakSet<object>()): HarnessDisplayJsonValue {
+  if (value === null) return null;
+
+  switch (typeof value) {
+    case 'string':
+    case 'boolean':
+      return value;
+    case 'number':
+      return Number.isFinite(value) ? value : null;
+    case 'bigint':
+      return value.toString();
+    case 'undefined':
+    case 'function':
+    case 'symbol':
+      return null;
+    case 'object':
+      break;
+  }
+
+  if (value instanceof Date) {
+    const time = value.getTime();
+    return Number.isFinite(time) ? value.toISOString() : null;
+  }
+
+  if (seen.has(value)) return null;
+  seen.add(value);
+
+  try {
+    const toJSON = (value as { toJSON?: unknown }).toJSON;
+    if (typeof toJSON === 'function' && !Array.isArray(value)) {
+      return toHarnessDisplayJsonValue(toJSON.call(value), seen);
+    }
+
+    if (Array.isArray(value)) {
+      return value.map(item => toHarnessDisplayJsonValue(item, seen));
+    }
+
+    const output: Record<string, HarnessDisplayJsonValue> = {};
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      if (child === undefined) continue;
+      Object.defineProperty(output, key, {
+        value: toHarnessDisplayJsonValue(child, seen),
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
+    return output;
+  } catch {
+    return null;
+  } finally {
+    seen.delete(value);
+  }
+}
+
+function encodeActiveTool(tool: ActiveToolState): HarnessDisplayActiveToolSnapshotV1 {
+  const encoded: HarnessDisplayActiveToolSnapshotV1 = {
+    toolCallId: tool.toolCallId,
+    toolName: tool.toolName,
+    args: toHarnessDisplayJsonValue(tool.args),
+    startedAt: tool.startedAt,
+  };
+  if (tool.subagentSessionId !== undefined) encoded.subagentSessionId = tool.subagentSessionId;
+  return encoded;
+}
+
+function encodeActiveSubagent(subagent: ActiveSubagentState): HarnessDisplayActiveSubagentSnapshotV1 {
+  return {
+    subagentSessionId: subagent.subagentSessionId,
+    agentType: subagent.agentType,
+    task: subagent.task,
+    parentToolCallId: subagent.parentToolCallId,
+    startedAt: subagent.startedAt,
+  };
+}
+
+function encodePending(pending: SessionDisplayPending | null): HarnessDisplayPendingSnapshotV1 | null {
+  if (!pending) return null;
+  const { payload: _payload, ...pendingWithoutPayload } = pending;
+  const encoded: HarnessDisplayPendingSnapshotV1 = pendingWithoutPayload;
+  if (pending.payload !== undefined) encoded.payload = toHarnessDisplayJsonValue(pending.payload);
+  return encoded;
+}
+
+export function toHarnessDisplayStateSnapshotV1(state: SessionDisplayState): HarnessDisplayStateSnapshotV1 {
+  const snapshot: HarnessDisplayStateSnapshotV1 = {
+    version: 1,
+    sessionId: state.sessionId,
+    threadId: state.threadId,
+    resourceId: state.resourceId,
+    lifecycleState: state.lifecycleState,
+    modeId: state.modeId,
+    modelId: state.modelId,
+    createdAt: state.createdAt,
+    lastActivityAt: state.lastActivityAt,
+    isRunning: state.isRunning,
+    activeTools: Object.fromEntries(
+      Object.entries(state.activeTools).map(([id, tool]) => [id, encodeActiveTool(tool)]),
+    ),
+    toolInputBuffers: Object.fromEntries(
+      Object.entries(state.toolInputBuffers).map(([id, buffer]) => [
+        id,
+        { toolName: buffer.toolName, text: buffer.text },
+      ]),
+    ),
+    activeSubagents: Object.fromEntries(
+      Object.entries(state.activeSubagents).map(([id, subagent]) => [id, encodeActiveSubagent(subagent)]),
+    ),
+    tokenUsage: { ...state.tokenUsage },
+    pending: encodePending(state.pending),
+    queueDepth: state.queueDepth,
+  };
+
+  if (state.parentSessionId !== undefined) snapshot.parentSessionId = state.parentSessionId;
+  if (state.currentRunId !== undefined) snapshot.currentRunId = state.currentRunId;
+  if (state.currentMessageId !== undefined) snapshot.currentMessageId = state.currentMessageId;
+  if (state.currentTraceId !== undefined) snapshot.currentTraceId = state.currentTraceId;
+  if (state.currentQueuedItemId !== undefined) snapshot.currentQueuedItemId = state.currentQueuedItemId;
+  if (state.goal !== undefined) snapshot.goal = toHarnessDisplayJsonValue(state.goal);
+
+  return snapshot;
+}

--- a/packages/core/src/harness/v1/index.ts
+++ b/packages/core/src/harness/v1/index.ts
@@ -10,6 +10,15 @@
 export { Harness } from './harness';
 export { Session } from './session';
 export type { SessionLifecycleState, SessionDisplayState } from './session';
+export { toHarnessDisplayStateSnapshotV1 } from './display-state';
+export type {
+  HarnessDisplayActiveSubagentSnapshotV1,
+  HarnessDisplayActiveToolSnapshotV1,
+  HarnessDisplayJsonValue,
+  HarnessDisplayPendingSnapshotV1,
+  HarnessDisplayStateSnapshotV1,
+  HarnessDisplayToolInputBufferSnapshotV1,
+} from './display-state';
 
 export type {
   AgentEndEvent,

--- a/packages/server/src/server/handlers/harness-display-state.ts
+++ b/packages/server/src/server/handlers/harness-display-state.ts
@@ -1,0 +1,135 @@
+import type {
+  HarnessDisplayActiveSubagentSnapshotV1,
+  HarnessDisplayActiveToolSnapshotV1,
+  HarnessDisplayJsonValue,
+  HarnessDisplayPendingSnapshotV1,
+  HarnessDisplayStateSnapshotV1,
+  SessionDisplayState,
+} from '@mastra/core/harness/v1';
+
+type ActiveToolState = SessionDisplayState['activeTools'][string];
+type ActiveSubagentState = SessionDisplayState['activeSubagents'][string];
+type SessionDisplayPending = NonNullable<SessionDisplayState['pending']>;
+
+function toHarnessDisplayJsonValue(value: unknown, seen = new WeakSet<object>()): HarnessDisplayJsonValue {
+  if (value === null) return null;
+
+  switch (typeof value) {
+    case 'string':
+    case 'boolean':
+      return value;
+    case 'number':
+      return Number.isFinite(value) ? value : null;
+    case 'bigint':
+      return value.toString();
+    case 'undefined':
+    case 'function':
+    case 'symbol':
+      return null;
+    case 'object':
+      break;
+  }
+
+  if (value instanceof Date) {
+    const time = value.getTime();
+    return Number.isFinite(time) ? value.toISOString() : null;
+  }
+
+  if (seen.has(value)) return null;
+  seen.add(value);
+
+  try {
+    const toJSON = (value as { toJSON?: unknown }).toJSON;
+    if (typeof toJSON === 'function' && !Array.isArray(value)) {
+      return toHarnessDisplayJsonValue(toJSON.call(value), seen);
+    }
+
+    if (Array.isArray(value)) {
+      return value.map(item => toHarnessDisplayJsonValue(item, seen));
+    }
+
+    const output: Record<string, HarnessDisplayJsonValue> = {};
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      if (child === undefined) continue;
+      Object.defineProperty(output, key, {
+        value: toHarnessDisplayJsonValue(child, seen),
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
+    return output;
+  } catch {
+    return null;
+  } finally {
+    seen.delete(value);
+  }
+}
+
+function encodeActiveTool(tool: ActiveToolState): HarnessDisplayActiveToolSnapshotV1 {
+  const encoded: HarnessDisplayActiveToolSnapshotV1 = {
+    toolCallId: tool.toolCallId,
+    toolName: tool.toolName,
+    args: toHarnessDisplayJsonValue(tool.args),
+    startedAt: tool.startedAt,
+  };
+  if (tool.subagentSessionId !== undefined) encoded.subagentSessionId = tool.subagentSessionId;
+  return encoded;
+}
+
+function encodeActiveSubagent(subagent: ActiveSubagentState): HarnessDisplayActiveSubagentSnapshotV1 {
+  return {
+    subagentSessionId: subagent.subagentSessionId,
+    agentType: subagent.agentType,
+    task: subagent.task,
+    parentToolCallId: subagent.parentToolCallId,
+    startedAt: subagent.startedAt,
+  };
+}
+
+function encodePending(pending: SessionDisplayPending | null): HarnessDisplayPendingSnapshotV1 | null {
+  if (!pending) return null;
+  const { payload: _payload, ...pendingWithoutPayload } = pending;
+  const encoded: HarnessDisplayPendingSnapshotV1 = pendingWithoutPayload;
+  if (pending.payload !== undefined) encoded.payload = toHarnessDisplayJsonValue(pending.payload);
+  return encoded;
+}
+
+export function toHarnessDisplayStateSnapshotV1(state: SessionDisplayState): HarnessDisplayStateSnapshotV1 {
+  const snapshot: HarnessDisplayStateSnapshotV1 = {
+    version: 1,
+    sessionId: state.sessionId,
+    threadId: state.threadId,
+    resourceId: state.resourceId,
+    lifecycleState: state.lifecycleState,
+    modeId: state.modeId,
+    modelId: state.modelId,
+    createdAt: state.createdAt,
+    lastActivityAt: state.lastActivityAt,
+    isRunning: state.isRunning,
+    activeTools: Object.fromEntries(
+      Object.entries(state.activeTools).map(([id, tool]) => [id, encodeActiveTool(tool)]),
+    ),
+    toolInputBuffers: Object.fromEntries(
+      Object.entries(state.toolInputBuffers).map(([id, buffer]) => [
+        id,
+        { toolName: buffer.toolName, text: buffer.text },
+      ]),
+    ),
+    activeSubagents: Object.fromEntries(
+      Object.entries(state.activeSubagents).map(([id, subagent]) => [id, encodeActiveSubagent(subagent)]),
+    ),
+    tokenUsage: { ...state.tokenUsage },
+    pending: encodePending(state.pending),
+    queueDepth: state.queueDepth,
+  };
+
+  if (state.parentSessionId !== undefined) snapshot.parentSessionId = state.parentSessionId;
+  if (state.currentRunId !== undefined) snapshot.currentRunId = state.currentRunId;
+  if (state.currentMessageId !== undefined) snapshot.currentMessageId = state.currentMessageId;
+  if (state.currentTraceId !== undefined) snapshot.currentTraceId = state.currentTraceId;
+  if (state.currentQueuedItemId !== undefined) snapshot.currentQueuedItemId = state.currentQueuedItemId;
+  if (state.goal !== undefined) snapshot.goal = toHarnessDisplayJsonValue(state.goal);
+
+  return snapshot;
+}

--- a/packages/server/src/server/handlers/harness.test.ts
+++ b/packages/server/src/server/handlers/harness.test.ts
@@ -276,9 +276,23 @@ describe('Harness server routes', () => {
 
   it('creates a session with auth-derived resource and returns a snapshot', async () => {
     const record = makeRecord();
+    const displayState = makeDisplayState(record);
+    displayState.activeTools = {
+      'tool-1': {
+        toolCallId: 'tool-1',
+        toolName: 'lookup',
+        args: {
+          when: new Date('2026-05-23T00:00:00.000Z'),
+          count: 12n,
+          invalid: Number.POSITIVE_INFINITY,
+          omitted: undefined,
+        },
+        startedAt: 300,
+      },
+    };
     const session = {
       getRecord: () => record,
-      getDisplayState: () => makeDisplayState(record),
+      getDisplayState: () => displayState,
       getState: vi.fn(async () => record.state),
       listMessages: vi.fn(async () => [{ id: 'message-1', role: 'user', content: 'hello' }]),
     };
@@ -304,9 +318,23 @@ describe('Harness server routes', () => {
       session: {
         summary: { sessionId: 'session-1', resourceId: 'resource-1' },
         state: { view: 'open' },
+        displayState: {
+          version: 1,
+          sessionId: 'session-1',
+          activeTools: {
+            'tool-1': {
+              args: {
+                when: '2026-05-23T00:00:00.000Z',
+                count: '12',
+                invalid: null,
+              },
+            },
+          },
+        },
         messages: { cursor: { threadId: 'thread-1', route: 'thread-messages' } },
       },
     });
+    expect(result.session.displayState.activeTools['tool-1'].args).not.toHaveProperty('omitted');
   });
 
   it('ignores create options supplied only through flattened query params', async () => {
@@ -604,7 +632,10 @@ describe('Harness server routes', () => {
     expect(harness.session).not.toHaveBeenCalled();
     expect(body).toMatchObject({
       summary: { sessionId: 'session-1', lifecycle: 'active' },
-      displayState: { sessionId: 'session-1' },
+      displayState: {
+        version: 1,
+        sessionId: 'session-1',
+      },
       tokenUsage: { totalTokens: 3 },
     });
   });

--- a/packages/server/src/server/handlers/harness.ts
+++ b/packages/server/src/server/handlers/harness.ts
@@ -5,12 +5,12 @@ import type { IncomingHttpHeaders, IncomingMessage, RequestOptions } from 'node:
 import { request as httpsRequest } from 'node:https';
 import { isIP } from 'node:net';
 
-import { parseHarnessEventId } from '@mastra/core/harness/v1';
 import type {
   AttachmentRef,
   GoalOptions,
   GoalState,
   HarnessChannelDiagnostics,
+  HarnessDisplayStateSnapshotV1,
   HarnessMessage,
   InboxResponseResult,
   PermissionRules,
@@ -61,11 +61,13 @@ import {
 } from '../schemas/harness';
 import { createRoute } from '../server-adapter/routes/route-builder';
 
+import { toHarnessDisplayStateSnapshotV1 } from './harness-display-state';
 import { enforceThreadAccess, getEffectiveResourceId } from './utils';
 
 type SessionLifecycleStatus = 'active' | 'closing' | 'closed';
 type PendingInboxKind = 'tool-approval' | 'tool-suspension' | 'question' | 'plan-approval';
 type PublicPendingResume = Omit<NonNullable<SessionRecord['pendingResume']>, 'runtimeDependencies'>;
+type ParsedHarnessEventId = { epoch: string; sequence: number };
 type UrlAttachmentInput = {
   kind: 'url';
   url: string;
@@ -148,7 +150,7 @@ type HarnessSessionSnapshot = {
     nextCursor?: string;
     sessionOwnedOnly: true;
   };
-  displayState?: SessionDisplayState;
+  displayState?: HarnessDisplayStateSnapshotV1;
   goal?: unknown | null;
   channelBindings: unknown[];
   tokenUsage: SessionRecord['tokenUsage'];
@@ -755,6 +757,31 @@ function throwHarnessHttpError(
     message,
     res: jsonResponse(toHarnessErrorBody(code, message, details, retryable), { status }),
   });
+}
+
+function parseHarnessEventId(eventId: string): ParsedHarnessEventId {
+  const parts = eventId.split(':');
+  if (parts.length !== 3 || parts[0] !== 'harness-v1' || parts[1] === '' || parts[2] === '') {
+    throwHarnessHttpError(400, 'harness.validation', 'expected event id grammar harness-v1:<epoch>:<seq>', {
+      field: 'lastEventId',
+      reason: 'invalid',
+    });
+  }
+  const sequenceText = parts[2]!;
+  if (!/^(0|[1-9][0-9]*)$/.test(sequenceText)) {
+    throwHarnessHttpError(400, 'harness.validation', 'event id sequence must be an unsigned decimal integer', {
+      field: 'lastEventId',
+      reason: 'invalid',
+    });
+  }
+  const sequence = Number(sequenceText);
+  if (!Number.isSafeInteger(sequence)) {
+    throwHarnessHttpError(400, 'harness.validation', 'event id sequence must be within JavaScript safe integer range', {
+      field: 'lastEventId',
+      reason: 'invalid',
+    });
+  }
+  return { epoch: parts[1]!, sequence };
 }
 
 function getAuthResourceId(requestContext: RequestContext): string {
@@ -1675,7 +1702,7 @@ function snapshotFromRecord(
       truncated: false,
       sessionOwnedOnly: true,
     },
-    displayState,
+    displayState: toHarnessDisplayStateSnapshotV1(displayState),
     goal: record.goal ?? null,
     channelBindings: [],
     tokenUsage: { ...record.tokenUsage },

--- a/packages/server/src/server/schemas/harness.ts
+++ b/packages/server/src/server/schemas/harness.ts
@@ -95,6 +95,74 @@ const durableWorkListSummarySchema = z.object({
   sessionOwnedOnly: z.literal(true),
 });
 
+const harnessDisplayActiveToolSnapshotV1Schema = z.object({
+  toolCallId: z.string(),
+  toolName: z.string(),
+  args: jsonValueSchema,
+  startedAt: z.number(),
+  subagentSessionId: z.string().optional(),
+});
+
+const harnessDisplayToolInputBufferSnapshotV1Schema = z.object({
+  toolName: z.string(),
+  text: z.string(),
+});
+
+const harnessDisplayActiveSubagentSnapshotV1Schema = z.object({
+  subagentSessionId: z.string(),
+  agentType: z.string(),
+  task: z.string(),
+  parentToolCallId: z.string(),
+  startedAt: z.number(),
+});
+
+const harnessDisplayPendingSnapshotV1Schema = z.object({
+  kind: z.enum(['tool-approval', 'tool-suspension', 'question', 'plan-approval']),
+  itemId: z.string().optional(),
+  runId: z.string(),
+  toolCallId: z.string(),
+  toolName: z.string().optional(),
+  source: z.enum(['parent', 'subagent']),
+  subagentToolCallId: z.string().optional(),
+  requestedAt: z.number(),
+  queuedItemId: z.string().optional(),
+  modeId: z.string().optional(),
+  resumedAt: z.number().optional(),
+  payload: jsonValueSchema.optional(),
+  transitionModeId: z.string().optional(),
+  approvedTransitionModeId: z.string().optional(),
+  modeTransitionAppliedAt: z.number().optional(),
+});
+
+export const harnessDisplayStateSnapshotV1Schema = z.object({
+  version: z.literal(1),
+  sessionId: z.string(),
+  threadId: z.string(),
+  resourceId: z.string(),
+  parentSessionId: z.string().optional(),
+  lifecycleState: z.enum(['live', 'closing', 'closed', 'deleted', 'evicted']),
+  modeId: z.string(),
+  modelId: z.string(),
+  createdAt: z.number(),
+  lastActivityAt: z.number(),
+  isRunning: z.boolean(),
+  currentRunId: z.string().optional(),
+  currentMessageId: z.string().optional(),
+  currentTraceId: z.string().optional(),
+  activeTools: z.record(z.string(), harnessDisplayActiveToolSnapshotV1Schema),
+  toolInputBuffers: z.record(z.string(), harnessDisplayToolInputBufferSnapshotV1Schema),
+  activeSubagents: z.record(z.string(), harnessDisplayActiveSubagentSnapshotV1Schema),
+  tokenUsage: z.object({
+    promptTokens: z.number(),
+    completionTokens: z.number(),
+    totalTokens: z.number(),
+  }),
+  pending: harnessDisplayPendingSnapshotV1Schema.nullable(),
+  queueDepth: z.number(),
+  currentQueuedItemId: z.string().optional(),
+  goal: jsonValueSchema.optional(),
+});
+
 export const harnessSessionListItemSchema = z.object({
   sessionId: z.string(),
   harnessName: z.string(),
@@ -150,7 +218,7 @@ export const harnessSessionSnapshotSchema = z.object({
     nextCursor: z.string().optional(),
     sessionOwnedOnly: z.literal(true),
   }),
-  displayState: z.unknown().optional(),
+  displayState: harnessDisplayStateSnapshotV1Schema.optional(),
   goal: z.unknown().nullable().optional(),
   channelBindings: z.array(z.unknown()),
   tokenUsage: z.object({


### PR DESCRIPTION
## Summary
- add a versioned Harness display-state DTO in @mastra/core with JSON-safe encoding for remote session snapshots
- wire server session snapshot responses and schemas to return typed displayState, then regenerate client-js route types
- expose typed RemoteSession.getDisplayState() / HarnessDisplayState in client-js

## Review evidence
- agy review: no blockers; applied toJSON and schema forward-compat recommendations
- local Codex review pass 1: fixed __proto__ preservation in JSON-safe encoding
- local Codex review pass 2: fixed changeset bump, placeholder model tokens, and explicit subagent DTO encoding
- CodeRabbit CLI: applied changeset wording/example findings; did not apply direct server import of the core encoder because check:core-imports fails against the public @mastra/core peer floor for fork-only Harness value imports, so the server keeps a matching local route-layer encoder

## Validation
- pnpm --dir /tmp/mastra-fork-pf-591-display-state-dto --filter @mastra/core typecheck
- pnpm --dir /tmp/mastra-fork-pf-591-display-state-dto build:core
- pnpm --dir /tmp/mastra-fork-pf-591-display-state-dto --filter @mastra/core test -- src/harness/v1/display-state.test.ts src/harness/v1/session.display-state.test.ts
- pnpm --dir /tmp/mastra-fork-pf-591-display-state-dto --filter @mastra/server check:core-imports
- pnpm --dir /tmp/mastra-fork-pf-591-display-state-dto --filter @mastra/server exec vitest run src/server/handlers/harness.test.ts
- pnpm --dir /tmp/mastra-fork-pf-591-display-state-dto --filter @mastra/server build:lib
- pnpm --dir /tmp/mastra-fork-pf-591-display-state-dto --filter @mastra/client-js test -- src/resources/harness.test.ts
- pnpm --dir /tmp/mastra-fork-pf-591-display-state-dto --filter @mastra/client-js build:lib
- git diff --check

Linear: PF-591

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a safe, versioned "snapshot" format for remote Harness sessions so you can take a clean picture of a session's state (what tools are running, queued work, token usage, etc.) and send it over the network without leaking runtime objects or causing serialization issues.

---

## Overview

Adds a versioned Harness display-state DTO (v1) and JSON-safe encoder to capture remote session snapshots, wires that typed snapshot through server responses and client APIs, and provides tests and schemas to validate encoding and shape.

## Key changes

- `@mastra/core`
  - New: packages/core/src/harness/v1/display-state.ts
    - Introduces HarnessDisplayStateSnapshotV1 and related snapshot types (active tool, tool input buffer, active subagent, pending snapshot).
    - Exports HarnessDisplayJsonValue and toHarnessDisplayStateSnapshotV1(state).
    - Encoder rules: Date → ISO, bigint → string, non-finite numbers → null, skip undefined, support toJSON(), protect against cycles (WeakSet), and preserve __proto__ as data (prevent prototype pollution).
  - New tests: packages/core/src/harness/v1/display-state.test.ts — Vitest coverage for encoder behaviors and edge cases.
  - Exports wired: packages/core/src/harness/v1/index.ts re-exports display-state APIs.

- `@mastra/server`
  - New: packages/server/src/server/handlers/harness-display-state.ts
    - Local server-side encoder mirroring core encoding logic (kept local to satisfy `@mastra/core` peer-floor/import constraints).
    - toHarnessDisplayStateSnapshotV1 exported for server use.
  - Updated handlers: packages/server/src/server/handlers/harness.ts
    - Uses server encoder to populate snapshot responses with HarnessDisplayStateSnapshotV1.
    - Replaced import of parseHarnessEventId from core with a local implementation validating harness-v1:<epoch>:<seq>.
  - Schemas: packages/server/src/server/schemas/harness.ts
    - Added harnessDisplayStateSnapshotV1Schema and replaced displayState: z.unknown() with the new typed schema.
  - Tests: packages/server/src/server/handlers/harness.test.ts updated to assert JSON-safe normalization in create/read responses.

- `@mastra/client-js`
  - client-sdks/client-js/src/resources/harness.ts
    - HarnessSessionSnapshot now reintroduces displayState as optional HarnessDisplayStateSnapshotV1.
    - Export alias HarnessDisplayState added.
    - RemoteSession.getDisplayState() now returns HarnessDisplayStateSnapshotV1 | undefined (was unknown).
  - client-sdks/client-js/src/route-types.generated.ts
    - Generated route response types: displayState changed from unknown to the structured union including version, identifiers, lifecycle and nested structured fields (activeTools, toolInputBuffers, activeSubagents, tokenUsage, pending).
    - Nested args/payload/goal types specialized to endpoint-specific auxiliary types.
  - client-sdks/client-js/src/index.ts exports HarnessDisplayState.

- Release & docs
  - .changeset/pf-591-display-state-dto.md: documents minor bumps for core/server/client-js and usage example showing snapshot.version === 1 guard.
  - Commits include refined changeset wording and JSDoc documenting encoder rules.

## Validation & reviews

- Automated/CI validation reported:
  - Typecheck/build for `@mastra/core`; server and client-js builds/tests.
  - Unit tests for core display-state files and server harness handler tests.
  - check:core-imports run and prevented direct server import of core encoder (reason server retains local encoder).
  - git diff --check run.
- Reviews:
  - Agy: no blockers; applied toJSON and schema forward-compat recommendations.
  - Local Codex reviews: fixed __proto__ preservation, changeset/placeholder model token issues, explicit subagent DTO encoding.
  - CodeRabbit CLI: guided changeset wording/examples; flagged core-imports constraint.
- Author followups:
  - Fixed actionable changeset wording and added JSDoc; chose not to manually edit generated route-types file (requested generator-level deduplication in follow-up PR).

## Notes for reviewers / follow-ups

- Server intentionally keeps a local encoder implementation to avoid importing certain Harness runtime types from `@mastra/core` due to peer-floor / fork-only constraints — this is deliberate and validated by check:core-imports.
- Generated route-types file contains duplicated displayState blocks (generated); deduplication should be addressed in the route-types generator in a separate PR if desired.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->