### PR TITLE
[PF-348] Forward request context in evented workflows

### DIFF
--- a/.changeset/pf-348-evented-request-context.md
+++ b/.changeset/pf-348-evented-request-context.md
@@ -1,0 +1,7 @@
+---
+"@mastra/core": patch
+---
+
+Fixed `EventedAgent` fire-and-forget workflow runs to forward the caller's `requestContext` into workflow execution.
+
+Runtime workflow steps now receive the same request-scoped context as synchronous durable-agent runs, including tool execution, per-step processors, output processors, scorers, and observability selection.

--- a/packages/core/src/agent/durable/__tests__/evented-agent-request-context.test.ts
+++ b/packages/core/src/agent/durable/__tests__/evented-agent-request-context.test.ts
@@ -1,0 +1,71 @@
+import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { EventEmitterPubSub } from '../../../events/event-emitter';
+import { RequestContext } from '../../../request-context';
+import { Agent } from '../../agent';
+import { EventedAgent } from '../evented-agent';
+
+function createTextModel(text: string) {
+  return new MockLanguageModelV2({
+    doStream: async () => ({
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'id-0', modelId: '__AI_SDK_OPENAI_MODEL_REALTIME__', timestamp: new Date(0) },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: text },
+        { type: 'text-end', id: 'text-1' },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        },
+      ]),
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+    }),
+  });
+}
+
+describe('EventedAgent requestContext forwarding', () => {
+  const pubsubs: EventEmitterPubSub[] = [];
+
+  afterEach(async () => {
+    await Promise.all(pubsubs.splice(0).map(pubsub => pubsub.close()));
+  });
+
+  it('passes requestContext to fire-and-forget workflow execution', async () => {
+    const startAsync = vi.fn(async () => undefined);
+    const createRun = vi.fn(async () => ({ startAsync }));
+    const pubsub = new EventEmitterPubSub();
+    pubsubs.push(pubsub);
+    const baseAgent = new Agent({
+      id: 'evented-request-context-agent',
+      name: 'Evented Request Context Agent',
+      instructions: 'Test requestContext',
+      model: createTextModel('Hello!') as LanguageModelV2,
+    });
+    const eventedAgent = new (class extends EventedAgent {
+      override getWorkflow() {
+        return { createRun } as unknown as ReturnType<EventedAgent['getWorkflow']>;
+      }
+    })({ agent: baseAgent, pubsub });
+
+    const requestContext = new RequestContext();
+    requestContext.set('tenantId', 'tenant-123');
+
+    const { cleanup } = await eventedAgent.stream('Hello', { requestContext });
+    try {
+      await vi.waitFor(() => expect(startAsync).toHaveBeenCalledTimes(1));
+      expect(startAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inputData: expect.any(Object),
+          requestContext,
+        }),
+      );
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/packages/core/src/agent/durable/evented-agent.ts
+++ b/packages/core/src/agent/durable/evented-agent.ts
@@ -80,12 +80,13 @@ export class EventedAgent<
   protected override async executeWorkflow(runId: string, workflowInput: DurableAgenticWorkflowInput): Promise<void> {
     try {
       const workflow = this.getWorkflow();
+      const requestContext = this.runRegistryInternal.get(runId)?.requestContext;
       const run = await workflow.createRun({
         runId,
         pubsub: this.pubsubInternal,
       });
       // Fire and forget - use startAsync for non-blocking execution
-      await run.startAsync({ inputData: workflowInput });
+      await run.startAsync({ inputData: workflowInput, requestContext });
     } catch (error) {
       await this.emitError(runId, error instanceof Error ? error : new Error(String(error)));
     }


### PR DESCRIPTION
## Summary

- Fixes the PF-379 readiness-ledger gap tracked for PF-348: `EventedAgent` fire-and-forget workflow execution now forwards the caller `requestContext` into `run.startAsync`.
- Adds focused regression coverage proving the same `RequestContext` object supplied to `eventedAgent.stream()` reaches workflow start.
- Adds an `@mastra/core` patch changeset.

## Source / Coordination Evidence

- Source gap verified in `harness-spec-brainstorming/IMPLEMENTATION_READINESS.md`: the evented workflow request-context row was still marked `gap`.
- Source verified in `packages/core/src/agent/durable/evented-agent.ts`: the fire-and-forget path called `run.startAsync({ inputData })`.
- Source verified in `packages/core/src/agent/durable/durable-agent.ts`: the synchronous durable workflow path already forwards `requestContext`.
- Open PR overlap checked before implementation:
  - #177 message conversion / signals: no overlap with durable evented workflow execution.
  - #178 PostHog log-event exporter: no overlap.
  - #179 subagent processor chains: related Harness runtime area, but no same-file overlap.
  - #180 observability capability review feedback: no overlap.
  - #181 signal lifecycle docs: no overlap.
  - #182 Harness SSE replay coverage: no overlap.
- Linear update could not be posted from this session because Linear MCP returned `auth_revoked`.

## Validation

- `pnpm --filter ./packages/core test src/agent/durable/__tests__/evented-agent-request-context.test.ts`
- `pnpm build:core`
- `pnpm --filter ./packages/core check`
- `pnpm -C /tmp/mbenhamd-mastra-pf-348-evented-request-context prettier:changed`
- `git diff --check`

## Review

- Local Codex review pass 1 found one valid changeset wording nit; fixed before push.
- Local Codex review pass 2: no findings.
- CodeRabbit CLI rerun after the wording fix: 0 findings.
- Agy read-only council review timed out without a response; no findings were received, so this PR records that limitation instead of claiming Agy approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When EventedAgent sends a background task, it was forgetting to pass along who/what the request belonged to. This PR makes sure that same request context is forwarded so the background workflow sees the original caller's context.

## Summary

This PR fixes EventedAgent's fire-and-forget workflow path so the caller's RequestContext is forwarded into workflow execution. executeWorkflow now retrieves the run's requestContext from runRegistryInternal and passes it to run.startAsync alongside inputData. This ensures evented workflows receive the same request-scoped context as synchronous DurableAgent runs (affecting tool execution, per-step processors, output processors, scorers, and observability selection). A focused regression test verifies the exact RequestContext object supplied to eventedAgent.stream() reaches workflow start. A patch changeset for `@mastra/core` is included.

## Changes

- packages/core/src/agent/durable/evented-agent.ts
  - executeWorkflow now reads requestContext via this.runRegistryInternal.get(runId)?.requestContext and calls run.startAsync({ inputData: workflowInput, requestContext }).
- packages/core/src/agent/durable/__tests__/evented-agent-request-context.test.ts
  - Added a Vitest regression test that spies on run.startAsync to assert it is called once and receives the original RequestContext passed to eventedAgent.stream().
- .changeset/pf-348-evented-request-context.md
  - Patch changeset documenting the fix and bumping `@mastra/core`.

## Validation

- Local test: pnpm --filter ./packages/core test src/agent/durable/__tests__/evented-agent-request-context.test.ts
- Build/check: pnpm build:core, pnpm --filter ./packages/core check
- Formatting and git hygiene: prettier check, git diff --check

## Notes

- No public API surface changes.
- Change addresses PF-379 readiness-ledger gap noted in IMPLEMENTATION_READINESS.md and aligns EventedAgent behavior with DurableAgent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->