### PR TITLE
[PF-602] Bind PG test Docker ports to localhost

### DIFF
--- a/stores/pg/docker-compose.perf.yaml
+++ b/stores/pg/docker-compose.perf.yaml
@@ -3,7 +3,7 @@ services:
     image: pgvector/pgvector:pg16
     container_name: 'pg-perf-test-db'
     ports:
-      - '5435:5432'
+      - '127.0.0.1:5435:5432'
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}

--- a/stores/pg/docker-compose.yaml
+++ b/stores/pg/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     image: pgvector/pgvector:0.8.2-pg16
     container_name: 'pg-test-db'
     ports:
-      - '5434:5432'
+      - '127.0.0.1:5434:5432'
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}

--- a/stores/pg/src/storage/domains/memory/row-number-performance.test.ts
+++ b/stores/pg/src/storage/domains/memory/row-number-performance.test.ts
@@ -22,7 +22,7 @@ import type { MemoryPG } from '.';
 describe('ROW_NUMBER Performance Issue #11150', () => {
   let store: PostgresStore;
   let memoryStore: MemoryPG;
-  const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@localhost:5434/mastra';
+  const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@127.0.0.1:5434/mastra';
 
   // Test configuration - adjust these to reproduce the issue
   const THREADS_COUNT = 10;

--- a/stores/pg/src/storage/performance-indexes/performance-indexes.integration.test.ts
+++ b/stores/pg/src/storage/performance-indexes/performance-indexes.integration.test.ts
@@ -8,7 +8,7 @@ describe('PostgresStore Performance Indexes Integration', () => {
   let store: PostgresStore;
   let dbOps: PgDB;
   let performanceTest: PostgresPerformanceTest;
-  const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@localhost:5434/mastra';
+  const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@127.0.0.1:5435/mastra';
 
   beforeAll(async () => {
     store = new PostgresStore({ id: 'integration-test-store', connectionString });

--- a/stores/pg/src/storage/test-utils.ts
+++ b/stores/pg/src/storage/test-utils.ts
@@ -9,7 +9,7 @@ import { exportSchemas, PostgresStore } from '.';
 
 export const TEST_CONFIG: PostgresStoreConfig = {
   id: 'test-postgres-store',
-  host: process.env.POSTGRES_HOST || 'localhost',
+  host: process.env.POSTGRES_HOST || '127.0.0.1',
   port: Number(process.env.POSTGRES_PORT) || 5434,
   database: process.env.POSTGRES_DB || 'postgres',
   user: process.env.POSTGRES_USER || 'postgres',

--- a/stores/pg/src/vector/index.test.ts
+++ b/stores/pg/src/vector/index.test.ts
@@ -9,7 +9,7 @@ describe('PgVector', () => {
   let vectorDB: PgVector;
   const testIndexName = 'test_vectors';
   const testIndexName2 = 'test_vectors1';
-  const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@localhost:5434/mastra';
+  const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@127.0.0.1:5434/mastra';
 
   beforeAll(async () => {
     // Initialize PgVector
@@ -24,7 +24,7 @@ describe('PgVector', () => {
 
   // Shared vector store test suite
   describe('Shared Vector Store Test Suite', () => {
-    const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@localhost:5434/mastra';
+    const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@127.0.0.1:5434/mastra';
     const sharedTestVectorDB = new PgVector({ connectionString, id: 'pg-shared-test' });
 
     createVectorTestSuite({
@@ -1281,7 +1281,7 @@ describe('PgVector', () => {
     // Tests for halfvec type support (Issue #10999)
     // Note: halfvec requires pgvector >= 0.7.0
     describe('PgVector halfvec Type Support', () => {
-      const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@localhost:5434/mastra';
+      const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@127.0.0.1:5434/mastra';
       let halfvecVectorDB: PgVector;
       let halfvecSupported = false;
 
@@ -1543,7 +1543,7 @@ describe('PgVector', () => {
     // Tests for bit vector type support (Issue #11035)
     // Note: bit requires pgvector >= 0.7.0
     describe('PgVector bit Type Support', () => {
-      const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@localhost:5434/mastra';
+      const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@127.0.0.1:5434/mastra';
       let bitVectorDB: PgVector;
       let bitSupported = false;
 
@@ -1749,7 +1749,7 @@ describe('PgVector', () => {
     // Tests for sparsevec type support (Issue #11035)
     // Note: sparsevec requires pgvector >= 0.7.0
     describe('PgVector sparsevec Type Support', () => {
-      const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@localhost:5434/mastra';
+      const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@127.0.0.1:5434/mastra';
       let sparseVectorDB: PgVector;
       let sparsevecSupported = false;
 
@@ -1990,7 +1990,7 @@ describe('PgVector', () => {
 
     // Tests for operator class generation for new types (Issue #11035)
     describe('getVectorOps for bit and sparsevec types', () => {
-      const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@localhost:5434/mastra';
+      const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@127.0.0.1:5434/mastra';
       let db: PgVector;
 
       beforeAll(async () => {
@@ -2129,7 +2129,7 @@ describe('PgVector', () => {
 
     // Tests for validation logic (Issue #11035)
     describe('Validation for bit and sparsevec constraints', () => {
-      const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@localhost:5434/mastra';
+      const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@127.0.0.1:5434/mastra';
       let validationDB: PgVector;
 
       beforeAll(async () => {
@@ -2957,7 +2957,7 @@ describe('PgVector', () => {
   // --- Validation tests ---
   describe('Validation', () => {
     const customSchema = 'custom_schema';
-    const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@localhost:5434/mastra';
+    const connectionString = process.env.DB_URL || 'postgresql://postgres:postgres@127.0.0.1:5434/mastra';
     describe('Connection String Config', () => {
       it('throws if connectionString is empty', () => {
         expect(() => new PgVector({ id: 'test-vector', connectionString: '' })).toThrow(

--- a/stores/pg/src/vector/vector.performance.test.ts
+++ b/stores/pg/src/vector/vector.performance.test.ts
@@ -32,7 +32,7 @@ class PGPerformanceVector extends PgVector {
   private perfPool: pg.Pool;
 
   constructor(connectionString: string) {
-    super(connectionString);
+    super({ id: 'pg-vector-performance-test', connectionString });
 
     const basePool = new pg.Pool({
       connectionString,
@@ -80,6 +80,10 @@ class PGPerformanceVector extends PgVector {
       client.release();
     }
   }
+
+  override async disconnect() {
+    await Promise.all([super.disconnect(), this.perfPool.end()]);
+  }
 }
 
 const warmupCache = new Map<string, boolean>();
@@ -98,7 +102,7 @@ async function smartWarmup(
   }
 }
 
-const connectionString = process.env.DB_URL || `postgresql://postgres:postgres@localhost:5435/mastra`;
+const connectionString = process.env.DB_URL || `postgresql://postgres:postgres@127.0.0.1:5435/mastra`;
 describe('PostgreSQL Index Performance', () => {
   let vectorDB: PGPerformanceVector;
   const testIndexName = 'test_index_performance';


### PR DESCRIPTION
## Summary

PF-602 hardens the `@mastra/pg` local test databases so the normal and perf Docker Compose services publish only on loopback:

- binds `docker-compose.yaml` `5434` and `docker-compose.perf.yaml` `5435` to `127.0.0.1`
- moves DB-backed fallback connection strings from `localhost` to `127.0.0.1` to avoid IPv6-first `localhost` mismatches
- aligns the perf-index integration fallback with the perf compose port `5435`
- repairs `PGPerformanceVector` constructor drift and closes its secondary perf pool during teardown

No changeset: this is test/dev infra only, with no published package API or runtime behavior change.

## Notes

- `stores/pg/src/storage/performance-indexes/performance-indexes.integration.test.ts` intentionally moves from `5434` to `5435` because `stores/pg/vitest.perf.config.ts` includes `src/**/performance-indexes/*.test.ts`, and `pretest:perf` starts `docker-compose.perf.yaml`.
- `stores/pg/src/storage/domains/memory/row-number-performance.test.ts` stays on `5434` because `row-number-performance.test.ts` is not selected by the perf config pattern `src/**/*.performance.test.ts`; a direct perf-config run for that file returns `No test files found`.
- Existing `DB_URL` environment overrides still win over these defaults. Clear stale `DB_URL=...localhost...` values when validating the new fallback behavior.
- PF-603 tracks the stale perf-index seed failure where the suite still writes `mastra_traces` while current PG observability initializes spans tables.

## Validation

- `git diff --check` passed.
- Commit hook `lint-staged --quiet` passed.
- `pnpm --dir stores/pg exec tsc --noEmit --pretty false` passed.
- `pnpm --dir stores/pg pretest` passed.
- `docker ps --filter name=pg-test-db --format '{{.Names}} {{.Ports}}'` showed `pg-test-db 127.0.0.1:5434->5432/tcp`.
- `pnpm --dir stores/pg exec vitest run src/storage/domains/harness/index.test.ts --testNamePattern "exports harness tables" --reporter verbose` passed.
- `pnpm --dir stores/pg exec vitest run src/vector/index.test.ts --testNamePattern "should expose pool field as public" --reporter verbose` passed.
- `pnpm --dir stores/pg posttest` cleaned the normal compose container.
- `pnpm --dir stores/pg pretest:perf` passed.
- `docker ps --filter name=pg-perf-test-db --format '{{.Names}} {{.Ports}}'` showed `pg-perf-test-db 127.0.0.1:5435->5432/tcp`.
- `pnpm --dir stores/pg exec vitest run -c vitest.perf.config.ts src/vector/vector.performance.test.ts --testNamePattern "dim=64 size=100 k=50" --reporter verbose` passed: 20 passed, 920 skipped.
- `pnpm --dir stores/pg exec vitest run -c vitest.perf.config.ts src/storage/domains/memory/row-number-performance.test.ts --testNamePattern "should demonstrate" --reporter verbose` returned `No test files found`, confirming it is not selected by perf config.
- `pnpm --dir stores/pg exec vitest run -c vitest.perf.config.ts src/storage/performance-indexes/performance-indexes.integration.test.ts --reporter verbose` reached `127.0.0.1:5435` but failed on the pre-existing `mastra_traces` seed drift now tracked by PF-603.
- `pnpm --dir stores/pg posttest:perf` cleaned the perf compose container.
- Final `docker ps --filter name=pg-test-db --filter name=pg-perf-test-db --format '{{.Names}} {{.Ports}}'` returned no rows.

## Review

- Claude review: no blockers; requested PR-body disclosure for the perf-port alignment and secondary pool teardown. Included above.
- agy review: validated the loopback hardening and constructor drift; raised a row-number perf-port blocker that was verified against Vitest and rejected as incorrect.
- Codex review pass 1: no findings after initial scope review.
- Codex review pass 2/focused: found the secondary perf pool leak; fixed with `override disconnect()`. Repeated the row-number perf-port finding; verified with an actual perf-config run and rejected.
- CodeRabbit CLI: `coderabbit review --plain` completed with no findings after the final patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR makes the test PostgreSQL databases more secure by binding them to only accept connections from the local computer (loopback interface) instead of potentially any computer on the network. It also updates all the test code to use the loopback address correctly (127.0.0.1 instead of localhost) to ensure reliable connections.

---

## Overview
Hardens the `@mastra/pg` local test databases and integration tests by binding Docker Compose services to the loopback interface (`127.0.0.1`) and updating all test connection strings to use the explicit loopback address instead of the ambiguous `localhost` hostname.

## Changes

### Docker Compose Configuration
- **docker-compose.yaml**: Port `5434` now binds to `127.0.0.1:5434:5432` instead of exposing on all interfaces
- **docker-compose.perf.yaml**: Port `5435` now binds to `127.0.0.1:5435:5432` instead of exposing on all interfaces

### Test Connection Strings
Updated PostgreSQL connection fallback defaults from `localhost` to `127.0.0.1` across multiple test files:
- **test-utils.ts**: `TEST_CONFIG` host fallback updated
- **vector/index.test.ts**: Connection string standardized across all test suites (main setup plus halfvec, bit, sparsevec, operator-class, and validation suites)
- **row-number-performance.test.ts**: Connection string updated for ROW_NUMBER performance test
- **performance-indexes.integration.test.ts**: Connection string updated to use `127.0.0.1:5435` (now targets perf compose instance)

### Performance Test Vector Class
**vector/vector.performance.test.ts**:
- Constructor updated to use object argument format (`{ id: 'pg-vector-performance-test', connectionString }`) instead of single `connectionString` parameter
- Added `disconnect()` override to ensure test pool cleanup in parallel with base class disconnect
- Default connection string updated to use `127.0.0.1` instead of `localhost`

## Notes
- All changes are test/dev infrastructure only; no published package API or runtime behavior changes
- Environment variable `DB_URL` overrides still take precedence over defaults
- Performance index tests now route to port `5435` (perf compose) while other tests remain on `5434` (standard compose)
- Validation confirmed loopback binding and proper test execution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->