### PR TITLE
[PF-593] Link workspace journal rows to observability spans

### DIFF
--- a/.changeset/pf-593-workspace-journal-observability.md
+++ b/.changeset/pf-593-workspace-journal-observability.md
@@ -1,0 +1,19 @@
+---
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/pg': patch
+---
+
+Developers can now correlate Harness workspace action journal entries with observability traces.
+
+Workspace action journal entries accept optional `traceId` and `spanId` fields, and journal list calls can filter by those identifiers when debugging session activity. `spanId` requires `traceId` because span ids are trace-scoped. Workspace `WORKSPACE_ACTION` span handles also expose their trace/span identity and can record a durable `journalEntryId`.
+
+```ts
+await storage.listWorkspaceActionJournalEntries({
+  sessionId,
+  resourceId,
+  traceId,
+  spanId,
+  limit: 50,
+});
+```

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -545,6 +545,8 @@ export interface WorkspaceActionAttributes extends AIBaseAttributes {
   filesystemProvider?: string;
   /** Whether the operation succeeded */
   success?: boolean;
+  /** Durable Harness workspace action journal row id, when journaling succeeds */
+  journalEntryId?: string;
 }
 
 /**

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -986,6 +986,8 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
     cwd: { type: 'jsonb', nullable: true },
     actor: { type: 'jsonb', nullable: true },
     request_id: { type: 'text', nullable: true },
+    trace_id: { type: 'text', nullable: true },
+    span_id: { type: 'text', nullable: true },
     result: { type: 'jsonb', nullable: true },
     created_at: { type: 'bigint', nullable: false },
   },

--- a/packages/core/src/storage/domains/harness/inmemory.test.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.test.ts
@@ -613,9 +613,17 @@ describe('InMemoryHarness admission storage contract', () => {
         sessionId: 'session-1',
         resourceId: 'resource-1',
         spanId: 'span-2',
-        limit: 0,
+        limit: 10,
       }),
     ).rejects.toThrow('spanId filter requires traceId');
+    await expect(
+      storage.appendWorkspaceActionJournalEntry(
+        sampleWorkspaceActionJournalEntry({
+          id: 'invalid-span',
+          spanId: 'span-without-trace',
+        }),
+      ),
+    ).rejects.toThrow('spanId requires traceId');
   });
 
   it('filters workspace action journal rows by request and affected path', async () => {

--- a/packages/core/src/storage/domains/harness/inmemory.test.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.test.ts
@@ -556,6 +556,68 @@ describe('InMemoryHarness admission storage contract', () => {
     await expect(listIds({ harnessName: 'other-harness' })).resolves.toEqual(['other-namespace']);
   });
 
+  it('round-trips workspace action journal observability correlation fields', async () => {
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    await storage.saveSession(sampleSession(), { ownerId: 'h-1', ifVersion: 0 });
+
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'with-span',
+        traceId: 'trace-1',
+        spanId: 'span-1',
+      }),
+    );
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'other-span',
+        traceId: 'trace-2',
+        spanId: 'span-2',
+      }),
+    );
+
+    await expect(
+      storage.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        traceId: 'trace-1',
+        spanId: 'span-1',
+        limit: 10,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: 'with-span',
+        requestId: 'request-1',
+        traceId: 'trace-1',
+        spanId: 'span-1',
+      }),
+    ]);
+    await expect(
+      storage.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        traceId: 'trace-1',
+        limit: 10,
+      }),
+    ).resolves.toEqual([expect.objectContaining({ id: 'with-span' })]);
+    await expect(
+      storage.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        traceId: 'trace-2',
+        spanId: 'span-2',
+        limit: 10,
+      }),
+    ).resolves.toEqual([expect.objectContaining({ id: 'other-span' })]);
+    await expect(
+      storage.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        spanId: 'span-2',
+        limit: 0,
+      }),
+    ).rejects.toThrow('spanId filter requires traceId');
+  });
+
   it('filters workspace action journal rows by request and affected path', async () => {
     const storage = new InMemoryHarness({ db: new InMemoryDB() });
     await storage.saveSession(sampleSession(), { ownerId: 'h-1', ifVersion: 0 });

--- a/packages/core/src/storage/domains/harness/inmemory.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.ts
@@ -1054,6 +1054,7 @@ export class InMemoryHarness extends HarnessStorage {
   async appendWorkspaceActionJournalEntry(
     record: WorkspaceActionJournalEntry,
   ): Promise<AppendWorkspaceActionJournalEntryResult> {
+    assertWorkspaceActionTraceScope(record);
     assertWorkspaceActionKindMatches(record);
     const namespaced = { ...record, harnessName: resolveHarnessName(record.harnessName, this.harnessName) };
     const session = this.db.harnessSessions.get(sessionKey(namespaced.harnessName, namespaced.sessionId));
@@ -3532,6 +3533,12 @@ function assertWorkspaceActionKindMatches(record: WorkspaceActionJournalEntry): 
     if (actionKind !== undefined && actionKind !== record.actionKind) {
       throw new Error(`Workspace action journal kind mismatch: ${String(actionKind)} != ${record.actionKind}`);
     }
+  }
+}
+
+function assertWorkspaceActionTraceScope(record: WorkspaceActionJournalEntry): void {
+  if (record.spanId !== undefined && record.traceId === undefined) {
+    throw new Error('Workspace action journal spanId requires traceId');
   }
 }
 

--- a/packages/core/src/storage/domains/harness/inmemory.ts
+++ b/packages/core/src/storage/domains/harness/inmemory.ts
@@ -1077,10 +1077,15 @@ export class InMemoryHarness extends HarnessStorage {
     operation,
     policyDecision,
     requestId,
+    traceId,
+    spanId,
     affectedPath,
     after,
     limit,
   }: ListWorkspaceActionJournalInput): Promise<WorkspaceActionJournalEntry[]> {
+    if (spanId !== undefined && traceId === undefined) {
+      throw new Error('Workspace action journal spanId filter requires traceId');
+    }
     if (limit <= 0) return [];
     const namespace = resolveHarnessName(harnessName, this.harnessName);
     const rows = Array.from(this.db.harnessWorkspaceActionJournal.values()).filter(entry => {
@@ -1091,6 +1096,8 @@ export class InMemoryHarness extends HarnessStorage {
       if (operation !== undefined && entry.operation !== operation) return false;
       if (policyDecision !== undefined && entry.policyDecision !== policyDecision) return false;
       if (requestId !== undefined && entry.requestId !== requestId) return false;
+      if (traceId !== undefined && entry.traceId !== traceId) return false;
+      if (spanId !== undefined && entry.spanId !== spanId) return false;
       if (affectedPath !== undefined && !workspaceActionJournalEntryMatchesPath(entry, affectedPath)) return false;
       if (after !== undefined && compareWorkspaceActionJournalCursor(entry, after) <= 0) return false;
       return true;

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -504,6 +504,12 @@ export interface WorkspaceActionJournalEntry {
   cwd?: WorkspaceActionJournalPath;
   actor?: JsonValue;
   requestId?: string;
+  /**
+   * Optional observability correlation. Workspace action journaling is durable
+   * audit evidence and must not depend on tracing being enabled.
+   */
+  traceId?: string;
+  spanId?: string;
   result?: JsonValue;
   createdAt: number;
 }
