### PR TITLE
[PF-267] Add PostHog log-event exporter support

### DIFF
--- a/.changeset/sixty-glasses-beam.md
+++ b/.changeset/sixty-glasses-beam.md
@@ -1,0 +1,31 @@
+---
+'@mastra/posthog': minor
+---
+
+Export Mastra operational logs to PostHog for unified observability. Log export is disabled by default so existing tracing setups do not start sending new events unless users opt in.
+
+Enable log export with defaults:
+
+```ts
+new PosthogExporter({
+  apiKey: process.env.POSTHOG_API_KEY,
+  logs: true,
+});
+```
+
+Customize log export:
+
+```ts
+new PosthogExporter({
+  apiKey: process.env.POSTHOG_API_KEY,
+  logs: {
+    eventName: 'mastra_log',
+    minLevel: 'warn',
+    distinctId: event => event.log.correlationContext?.userId,
+    captureExceptions: true,
+    dedupe: true,
+  },
+});
+```
+
+Log events include trace/span correlation, user/session identifiers, structured log data, and optional Error Tracking fanout for error and fatal logs. Privacy mode redacts freeform log fields while preserving structural correlation properties.

--- a/.changeset/sixty-glasses-beam.md
+++ b/.changeset/sixty-glasses-beam.md
@@ -2,7 +2,8 @@
 '@mastra/posthog': minor
 ---
 
-Export Mastra operational logs to PostHog for unified observability. Log export is disabled by default so existing tracing setups do not start sending new events unless users opt in.
+Added optional PostHog export for Mastra operational logs.
+Log export is off by default, so existing tracing setups do not send new events until you opt in.
 
 Enable log export with defaults:
 
@@ -28,4 +29,6 @@ new PosthogExporter({
 });
 ```
 
-Log events include trace/span correlation, user/session identifiers, structured log data, and optional Error Tracking fanout for error and fatal logs. Privacy mode redacts freeform log fields while preserving structural correlation properties.
+Added `mastra_log` events with trace and span links, user and session identifiers, and structured log fields.
+Use `eventName`, `minLevel`, `distinctId`, `captureExceptions`, and `dedupe` to customize export behavior.
+Privacy mode redacts message and custom payload fields while preserving correlation fields.

--- a/observability/posthog/README.md
+++ b/observability/posthog/README.md
@@ -73,10 +73,59 @@ const mastra = new Mastra({
 - **Privacy mode**: Optional exclusion of input/output data for sensitive applications
 - **Serverless optimized**: Auto-configures batching for serverless environments
 
+### Log Events
+
+Mastra operational logs can also be exported to PostHog. Log export is disabled by default so existing tracing setups do not start sending new events unless you opt in:
+
+```typescript
+new PosthogExporter({
+  apiKey: process.env.POSTHOG_API_KEY,
+  logs: true,
+});
+```
+
+By default, enabled log export sends `info` and higher events as `mastra_log` with generic Mastra properties such as:
+
+- `mastra_log_id`
+- `mastra_log_level`
+- `mastra_log_message`
+- `mastra_log_data`
+- `mastra_log_metadata`
+- `mastra_log_tags`
+- `$ai_trace_id`
+- `$ai_span_id`
+- `$ai_session_id`
+- `mastra_resource_id`
+- `mastra_run_id`
+- `mastra_thread_id`
+- `mastra_request_id`
+- `service_name`
+- `environment`
+
+You can customize the event name, minimum level, distinct ID selection, duplicate handling, and Error Tracking fanout:
+
+```typescript
+new PosthogExporter({
+  apiKey: process.env.POSTHOG_API_KEY,
+  logs: {
+    eventName: 'mastra_log',
+    minLevel: 'warn',
+    distinctId: event => event.log.correlationContext?.userId,
+    captureExceptions: true,
+    dedupe: true,
+  },
+});
+```
+
+When `captureExceptions` is enabled, `error` and `fatal` logs with an embedded error in `data.error`, `data.err`, `data.exception`, or `metadata.error` are also sent to PostHog Error Tracking through the immediate exception capture path.
+
+When `enablePrivacyMode` is enabled, log export redacts `mastra_log_message` and omits freeform `data`, `metadata`, and `tags` fields. Duplicate handling is per exporter instance and drops repeated `logId` values from the in-memory dedupe cache.
+
 ### Supported Event Types
 
 - `$ai_generation`: LLM model calls (MODEL_GENERATION, MODEL_STEP)
 - `$ai_span`: Operations like tool calls, workflows, and streaming chunks
+- `mastra_log`: Mastra operational log events when `logs` is enabled
 - Hierarchical traces with parent-child relationships via `$ai_parent_id`
 - Session grouping with `$ai_session_id`
 
@@ -114,6 +163,13 @@ new PosthogExporter({
 
   // Optional: Privacy
   enablePrivacyMode: false, // Set to true to exclude input/output from LLM events
+
+  // Optional: Log export
+  logs: {
+    eventName: 'mastra_log',
+    minLevel: 'info',
+    captureExceptions: false,
+  },
 });
 ```
 
