### PR TITLE
[PF-268] Fix observability capability review feedback

### DIFF
--- a/.changeset/fair-buckets-duckdb.md
+++ b/.changeset/fair-buckets-duckdb.md
@@ -1,0 +1,7 @@
+---
+'@mastra/duckdb': patch
+---
+
+Fixed DuckDB observability capability reporting before initialization.
+
+Studio now waits for DuckDB observability storage to be ready before enabling metrics queries.

--- a/.changeset/fair-buckets-duckdb.md
+++ b/.changeset/fair-buckets-duckdb.md
@@ -2,6 +2,6 @@
 '@mastra/duckdb': patch
 ---
 
-Fixed DuckDB observability capability reporting before initialization.
+Fixed DuckDB observability capability reporting.
 
-Studio now waits for DuckDB observability storage to be ready before enabling metrics queries.
+Studio now shows only available observability features when using DuckDB storage.

--- a/.changeset/fair-buckets-system.md
+++ b/.changeset/fair-buckets-system.md
@@ -4,4 +4,4 @@
 
 Fixed observability capability reporting for custom storage classes.
 
-Studio can now show storage-backed observability features accurately when a storage adapter extends another implementation.
+Studio now correctly shows storage-backed observability features for custom storage classes.

--- a/.changeset/fair-buckets-system.md
+++ b/.changeset/fair-buckets-system.md
@@ -1,0 +1,7 @@
+---
+'@mastra/server': patch
+---
+
+Fixed observability capability reporting for custom storage classes.
+
+Studio can now show storage-backed observability features accurately when a storage adapter extends another implementation.

--- a/packages/server/src/server/handlers/system.test.ts
+++ b/packages/server/src/server/handlers/system.test.ts
@@ -1,6 +1,7 @@
 import { writeFileSync, unlinkSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { ObservabilityStorage } from '@mastra/core/storage';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GET_SYSTEM_PACKAGES_ROUTE } from './system';
 
