### PR TITLE
[PF-268] Expose observability storage capabilities

### DIFF
--- a/.changeset/floppy-books-watch.md
+++ b/.changeset/floppy-books-watch.md
@@ -1,0 +1,18 @@
+---
+'@mastra/core': minor
+'@mastra/server': minor
+'@mastra/client-js': minor
+'@mastra/playground-ui': minor
+'@mastra/duckdb': minor
+'@mastra/clickhouse': minor
+---
+
+Added observability storage capabilities so applications can inspect log, metric, and persistence support without probing storage methods.
+
+```ts
+const capabilities = mastra.getStorage()?.stores?.observability?.getCapabilities();
+
+if (capabilities?.metrics.aggregate === true) {
+  // The configured observability store supports metrics aggregation.
+}
+```

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -75508,6 +75508,50 @@ export type GetSystemPackages_Response = {
   storageType?: string | undefined;
   observabilityStorageType?: string | undefined;
   observabilityRuntimeStrategy?: ('realtime' | 'batch-with-updates' | 'insert-only' | 'event-sourced') | undefined;
+  observabilityStorageCapabilities?:
+    | {
+        tracing: {
+          preferredStrategy: 'realtime' | 'batch-with-updates' | 'insert-only' | 'event-sourced';
+          supportedStrategies: ('realtime' | 'batch-with-updates' | 'insert-only' | 'event-sourced')[];
+          runtimeStrategy?: ('realtime' | 'batch-with-updates' | 'insert-only' | 'event-sourced') | undefined;
+        };
+        logs: {
+          persist: boolean | 'unknown';
+          list: boolean | 'unknown';
+        };
+        metrics: {
+          persist: boolean | 'unknown';
+          list: boolean | 'unknown';
+          aggregate: boolean | 'unknown';
+          breakdown: boolean | 'unknown';
+          timeSeries: boolean | 'unknown';
+          percentiles: boolean | 'unknown';
+          discovery: boolean | 'unknown';
+        };
+        scores?:
+          | {
+              persist: boolean | 'unknown';
+              list: boolean | 'unknown';
+              getById: boolean | 'unknown';
+              aggregate: boolean | 'unknown';
+              breakdown: boolean | 'unknown';
+              timeSeries: boolean | 'unknown';
+              percentiles: boolean | 'unknown';
+            }
+          | undefined;
+        feedback?:
+          | {
+              persist: boolean | 'unknown';
+              list: boolean | 'unknown';
+              aggregate: boolean | 'unknown';
+              breakdown: boolean | 'unknown';
+              timeSeries: boolean | 'unknown';
+              percentiles: boolean | 'unknown';
+            }
+          | undefined;
+        persistence?: ('memory' | 'persistent' | 'unknown') | undefined;
+      }
+    | undefined;
 };
 
 export type GetSystemPackages_Request = Simplify<

