### PR TITLE
[PF-364] Cover Harness SSE replay gap recovery

### DIFF
--- a/client-sdks/client-js/src/resources/harness.test.ts
+++ b/client-sdks/client-js/src/resources/harness.test.ts
@@ -622,6 +622,53 @@ describe('Harness Resource', () => {
     secondUnsubscribe();
   });
 
+  it('refreshes the snapshot and clears stale replay cursors after a 412 replay gap', async () => {
+    mockJson({ session: makeSnapshot() });
+    mockJson(
+      {
+        code: 'harness.event_replay_unavailable',
+        message: 'Harness event replay cursor cannot be served',
+        details: { reason: 'stale_epoch' },
+      },
+      { status: 412, statusText: 'Precondition Failed' },
+    );
+    mockJson(makeSnapshot({ state: { refreshed: true }, summary: { lastActivityAt: 42 } }));
+    mockSse([]);
+    const listener = vi.fn();
+    const onReplayGap = vi.fn();
+
+    const session = await client.getHarness().session();
+    const unsubscribe = session.subscribe(listener, {
+      lastEventId: 'harness-v1:epoch-1:7',
+      onReplayGap,
+    });
+    await vi.waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(4));
+
+    expect(onReplayGap).toHaveBeenCalledTimes(1);
+    expect(listener).not.toHaveBeenCalled();
+    expect(session.getState()).toEqual({ refreshed: true });
+    expect(session.lastActivityAt).toBe(42);
+    expect((global.fetch as any).mock.calls[1]).toEqual([
+      'http://localhost:4111/api/harness/default/sessions/session-1/events',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'Last-Event-ID': 'harness-v1:epoch-1:7' }),
+      }),
+    ]);
+    expect((global.fetch as any).mock.calls[2][0]).toBe('http://localhost:4111/api/harness/default/sessions/session-1');
+    const reconnectCall = (global.fetch as any).mock.calls[3];
+    expect(reconnectCall[0]).toBe('http://localhost:4111/api/harness/default/sessions/session-1/events');
+    expect(reconnectCall[1].headers).not.toHaveProperty('Last-Event-ID');
+    unsubscribe();
+
+    mockSse([]);
+    const secondUnsubscribe = session.subscribe(() => {});
+    await vi.waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(5));
+    const nextSubscribeCall = (global.fetch as any).mock.calls[4];
+    expect(nextSubscribeCall[0]).toBe('http://localhost:4111/api/harness/default/sessions/session-1/events');
+    expect(nextSubscribeCall[1].headers).not.toHaveProperty('Last-Event-ID');
+    secondUnsubscribe();
+  });
+
   it('stops reconnecting on non-replay 4xx event stream failures', async () => {
     mockJson({ session: makeSnapshot() });
     mockJson({ code: 'harness.permission_denied', message: 'denied' }, { status: 403, statusText: 'Forbidden' });


### PR DESCRIPTION
## Summary

- add focused client-js regression coverage for Harness SSE replay-gap recovery
- verify a 412 replay-gap response refreshes the session snapshot
- verify the retrying stream and a later public subscription do not reuse the stale `Last-Event-ID`

## Coordination

Linear MCP is still unavailable in this session with `auth_revoked`, so I could not fetch/update PF-334/PF-364 directly. I used the user-provided PF-334/PF-364 scope and recorded evidence in this PR instead.

Open PR overlap checked before work:

- #177 touches Harness message conversion and signal history tests
- #178 touches PostHog observability exporter support
- #179 touches Harness subagent processor chains
- #180 touches observability capability review fixes
- #181 touches Agent signal lifecycle docs

This PR only touches `client-sdks/client-js/src/resources/harness.test.ts`, so it can proceed independently.

## Existing PF-334/PF-364 source evidence

Current `origin/main` already includes:

- `GET /harness/:name/sessions/:sessionId/events`
- durable replay through `getEventReplayState()` and `listEventsAfter()`
- deterministic 412 replay-gap responses
- message and queue result lookup routes
- client-js event subscription and result settlement recovery
- server/client tests for live stream, replay, malformed IDs, 412 gaps, result lookup, failed/expired evidence, resource mismatch, and disconnect cleanup

This PR fills the remaining client coverage for snapshot fallback after the 412 path.

## Validation

- `pnpm --filter @mastra/client-js test:unit src/resources/harness.test.ts` - 29 passed
- `/tmp/mbenhamd-mastra/node_modules/.bin/prettier --check client-sdks/client-js/src/resources/harness.test.ts`
- `git -C /tmp/mbenhamd-mastra-pf-364-sse-replay-client-coverage diff --check`
- CodeRabbit CLI local review: 0 findings
- Codex review pass 1: found stale public cursor coverage gap; fixed
- Codex review pass 2: no findings
- Codex final review after fix: no findings
- Agy review: nitpicks addressed
- Claude review: unavailable/stuck locally; terminated without useful output

No changeset: test-only coverage, no package behavior or public API change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

When a messaging app loses track of where it left off reading messages, it needs to refresh its state instead of using old information. This PR adds a test to verify that the JavaScript client app correctly handles this situation—when the server says "I can't find where you were," it refreshes the session data and stops using the old message position.

---

## Overview

This PR adds focused regression test coverage for client-side Harness SSE replay-gap recovery by introducing a new Vitest case in the harness test file. The test verifies correct client behavior when the event stream returns a 412 response indicating a replay-gap condition (stale epoch).

## Changes

**File Modified:** `client-sdks/client-js/src/resources/harness.test.ts`

**Lines Changed:** +47 / -0

## Test Coverage

The new test case validates the following behavior:
- When `session.subscribe` receives a 412 `harness.event_replay_unavailable` response, the `onReplayGap` callback fires exactly once
- The event listener is not invoked upon receiving the 412 response
- The session state and `lastActivityAt` are updated from the refreshed snapshot
- Subsequent reconnect and subscription requests omit the `Last-Event-ID` header, preventing reuse of stale replay cursors
- Fetch call ordering is correct across initial subscribe and subsequent resubscribe operations

## Review Status

- 29 unit tests passed
- Prettier check passed
- Diff check passed
- CodeRabbit CLI review: 0 findings
- No changeset included (test-only change)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->