@@ -141,7 +197,7 @@ new PosthogExporter({
 });
 ```
 
-Note: Privacy mode only applies to `$ai_generation` events. Span events (tool calls, etc.) still include input/output state.
+Note: Privacy mode redacts `$ai_generation` payloads and log-event freeform fields. Span events (tool calls, etc.) still include input/output state.
 
 ## Metadata
 

--- a/observability/posthog/src/tracing.test.ts
+++ b/observability/posthog/src/tracing.test.ts
@@ -1,4 +1,4 @@
-import type { AnyExportedSpan } from '@mastra/core/observability';
+import type { AnyExportedSpan, LogEvent } from '@mastra/core/observability';
 import { SpanType, TracingEventType } from '@mastra/core/observability';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
@@ -7,6 +7,7 @@ import { PosthogExporter } from './tracing';
 
 // Mock PostHog client
 const mockCapture = vi.fn();
+const mockCaptureExceptionImmediate = vi.fn();
 const mockShutdown = vi.fn();
 const mockPostHogConstructor = vi.fn();
 
@@ -17,6 +18,7 @@ vi.mock('posthog-node', () => {
         mockPostHogConstructor(...args);
       }
       capture = mockCapture;
+      captureExceptionImmediate = mockCaptureExceptionImmediate;
       shutdown = mockShutdown;
     },
   };
@@ -236,6 +238,174 @@ describe('PosthogExporter', () => {
       expect(mockCapture).toHaveBeenCalledWith(
         expect.objectContaining({
           distinctId: 'system',
+        }),
+      );
+    });
+  });
+
+  // --- Log Event Tests ---
+  describe('Log Events', () => {
+    function createLogEvent(overrides: Partial<LogEvent['log']> = {}): LogEvent {
+      return {
+        type: 'log',
+        log: {
+          logId: 'log-1',
+          timestamp: new Date('2026-05-01T00:00:00.000Z'),
+          level: 'info',
+          message: 'Operation completed',
+          traceId: 'trace-1',
+          spanId: 'span-1',
+          correlationContext: {
+            userId: 'user-1',
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            runId: 'run-1',
+            threadId: 'thread-1',
+            requestId: 'request-1',
+            serviceName: 'test-service',
+            environment: 'test',
+            tags: ['log-tag'],
+          },
+          data: { durationMs: 42 },
+          metadata: { source: 'test' },
+          ...overrides,
+        },
+      };
+    }
+
+    it('should capture enabled log events with generic Mastra properties', async () => {
+      exporter = new TestPosthogExporter({ ...validConfig, logs: true });
+
+      await exporter.onLogEvent(createLogEvent());
+
+      expect(mockCapture).toHaveBeenCalledWith({
+        distinctId: 'user-1',
+        event: 'mastra_log',
+        timestamp: new Date('2026-05-01T00:00:00.000Z'),
+        uuid: 'log-1',
+        properties: expect.objectContaining({
+          mastra_signal: 'log',
+          mastra_log_id: 'log-1',
+          mastra_log_level: 'info',
+          mastra_log_message: 'Operation completed',
+          mastra_log_data: { durationMs: 42 },
+          mastra_log_metadata: { source: 'test' },
+          mastra_log_tags: ['log-tag'],
+          $ai_trace_id: 'trace-1',
+          $ai_span_id: 'span-1',
+          $ai_session_id: 'session-1',
+          mastra_resource_id: 'resource-1',
+          mastra_run_id: 'run-1',
+          mastra_thread_id: 'thread-1',
+          mastra_request_id: 'request-1',
+          service_name: 'test-service',
+          environment: 'test',
+        }),
+      });
+    });
+
+    it('should skip log events when logs are disabled', async () => {
+      exporter = new TestPosthogExporter(validConfig);
+
+      await exporter.onLogEvent(createLogEvent());
+
+      expect(mockCapture).not.toHaveBeenCalled();
+    });
+
+    it('should respect the configured minimum log level and event name', async () => {
+      exporter = new TestPosthogExporter({ ...validConfig, logs: { eventName: 'mastra_warning', minLevel: 'warn' } });
+
+      await exporter.onLogEvent(createLogEvent({ logId: 'log-debug', level: 'debug' }));
+      await exporter.onLogEvent(createLogEvent({ logId: 'log-warn', level: 'warn' }));
+
+      expect(mockCapture).toHaveBeenCalledTimes(1);
+      expect(mockCapture).toHaveBeenCalledWith(expect.objectContaining({ event: 'mastra_warning', uuid: 'log-warn' }));
+    });
+
+    it('should dedupe repeated log IDs by default', async () => {
+      exporter = new TestPosthogExporter({ ...validConfig, logs: true });
+      const event = createLogEvent();
+
+      await exporter.onLogEvent(event);
+      await exporter.onLogEvent(event);
+
+      expect(mockCapture).toHaveBeenCalledTimes(1);
+    });
+
+    it('should use configured log distinct ID resolver before correlation context', async () => {
+      exporter = new TestPosthogExporter({
+        ...validConfig,
+        logs: {
+          distinctId: event => `tenant:${event.log.correlationContext?.organizationId}`,
+        },
+      });
+
+      await exporter.onLogEvent(createLogEvent({ correlationContext: { organizationId: 'org-1', userId: 'user-1' } }));
+
+      expect(mockCapture).toHaveBeenCalledWith(expect.objectContaining({ distinctId: 'tenant:org-1' }));
+    });
+
+    it('should prefer canonical correlation user ID over metadata user ID', async () => {
+      exporter = new TestPosthogExporter({ ...validConfig, logs: true });
+
+      await exporter.onLogEvent(
+        createLogEvent({
+          metadata: { userId: 'metadata-user' },
+          correlationContext: { userId: 'correlation-user' },
+        }),
+      );
+
+      expect(mockCapture).toHaveBeenCalledWith(expect.objectContaining({ distinctId: 'correlation-user' }));
+    });
+
+    it('should fall back to configured default distinct ID for logs without user identity', async () => {
+      exporter = new TestPosthogExporter({ ...validConfig, defaultDistinctId: 'system', logs: true });
+
+      await exporter.onLogEvent(createLogEvent({ correlationContext: undefined, metadata: undefined }));
+
+      expect(mockCapture).toHaveBeenCalledWith(expect.objectContaining({ distinctId: 'system' }));
+    });
+
+    it('should redact freeform log payload fields when privacy mode is enabled', async () => {
+      exporter = new TestPosthogExporter({ ...validConfig, enablePrivacyMode: true, logs: true });
+
+      await exporter.onLogEvent(createLogEvent({ data: { prompt: 'secret' }, metadata: { source: 'test' } }));
+
+      const properties = mockCapture.mock.calls[0][0].properties;
+      expect(properties).toMatchObject({
+        mastra_log_message: '[redacted]',
+        mastra_log_id: 'log-1',
+        $ai_trace_id: 'trace-1',
+      });
+      expect(properties).not.toHaveProperty('mastra_log_data');
+      expect(properties).not.toHaveProperty('mastra_log_metadata');
+      expect(properties).not.toHaveProperty('mastra_log_tags');
+    });
+
+    it('should clear log dedupe state on shutdown', async () => {
+      exporter = new TestPosthogExporter({ ...validConfig, logs: true });
+      const event = createLogEvent();
+
+      await exporter.onLogEvent(event);
+      await exporter.shutdown();
+      await exporter.onLogEvent(event);
+
+      expect(mockCapture).toHaveBeenCalledTimes(2);
+    });
+
+    it('should fan out error logs with embedded errors to PostHog Error Tracking when enabled', async () => {
+      exporter = new TestPosthogExporter({ ...validConfig, logs: { captureExceptions: true } });
+      const error = new Error('database failed');
+
+      await exporter.onLogEvent(createLogEvent({ level: 'error', data: { error } }));
+
+      expect(mockCapture).toHaveBeenCalledTimes(1);
+      expect(mockCaptureExceptionImmediate).toHaveBeenCalledWith(
+        error,
+        'user-1',
+        expect.objectContaining({
+          mastra_log_id: 'log-1',
+          mastra_log_level: 'error',
         }),
       );
     });

--- a/observability/posthog/src/tracing.ts
+++ b/observability/posthog/src/tracing.ts
@@ -1,4 +1,11 @@
-import type { AnyExportedSpan, ModelGenerationAttributes, SpanErrorInfo, UsageStats } from '@mastra/core/observability';
+import type {
+  AnyExportedSpan,
+  LogEvent,
+  LogLevel,
+  ModelGenerationAttributes,
+  SpanErrorInfo,
+  UsageStats,
+} from '@mastra/core/observability';
 import { SpanType } from '@mastra/core/observability';
 import type { TraceData, TrackingExporterConfig } from '@mastra/observability';
 import { TrackingExporter } from '@mastra/observability';
@@ -75,6 +82,37 @@ interface MastraContent {
 type SpanData = string | MastraMessage[] | Record<string, unknown> | unknown;
 
 const DISTINCT_ID = 'distinctId';
+const DEFAULT_LOG_EVENT_NAME = 'mastra_log';
+const DEFAULT_LOG_DEDUPE_CACHE_SIZE = 10_000;
+const LOG_LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+  fatal: 50,
+};
+
+export type PostHogLogDistinctIdResolver = (event: LogEvent) => string | undefined;
+
+export interface PostHogLogExportOptions {
+  /** PostHog event name used for Mastra operational logs. Defaults to `mastra_log`. */
+  eventName?: string;
+  /** Minimum log level to export. Defaults to `info`. */
+  minLevel?: LogLevel;
+  /** Static or dynamic distinct ID override for log events. */
+  distinctId?: string | PostHogLogDistinctIdResolver;
+  /** Whether to fan out error/fatal log events with embedded errors to PostHog Error Tracking. */
+  captureExceptions?: boolean;
+  /** Whether to drop duplicate log IDs within this exporter instance. Defaults to true. */
+  dedupe?: boolean;
+  /** Maximum remembered log IDs when dedupe is enabled. Defaults to 10000. */
+  dedupeCacheSize?: number;
+}
+
+type ResolvedPostHogLogExportOptions = Required<
+  Pick<PostHogLogExportOptions, 'eventName' | 'minLevel' | 'dedupe' | 'dedupeCacheSize' | 'captureExceptions'>
+> &
+  Pick<PostHogLogExportOptions, 'distinctId'>;
 
 export interface PosthogExporterConfig extends TrackingExporterConfig {
   /** PostHog API key. Defaults to POSTHOG_API_KEY environment variable. */
@@ -86,6 +124,8 @@ export interface PosthogExporterConfig extends TrackingExporterConfig {
   serverless?: boolean;
   defaultDistinctId?: string;
   enablePrivacyMode?: boolean;
+  /** Enable generic Mastra log-event export to PostHog. Disabled by default. */
+  logs?: boolean | PostHogLogExportOptions;
 }
 
 type PosthogRoot = unknown;
@@ -105,6 +145,7 @@ export class PosthogExporter extends TrackingExporter<
 > {
   name = 'posthog';
   #client: PostHog | undefined;
+  #seenLogIds = new Set<string>();
 
   private static readonly SERVERLESS_FLUSH_AT = 10;
   private static readonly SERVERLESS_FLUSH_INTERVAL = 2000;
@@ -230,6 +271,35 @@ export class PosthogExporter extends TrackingExporter<
     this.#client?.capture(eventMessage);
   }
 
+  async onLogEvent(event: LogEvent): Promise<void> {
+    const logOptions = this.getLogOptions();
+    if (this.isDisabled || !logOptions || !this.#client) return;
+
+    const { log } = event;
+    if (!this.shouldExportLog(log.level, logOptions.minLevel)) return;
+    if (logOptions.dedupe !== false && this.hasSeenLogId(log.logId, logOptions.dedupeCacheSize)) return;
+
+    const distinctId = this.getLogDistinctId(event, logOptions);
+    const properties = this.buildLogEventProperties(event);
+
+    this.#client.capture({
+      distinctId,
+      event: logOptions.eventName,
+      properties,
+      timestamp: log.timestamp,
+      uuid: log.logId,
+    });
+
+    if (logOptions.captureExceptions && this.shouldCaptureLogException(log.level)) {
+      const error = this.getLogError(log.data, log.metadata);
+      if (error) {
+        // Await the immediate Error Tracking path so request/serverless drains
+        // do not flush the log event before the derived exception is enqueued.
+        await this.#client.captureExceptionImmediate(error, distinctId, properties);
+      }
+    }
+  }
+
   private buildEventMessage(args: { span: AnyExportedSpan; traceData: PosthogTraceData }): EventMessage {
     const { span, traceData } = args;
 
@@ -349,6 +419,115 @@ export class PosthogExporter extends TrackingExporter<
     }
 
     return 'anonymous';
+  }
+
+  private getLogOptions(): ResolvedPostHogLogExportOptions | undefined {
+    const logs = this.config.logs;
+    if (!logs) return undefined;
+    const options = logs === true ? {} : logs;
+
+    return {
+      eventName: options.eventName ?? DEFAULT_LOG_EVENT_NAME,
+      minLevel: options.minLevel ?? 'info',
+      distinctId: options.distinctId,
+      captureExceptions: options.captureExceptions ?? false,
+      dedupe: options.dedupe ?? true,
+      dedupeCacheSize: options.dedupeCacheSize ?? DEFAULT_LOG_DEDUPE_CACHE_SIZE,
+    };
+  }
+
+  private shouldExportLog(level: LogLevel, minLevel: LogLevel): boolean {
+    return LOG_LEVEL_ORDER[level] >= LOG_LEVEL_ORDER[minLevel];
+  }
+
+  private hasSeenLogId(logId: string, cacheSize: number): boolean {
+    if (this.#seenLogIds.has(logId)) return true;
+
+    this.#seenLogIds.add(logId);
+    if (this.#seenLogIds.size > cacheSize) {
+      const first = this.#seenLogIds.values().next().value;
+      if (first) {
+        this.#seenLogIds.delete(first);
+      }
+    }
+
+    return false;
+  }
+
+  private getLogDistinctId(event: LogEvent, options: Pick<PostHogLogExportOptions, 'distinctId'>): string {
+    if (typeof options.distinctId === 'string') return options.distinctId;
+
+    const resolved = options.distinctId?.(event);
+    if (resolved) return resolved;
+
+    const correlationUserId = event.log.correlationContext?.userId;
+    if (correlationUserId) return correlationUserId;
+
+    const metadataUserId = event.log.metadata?.userId;
+    if (typeof metadataUserId === 'string' && metadataUserId.length > 0) return metadataUserId;
+
+    return this.config.defaultDistinctId ?? 'anonymous';
+  }
+
+  private buildLogEventProperties(event: LogEvent): Record<string, unknown> {
+    const { log } = event;
+    const properties: Record<string, unknown> = {
+      mastra_signal: 'log',
+      mastra_log_id: log.logId,
+      mastra_log_level: log.level,
+      mastra_log_message: this.config.enablePrivacyMode ? '[redacted]' : log.message,
+    };
+
+    if (log.traceId) properties.$ai_trace_id = log.traceId;
+    if (log.spanId) properties.$ai_span_id = log.spanId;
+    if (!this.config.enablePrivacyMode) {
+      const tags = log.correlationContext?.tags ?? log.tags;
+      if (this.hasObjectEntries(log.data)) properties.mastra_log_data = log.data;
+      if (this.hasObjectEntries(log.metadata)) properties.mastra_log_metadata = log.metadata;
+      if (tags?.length) properties.mastra_log_tags = tags;
+    }
+    if (log.correlationContext) {
+      if (log.correlationContext.sessionId) properties.$ai_session_id = log.correlationContext.sessionId;
+      if (log.correlationContext.resourceId) properties.mastra_resource_id = log.correlationContext.resourceId;
+      if (log.correlationContext.runId) properties.mastra_run_id = log.correlationContext.runId;
+      if (log.correlationContext.threadId) properties.mastra_thread_id = log.correlationContext.threadId;
+      if (log.correlationContext.requestId) properties.mastra_request_id = log.correlationContext.requestId;
+      if (log.correlationContext.serviceName) properties.service_name = log.correlationContext.serviceName;
+      if (log.correlationContext.environment) properties.environment = log.correlationContext.environment;
+    }
+
+    return properties;
+  }
+
+  private hasObjectEntries(value?: Record<string, unknown>): boolean {
+    return !!value && Object.keys(value).length > 0;
+  }
+
+  private shouldCaptureLogException(level: LogLevel): boolean {
+    return level === 'error' || level === 'fatal';
+  }
+
+  private getLogError(data?: Record<string, unknown>, metadata?: Record<string, unknown>): Error | undefined {
+    const error = data?.error ?? data?.err ?? data?.exception ?? metadata?.error;
+    return this.toError(error);
+  }
+
+  private toError(value: unknown): Error | undefined {
+    if (value instanceof Error) return value;
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+
+    const record = value as Record<string, unknown>;
+    const message = typeof record.message === 'string' ? record.message : undefined;
+    if (!message) return undefined;
+
+    const error = new Error(message);
+    if (typeof record.name === 'string') {
+      error.name = record.name;
+    }
+    if (typeof record.stack === 'string') {
+      error.stack = record.stack;
+    }
+    return error;
   }
 
   /**
@@ -571,6 +750,7 @@ export class PosthogExporter extends TrackingExporter<
   }
 
   override async _postShutdown(): Promise<void> {
+    this.#seenLogIds.clear();
     if (this.#client) {
       await this.#client.shutdown();
     }


### PR DESCRIPTION
## Summary

- adds optional `logs` support to `PosthogExporter` for Mastra `LogEvent` signals
- exports generic `mastra_log` events with trace/span, session, resource, run, request, service, environment, tags, data, and metadata properties
- supports event name customization, minimum log level filtering, distinct ID overrides, per-instance `logId` dedupe, privacy-mode redaction, and optional Error Tracking fanout for error/fatal logs
- documents the public API and adds a changeset for `@mastra/posthog`

## Issue / Coordination

- PF-267 / GitHub issue: https://github.com/mbenhamd/mastra/issues/72
- Linear MCP is currently returning `auth_revoked` in this environment, so GitHub issue #72 is the active fallback coordination surface.
- Open PR overlap check: #177 / PF-147 touches `packages/core/src/harness/**` and its changeset. This PR touches only `observability/posthog/**` plus a changeset, so it can proceed independently.
- Upstream sync note: `origin/main` and this branch are based on `b6beb5e006379505f37f2294be3d7cd580782967`; `upstream/main` is newer at `59b20e759fa039370f7e1859b9e06726fe143cc3`. I kept this feature PR scoped and did not mix an upstream sync into it.

## Validation

- `pnpm -C /tmp/mbenhamd-mastra-pf-267 --filter @mastra/posthog test` passed: 73 tests / 3 files
- `pnpm -C /tmp/mbenhamd-mastra-pf-267 --filter @mastra/posthog lint` passed
- `pnpm -C /tmp/mbenhamd-mastra-pf-267 --filter @mastra/posthog build` passed
- `pnpm -C /tmp/mbenhamd-mastra-pf-267 --filter @mastra/posthog exec tsc -p tsconfig.build.json --noEmit` passed
- `pnpm -C /tmp/mbenhamd-mastra-pf-267 --filter @mastra/posthog exec tsc -p tsconfig.json --noEmit` passed
- `pnpm -C /tmp/mbenhamd-mastra-pf-267 prettier:changed` passed
- `git -C /tmp/mbenhamd-mastra-pf-267 diff --check` passed

## Review Evidence

- Codex review pass 1 found a valid reliability issue with queued PostHog exception capture; fixed by awaiting `captureExceptionImmediate` for the optional Error Tracking fanout.
- Claude review found privacy/identity/shutdown/docs issues; fixed by honoring `enablePrivacyMode`, preferring canonical correlation identity, clearing log dedupe state on shutdown, and documenting exported fields.
- Codex final review found canonical `correlationContext.tags` and README privacy-note issues; fixed before push.
- Agy review command exited successfully but returned no printed findings.
- CodeRabbit CLI `coderabbit doctor` passed authentication/readiness.
- CodeRabbit CLI `coderabbit review --plain` initially found the changeset too thin; fixed.
- CodeRabbit CLI rerun reported no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This change lets Mastra optionally send its runtime logs to PostHog so you can see operational log events alongside other observability data. It's opt-in, respects privacy mode, and can optionally dedupe and forward errors to PostHog Error Tracking.

---

## Overview

Adds optional PostHog log-event exporting to the PosthogExporter, emitting generic mastra_log events with structured Mastra properties and trace/span/session correlation. Log export is disabled by default and must be enabled via the exporter config (logs: true or a detailed options object).

## Key Features

- Configurable log export via PosthogExporter.logs (boolean or PostHogLogExportOptions)
- Default event name: mastra_log; customizable via eventName
- Minimum log level filtering (minLevel, defaults to info)
- Per-exporter in-memory deduplication by logId (dedupe true by default, configurable dedupeCacheSize)
- distinctId resolution: static string, callback (PostHogLogDistinctIdResolver), correlationContext/userId, or defaultDistinctId fallback
- Privacy mode: honors enablePrivacyMode to redact mastra_log_message and omit freeform data/metadata/tags while keeping correlation fields
- Optional Error Tracking fanout: captureExceptions forwards embedded Error objects to PostHog via captureExceptionImmediate and awaits it to avoid flush races
- Deduplication state cleared on shutdown

## Exported/Public API Changes

- Added exported type: PostHogLogDistinctIdResolver
- Added exported interface: PostHogLogExportOptions
- PosthogExporterConfig now includes logs?: boolean | PostHogLogExportOptions

## Implementation Notes

- New onLogEvent handler implements filtering, dedupe cache, distinctId resolution, property shaping (trace/span/session, resource/run/request/service/environment, tags, data, metadata), privacy redaction, and optional error extraction.
- Deduplication uses an in-instance Set with configurable max size (default 10000).
- captureExceptionImmediate is awaited when used to ensure Error Tracking requests are not dropped on shutdown/flush.
- Minor refactors to imports and helper constants/types added to observability/posthog/src/tracing.ts.

## Tests & Validation

- Tests added/updated in observability/posthog/src/tracing.test.ts covering:
  - mastra_log emission and properties
  - enabled/disabled behavior
  - minLevel filtering and custom eventName
  - deduplication and dedupe state cleared on shutdown
  - distinctId resolution precedence and default fallback
  - privacy mode redaction of freeform fields
  - Error Tracking fanout via captureExceptionImmediate
- README updated with usage examples, property list, configuration options, privacy-mode behavior, and supported event types.
- Changeset added for `@mastra/posthog`.
- Contributor reports running tests, lint, build, TypeScript checks, prettier, and diff checks for `@mastra/posthog` (all passed). Reviewed feedback addressed (awaiting captureExceptionImmediate, privacy-mode handling, canonical correlation identity, dedupe cleanup, field docs).

## Coordination

- Linked to PF-267 and GitHub issue `#72` for coordination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->