@@ -254,13 +255,7 @@ describe('System Handlers', () => {
     });
 
     it('should omit inherited base observability storage capabilities', async () => {
-      class BaseObservabilityStorage {
-        getCapabilities() {
-          return mockObservabilityStorageCapabilities;
-        }
-      }
-
-      class LegacyObservabilityStorage extends BaseObservabilityStorage {
+      class LegacyObservabilityStorage extends ObservabilityStorage {
         runtimeTracingStrategy = 'realtime';
       }
 
@@ -281,6 +276,38 @@ describe('System Handlers', () => {
         storageType: 'mock-storage',
         observabilityStorageType: 'LegacyObservabilityStorage',
         observabilityRuntimeStrategy: 'realtime',
+      });
+    });
+
+    it('should return inherited explicit observability storage capabilities', async () => {
+      class SupportedObservabilityStorage extends ObservabilityStorage {
+        getCapabilities() {
+          return mockObservabilityStorageCapabilities;
+        }
+      }
+
+      class WrappedObservabilityStorage extends SupportedObservabilityStorage {
+        runtimeTracingStrategy = 'realtime';
+      }
+
+      const result = await GET_SYSTEM_PACKAGES_ROUTE.handler({
+        mastra: createMockMastra(false, {
+          name: 'mock-storage',
+          stores: {
+            observability: new WrappedObservabilityStorage(),
+          },
+        }),
+      } as any);
+
+      expect(result).toEqual({
+        packages: [],
+        isDev: false,
+        cmsEnabled: false,
+        observabilityEnabled: false,
+        storageType: 'mock-storage',
+        observabilityStorageType: 'WrappedObservabilityStorage',
+        observabilityRuntimeStrategy: 'realtime',
+        observabilityStorageCapabilities: mockObservabilityStorageCapabilities,
       });
     });
 

--- a/packages/server/src/server/handlers/system.ts
+++ b/packages/server/src/server/handlers/system.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from 'node:fs';
 
+import { ObservabilityStorage } from '@mastra/core/storage';
+
 import type { MastraPackage, SystemPackagesResponse } from '../schemas/system';
 import {
   apiSchemaManifestResponseSchema,
@@ -33,11 +35,13 @@ function getObservabilityStorageCapabilities(
     return undefined;
   }
 
-  const prototype = Object.getPrototypeOf(candidate);
-  const hasExplicitCapabilities =
-    Object.prototype.hasOwnProperty.call(candidate, 'getCapabilities') ||
-    (prototype && Object.prototype.hasOwnProperty.call(prototype, 'getCapabilities'));
-  if (!hasExplicitCapabilities) {
+  let owner = Object.prototype.hasOwnProperty.call(candidate, 'getCapabilities')
+    ? candidate
+    : Object.getPrototypeOf(candidate);
+  while (owner && owner !== Object.prototype && !Object.prototype.hasOwnProperty.call(owner, 'getCapabilities')) {
+    owner = Object.getPrototypeOf(owner);
+  }
+  if (!owner || owner === Object.prototype || owner === ObservabilityStorage.prototype) {
     return undefined;
   }
 

--- a/stores/duckdb/src/storage/domains/observability/index.test.ts
+++ b/stores/duckdb/src/storage/domains/observability/index.test.ts
@@ -211,7 +211,7 @@ describe('ObservabilityStorageDuckDB', () => {
     }
   });
 
-  it('reports delta list capabilities through the lazy store facade before init', async () => {
+  it('reports delta list feature support but conservative capabilities through the lazy store facade before init', async () => {
     const originalFeatures = new Set(coreFeatures);
     const lazyStore = new DuckDBStore({ path: ':memory:' });
 
@@ -221,15 +221,15 @@ describe('ObservabilityStorageDuckDB', () => {
       expect(lazyStore.observability.getFeatures()).toEqual(['delta-polling']);
       expect(lazyStore.observability.getCapabilities()).toMatchObject({
         metrics: {
-          persist: true,
-          list: true,
-          aggregate: true,
-          breakdown: true,
-          timeSeries: true,
-          percentiles: true,
-          discovery: true,
+          persist: false,
+          list: false,
+          aggregate: false,
+          breakdown: false,
+          timeSeries: false,
+          percentiles: false,
+          discovery: false,
         },
-        persistence: 'memory',
+        persistence: 'unknown',
       });
     } finally {
       coreFeatures.clear();

--- a/stores/duckdb/src/storage/index.ts
+++ b/stores/duckdb/src/storage/index.ts
@@ -162,52 +162,11 @@ export class ObservabilityStorageDuckDB extends CoreObservabilityStorage {
   }
 
   getCapabilities() {
-    if (this.unavailableError) {
+    if (this.unavailableError || !this.delegate) {
       return DUCKDB_UNAVAILABLE_OBSERVABILITY_CAPABILITIES;
     }
 
-    const runtimeStrategy = this.runtimeTracingStrategy;
-
-    return (
-      this.delegate?.getCapabilities() ?? {
-        tracing: {
-          preferredStrategy: this.observabilityStrategy.preferred,
-          supportedStrategies: this.observabilityStrategy.supported,
-          ...(runtimeStrategy ? { runtimeStrategy } : {}),
-        },
-        logs: {
-          persist: true,
-          list: true,
-        },
-        metrics: {
-          persist: true,
-          list: true,
-          aggregate: true,
-          breakdown: true,
-          timeSeries: true,
-          percentiles: true,
-          discovery: true,
-        },
-        scores: {
-          persist: true,
-          list: true,
-          getById: true,
-          aggregate: true,
-          breakdown: true,
-          timeSeries: true,
-          percentiles: true,
-        },
-        feedback: {
-          persist: true,
-          list: true,
-          aggregate: true,
-          breakdown: true,
-          timeSeries: true,
-          percentiles: true,
-        },
-        persistence: this.db.isEphemeral ? ('memory' as const) : ('persistent' as const),
-      }
-    );
+    return this.delegate.getCapabilities();
   }
 
   async init(...args: Parameters<ObservabilityStoreImpl['init']>): ReturnType<ObservabilityStoreImpl['init']> {


### PR DESCRIPTION
## Summary

Follow-up for merged PR #176 review threads:

- Fixes `/system/packages` capability detection so custom observability storage classes that inherit an explicit `getCapabilities()` implementation report capabilities, while subclasses that only inherit the base `ObservabilityStorage` default remain omitted.
- Makes DuckDB's lazy observability facade report conservative unavailable capabilities until its concrete delegate is initialized, so Studio does not enable metrics queries before DuckDB observability storage is ready.
- Splits release notes into package-specific patch changesets for `@mastra/server` and `@mastra/duckdb`.

Review threads addressed from PR #176:

- https://github.com/mbenhamd/mastra/pull/176#discussion_r3293529290
- https://github.com/mbenhamd/mastra/pull/176#discussion_r3293529291

## Coordination

Linear MCP is currently unavailable in this environment with `auth_revoked`, so I am recording PF-268 follow-up evidence in GitHub until Linear access is restored.

Open PR overlap checked after refreshing remotes:

- #177 `[PF-147] Sync Harness message conversion with signals` — no touched-file overlap.
- #178 `[PF-267] Add PostHog log-event exporter support` — no touched-file overlap.
- #179 `[PF-266] Add Harness subagent processor chains` — no touched-file overlap.

Fork sync checked before opening: `origin/main...upstream/main` is `173 0`, so the fork includes current upstream main and is 0 commits behind.

## Validation

- `pnpm --filter ./packages/server test src/server/handlers/system.test.ts`
- `pnpm --filter ./packages/server check:core-imports`
- `pnpm --filter ./packages/server exec eslint src/server/handlers/system.ts src/server/handlers/system.test.ts`
- `pnpm --filter ./stores/duckdb test src/storage/domains/observability/index.test.ts`
- `pnpm --filter ./stores/duckdb exec eslint src/storage/index.ts src/storage/domains/observability/index.test.ts`
- `pnpm --filter ./stores/duckdb typecheck`
- `pnpm -C /tmp/mbenhamd-mastra-pf-268-review-fixes prettier:changed`
- `git diff --check`
- Local Codex review pass 1: no findings.
- Local Codex review pass 2: changeset split finding fixed; no remaining code/test/changeset findings.
- Agy council: prototype owner check finding fixed by comparing against `ObservabilityStorage.prototype`; DuckDB conservative capability finding accepted.
- Claude council: unavailable/stuck locally; process produced no output and was terminated.
- CodeRabbit CLI structured review after fixes: 0 findings.

Note: `pnpm install --offline` was used in this worktree. Existing ignored built `dist` artifacts were copied from the sibling Mastra worktree to satisfy local package exports for focused tests; no generated build artifacts are committed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

This PR fixes how the system reports which observability (monitoring) features are available for different storage implementations. It stops claiming features are available before the storage is ready and correctly recognizes when a custom storage actually provides its own observability capabilities versus merely inheriting defaults.

## Summary of Changes

### Observability Capability Detection Logic
- packages/server/src/server/handlers/system.ts
  - getObservabilityStorageCapabilities now walks the prototype chain to detect whether getCapabilities is explicitly implemented by a storage class.
  - Returns undefined when getCapabilities isn't found (or when reaching ObservabilityStorage.prototype).
  - Safely parses getCapabilities() results and falls back to undefined on parse errors or exceptions.

### DuckDB Observability Storage
- stores/duckdb/src/storage/index.ts
  - ObservabilityStorageDuckDB.getCapabilities() now returns a conservative DUCKDB_UNAVAILABLE_OBSERVABILITY_CAPABILITIES when the concrete delegate isn't initialized (!this.delegate) or an incompatibility is recorded (this.unavailableError).
  - Once the delegate exists, getCapabilities() forwards to the delegate.
  - Removed previous inline capability-matrix construction that could report capabilities prematurely.

### Tests
- packages/server/src/server/handlers/system.test.ts
  - Tests updated to model inheritance using ObservabilityStorage subclasses.
  - Ensures base-class-inherited defaults are omitted while explicitly implemented getCapabilities() results are returned for wrapped/custom storages.
- stores/duckdb/src/storage/domains/observability/index.test.ts
  - Lazy-facade-before-init test updated to expect conservative unavailable capability reporting (metrics persistence/list/aggregation and discovery false, persistence: "unknown") while still reporting delta-list support where applicable.

### Release Notes
- .changeset/fair-buckets-system.md and .changeset/fair-buckets-duckdb.md
  - Split changes into package-specific patch changesets for `@mastra/server` and `@mastra/duckdb` documenting the capability-reporting fixes and DuckDB conservative reporting behavior.

## Coordination, Validation, and Context
- Addresses review feedback from PR `#176` and associated discussion threads.
- Verified no touched-file overlap with open PRs `#177`, `#178`, `#179`; fork/main synced with upstream/main.
- Validation performed: package tests and ESLint/typecheck for ./packages/server and ./stores/duckdb; prettier & git diff --check; CodeRabbit/Codex reviews with 0 findings.
- Test results: ./packages/server system tests: 14 passed; ./stores/duckdb observability tests: 154 passed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->