@@ -527,7 +533,8 @@ export interface WorkspaceActionJournalPathFilter {
  * at least one concrete selector (`rootId`, `path`, or `relativePath`) and
  * matches those selectors with AND semantics against the source `path` by
  * default; set `includeToPath` when rename/move destinations should also be
- * considered affected. Command `cwd` is not an affected path.
+ * considered affected. Command `cwd` is not an affected path. `spanId` is only
+ * meaningful within a trace and requires `traceId` when filtering.
  */
 export interface ListWorkspaceActionJournalInput {
   harnessName?: string;
@@ -538,6 +545,8 @@ export interface ListWorkspaceActionJournalInput {
   operation?: string;
   policyDecision?: WorkspaceActionJournalEntry['policyDecision'];
   requestId?: string;
+  traceId?: string;
+  spanId?: string;
   affectedPath?: WorkspaceActionJournalPathFilter;
   after?: {
     createdAt: number;

--- a/packages/core/src/workspace/tools/__tests__/workspace-tracing.test.ts
+++ b/packages/core/src/workspace/tools/__tests__/workspace-tracing.test.ts
@@ -49,6 +49,8 @@ function createMockSpan() {
       childSpans.push(childRecord);
 
       return {
+        id: `span-${childSpans.length}`,
+        traceId: 'trace-1',
         end: vi.fn((options?: any) => {
           childRecord.ended = true;
           childRecord.endAttributes = options?.attributes;
@@ -81,6 +83,8 @@ describe('startWorkspaceSpan', () => {
     });
 
     expect(handle.span).toBeDefined();
+    expect(handle.traceId).toBe('trace-1');
+    expect(handle.spanId).toBe('span-1');
     expect(childSpans).toHaveLength(1);
     expect(childSpans[0]!.type).toBe(SpanType.WORKSPACE_ACTION);
     expect(childSpans[0]!.name).toBe('workspace:filesystem:readFile');
@@ -98,6 +102,8 @@ describe('startWorkspaceSpan', () => {
     });
 
     expect(handle.span).toBeUndefined();
+    expect(handle.traceId).toBeUndefined();
+    expect(handle.spanId).toBeUndefined();
     // Should not throw
     handle.end();
     handle.error(new Error('test'));
@@ -114,6 +120,29 @@ describe('startWorkspaceSpan', () => {
     handle.error(new Error('test'));
   });
 
+  it('does not expose invalid span sentinel ids as journal correlation ids', () => {
+    const invalidSpan = {
+      createChildSpan: vi.fn(() => ({
+        id: '0000000000000000',
+        traceId: '00000000000000000000000000000000',
+        externalTraceId: undefined,
+        isValid: false,
+        end: vi.fn(),
+        error: vi.fn(),
+        update: vi.fn(),
+        createChildSpan: vi.fn(),
+      })),
+    } as unknown as AnySpan;
+
+    const handle = startWorkspaceSpan({ tracing: { currentSpan: invalidSpan } } as any, undefined, {
+      category: 'filesystem',
+      operation: 'readFile',
+    });
+
+    expect(handle.traceId).toBeUndefined();
+    expect(handle.spanId).toBeUndefined();
+  });
+
   it('end() passes through attributes and output separately', async () => {
     const { mockParentSpan, childSpans } = createMockSpan();
 
@@ -127,6 +156,22 @@ describe('startWorkspaceSpan', () => {
     expect(childSpans[0]!.ended).toBe(true);
     expect(childSpans[0]!.endAttributes?.success).toBe(true);
     expect(childSpans[0]!.endOutput).toEqual({ resultCount: 3 });
+  });
+
+  it('end() can attach a durable workspace action journal entry id', () => {
+    const { mockParentSpan, childSpans } = createMockSpan();
+
+    const handle = startWorkspaceSpan({ tracing: { currentSpan: mockParentSpan } } as any, undefined, {
+      category: 'filesystem',
+      operation: 'writeFile',
+    });
+
+    handle.end({ success: true, journalEntryId: 'journal-1' }, { bytesTransferred: 12 });
+
+    expect(childSpans[0]!.endAttributes).toMatchObject({
+      success: true,
+      journalEntryId: 'journal-1',
+    });
   });
 
   it('end() does not set success when caller omits it', () => {

--- a/packages/core/src/workspace/tools/tracing.ts
+++ b/packages/core/src/workspace/tools/tracing.ts
@@ -36,6 +36,10 @@ export interface WorkspaceSpanOptions {
 export interface WorkspaceSpanHandle {
   /** The underlying span (undefined when tracing is not active) */
   span: AnySpan | undefined;
+  /** OpenTelemetry-compatible trace id for the workspace action span */
+  traceId: string | undefined;
+  /** Span id for the workspace action span */
+  spanId: string | undefined;
   /** End the span with final attributes and output */
   end(attrs?: Partial<WorkspaceActionAttributes>, output?: unknown): void;
   /** End the span with an error */
@@ -151,6 +155,8 @@ export function startWorkspaceSpan(
 
   return {
     span,
+    traceId: span.isValid === false ? undefined : (span.externalTraceId ?? span.traceId),
+    spanId: span.isValid === false ? undefined : span.id,
     end(attrs?: Partial<WorkspaceActionAttributes>, output?: unknown) {
       span?.end({
         output: sanitizeWorkspaceTraceData(output),
@@ -175,6 +181,8 @@ export function startWorkspaceSpan(
 /** No-op handle when tracing is not available */
 const noOpHandle: WorkspaceSpanHandle = {
   span: undefined,
+  traceId: undefined,
+  spanId: undefined,
   end() {},
   error() {},
 };

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -733,9 +733,17 @@ describe('HarnessLibSQL active session admission', () => {
         sessionId: 'session-1',
         resourceId: 'resource-1',
         spanId: 'span-2',
-        limit: 0,
+        limit: 10,
       }),
     ).rejects.toThrow('spanId filter requires traceId');
+    await expect(
+      storage.appendWorkspaceActionJournalEntry(
+        sampleWorkspaceActionJournalEntry({
+          id: 'invalid-span',
+          spanId: 'span-without-trace',
+        }),
+      ),
+    ).rejects.toThrow('spanId requires traceId');
   });
 
   it('widens existing workspace action journal tables with observability columns', async () => {

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -16,6 +16,7 @@ import {
   TABLE_HARNESS_SESSIONS,
   TABLE_HARNESS_THREAD_DELETE_FENCES,
   TABLE_HARNESS_WAKEUPS,
+  TABLE_HARNESS_WORKSPACE_ACTIONS,
   HarnessStorageAttachmentInUseError,
   HarnessStorageAttachmentUnavailableError,
   HarnessStorageChannelActionClaimConflictError,
@@ -674,6 +675,115 @@ describe('HarnessLibSQL active session admission', () => {
     await expect(listIds({ actionKind: 'command', operation: 'run', policyDecision: 'deny' })).resolves.toEqual(['c']);
     await expect(listIds({ actionKind: 'file', after: { createdAt: 1000, id: 'a' } })).resolves.toEqual(['b']);
     await expect(listIds({ harnessName: 'other-harness' })).resolves.toEqual(['other-namespace']);
+  });
+
+  it('round-trips workspace action journal observability correlation fields', async () => {
+    await storage.saveSession(sampleSession(), { ownerId: 'h-1', ifVersion: 0 });
+
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'with-span',
+        traceId: 'trace-1',
+        spanId: 'span-1',
+      }),
+    );
+    await storage.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'other-span',
+        traceId: 'trace-2',
+        spanId: 'span-2',
+      }),
+    );
+
+    await expect(
+      storage.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        traceId: 'trace-1',
+        spanId: 'span-1',
+        limit: 10,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: 'with-span',
+        requestId: 'request-1',
+        traceId: 'trace-1',
+        spanId: 'span-1',
+      }),
+    ]);
+    await expect(
+      storage.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        traceId: 'trace-1',
+        limit: 10,
+      }),
+    ).resolves.toEqual([expect.objectContaining({ id: 'with-span' })]);
+    await expect(
+      storage.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        traceId: 'trace-2',
+        spanId: 'span-2',
+        limit: 10,
+      }),
+    ).resolves.toEqual([expect.objectContaining({ id: 'other-span' })]);
+    await expect(
+      storage.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        spanId: 'span-2',
+        limit: 0,
+      }),
+    ).rejects.toThrow('spanId filter requires traceId');
+  });
+
+  it('widens existing workspace action journal tables with observability columns', async () => {
+    const client = createHarnessTestClient();
+    await client.execute({
+      sql: `CREATE TABLE ${TABLE_HARNESS_WORKSPACE_ACTIONS} (
+        id TEXT NOT NULL,
+        harness_name TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        resource_id TEXT NOT NULL,
+        thread_id TEXT NOT NULL,
+        action_kind TEXT NOT NULL,
+        operation TEXT,
+        action TEXT NOT NULL,
+        policy_decision TEXT NOT NULL,
+        policy_reasons TEXT NOT NULL,
+        matched_rules TEXT NOT NULL,
+        path TEXT,
+        to_path TEXT,
+        cwd TEXT,
+        actor TEXT,
+        request_id TEXT,
+        result TEXT,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (harness_name, session_id, id)
+      )`,
+      args: [],
+    });
+    const storage = new HarnessLibSQL({ client });
+    await storage.init();
+    await storage.saveSession(sampleSession(), { ownerId: 'h-1', ifVersion: 0 });
+    await expect(
+      storage.appendWorkspaceActionJournalEntry(
+        sampleWorkspaceActionJournalEntry({
+          id: 'with-span',
+          traceId: 'trace-1',
+          spanId: 'span-1',
+        }),
+      ),
+    ).resolves.toEqual({ created: true });
+    await expect(
+      storage.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        traceId: 'trace-1',
+        limit: 10,
+      }),
+    ).resolves.toEqual([expect.objectContaining({ id: 'with-span', spanId: 'span-1' })]);
   });
 
   it('filters workspace action journal rows by request and affected path', async () => {

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -1531,8 +1531,9 @@ export class HarnessLibSQL extends HarnessStorage {
     const result = await this.#client.execute({
       sql: `INSERT INTO ${TABLE_HARNESS_WORKSPACE_ACTIONS}
             (id, harness_name, session_id, resource_id, thread_id, action_kind, operation, action,
-             policy_decision, policy_reasons, matched_rules, path, to_path, cwd, actor, request_id, result, created_at)
-            SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+             policy_decision, policy_reasons, matched_rules, path, to_path, cwd, actor, request_id,
+             trace_id, span_id, result, created_at)
+            SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
             WHERE EXISTS (
               SELECT 1 FROM ${TABLE_HARNESS_SESSIONS}
               WHERE harness_name = ? AND id = ? AND resource_id = ? AND thread_id = ?
@@ -1555,6 +1556,8 @@ export class HarnessLibSQL extends HarnessStorage {
         record.cwd === undefined ? null : JSON.stringify(record.cwd),
         record.actor === undefined ? null : JSON.stringify(record.actor),
         record.requestId ?? null,
+        record.traceId ?? null,
+        record.spanId ?? null,
         record.result === undefined ? null : JSON.stringify(record.result),
         record.createdAt,
         namespace,
@@ -1575,10 +1578,15 @@ export class HarnessLibSQL extends HarnessStorage {
     operation,
     policyDecision,
     requestId,
+    traceId,
+    spanId,
     affectedPath,
     after,
     limit,
   }: ListWorkspaceActionJournalInput): Promise<WorkspaceActionJournalEntry[]> {
+    if (spanId !== undefined && traceId === undefined) {
+      throw new Error('Workspace action journal spanId filter requires traceId');
+    }
     if (limit <= 0) return [];
     const namespace = this.#resolveHarnessName(harnessName);
     await this.#ensureWorkspaceActionsTable();
@@ -1603,6 +1611,14 @@ export class HarnessLibSQL extends HarnessStorage {
     if (requestId !== undefined) {
       conditions.push('request_id = ?');
       args.push(requestId);
+    }
+    if (traceId !== undefined) {
+      conditions.push('trace_id = ?');
+      args.push(traceId);
+    }
+    if (spanId !== undefined) {
+      conditions.push('span_id = ?');
+      args.push(spanId);
     }
     addWorkspaceActionPathFilter(conditions, args, affectedPath);
     if (after !== undefined) {
@@ -3855,6 +3871,11 @@ export class HarnessLibSQL extends HarnessStorage {
         schema: TABLE_SCHEMAS[TABLE_HARNESS_WORKSPACE_ACTIONS],
         compositePrimaryKey: workspaceActionsConfig?.compositePrimaryKey,
       });
+      await this.#db.alterTable({
+        tableName: TABLE_HARNESS_WORKSPACE_ACTIONS,
+        schema: TABLE_SCHEMAS[TABLE_HARNESS_WORKSPACE_ACTIONS],
+        ifNotExists: ['trace_id', 'span_id'],
+      });
       await this.#client.execute({
         sql: `CREATE INDEX IF NOT EXISTS idx_harness_workspace_actions_session
               ON "${TABLE_HARNESS_WORKSPACE_ACTIONS}" ("harness_name", "session_id", "resource_id", "thread_id", "created_at", "id")`,
@@ -5129,6 +5150,8 @@ function rowToWorkspaceActionJournalEntry(row: Record<string, unknown>): Workspa
     ...(row.cwd == null ? {} : { cwd: parseJson(row.cwd) as WorkspaceActionJournalEntry['cwd'] }),
     ...(row.actor == null ? {} : { actor: parseJson(row.actor) as JsonValue }),
     ...(row.request_id == null ? {} : { requestId: String(row.request_id) }),
+    ...(row.trace_id == null ? {} : { traceId: String(row.trace_id) }),
+    ...(row.span_id == null ? {} : { spanId: String(row.span_id) }),
     ...(row.result == null ? {} : { result: parseJson(row.result) as JsonValue }),
     createdAt: Number(row.created_at),
   };

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -1525,6 +1525,7 @@ export class HarnessLibSQL extends HarnessStorage {
   async appendWorkspaceActionJournalEntry(
     record: WorkspaceActionJournalEntry,
   ): Promise<AppendWorkspaceActionJournalEntryResult> {
+    assertWorkspaceActionTraceScope(record);
     assertWorkspaceActionKindMatches(record);
     const namespace = this.#resolveHarnessName(record.harnessName);
     await this.#ensureWorkspaceActionsTable();
@@ -5166,6 +5167,12 @@ function assertWorkspaceActionKindMatches(record: WorkspaceActionJournalEntry): 
     if (actionKind !== undefined && actionKind !== record.actionKind) {
       throw new Error(`Workspace action journal kind mismatch: ${String(actionKind)} != ${record.actionKind}`);
     }
+  }
+}
+
+function assertWorkspaceActionTraceScope(record: WorkspaceActionJournalEntry): void {
+  if (record.spanId !== undefined && record.traceId === undefined) {
+    throw new Error('Workspace action journal spanId requires traceId');
   }
 }
 

--- a/stores/pg/src/storage/domains/harness/index.test.ts
+++ b/stores/pg/src/storage/domains/harness/index.test.ts
@@ -444,9 +444,17 @@ describe('HarnessPG', () => {
         sessionId: 'session-1',
         resourceId: 'resource-1',
         spanId: 'span-2',
-        limit: 0,
+        limit: 10,
       }),
     ).rejects.toThrow('spanId filter requires traceId');
+    await expect(
+      harness!.appendWorkspaceActionJournalEntry(
+        sampleWorkspaceActionJournalEntry({
+          id: 'invalid-span',
+          spanId: 'span-without-trace',
+        }),
+      ),
+    ).rejects.toThrow('spanId requires traceId');
   });
 
   it('widens existing workspace action journal tables with observability columns', async () => {

--- a/stores/pg/src/storage/domains/harness/index.test.ts
+++ b/stores/pg/src/storage/domains/harness/index.test.ts
@@ -385,6 +385,120 @@ describe('HarnessPG', () => {
     await expect(listIds({ harnessName: 'other-harness' })).resolves.toEqual(['other-namespace']);
   });
 
+  it('round-trips workspace action journal observability correlation fields', async () => {
+    const harness = store.stores.harness;
+    expect(harness).toBeDefined();
+
+    await harness!.saveSession(createSampleSessionRecord(), { ownerId: 'h-1', ifVersion: 0 });
+
+    await harness!.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'with-span',
+        traceId: 'trace-1',
+        spanId: 'span-1',
+      }),
+    );
+    await harness!.appendWorkspaceActionJournalEntry(
+      sampleWorkspaceActionJournalEntry({
+        id: 'other-span',
+        traceId: 'trace-2',
+        spanId: 'span-2',
+      }),
+    );
+
+    await expect(
+      harness!.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        traceId: 'trace-1',
+        spanId: 'span-1',
+        limit: 10,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: 'with-span',
+        requestId: 'request-1',
+        traceId: 'trace-1',
+        spanId: 'span-1',
+      }),
+    ]);
+    await expect(
+      harness!.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        traceId: 'trace-1',
+        limit: 10,
+      }),
+    ).resolves.toEqual([expect.objectContaining({ id: 'with-span' })]);
+    await expect(
+      harness!.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        traceId: 'trace-2',
+        spanId: 'span-2',
+        limit: 10,
+      }),
+    ).resolves.toEqual([expect.objectContaining({ id: 'other-span' })]);
+    await expect(
+      harness!.listWorkspaceActionJournalEntries({
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        spanId: 'span-2',
+        limit: 0,
+      }),
+    ).rejects.toThrow('spanId filter requires traceId');
+  });
+
+  it('widens existing workspace action journal tables with observability columns', async () => {
+    const schemaName = `pf_593_workspace_actions_${randomUUID().replaceAll('-', '_')}`;
+    await store.db.none(`CREATE SCHEMA "${schemaName}"`);
+    try {
+      await store.db.none(`CREATE TABLE "${schemaName}"."${TABLE_HARNESS_WORKSPACE_ACTIONS}" (
+        id TEXT NOT NULL,
+        harness_name TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        resource_id TEXT NOT NULL,
+        thread_id TEXT NOT NULL,
+        action_kind TEXT NOT NULL,
+        operation TEXT,
+        action JSONB NOT NULL,
+        policy_decision TEXT NOT NULL,
+        policy_reasons JSONB NOT NULL,
+        matched_rules JSONB NOT NULL,
+        path JSONB,
+        to_path JSONB,
+        cwd JSONB,
+        actor JSONB,
+        request_id TEXT,
+        result JSONB,
+        created_at BIGINT NOT NULL,
+        PRIMARY KEY (harness_name, session_id, id)
+      )`);
+      const harness = new HarnessPG({ client: store.db, schemaName });
+      await harness.init();
+      await harness.saveSession(createSampleSessionRecord(), { ownerId: 'h-1', ifVersion: 0 });
+      await expect(
+        harness.appendWorkspaceActionJournalEntry(
+          sampleWorkspaceActionJournalEntry({
+            id: 'with-span',
+            traceId: 'trace-1',
+            spanId: 'span-1',
+          }),
+        ),
+      ).resolves.toEqual({ created: true });
+      await expect(
+        harness.listWorkspaceActionJournalEntries({
+          sessionId: 'session-1',
+          resourceId: 'resource-1',
+          traceId: 'trace-1',
+          limit: 10,
+        }),
+      ).resolves.toEqual([expect.objectContaining({ id: 'with-span', spanId: 'span-1' })]);
+    } finally {
+      await store.db.none(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    }
+  });
+
   it('filters workspace action journal rows by request and affected path', async () => {
     const harness = store.stores.harness;
     expect(harness).toBeDefined();

--- a/stores/pg/src/storage/domains/harness/index.ts
+++ b/stores/pg/src/storage/domains/harness/index.ts
@@ -1866,6 +1866,7 @@ export class HarnessPG extends HarnessStorage {
   async appendWorkspaceActionJournalEntry(
     record: WorkspaceActionJournalEntry,
   ): Promise<AppendWorkspaceActionJournalEntryResult> {
+    assertWorkspaceActionTraceScope(record);
     assertWorkspaceActionKindMatches(record);
     const namespace = this.#resolveHarnessName(record.harnessName);
     await this.#ensureWorkspaceActionsTable();
@@ -4861,6 +4862,12 @@ function assertWorkspaceActionKindMatches(record: WorkspaceActionJournalEntry): 
     if (actionKind !== undefined && actionKind !== record.actionKind) {
       throw new Error(`Workspace action journal kind mismatch: ${String(actionKind)} != ${record.actionKind}`);
     }
+  }
+}
+
+function assertWorkspaceActionTraceScope(record: WorkspaceActionJournalEntry): void {
+  if (record.spanId !== undefined && record.traceId === undefined) {
+    throw new Error('Workspace action journal spanId requires traceId');
   }
 }
 

--- a/stores/pg/src/storage/domains/harness/index.ts
+++ b/stores/pg/src/storage/domains/harness/index.ts
@@ -1872,8 +1872,9 @@ export class HarnessPG extends HarnessStorage {
     const result = await this.#client.execute({
       sql: `INSERT INTO ${TABLE_HARNESS_WORKSPACE_ACTIONS}
             (id, harness_name, session_id, resource_id, thread_id, action_kind, operation, action,
-             policy_decision, policy_reasons, matched_rules, path, to_path, cwd, actor, request_id, result, created_at)
-            SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+             policy_decision, policy_reasons, matched_rules, path, to_path, cwd, actor, request_id,
+             trace_id, span_id, result, created_at)
+            SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
             FROM ${TABLE_HARNESS_SESSIONS}
             WHERE harness_name = ? AND id = ? AND resource_id = ? AND thread_id = ?
             FOR KEY SHARE
@@ -1895,6 +1896,8 @@ export class HarnessPG extends HarnessStorage {
         record.cwd === undefined ? null : JSON.stringify(record.cwd),
         record.actor === undefined ? null : JSON.stringify(record.actor),
         record.requestId ?? null,
+        record.traceId ?? null,
+        record.spanId ?? null,
         record.result === undefined ? null : JSON.stringify(record.result),
         record.createdAt,
         namespace,
@@ -1915,10 +1918,15 @@ export class HarnessPG extends HarnessStorage {
     operation,
     policyDecision,
     requestId,
+    traceId,
+    spanId,
     affectedPath,
     after,
     limit,
   }: ListWorkspaceActionJournalInput): Promise<WorkspaceActionJournalEntry[]> {
+    if (spanId !== undefined && traceId === undefined) {
+      throw new Error('Workspace action journal spanId filter requires traceId');
+    }
     if (limit <= 0) return [];
     const namespace = this.#resolveHarnessName(harnessName);
     await this.#ensureWorkspaceActionsTable();
@@ -1943,6 +1951,14 @@ export class HarnessPG extends HarnessStorage {
     if (requestId !== undefined) {
       conditions.push('request_id = ?');
       args.push(requestId);
+    }
+    if (traceId !== undefined) {
+      conditions.push('trace_id = ?');
+      args.push(traceId);
+    }
+    if (spanId !== undefined) {
+      conditions.push('span_id = ?');
+      args.push(spanId);
     }
     addWorkspaceActionPathFilter(conditions, args, affectedPath);
     if (after !== undefined) {
@@ -3766,6 +3782,11 @@ export class HarnessPG extends HarnessStorage {
         schema: TABLE_SCHEMAS[TABLE_HARNESS_WORKSPACE_ACTIONS],
         compositePrimaryKey: workspaceActionsConfig?.compositePrimaryKey,
       });
+      await this.#db.alterTable({
+        tableName: TABLE_HARNESS_WORKSPACE_ACTIONS,
+        schema: TABLE_SCHEMAS[TABLE_HARNESS_WORKSPACE_ACTIONS],
+        ifNotExists: ['trace_id', 'span_id'],
+      });
       await this.#createDefaultIndexes(['idx_harness_workspace_actions_session']);
       await this.#createDefaultIndexes(['idx_harness_workspace_actions_page']);
     })().catch(error => {
@@ -4824,6 +4845,8 @@ function rowToWorkspaceActionJournalEntry(row: Record<string, unknown>): Workspa
     ...(row.cwd == null ? {} : { cwd: parseJson(row.cwd) as WorkspaceActionJournalEntry['cwd'] }),
     ...(row.actor == null ? {} : { actor: parseJson(row.actor) as JsonValue }),
     ...(row.request_id == null ? {} : { requestId: String(row.request_id) }),
+    ...(row.trace_id == null ? {} : { traceId: String(row.trace_id) }),
+    ...(row.span_id == null ? {} : { spanId: String(row.span_id) }),
     ...(row.result == null ? {} : { result: parseJson(row.result) as JsonValue }),
     createdAt: Number(row.created_at),
   };


### PR DESCRIPTION
## Summary

- Adds optional `traceId` and `spanId` to Harness workspace action journal rows.
- Persists and reads those fields in InMemory, LibSQL, and PG Harness storage.
- Adds trace/span filters for journal listing; `spanId` now requires `traceId` because span ids are trace-scoped.
- Exposes `traceId`/`spanId` on `WorkspaceSpanHandle` and allows `journalEntryId` on `WORKSPACE_ACTION` span attributes for later runtime writers.
- Widens existing LibSQL/PG workspace action tables with nullable observability columns.

Linear: PF-593

## Review workflow

- Agy council reviewed source plan: recommended correlation fields + filter storage only, and deferred runtime journal writing to a separate action-classification issue.
- Claude council reviewed the diff: identified missing adapter widening migrations; fixed with LibSQL/PG `alterTable(... ifNotExists: ['trace_id', 'span_id'])` and migration tests.
- Local Codex review pass 1: no findings.
- Local Codex review pass 2: found span-only filtering weakness; fixed by requiring `traceId` with `spanId` and updating tests.
- CodeRabbit CLI pass 1: found changeset wording and invariant ordering issues; fixed both. A second CodeRabbit rerun was started after fixes but hung in review phase and was stopped; GitHub app review should run on this PR.

## Validation

- `pnpm --dir /tmp/mastra-fork-pf-593-journal-observability --filter @mastra/core test -- src/workspace/tools/__tests__/workspace-tracing.test.ts src/storage/domains/harness/inmemory.test.ts`
- `pnpm --dir /tmp/mastra-fork-pf-593-journal-observability --filter @mastra/core typecheck`
- `pnpm --dir /tmp/mastra-fork-pf-593-journal-observability build:core`
- `timeout 60s pnpm --dir /tmp/mastra-fork-pf-593-journal-observability --filter @mastra/libsql exec vitest run src/storage/domains/harness/index.test.ts --testNamePattern "observability correlation|observability columns" --reporter verbose`
- `timeout 120s pnpm --dir /tmp/mastra-fork-pf-593-journal-observability --filter @mastra/pg exec vitest run src/storage/domains/harness/index.test.ts --testNamePattern "observability correlation|observability columns" --reporter verbose`
- `pnpm --dir /tmp/mastra-fork-pf-593-journal-observability --filter @mastra/libsql build:lib`
- `pnpm --dir /tmp/mastra-fork-pf-593-journal-observability --filter @mastra/pg build:lib`
- `git -C /tmp/mastra-fork-pf-593-journal-observability diff --check`

## Notes

- Full PG Harness file passed before the final review patch; focused PG coverage passed after the final patch.
- Full LibSQL Harness file had one unrelated existing timeout in `rejects stale same-claim updates when another writer changes the row after the validation read`; focused LibSQL coverage passed.
- During PG validation, the package compose DB was found exposed on `0.0.0.0:5434` and had hostile connection attempts. I recreated the test DB bound to `127.0.0.1` for validation and will track compose hardening separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

This PR connects the workspace "notebook" entries to tracing "breadcrumbs" by adding optional traceId and spanId so you can find the journal row that matches an observability span, making debugging across systems much easier.

## Overview

Adds observability correlation for Harness workspace action journal entries: optional traceId/spanId fields everywhere they’re needed (types, span handles, and storage), validation that spanId requires traceId, persistence and querying of these fields in InMemory, LibSQL, and Postgres stores, and support for attaching the durable journalEntryId to span end attributes.

## Key Changes

- Types & Tracing
  - Added workspace action attribute: optional journalEntryId on WorkspaceActionAttributes.
  - WorkspaceSpanHandle exposes traceId and spanId (string | undefined) and startWorkspaceSpan populates them only for valid span contexts.
  - startWorkspaceSpan / span end updated so end can attach journalEntryId to span end attributes.

- Journal Types & Inputs
  - WorkspaceActionJournalEntry now includes optional traceId and spanId.
  - ListWorkspaceActionJournalInput accepts optional traceId and spanId; docs clarify spanId is trace-scoped and requires traceId.

- Storage Schema & Migrations
  - mastra_harness_workspace_actions schema widened to add nullable text columns trace_id and span_id.
  - LibSQL and PG adapters apply conditional ALTER TABLE to add these columns when missing (migration tests added).
  - Row-to-entry mappers populate traceId/spanId; INSERTs include trace_id/span_id.

- Validation & Querying
  - Added assertWorkspaceActionTraceScope used by all append paths to reject records with spanId but no traceId.
  - listWorkspaceActionJournalEntries in InMemory/LibSQL/PG validate that spanId requires traceId and allow filtering by traceId and spanId (spanId filter only valid with traceId).

- Testing
  - New and updated vitest suites for InMemory, LibSQL, and PG that:
    - Round-trip traceId/spanId persistence and listing filters.
    - Assert listing with spanId but without traceId throws.
    - Assert appending with spanId but without traceId throws (append-time validation).
    - Test widening existing tables and retrieving rows with populated spanId.
    - Updated test assertions (limit: 0 -> limit: 10) and other minor test fixes.
  - Validation runs performed across core, libsql, and pg packages (some targeted due to unrelated timeouts); PG test DB binding issue discovered and mitigated by rebinding to 127.0.0.1.

- Reviews & Workflow Notes
  - Agy council: recommended storing correlation fields and implementing storage-only filters; append invariant enforcement confirmed (all append paths call assertWorkspaceActionTraceScope).
  - Claude council: flagged missing adapter widening migrations; addressed by adding conditional ALTER TABLE statements and tests.
  - Codex/CodeRabbit CLI local runs: CodeRabbit had an earlier local pass; final local rerun hung in sandbox—treat GitHub app as authoritative for final review.
  - Follow-up fixes included append-time validation, test adjustments, and migration test additions.

## Versioning
Changeset added to bump patch versions for `@mastra/core`, `@mastra/libsql`, and `@mastra/pg`.

## Notes for reviewers
- Pay attention to the append-time assertWorkspaceActionTraceScope to ensure spanId/traceId invariant is enforced in all write paths.
- Verify conditional ALTER TABLE usage and migration tests cover existing-table widening scenarios.
- Runtime writing of correlation fields to spans was intentionally deferred; this PR implements storage+exposure and durable-journalId attachment on span end, not automatic runtime writers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->