--- a/docs/src/content/en/docs/observability/metrics/overview.mdx
+++ b/docs/src/content/en/docs/observability/metrics/overview.mdx
@@ -72,7 +72,7 @@ export const mastra = new Mastra({
 
 ## Studio
 
-The Studio metrics dashboard visualizes all automatic metrics with KPI cards, detailed breakdowns, and configurable time ranges. See [Studio observability](/docs/studio/observability) for a full walkthrough.
+The Studio metrics dashboard visualizes all automatic metrics with KPI cards, detailed breakdowns, and configurable time ranges. Studio reads the attached observability storage capabilities before it requests metric data, so adapters that do not support the full metrics query surface show the unsupported-storage state instead of issuing probe queries. See [Studio observability](/docs/studio/observability) for a full walkthrough.
 
 ## What Mastra measures
 

--- a/packages/core/src/storage/domains/observability/base.test.ts
+++ b/packages/core/src/storage/domains/observability/base.test.ts
@@ -1,11 +1,57 @@
 import { describe, expect, it } from 'vitest';
+import { InMemoryDB } from '../inmemory-db';
 import { ObservabilityStorage } from './base';
+import { ObservabilityInMemory } from './inmemory';
 
 describe('ObservabilityStorage base class', () => {
   const storage = new ObservabilityStorage();
 
   it('does not advertise observability features by default', () => {
     expect(storage.getFeatures()).toBeUndefined();
+  });
+
+  it('reports conservative capabilities by default', () => {
+    expect(storage.getCapabilities()).toEqual({
+      tracing: {
+        preferredStrategy: 'batch-with-updates',
+        supportedStrategies: ['realtime', 'batch-with-updates', 'insert-only'],
+      },
+      logs: {
+        persist: false,
+        list: false,
+      },
+      metrics: {
+        persist: false,
+        list: false,
+        aggregate: false,
+        breakdown: false,
+        timeSeries: false,
+        percentiles: false,
+        discovery: false,
+      },
+      persistence: 'unknown',
+    });
+  });
+
+  it('reports in-memory log and metric capabilities', () => {
+    const inMemory = new ObservabilityInMemory({ db: new InMemoryDB() });
+
+    expect(inMemory.getCapabilities()).toMatchObject({
+      logs: {
+        persist: true,
+        list: true,
+      },
+      metrics: {
+        persist: true,
+        list: true,
+        aggregate: true,
+        breakdown: true,
+        timeSeries: true,
+        percentiles: true,
+        discovery: true,
+      },
+      persistence: 'memory',
+    });
   });
 
   const methodCases: Array<{ name: string; callThunk: () => Promise<unknown>; expectedMessage: string }> = [

--- a/packages/core/src/storage/domains/observability/base.ts
+++ b/packages/core/src/storage/domains/observability/base.ts
@@ -89,6 +89,47 @@ import { extractBranchSpans, getBranchArgsSchema } from './tracing';
 import type { ObservabilityStorageStrategy, TracingStorageStrategy } from './types';
 
 export type ObservabilityStorageFeature = 'delta-polling';
+export type ObservabilityCapabilitySupport = boolean | 'unknown';
+export type ObservabilityStoragePersistence = 'memory' | 'persistent' | 'unknown';
+
+export interface ObservabilityStorageCapabilities {
+  tracing: {
+    preferredStrategy: ObservabilityStorageStrategy;
+    supportedStrategies: ObservabilityStorageStrategy[];
+    runtimeStrategy?: ObservabilityStorageStrategy;
+  };
+  logs: {
+    persist: ObservabilityCapabilitySupport;
+    list: ObservabilityCapabilitySupport;
+  };
+  metrics: {
+    persist: ObservabilityCapabilitySupport;
+    list: ObservabilityCapabilitySupport;
+    aggregate: ObservabilityCapabilitySupport;
+    breakdown: ObservabilityCapabilitySupport;
+    timeSeries: ObservabilityCapabilitySupport;
+    percentiles: ObservabilityCapabilitySupport;
+    discovery: ObservabilityCapabilitySupport;
+  };
+  scores?: {
+    persist: ObservabilityCapabilitySupport;
+    list: ObservabilityCapabilitySupport;
+    getById: ObservabilityCapabilitySupport;
+    aggregate: ObservabilityCapabilitySupport;
+    breakdown: ObservabilityCapabilitySupport;
+    timeSeries: ObservabilityCapabilitySupport;
+    percentiles: ObservabilityCapabilitySupport;
+  };
+  feedback?: {
+    persist: ObservabilityCapabilitySupport;
+    list: ObservabilityCapabilitySupport;
+    aggregate: ObservabilityCapabilitySupport;
+    breakdown: ObservabilityCapabilitySupport;
+    timeSeries: ObservabilityCapabilitySupport;
+    percentiles: ObservabilityCapabilitySupport;
+  };
+  persistence?: ObservabilityStoragePersistence;
+}
 
 /**
  * Base storage class for observability data (traces, metrics, logs, scores, feedback).
@@ -153,6 +194,37 @@ export class ObservabilityStorage extends StorageDomain {
    */
   public getFeatures(): readonly ObservabilityStorageFeature[] | undefined {
     return undefined;
+  }
+
+  /**
+   * Reports which observability APIs this storage domain supports without
+   * issuing writes or queries. Subclasses should override this when they
+   * implement any of the optional log, metric, score, or feedback methods.
+   */
+  public getCapabilities(): ObservabilityStorageCapabilities {
+    const runtimeStrategy = this.runtimeTracingStrategy;
+
+    return {
+      tracing: {
+        preferredStrategy: this.observabilityStrategy.preferred,
+        supportedStrategies: this.observabilityStrategy.supported,
+        ...(runtimeStrategy ? { runtimeStrategy } : {}),
+      },
+      logs: {
+        persist: false,
+        list: false,
+      },
+      metrics: {
+        persist: false,
+        list: false,
+        aggregate: false,
+        breakdown: false,
+        timeSeries: false,
+        percentiles: false,
+        discovery: false,
+      },
+      persistence: 'unknown',
+    };
   }
 
   /**

--- a/packages/core/src/storage/domains/observability/inmemory.ts
+++ b/packages/core/src/storage/domains/observability/inmemory.ts
@@ -4,6 +4,7 @@ import { EntityType } from '../../../observability';
 import { jsonValueEquals } from '../../utils';
 import type { InMemoryDB } from '../inmemory-db';
 import { ObservabilityStorage } from './base';
+import type { ObservabilityStorageCapabilities } from './base';
 import type {
   GetEntityTypesArgs,
   GetEntityTypesResponse,
@@ -138,6 +139,43 @@ export class ObservabilityInMemory extends ObservabilityStorage {
     }
 
     return ['delta-polling'] as const;
+  }
+
+  override getCapabilities(): ObservabilityStorageCapabilities {
+    return {
+      ...super.getCapabilities(),
+      logs: {
+        persist: true,
+        list: true,
+      },
+      metrics: {
+        persist: true,
+        list: true,
+        aggregate: true,
+        breakdown: true,
+        timeSeries: true,
+        percentiles: true,
+        discovery: true,
+      },
+      scores: {
+        persist: true,
+        list: true,
+        getById: true,
+        aggregate: true,
+        breakdown: true,
+        timeSeries: true,
+        percentiles: true,
+      },
+      feedback: {
+        persist: true,
+        list: true,
+        aggregate: true,
+        breakdown: true,
+        timeSeries: true,
+        percentiles: true,
+      },
+      persistence: 'memory',
+    };
   }
 
   async dangerouslyClearAll(): Promise<void> {

--- a/packages/playground-ui/src/domains/metrics/hooks/use-agent-runs-kpi-metrics.tsx
+++ b/packages/playground-ui/src/domains/metrics/hooks/use-agent-runs-kpi-metrics.tsx
@@ -2,8 +2,12 @@ import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 import { useMetricsFilters } from './use-metrics-filters';
 
+type UseAgentRunsKpiMetricsOptions = {
+  enabled?: boolean;
+};
+
 /** Total Agent Runs — count of agent duration metric observations */
-export function useAgentRunsKpiMetrics() {
+export function useAgentRunsKpiMetrics({ enabled = true }: UseAgentRunsKpiMetricsOptions = {}) {
   const client = useMastraClient();
   const { filters, filterKey } = useMetricsFilters();
 
@@ -16,5 +20,6 @@ export function useAgentRunsKpiMetrics() {
         filters,
         comparePeriod: 'previous_period',
       }),
+    enabled,
   });
 }

--- a/packages/playground-ui/src/domains/traces/hooks/use-entity-names.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-entity-names.ts
@@ -6,9 +6,10 @@ import { ROOT_ENTITY_TYPE_OPTIONS } from '@/domains/traces/trace-filters';
 type UseEntityNamesOptions = {
   entityType?: EntityType;
   rootOnly?: boolean;
+  enabled?: boolean;
 };
 
-export const useEntityNames = ({ entityType, rootOnly = false }: UseEntityNamesOptions = {}) => {
+export const useEntityNames = ({ entityType, rootOnly = false, enabled = true }: UseEntityNamesOptions = {}) => {
   const client = useMastraClient();
 
   // Mirror the queryFn branches so the cache key reflects what the server
@@ -43,5 +44,6 @@ export const useEntityNames = ({ entityType, rootOnly = false }: UseEntityNamesO
     },
     select: data => data?.names ?? [],
     retry: false,
+    enabled,
   });
 };

--- a/packages/playground-ui/src/domains/traces/hooks/use-environments.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-environments.ts
@@ -1,7 +1,11 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 
-export const useEnvironments = () => {
+type UseEnvironmentsOptions = {
+  enabled?: boolean;
+};
+
+export const useEnvironments = ({ enabled = true }: UseEnvironmentsOptions = {}) => {
   const client = useMastraClient();
 
   return useQuery({
@@ -15,5 +19,6 @@ export const useEnvironments = () => {
     },
     select: data => data?.environments ?? [],
     retry: false,
+    enabled,
   });
 };

--- a/packages/playground-ui/src/domains/traces/hooks/use-service-names.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-service-names.ts
@@ -1,7 +1,11 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 
-export const useServiceNames = () => {
+type UseServiceNamesOptions = {
+  enabled?: boolean;
+};
+
+export const useServiceNames = ({ enabled = true }: UseServiceNamesOptions = {}) => {
   const client = useMastraClient();
 
   return useQuery({
@@ -15,5 +19,6 @@ export const useServiceNames = () => {
     },
     select: data => data?.serviceNames ?? [],
     retry: false,
+    enabled,
   });
 };

--- a/packages/playground-ui/src/domains/traces/hooks/use-tags.ts
+++ b/packages/playground-ui/src/domains/traces/hooks/use-tags.ts
@@ -1,7 +1,11 @@
 import { useMastraClient } from '@mastra/react';
 import { useQuery } from '@tanstack/react-query';
 
-export const useTags = () => {
+type UseTagsOptions = {
+  enabled?: boolean;
+};
+
+export const useTags = ({ enabled = true }: UseTagsOptions = {}) => {
   const client = useMastraClient();
 
   return useQuery({
@@ -16,5 +20,6 @@ export const useTags = () => {
     },
     select: data => data?.tags ?? [],
     retry: false,
+    enabled,
   });
 };

--- a/packages/playground/e2e/tests/metrics/page.spec.ts
+++ b/packages/playground/e2e/tests/metrics/page.spec.ts
@@ -39,6 +39,61 @@ test('renders Memory card with thread/resource tabs when metrics are available',
   await expect(resourcesTab).toHaveAttribute('aria-selected', 'true');
 });
 
+test('does not probe metrics endpoints when storage capabilities are unsupported', async ({ page }) => {
+  await page.route('**/api/system/packages', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        packages: [],
+        isDev: false,
+        cmsEnabled: true,
+        observabilityEnabled: true,
+        storageType: 'LibSQLStore',
+        observabilityStorageType: 'ObservabilityStorage',
+        observabilityStorageCapabilities: {
+          tracing: {
+            preferredStrategy: 'batch-with-updates',
+            supportedStrategies: ['batch-with-updates'],
+            runtimeStrategy: 'batch-with-updates',
+          },
+          logs: {
+            persist: false,
+            list: false,
+          },
+          metrics: {
+            persist: false,
+            list: false,
+            aggregate: false,
+            breakdown: false,
+            timeSeries: false,
+            percentiles: false,
+            discovery: false,
+          },
+          persistence: 'persistent',
+        },
+      }),
+    });
+  });
+
+  const unexpectedRequests: string[] = [];
+  await page.route('**/api/observability/metrics**', async route => {
+    unexpectedRequests.push(route.request().url());
+    await route.fulfill({ status: 500, body: 'unexpected metrics request' });
+  });
+  await page.route('**/api/observability/discovery/**', async route => {
+    unexpectedRequests.push(route.request().url());
+    await route.fulfill({ status: 500, body: 'unexpected discovery request' });
+  });
+
+  await page.goto('/metrics');
+
+  await expect(
+    page.getByRole('heading', { name: 'Metrics are not available with your current storage' }),
+  ).toBeVisible();
+  expect(unexpectedRequests).toEqual([]);
+});
+
 test('persists dimensional filter as URL param', async ({ page }) => {
   await page.goto('/metrics?filterEnvironment=production');
 

--- a/packages/playground/src/pages/metrics/index.tsx
+++ b/packages/playground/src/pages/metrics/index.tsx
@@ -54,6 +54,30 @@ const ANALYTICS_OBSERVABILITY_TYPES = new Set([
   'ObservabilityInMemory',
 ]);
 
+type MetricsStorageCapabilities = {
+  persist?: boolean | 'unknown';
+  list?: boolean | 'unknown';
+  aggregate?: boolean | 'unknown';
+  breakdown?: boolean | 'unknown';
+  timeSeries?: boolean | 'unknown';
+  percentiles?: boolean | 'unknown';
+  discovery?: boolean | 'unknown';
+};
+
+function supportsMetricsDashboard(metricsCapabilities: MetricsStorageCapabilities | undefined) {
+  if (!metricsCapabilities) return false;
+
+  return (
+    metricsCapabilities.persist === true &&
+    metricsCapabilities.list === true &&
+    metricsCapabilities.aggregate === true &&
+    metricsCapabilities.breakdown === true &&
+    metricsCapabilities.timeSeries === true &&
+    metricsCapabilities.percentiles === true &&
+    metricsCapabilities.discovery === true
+  );
+}
+
 const PERIOD_PARAM = 'period';
 const DATE_FROM_PARAM = 'dateFrom';
 const DATE_TO_PARAM = 'dateTo';
@@ -186,19 +210,32 @@ export default function Metrics() {
 
 function MetricsContent() {
   const [searchParams] = useSearchParams();
-  const { error, isLoading: isMetricsLoading } = useAgentRunsKpiMetrics();
   const { filterTokens, setFilterTokens } = useMetrics();
   const [autoFocusFilterFieldId, setAutoFocusFilterFieldId] = useState<string | undefined>();
 
-  const { data: packagesData, isLoading: isPackagesLoading } = useMastraPackages();
+  const { data: packagesData, error: packagesError, isLoading: isPackagesLoading } = useMastraPackages();
   const observabilityType = packagesData?.observabilityStorageType;
-  const supportsMetrics = observabilityType ? ANALYTICS_OBSERVABILITY_TYPES.has(observabilityType) : false;
-  const isInMemory = observabilityType === 'ObservabilityInMemory';
+  const metricsCapabilities = packagesData?.observabilityStorageCapabilities?.metrics;
+  const supportsMetrics = metricsCapabilities
+    ? supportsMetricsDashboard(metricsCapabilities)
+    : observabilityType
+      ? ANALYTICS_OBSERVABILITY_TYPES.has(observabilityType)
+      : false;
+  const isInMemory =
+    packagesData?.observabilityStorageCapabilities?.persistence === 'memory' ||
+    observabilityType === 'ObservabilityInMemory';
+  const metricsQueriesEnabled = supportsMetrics && !isPackagesLoading;
+  const { error, isLoading: isMetricsLoading } = useAgentRunsKpiMetrics({ enabled: metricsQueriesEnabled });
+  const loadError = packagesError ?? error;
 
-  const { data: tagsData, isLoading: isTagsLoading } = useTags();
-  const { data: entityNamesData, isLoading: isEntityNamesLoading } = useEntityNames();
-  const { data: serviceNamesData, isLoading: isServiceNamesLoading } = useServiceNames();
-  const { data: environmentsData, isLoading: isEnvironmentsLoading } = useEnvironments();
+  const { data: tagsData, isLoading: isTagsLoading } = useTags({ enabled: metricsQueriesEnabled });
+  const { data: entityNamesData, isLoading: isEntityNamesLoading } = useEntityNames({ enabled: metricsQueriesEnabled });
+  const { data: serviceNamesData, isLoading: isServiceNamesLoading } = useServiceNames({
+    enabled: metricsQueriesEnabled,
+  });
+  const { data: environmentsData, isLoading: isEnvironmentsLoading } = useEnvironments({
+    enabled: metricsQueriesEnabled,
+  });
 
   const filterFields = useMemo(
     () =>
@@ -258,7 +295,7 @@ function MetricsContent() {
     setFilterTokens(neutralTokens);
   }, [filterFields, filterTokens, setFilterTokens]);
 
-  if (error && is401UnauthorizedError(error)) {
+  if (loadError && is401UnauthorizedError(loadError)) {
     return (
       <NoDataPageLayout>
         <SessionExpired />
@@ -266,7 +303,7 @@ function MetricsContent() {
     );
   }
 
-  if (error && is403ForbiddenError(error)) {
+  if (loadError && is403ForbiddenError(loadError)) {
     return (
       <NoDataPageLayout>
         <PermissionDenied resource="metrics" />
@@ -274,10 +311,10 @@ function MetricsContent() {
     );
   }
 
-  if (error) {
+  if (loadError) {
     return (
       <NoDataPageLayout>
-        <ErrorState title="Failed to load metrics" message={error.message} />
+        <ErrorState title="Failed to load metrics" message={loadError.message} />
       </NoDataPageLayout>
     );
   }

--- a/packages/server/src/server/handlers/system.test.ts
+++ b/packages/server/src/server/handlers/system.test.ts
@@ -10,8 +10,31 @@ type MockStorage = {
     observability?: {
       constructor?: { name?: string };
       runtimeTracingStrategy?: 'realtime' | 'batch-with-updates' | 'insert-only' | 'event-sourced';
+      getCapabilities?: () => unknown;
     };
   };
+};
+
+const mockObservabilityStorageCapabilities = {
+  tracing: {
+    preferredStrategy: 'realtime',
+    supportedStrategies: ['realtime'],
+    runtimeStrategy: 'realtime',
+  },
+  logs: {
+    persist: true,
+    list: true,
+  },
+  metrics: {
+    persist: true,
+    list: true,
+    aggregate: true,
+    breakdown: true,
+    timeSeries: true,
+    percentiles: true,
+    discovery: true,
+  },
+  persistence: 'persistent',
 };
 
 const createMockMastra = (hasEditor: boolean, storage?: MockStorage, hasObservability = false) =>
@@ -188,6 +211,115 @@ describe('System Handlers', () => {
             observability: {
               constructor: { name: 'MockObservabilityStore' },
               runtimeTracingStrategy: 'realtime',
+            },
+          },
+        }),
+      } as any);
+
+      expect(result).toEqual({
+        packages: [],
+        isDev: false,
+        cmsEnabled: false,
+        observabilityEnabled: false,
+        storageType: 'mock-storage',
+        observabilityStorageType: 'MockObservabilityStore',
+        observabilityRuntimeStrategy: 'realtime',
+      });
+    });
+
+    it('should return observability storage capabilities when the store exposes them', async () => {
+      const result = await GET_SYSTEM_PACKAGES_ROUTE.handler({
+        mastra: createMockMastra(false, {
+          name: 'mock-storage',
+          stores: {
+            observability: {
+              constructor: { name: 'MockObservabilityStore' },
+              runtimeTracingStrategy: 'realtime',
+              getCapabilities: () => mockObservabilityStorageCapabilities,
+            },
+          },
+        }),
+      } as any);
+
+      expect(result).toEqual({
+        packages: [],
+        isDev: false,
+        cmsEnabled: false,
+        observabilityEnabled: false,
+        storageType: 'mock-storage',
+        observabilityStorageType: 'MockObservabilityStore',
+        observabilityRuntimeStrategy: 'realtime',
+        observabilityStorageCapabilities: mockObservabilityStorageCapabilities,
+      });
+    });
+
+    it('should omit inherited base observability storage capabilities', async () => {
+      class BaseObservabilityStorage {
+        getCapabilities() {
+          return mockObservabilityStorageCapabilities;
+        }
+      }
+
+      class LegacyObservabilityStorage extends BaseObservabilityStorage {
+        runtimeTracingStrategy = 'realtime';
+      }
+
+      const result = await GET_SYSTEM_PACKAGES_ROUTE.handler({
+        mastra: createMockMastra(false, {
+          name: 'mock-storage',
+          stores: {
+            observability: new LegacyObservabilityStorage(),
+          },
+        }),
+      } as any);
+
+      expect(result).toEqual({
+        packages: [],
+        isDev: false,
+        cmsEnabled: false,
+        observabilityEnabled: false,
+        storageType: 'mock-storage',
+        observabilityStorageType: 'LegacyObservabilityStorage',
+        observabilityRuntimeStrategy: 'realtime',
+      });
+    });
+
+    it('should omit invalid observability storage capabilities', async () => {
+      const result = await GET_SYSTEM_PACKAGES_ROUTE.handler({
+        mastra: createMockMastra(false, {
+          name: 'mock-storage',
+          stores: {
+            observability: {
+              constructor: { name: 'MockObservabilityStore' },
+              runtimeTracingStrategy: 'realtime',
+              getCapabilities: () => ({ metrics: { persist: true } }),
+            },
+          },
+        }),
+      } as any);
+
+      expect(result).toEqual({
+        packages: [],
+        isDev: false,
+        cmsEnabled: false,
+        observabilityEnabled: false,
+        storageType: 'mock-storage',
+        observabilityStorageType: 'MockObservabilityStore',
+        observabilityRuntimeStrategy: 'realtime',
+      });
+    });
+
+    it('should omit observability storage capabilities when capability inspection throws', async () => {
+      const result = await GET_SYSTEM_PACKAGES_ROUTE.handler({
+        mastra: createMockMastra(false, {
+          name: 'mock-storage',
+          stores: {
+            observability: {
+              constructor: { name: 'MockObservabilityStore' },
+              runtimeTracingStrategy: 'realtime',
+              getCapabilities: () => {
+                throw new Error('capabilities unavailable');
+              },
             },
           },
         }),

--- a/packages/server/src/server/handlers/system.ts
+++ b/packages/server/src/server/handlers/system.ts
@@ -1,7 +1,11 @@
 import { readFileSync } from 'node:fs';
 
-import type { MastraPackage } from '../schemas/system';
-import { apiSchemaManifestResponseSchema, systemPackagesResponseSchema } from '../schemas/system';
+import type { MastraPackage, SystemPackagesResponse } from '../schemas/system';
+import {
+  apiSchemaManifestResponseSchema,
+  observabilityStorageCapabilitiesSchema,
+  systemPackagesResponseSchema,
+} from '../schemas/system';
 import { createRoute } from '../server-adapter/routes/route-builder';
 import { handleError } from './error';
 
@@ -20,6 +24,30 @@ export const GET_API_SCHEMA_ROUTE = createRoute({
     return buildApiSchemaManifest();
   },
 });
+
+function getObservabilityStorageCapabilities(
+  observabilityStorage: unknown,
+): SystemPackagesResponse['observabilityStorageCapabilities'] {
+  const candidate = observabilityStorage as { getCapabilities?: () => unknown } | undefined;
+  if (typeof candidate?.getCapabilities !== 'function') {
+    return undefined;
+  }
+
+  const prototype = Object.getPrototypeOf(candidate);
+  const hasExplicitCapabilities =
+    Object.prototype.hasOwnProperty.call(candidate, 'getCapabilities') ||
+    (prototype && Object.prototype.hasOwnProperty.call(prototype, 'getCapabilities'));
+  if (!hasExplicitCapabilities) {
+    return undefined;
+  }
+
+  try {
+    const result = observabilityStorageCapabilitiesSchema.safeParse(candidate.getCapabilities());
+    return result.success ? result.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 export const GET_SYSTEM_PACKAGES_ROUTE = createRoute({
   method: 'GET',
@@ -50,6 +78,7 @@ export const GET_SYSTEM_PACKAGES_ROUTE = createRoute({
       const observabilityStorage = storage?.stores?.observability;
       const observabilityStorageType = observabilityStorage?.constructor.name;
       const observabilityRuntimeStrategy = observabilityStorage?.runtimeTracingStrategy;
+      const observabilityStorageCapabilities = getObservabilityStorageCapabilities(observabilityStorage);
       const observabilityEnabled = !!mastra.observability.getDefaultInstance();
 
       return {
@@ -60,6 +89,7 @@ export const GET_SYSTEM_PACKAGES_ROUTE = createRoute({
         storageType,
         observabilityStorageType,
         observabilityRuntimeStrategy,
+        ...(observabilityStorageCapabilities ? { observabilityStorageCapabilities } : {}),
       };
     } catch (error) {
       return handleError(error, 'Error getting system packages');

--- a/packages/server/src/server/schemas/system.ts
+++ b/packages/server/src/server/schemas/system.ts
@@ -12,6 +12,51 @@ export const observabilityRuntimeStrategySchema = z.enum([
   'event-sourced',
 ]);
 
+const observabilityCapabilitySupportSchema = z.union([z.boolean(), z.literal('unknown')]);
+
+export const observabilityStorageCapabilitiesSchema = z.object({
+  tracing: z.object({
+    preferredStrategy: observabilityRuntimeStrategySchema,
+    supportedStrategies: z.array(observabilityRuntimeStrategySchema),
+    runtimeStrategy: observabilityRuntimeStrategySchema.optional(),
+  }),
+  logs: z.object({
+    persist: observabilityCapabilitySupportSchema,
+    list: observabilityCapabilitySupportSchema,
+  }),
+  metrics: z.object({
+    persist: observabilityCapabilitySupportSchema,
+    list: observabilityCapabilitySupportSchema,
+    aggregate: observabilityCapabilitySupportSchema,
+    breakdown: observabilityCapabilitySupportSchema,
+    timeSeries: observabilityCapabilitySupportSchema,
+    percentiles: observabilityCapabilitySupportSchema,
+    discovery: observabilityCapabilitySupportSchema,
+  }),
+  scores: z
+    .object({
+      persist: observabilityCapabilitySupportSchema,
+      list: observabilityCapabilitySupportSchema,
+      getById: observabilityCapabilitySupportSchema,
+      aggregate: observabilityCapabilitySupportSchema,
+      breakdown: observabilityCapabilitySupportSchema,
+      timeSeries: observabilityCapabilitySupportSchema,
+      percentiles: observabilityCapabilitySupportSchema,
+    })
+    .optional(),
+  feedback: z
+    .object({
+      persist: observabilityCapabilitySupportSchema,
+      list: observabilityCapabilitySupportSchema,
+      aggregate: observabilityCapabilitySupportSchema,
+      breakdown: observabilityCapabilitySupportSchema,
+      timeSeries: observabilityCapabilitySupportSchema,
+      percentiles: observabilityCapabilitySupportSchema,
+    })
+    .optional(),
+  persistence: z.enum(['memory', 'persistent', 'unknown']).optional(),
+});
+
 export const systemPackagesResponseSchema = z.object({
   packages: z.array(mastraPackageSchema),
   isDev: z.boolean(),
@@ -20,6 +65,7 @@ export const systemPackagesResponseSchema = z.object({
   storageType: z.string().optional(),
   observabilityStorageType: z.string().optional(),
   observabilityRuntimeStrategy: observabilityRuntimeStrategySchema.optional(),
+  observabilityStorageCapabilities: observabilityStorageCapabilitiesSchema.optional(),
 });
 
 const jsonSchemaRecordSchema = z.record(z.string(), z.unknown());

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.test.ts
@@ -128,6 +128,46 @@ describe('ObservabilityStorageClickhouseVNext', () => {
     });
   });
 
+  it('reports persistent observability capabilities', () => {
+    expect(storage.getCapabilities()).toMatchObject({
+      tracing: {
+        preferredStrategy: 'insert-only',
+        supportedStrategies: ['insert-only'],
+      },
+      logs: {
+        persist: true,
+        list: true,
+      },
+      metrics: {
+        persist: true,
+        list: true,
+        aggregate: true,
+        breakdown: true,
+        timeSeries: true,
+        percentiles: true,
+        discovery: true,
+      },
+      scores: {
+        persist: true,
+        list: true,
+        getById: true,
+        aggregate: true,
+        breakdown: true,
+        timeSeries: true,
+        percentiles: true,
+      },
+      feedback: {
+        persist: true,
+        list: true,
+        aggregate: true,
+        breakdown: true,
+        timeSeries: true,
+        percentiles: true,
+      },
+      persistence: 'persistent',
+    });
+  });
+
   describe('delta polling', () => {
     async function withFallbackStorage<T>(
       run: (fallbackStorage: ObservabilityStorageClickhouseVNext) => Promise<T>,

--- a/stores/clickhouse/src/storage/domains/observability/v-next/index.ts
+++ b/stores/clickhouse/src/storage/domains/observability/v-next/index.ts
@@ -569,6 +569,49 @@ export class ObservabilityStorageClickhouseVNext extends ObservabilityStorage {
     return ['delta-polling'] as const;
   }
 
+  getCapabilities() {
+    const runtimeStrategy = this.runtimeTracingStrategy;
+
+    return {
+      tracing: {
+        preferredStrategy: this.observabilityStrategy.preferred,
+        supportedStrategies: this.observabilityStrategy.supported,
+        ...(runtimeStrategy ? { runtimeStrategy } : {}),
+      },
+      logs: {
+        persist: true,
+        list: true,
+      },
+      metrics: {
+        persist: true,
+        list: true,
+        aggregate: true,
+        breakdown: true,
+        timeSeries: true,
+        percentiles: true,
+        discovery: true,
+      },
+      scores: {
+        persist: true,
+        list: true,
+        getById: true,
+        aggregate: true,
+        breakdown: true,
+        timeSeries: true,
+        percentiles: true,
+      },
+      feedback: {
+        persist: true,
+        list: true,
+        aggregate: true,
+        breakdown: true,
+        timeSeries: true,
+        percentiles: true,
+      },
+      persistence: 'persistent' as const,
+    };
+  }
+
   // -------------------------------------------------------------------------
   // Tracing — writes
   // -------------------------------------------------------------------------

--- a/stores/duckdb/src/storage/db/index.ts
+++ b/stores/duckdb/src/storage/db/index.ts
@@ -70,6 +70,10 @@ export class DuckDBConnection extends MastraBase {
     this.path = config.path ?? 'mastra.duckdb';
   }
 
+  get isEphemeral(): boolean {
+    return this.path === ':memory:';
+  }
+
   private async initialize(): Promise<void> {
     if (this.initialized && this.instance) return;
 

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -101,6 +101,95 @@ describe('ObservabilityStorageDuckDB', () => {
     });
   });
 
+  it('reports in-memory observability capabilities for ephemeral DuckDB', () => {
+    expect(storage.getCapabilities()).toMatchObject({
+      tracing: {
+        preferredStrategy: 'event-sourced',
+        supportedStrategies: ['event-sourced'],
+      },
+      logs: {
+        persist: true,
+        list: true,
+      },
+      metrics: {
+        persist: true,
+        list: true,
+        aggregate: true,
+        breakdown: true,
+        timeSeries: true,
+        percentiles: true,
+        discovery: true,
+      },
+      scores: {
+        persist: true,
+        list: true,
+        getById: true,
+        aggregate: true,
+        breakdown: true,
+        timeSeries: true,
+        percentiles: true,
+      },
+      feedback: {
+        persist: true,
+        list: true,
+        aggregate: true,
+        breakdown: true,
+        timeSeries: true,
+        percentiles: true,
+      },
+      persistence: 'memory',
+    });
+  });
+
+  it('reports persistent observability capabilities for file-backed DuckDB', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mastra-duckdb-capabilities-'));
+    const persistentStore = new DuckDBStore({ path: join(dir, 'observability.duckdb') });
+
+    try {
+      await persistentStore.init();
+      expect(persistentStore.observability.getCapabilities()).toMatchObject({
+        tracing: {
+          preferredStrategy: 'event-sourced',
+          supportedStrategies: ['event-sourced'],
+        },
+        logs: {
+          persist: true,
+          list: true,
+        },
+        metrics: {
+          persist: true,
+          list: true,
+          aggregate: true,
+          breakdown: true,
+          timeSeries: true,
+          percentiles: true,
+          discovery: true,
+        },
+        scores: {
+          persist: true,
+          list: true,
+          getById: true,
+          aggregate: true,
+          breakdown: true,
+          timeSeries: true,
+          percentiles: true,
+        },
+        feedback: {
+          persist: true,
+          list: true,
+          aggregate: true,
+          breakdown: true,
+          timeSeries: true,
+          percentiles: true,
+        },
+        persistence: 'persistent',
+      });
+    } finally {
+      await persistentStore.db.close();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('gates delta list capabilities on the observability delta feature flag', async () => {
     const originalFeatures = new Set(coreFeatures);
 
@@ -130,11 +219,50 @@ describe('ObservabilityStorageDuckDB', () => {
       coreFeatures.add('observability-delta-polling');
 
       expect(lazyStore.observability.getFeatures()).toEqual(['delta-polling']);
+      expect(lazyStore.observability.getCapabilities()).toMatchObject({
+        metrics: {
+          persist: true,
+          list: true,
+          aggregate: true,
+          breakdown: true,
+          timeSeries: true,
+          percentiles: true,
+          discovery: true,
+        },
+        persistence: 'memory',
+      });
     } finally {
       coreFeatures.clear();
       for (const feature of originalFeatures) {
         coreFeatures.add(feature);
       }
+      await lazyStore.db.close();
+    }
+  });
+
+  it('reports unsupported capabilities through the lazy store facade after a compatibility failure', async () => {
+    const lazyStore = new DuckDBStore({ path: ':memory:' });
+
+    try {
+      (lazyStore.observability as any).unavailableError = new Error('upgrade @mastra/core');
+
+      expect(lazyStore.observability.getCapabilities()).toMatchObject({
+        logs: {
+          persist: false,
+          list: false,
+        },
+        metrics: {
+          persist: false,
+          list: false,
+          aggregate: false,
+          breakdown: false,
+          timeSeries: false,
+          percentiles: false,
+          discovery: false,
+        },
+        persistence: 'unknown',
+      });
+    } finally {
       await lazyStore.db.close();
     }
   });

--- a/stores/duckdb/src/storage/domains/observability/index.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.ts
@@ -208,6 +208,49 @@ export class ObservabilityStorageDuckDB extends ObservabilityStorage {
     return ['delta-polling'] as const;
   }
 
+  getCapabilities() {
+    const runtimeStrategy = this.runtimeTracingStrategy;
+
+    return {
+      tracing: {
+        preferredStrategy: this.observabilityStrategy.preferred,
+        supportedStrategies: this.observabilityStrategy.supported,
+        ...(runtimeStrategy ? { runtimeStrategy } : {}),
+      },
+      logs: {
+        persist: true,
+        list: true,
+      },
+      metrics: {
+        persist: true,
+        list: true,
+        aggregate: true,
+        breakdown: true,
+        timeSeries: true,
+        percentiles: true,
+        discovery: true,
+      },
+      scores: {
+        persist: true,
+        list: true,
+        getById: true,
+        aggregate: true,
+        breakdown: true,
+        timeSeries: true,
+        percentiles: true,
+      },
+      feedback: {
+        persist: true,
+        list: true,
+        aggregate: true,
+        breakdown: true,
+        timeSeries: true,
+        percentiles: true,
+      },
+      persistence: this.db.isEphemeral ? ('memory' as const) : ('persistent' as const),
+    };
+  }
+
   // Tracing
   async createSpan(args: CreateSpanArgs): Promise<void> {
     return tracingOps.createSpan(this.db, args);

--- a/stores/duckdb/src/storage/domains/observability/metrics.ts
+++ b/stores/duckdb/src/storage/domains/observability/metrics.ts
@@ -1,4 +1,3 @@
-import { METRIC_DISTINCT_COLUMNS } from '@mastra/core/storage';
 import type {
   BatchCreateMetricsArgs,
   ListMetricsArgs,

--- a/stores/duckdb/src/storage/index.ts
+++ b/stores/duckdb/src/storage/index.ts
@@ -9,10 +9,53 @@ import type {
   ObservabilityStorageDuckDB as ObservabilityStorageDuckDBImpl,
 } from './domains/observability/index';
 
+type ObservabilityStoreImpl = ObservabilityStorageDuckDBImpl;
+
 const OBSERVABILITY_UPGRADE_MESSAGE =
   'DuckDB observability storage requires `@mastra/core` with observability storage support. Upgrade `@mastra/core` to use this store.';
 const OBSERVABILITY_DELTA_POLLING_FEATURE = 'observability-delta-polling';
 const DUCKDB_OBSERVABILITY_FEATURES = ['delta-polling'] as const;
+const DUCKDB_OBSERVABILITY_STRATEGY: ObservabilityStoreImpl['observabilityStrategy'] = {
+  preferred: 'event-sourced',
+  supported: ['event-sourced'],
+};
+const DUCKDB_UNAVAILABLE_OBSERVABILITY_CAPABILITIES = {
+  tracing: {
+    preferredStrategy: DUCKDB_OBSERVABILITY_STRATEGY.preferred,
+    supportedStrategies: DUCKDB_OBSERVABILITY_STRATEGY.supported,
+  },
+  logs: {
+    persist: false,
+    list: false,
+  },
+  metrics: {
+    persist: false,
+    list: false,
+    aggregate: false,
+    breakdown: false,
+    timeSeries: false,
+    percentiles: false,
+    discovery: false,
+  },
+  scores: {
+    persist: false,
+    list: false,
+    getById: false,
+    aggregate: false,
+    breakdown: false,
+    timeSeries: false,
+    percentiles: false,
+  },
+  feedback: {
+    persist: false,
+    list: false,
+    aggregate: false,
+    breakdown: false,
+    timeSeries: false,
+    percentiles: false,
+  },
+  persistence: 'unknown' as const,
+};
 
 function isObservabilityCompatibilityError(error: unknown): boolean {
   if (!(error instanceof Error)) {
@@ -32,8 +75,6 @@ function isObservabilityCompatibilityError(error: unknown): boolean {
 export { DuckDBConnection } from './db/index';
 export type { DuckDBStorageConfig } from './db/index';
 export type { ObservabilityDuckDBConfig } from './domains/observability/index';
-
-type ObservabilityStoreImpl = ObservabilityStorageDuckDBImpl;
 
 /**
  * Lazy DuckDB observability facade.
@@ -103,12 +144,7 @@ export class ObservabilityStorageDuckDB extends CoreObservabilityStorage {
   }
 
   get observabilityStrategy(): ObservabilityStoreImpl['observabilityStrategy'] {
-    return (
-      this.delegate?.observabilityStrategy ?? {
-        preferred: 'event-sourced',
-        supported: ['event-sourced'],
-      }
-    );
+    return this.delegate?.observabilityStrategy ?? DUCKDB_OBSERVABILITY_STRATEGY;
   }
 
   get tracingStrategy(): ObservabilityStoreImpl['tracingStrategy'] {
@@ -123,6 +159,55 @@ export class ObservabilityStorageDuckDB extends CoreObservabilityStorage {
     }
 
     return DUCKDB_OBSERVABILITY_FEATURES;
+  }
+
+  getCapabilities() {
+    if (this.unavailableError) {
+      return DUCKDB_UNAVAILABLE_OBSERVABILITY_CAPABILITIES;
+    }
+
+    const runtimeStrategy = this.runtimeTracingStrategy;
+
+    return (
+      this.delegate?.getCapabilities() ?? {
+        tracing: {
+          preferredStrategy: this.observabilityStrategy.preferred,
+          supportedStrategies: this.observabilityStrategy.supported,
+          ...(runtimeStrategy ? { runtimeStrategy } : {}),
+        },
+        logs: {
+          persist: true,
+          list: true,
+        },
+        metrics: {
+          persist: true,
+          list: true,
+          aggregate: true,
+          breakdown: true,
+          timeSeries: true,
+          percentiles: true,
+          discovery: true,
+        },
+        scores: {
+          persist: true,
+          list: true,
+          getById: true,
+          aggregate: true,
+          breakdown: true,
+          timeSeries: true,
+          percentiles: true,
+        },
+        feedback: {
+          persist: true,
+          list: true,
+          aggregate: true,
+          breakdown: true,
+          timeSeries: true,
+          percentiles: true,
+        },
+        persistence: this.db.isEphemeral ? ('memory' as const) : ('persistent' as const),
+      }
+    );
   }
 
   async init(...args: Parameters<ObservabilityStoreImpl['init']>): ReturnType<ObservabilityStoreImpl['init']> {


### PR DESCRIPTION
## Summary

- add `ObservabilityStorage.getCapabilities()` with conservative defaults and explicit InMemory, DuckDB, and ClickHouse vNext support descriptors
- expose optional `observabilityStorageCapabilities` from `GET /system/packages` and regenerate client-js route types
- gate Studio metrics/discovery queries on storage capabilities while preserving constructor fallback for older servers/stores
- mark DuckDB `:memory:` as ephemeral, keep file-backed DuckDB and ClickHouse persistent, and document the new inspection API
- remove a duplicate DuckDB metric import that was already breaking DuckDB package typecheck/build

## Coordination

- PF-268 / GitHub issue #73
- Linear MCP auth is currently revoked in this session, so coordination/evidence is recorded on GitHub until Linear auth is restored
- Checked open PRs in `mbenhamd/mastra` before implementation: none
- Fork was verified 0 commits behind `mastra-ai/mastra:main` before this work
- Local council/review used: agy, Claude, two Codex review passes, and CodeRabbit CLI

## Validation

- `pnpm --filter @mastra/server generate:route-types`
- `pnpm --filter @mastra/core test -- src/storage/domains/observability/base.test.ts`
- `pnpm exec vitest run src/server/handlers/system.test.ts` from `packages/server`
- `pnpm --filter @mastra/duckdb test -- src/storage/domains/observability/index.test.ts`
- `pnpm --filter @mastra/duckdb typecheck`
- `pnpm --filter @mastra/duckdb build:lib`
- `pnpm --filter @mastra/clickhouse test -- src/storage/domains/observability/v-next/index.test.ts`
- `pnpm --filter @mastra/server check:core-imports`
- `pnpm --filter @mastra/server build:lib`
- `pnpm --filter @mastra/client-js build:lib`
- `pnpm --filter @mastra/playground-ui build`
- `pnpm --filter @internal/playground typecheck` still fails on existing unrelated baseline errors in `src/App.tsx` duplicate `RouteObject` imports and `src/services/mastra-runtime-provider.tsx` `buildStreamErrorMessage` conflict
- `git diff --check`

## Review Notes

- CodeRabbit CLI first flagged the changeset example; fixed by adding a public API snippet.
- CodeRabbit CLI second run timed out after findings. Fixed the valid ClickHouse test coverage finding. The suggested `@mastra/playground` changeset entry was not applied because the touched playground package is private and named `@internal/playground`; release-facing UI changes are covered by `@mastra/playground-ui`.
- Playground E2E coverage was added for unsupported capabilities not probing metrics/discovery endpoints, but it was not run because the package E2E setup requires a full app build/server.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a way for applications to ask their storage system "what can you do?" without having to probe it directly. Instead of trying different operations to see what works, the app can now get a clear list of supported features (like metrics, logs, and tracing) and whether the storage keeps data permanently or just in memory.

## Overview

This PR implements the observability storage capabilities inspection API referenced in PF-268 and GitHub issue `#73`. It introduces a `getCapabilities()` method across the observability storage domain to explicitly report supported features (tracing strategies, logs, metrics, scores, feedback) and persistence characteristics (memory vs persistent vs unknown), then exposes this capability information through the GET `/system/packages` API response. The Studio UI now uses these capabilities to gate metrics/discovery queries instead of probing the storage directly.

## Core Changes

**Observability Storage Capabilities API**
- Added `ObservabilityStorage.getCapabilities()` returning an `ObservabilityStorageCapabilities` object with conservative defaults (logs/metrics marked as unsupported, persistence set to `'unknown'`)
- Introduced supporting types: `ObservabilityCapabilitySupport` (boolean | 'unknown'), `ObservabilityStoragePersistence` ('memory' | 'persistent' | 'unknown')
- Each capability includes nested flags for `persist`, `list`, and domain-specific features (e.g., `aggregate`, `breakdown`, `timeSeries`, `percentiles`, `discovery` for metrics)

**Storage Implementations**
- `ObservabilityInMemory`: Reports full in-memory persistence and enabled capabilities for logs, metrics, scores, and feedback
- `ObservabilityStorageDuckDB`: Declares ephemeral (`:memory:`) vs persistent (file-backed) modes; reports `persistence: 'memory'` for in-memory, `'persistent'` for file-backed
- `ObservabilityStorageClickhouseVNext`: Reports persistent capabilities across all domains with insert-only tracing strategy

**API Exposure**
- Server handler (`/system/packages`) now safely inspects storage for `getCapabilities()` and includes the result in responses when available
- Client SDK route types updated with optional `observabilityStorageCapabilities` field
- Includes validation against `observabilityStorageCapabilitiesSchema` with graceful fallback if inspection fails or returns invalid data

**Playground UI Gating**
- Updated metrics page to compute `supportsMetricsDashboard` by checking all required capability flags rather than just storage type
- Modified hooks (`useAgentRunsKpiMetrics`, `useTags`, `useEntityNames`, `useServiceNames`, `useEnvironments`) to accept optional `enabled` flag (defaults to `true`)
- Metrics queries are now disabled while packages are loading or when storage capabilities are unsupported
- Consolidated error handling to avoid separate probe queries for availability detection

**DuckDB Maintenance**
- Added `isEphemeral` getter to `DuckDBConnection` to identify `:memory:` configurations
- Removed duplicate `METRIC_DISTINCT_COLUMNS` import that caused typecheck/build failures
- Introduced shared constants (`DUCKDB_OBSERVABILITY_STRATEGY`, `DUCKDB_UNAVAILABLE_OBSERVABILITY_CAPABILITIES`) for fallback behavior

## Testing

- Unit tests added for base `ObservabilityStorage` default capabilities
- `ObservabilityInMemory` capability reporting validated
- `ObservabilityStorageDuckDB` tests cover both ephemeral and persistent modes, lazy initialization with delta polling, and recovery after compatibility failures
- `ObservabilityStorageClickhouseVNext` integration test validates persistent capability reporting
- Server handler tests verify capability exposure, schema validation, and error handling
- Playground E2E test validates that metrics endpoints are not probed when capabilities are unsupported

## Documentation

- Updated metrics overview documentation to clarify that Studio checks storage capabilities before requesting metrics and shows "unsupported-storage" state instead of probe queries

## Breaking Changes

None. The `observabilityStorageCapabilities` field in API responses and types is optional; existing clients and storage implementations without the method continue to work with default/absent capability data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->