### PR TITLE
[GH-61] Clarify signal lifecycle docs

### DIFF
--- a/docs/src/content/en/docs/agents/signals.mdx
+++ b/docs/src/content/en/docs/agents/signals.mdx
@@ -46,6 +46,27 @@ for await (const chunk of subscription.stream) {
 
 When the thread has a running agent stream, the signal becomes new input inside that agent loop. When the thread is idle, Mastra starts a stream with the signal as the first input.
 
+## Signal lifecycle
+
+A signal can start outside the agent loop. The producer can be a user interface, webhook, scheduler, or another runtime component. Pass the event to `sendSignal()` as an `AgentSignalInput`; Mastra then normalizes the signal, generates an id and timestamp when the caller did not provide them, accepts the signal for the targeted thread or run, and returns a `SendAgentSignalResult` that contains the `CreatedAgentSignal`.
+
+After acceptance, delivery depends on the target state and behavior options:
+
+- Same-agent active thread with `deliver`: Mastra queues the signal for the running agent loop.
+- Idle thread with `wake`: Mastra starts a new stream with the signal as the first input.
+- `persist`: Mastra writes the signal to memory and returns a `persisted` promise without starting or interrupting loop execution.
+- `discard`: Mastra ignores the signal for runtime execution.
+
+Processors can also call `sendSignal` from their processor context. Processor-created signals are added to the message list and are emitted as `data-*` stream parts when a stream writer is available.
+
+When persisted, signals are stored as `role: "signal"` messages in memory. A `user-message` signal is converted back to normal user input for the model. Custom signal types are rendered as XML-style user-role context for the model so they do not look like assistant output.
+
+## Producer and policy boundaries
+
+Use signal `contents`, `attributes`, and `metadata` for delivery context, rendering hints, and durable thread history. When custom signal types are rendered as XML-style model context, Mastra validates XML-safe signal and attribute names and escapes the rendered contents and attributes. Mastra does not interpret signal fields as trusted permission or routing decisions. When a signal informs tool availability, approval behavior, workflow branching, or structured output, validate the signal values and enforce the result through [processors](/docs/agents/processors), [workflows](/docs/workflows/control-flow), or dynamic agent configuration.
+
+Regex is appropriate for exact lexical identifiers such as URLs, file extensions, provider ids, tool ids, and UUIDs. Avoid using inline regex as the only mechanism for deciding user intent, required capabilities, grounding requirements, workflow branches, or tool policy.
+
 ## Control signal behavior
 
 By default, Mastra delivers signals to active runs and wakes idle threads. Use `ifActive.behavior` and `ifIdle.behavior` to change that behavior.


### PR DESCRIPTION
## Summary

- clarify the current Agent signal lifecycle after `sendSignal()` acceptance
- document how persisted and processor-created signals appear in runtime/message flows
- add producer/policy boundary guidance so signal metadata is not treated as authorization or routing policy by itself

Refs https://github.com/mbenhamd/mastra/issues/61.

## Coordination

Linear MCP is unavailable in this session with `auth_revoked`, so I recorded the dev1/Codex claim and overlap note on GitHub issue #61 instead.

Open PR overlap checked before work:

- #177 touches Harness message conversion and signal history tests
- #178 touches PostHog observability exporter support
- #179 touches Harness subagent processor chains
- #180 touches server observability capability and DuckDB observability review fixes

This PR only touches `docs/src/content/en/docs/agents/signals.mdx`, so it can proceed independently of those PRs.

## Source evidence

Checked the current fork source for signal behavior:

- `packages/core/src/agent/signals.ts`
- `packages/core/src/agent/types.ts`
- `packages/core/src/agent/thread-stream-runtime.ts`
- `packages/core/src/processors/runner.ts`
- `packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts`
- `packages/core/src/agent/__tests__/agent-signals.test.ts`
- `packages/core/src/processors/sendSignal-integration.test.ts`

Historical Flow Signals / Tool Gate files referenced by the issue are absent from current `main` after the upstream sync, so this PR keeps to current Agent signals docs and does not reintroduce removed implementation lanes.

## Validation

- `/tmp/mbenhamd-mastra/node_modules/.bin/prettier --check docs/src/content/en/docs/agents/signals.mdx`
- `/tmp/mbenhamd-mastra/docs/node_modules/.bin/remark --rc-path /tmp/mbenhamd-mastra/docs/.remarkrc.mjs --no-stdout --frail --quiet --ext mdx /tmp/mbenhamd-mastra-issue-61-runtime-signals/docs/src/content/en/docs/agents/signals.mdx`
- `git -C /tmp/mbenhamd-mastra-issue-61-runtime-signals diff --check`
- Agy review: resolved valid docs accuracy/readability findings
- Codex local review pass 1: resolved valid docs accuracy/readability findings
- Codex local review pass 2: no findings
- CodeRabbit CLI local review: 0 findings

Note: the fresh worktree does not have its own `node_modules`, so targeted checks used the already-installed tooling from `/tmp/mbenhamd-mastra`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds documentation that explains what happens to a signal after you send it to an agent—where it goes, how it gets stored, whether it wakes up the agent or just sits in memory, and important safety guidance about not treating signal data as a trusted source for permissions or routing decisions.

## Overview

Adds two new documentation sections to clarify the signal lifecycle in the Mastra agent framework:

1. **Signal lifecycle** — Documents the complete journey of a signal from `sendSignal()` acceptance through delivery:
   - How Mastra normalizes producer-provided events and assigns IDs/timestamps when not provided
   - Delivery behavior based on thread state and options (`deliver`, `wake`, `persist`, `discard`)
   - How processor-originated signals are added to message lists and emitted as stream parts
   - How persisted signals are stored as `role: "signal"` messages in memory
   - Rendering logic: `user-message` signals convert back to normal user input, while custom signal types render as XML-style context to avoid looking like assistant output

2. **Producer and policy boundaries** — Provides critical guidance on signal field usage:
   - Documents valid use cases: delivery context, rendering hints, and thread history
   - Warns against treating signal fields as trusted permission or routing decisions
   - Recommends validating signal values and enforcing results through processors, workflows, or agent configuration
   - Advises against using regex as the sole mechanism for decision-making on user intent or tool policy

This documentation helps developers understand signal flow mechanics and implement them safely in production applications, preventing security or routing logic errors from misinterpreting signal metadata as authorization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->