### PR TITLE
[PF-372] Add Harness channel outbox worker

### DIFF
--- a/.changeset/pf-372-channel-outbox-worker.md
+++ b/.changeset/pf-372-channel-outbox-worker.md
@@ -1,0 +1,19 @@
+---
+"@mastra/core": patch
+---
+
+Added a `HarnessChannelOutboxWorker` that periodically dispatches durable Harness channel outbox rows through the existing Harness channel runtime.
+
+Mastra now auto-registers the worker for Harness instances with configured channel bindings and storage, while leaving channel claim, retry, and provider delivery semantics inside `harness.channels.dispatchOutbox()`.
+
+```ts
+import { Mastra } from '@mastra/core';
+
+const mastra = new Mastra({
+  harnessChannelOutbox: {
+    enabled: true,
+    pollIntervalMs: 30_000,
+    batchSize: 100,
+  },
+});
+```

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -50,8 +50,14 @@ import { normalizeToolPayloadTransformPolicy } from '../tools/payload-transform'
 import type { MastraTTS } from '../tts';
 import type { MastraIdGenerator, IdGeneratorContext } from '../types';
 import type { MastraVector } from '../vector';
-import { OrchestrationWorker, SchedulerWorker, BackgroundTaskWorker, HarnessWakeupWorker } from '../worker';
-import type { HarnessWakeupWorkerConfig, MastraWorker, WorkerDeps } from '../worker';
+import {
+  OrchestrationWorker,
+  SchedulerWorker,
+  BackgroundTaskWorker,
+  HarnessWakeupWorker,
+  HarnessChannelOutboxWorker,
+} from '../worker';
+import type { HarnessWakeupWorkerConfig, HarnessChannelOutboxWorkerConfig, MastraWorker, WorkerDeps } from '../worker';
 import type { AnyWorkflow, Workflow } from '../workflows';
 import { WorkflowEventProcessor } from '../workflows/evented/workflow-event-processor';
 import { WorkflowScheduler, computeNextFireAt } from '../workflows/scheduler';
@@ -443,6 +449,14 @@ export interface Config<
   harnessWakeups?: HarnessWakeupWorkerConfig;
 
   /**
+   * Worker configuration for durable Harness channel outbox delivery.
+   * The worker periodically invokes each registered Harness channel outbox
+   * dispatcher and leaves claim, retry, and provider delivery semantics to the
+   * Harness channel runtime.
+   */
+  harnessChannelOutbox?: HarnessChannelOutboxWorkerConfig;
+
+  /**
    * Platform channels for messaging integrations (Slack, Discord, etc.).
    * Routes are automatically registered and agents can reference channel configs.
    *
@@ -644,6 +658,7 @@ export class Mastra<
   #latestWorkerStartTokens = new WeakMap<MastraWorker, number>();
   #latestWorkerStartLifecycleGenerations = new WeakMap<MastraWorker, number>();
   #harnessWakeupConfig?: HarnessWakeupWorkerConfig;
+  #harnessChannelOutboxConfig?: HarnessChannelOutboxWorkerConfig;
   // Lazily-constructed processor used by handleWorkflowEvent(). Shared between
   // pull-mode workers (OrchestrationWorker) and push-mode entry points
   // (in-process EventEmitter listener, the /api/workers/events HTTP route).
@@ -1042,6 +1057,7 @@ export class Mastra<
     const rawWorkersEnv = process.env.MASTRA_WORKERS;
     let workersOption: MastraWorker[] | false | undefined;
     this.#harnessWakeupConfig = config?.harnessWakeups;
+    this.#harnessChannelOutboxConfig = config?.harnessChannelOutbox;
     if (rawWorkersEnv === 'false') {
       workersOption = false;
     } else {
@@ -1322,6 +1338,7 @@ export class Mastra<
         harness.__registerMastra(this, key);
         this.#harnesses[key] = harness;
       }
+      this.#ensureHarnessChannelOutboxWorker();
     }
 
     registerHook(AvailableHooks.ON_SCORER_RUN, createOnScorerHook(this));
@@ -1448,6 +1465,69 @@ export class Mastra<
         },
       });
     }
+  }
+
+  #ensureHarnessChannelOutboxWorker(): void {
+    if (
+      !this.#autoCreateWorkers ||
+      this.#harnessChannelOutboxConfig?.enabled === false ||
+      this.#workers.some(worker => worker.name === 'harnessChannelOutbox')
+    ) {
+      return;
+    }
+    if (Object.keys(this.#harnesses).length === 0) {
+      return;
+    }
+    const hasHarnessStorage =
+      this.#storage !== undefined ||
+      Object.values(this.#harnesses).some(harness => harness?._internalGetSessionStorage() !== undefined);
+    if (!hasHarnessStorage || !this.#hasDispatchableHarnessChannelBindings()) {
+      return;
+    }
+
+    const worker = new HarnessChannelOutboxWorker(this.#harnessChannelOutboxConfig);
+    worker.__registerMastra(this);
+    this.#workers.push(worker);
+
+    if (this.#workersStarted && (!this.#workerFilter || this.#workerFilter.has(worker.name))) {
+      void this.#trackWorkerStart(worker, {
+        onlyIfWorkersStarted: true,
+        onlyIfLifecycleGeneration: this.#workerLifecycleGeneration,
+        startLifecycleGeneration: this.#workerLifecycleGeneration,
+        stopIfWorkersStopped: true,
+        stopIfLifecycleGenerationChangesFrom: this.#workerLifecycleGeneration,
+        onError: error => {
+          this.#logger?.error?.('Failed to start worker "harnessChannelOutbox"', error);
+        },
+      });
+    }
+  }
+
+  #hasDispatchableHarnessChannelBindings(): boolean {
+    const harnessFilter = this.#harnessChannelOutboxFilter('harnesses', this.#harnessChannelOutboxConfig?.harnesses);
+    const channelFilter = this.#harnessChannelOutboxFilter('channels', this.#harnessChannelOutboxConfig?.channels);
+    const hasGlobalHarnessStorage = this.#storage?.stores?.harness !== undefined;
+    return Object.entries(this.#harnesses).some(([harnessName, harness]) => {
+      if (harnessFilter && !harnessFilter.has(harnessName)) return false;
+      if (!hasGlobalHarnessStorage && harness._internalGetSessionStorage() === undefined) return false;
+      return harness.listChannelBindings().some(binding => !channelFilter || channelFilter.has(binding.channelId));
+    });
+  }
+
+  #harnessChannelOutboxFilter(
+    field: 'harnesses' | 'channels',
+    values: readonly string[] | undefined,
+  ): Set<string> | undefined {
+    if (values === undefined) return undefined;
+    if (!Array.isArray(values)) {
+      throw new Error(`HarnessChannelOutboxWorker: ${field} must be an array`);
+    }
+    for (const value of values) {
+      if (typeof value !== 'string' || value.length === 0) {
+        throw new Error(`HarnessChannelOutboxWorker: ${field} entries must be non-empty strings`);
+      }
+    }
+    return new Set(values);
   }
 
   /**
@@ -3687,6 +3767,7 @@ export class Mastra<
     // is available so declarative schedules still get registered + fired.
     this.#ensureScheduler();
     this.#ensureHarnessWakeupWorker();
+    this.#ensureHarnessChannelOutboxWorker();
   }
 
   public setLogger({ logger }: { logger: TLogger }) {

--- a/packages/core/src/worker/index.ts
+++ b/packages/core/src/worker/index.ts
@@ -8,6 +8,8 @@ export { BackgroundTaskWorker } from './workers/background-task-worker';
 export type { BackgroundTaskWorkerConfig } from './workers/background-task-worker';
 export { HarnessWakeupWorker } from './workers/harness-wakeup-worker';
 export type { HarnessWakeupWorkerConfig } from './workers/harness-wakeup-worker';
+export { HarnessChannelOutboxWorker } from './workers/harness-channel-outbox-worker';
+export type { HarnessChannelOutboxWorkerConfig } from './workers/harness-channel-outbox-worker';
 export type { StepExecutionStrategy, StepExecutionParams } from './types';
 export { InProcessStrategy } from './strategies/in-process-strategy';
 export { HttpRemoteStrategy, StepExecutionError } from './strategies/http-remote-strategy';

--- a/packages/core/src/worker/worker.test.ts
+++ b/packages/core/src/worker/worker.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Mastra } from '../mastra';
 import type { HarnessWakeupItem } from '../storage/domains/harness';
+import { InMemoryStore } from '../storage/mock';
 import { MastraWorker } from './worker';
 import type { WorkerDeps } from './worker';
 import { BackgroundTaskWorker } from './workers/background-task-worker';
+import { HarnessChannelOutboxWorker } from './workers/harness-channel-outbox-worker';
 import { HarnessWakeupWorker } from './workers/harness-wakeup-worker';
 import { OrchestrationWorker } from './workers/orchestration-worker';
 import { SchedulerWorker } from './workers/scheduler-worker';
@@ -57,6 +60,22 @@ function createMockDeps(): WorkerDeps & { _pubsub: any; _storage: any; _logger: 
     _storage: storage,
     _logger: logger,
   };
+}
+
+function sampleChannelBinding(channelId = 'support') {
+  return {
+    harnessName: 'default',
+    channelId,
+    bindingId: channelId,
+    providerId: 'provider',
+    platform: 'provider',
+    callbackTarget: channelId,
+    durableId: `default:${channelId}:${channelId}`,
+  };
+}
+
+function sampleOutboxDispatchResult(claimed = 0) {
+  return { claimed, sent: claimed, failed: 0, dead: 0, items: [] };
 }
 
 describe('MastraWorker (abstract)', () => {
@@ -171,6 +190,276 @@ describe('BackgroundTaskWorker', () => {
   it('start() before init() throws', async () => {
     const worker = new BackgroundTaskWorker();
     await expect(worker.start()).rejects.toThrow('call init() before start()');
+  });
+});
+
+describe('HarnessChannelOutboxWorker', () => {
+  it('rejects invalid configuration values', () => {
+    const cases: Array<[string, ConstructorParameters<typeof HarnessChannelOutboxWorker>[0]]> = [
+      ['batchSize', { batchSize: 0 }],
+      ['batchSize', { batchSize: 1.5 }],
+      ['pollIntervalMs', { pollIntervalMs: 0 }],
+      ['pollIntervalMs', { pollIntervalMs: Number.POSITIVE_INFINITY }],
+    ];
+
+    for (const [name, config] of cases) {
+      expect(() => new HarnessChannelOutboxWorker(config)).toThrow(`${name} must be a positive integer`);
+    }
+    expect(() => new HarnessChannelOutboxWorker({ harnesses: ['default'], channels: ['support'] })).not.toThrow();
+    expect(() => new HarnessChannelOutboxWorker({ harnesses: [''] })).toThrow(
+      'harnesses entries must be non-empty strings',
+    );
+    expect(() => new HarnessChannelOutboxWorker({ enabled: 'false' as any })).toThrow('enabled must be a boolean');
+  });
+
+  it('start() before init() throws and stop() is idempotent', async () => {
+    const worker = new HarnessChannelOutboxWorker();
+    await expect(worker.start()).rejects.toThrow('call init() before start()');
+
+    await worker.init(createMockDeps());
+    await worker.start();
+    expect(worker.isRunning).toBe(true);
+    await worker.stop();
+    expect(worker.isRunning).toBe(false);
+    await worker.stop();
+    expect(worker.isRunning).toBe(false);
+  });
+
+  it('dispatches outbox once per harness by default instead of once per channel', async () => {
+    const dispatchOutbox = vi.fn().mockResolvedValue(sampleOutboxDispatchResult(2));
+    const worker = new HarnessChannelOutboxWorker({ pollIntervalMs: 60_000 });
+    const deps = createMockDeps();
+    deps.mastra = {
+      getHarnesses: () => ({
+        default: {
+          listChannelBindings: () => [sampleChannelBinding('support'), sampleChannelBinding('alerts')],
+          _internalGetSessionStorage: () => ({}),
+          channels: { dispatchOutbox },
+        },
+      }),
+    } as any;
+
+    await worker.init(deps);
+    await expect(worker.runOnce()).resolves.toBe(2);
+
+    expect(dispatchOutbox).toHaveBeenCalledTimes(1);
+    expect(dispatchOutbox).toHaveBeenCalledWith({});
+  });
+
+  it('dispatches only explicitly configured channels', async () => {
+    const dispatchOutbox = vi
+      .fn()
+      .mockResolvedValueOnce(sampleOutboxDispatchResult(1))
+      .mockResolvedValueOnce(sampleOutboxDispatchResult(3));
+    const worker = new HarnessChannelOutboxWorker({ channels: ['support', 'alerts'], batchSize: 5 });
+    const deps = createMockDeps();
+    deps.mastra = {
+      getHarnesses: () => ({
+        default: {
+          listChannelBindings: () => [
+            sampleChannelBinding('support'),
+            sampleChannelBinding('support'),
+            sampleChannelBinding('ignored'),
+            sampleChannelBinding('alerts'),
+          ],
+          _internalGetSessionStorage: () => ({}),
+          channels: { dispatchOutbox },
+        },
+      }),
+    } as any;
+
+    await worker.init(deps);
+    await expect(worker.runOnce()).resolves.toBe(4);
+
+    expect(dispatchOutbox).toHaveBeenCalledTimes(2);
+    expect(dispatchOutbox).toHaveBeenNthCalledWith(1, { limit: 5, channelId: 'support' });
+    expect(dispatchOutbox).toHaveBeenNthCalledWith(2, { limit: 5, channelId: 'alerts' });
+  });
+
+  it('skips concurrent runOnce calls while a tick is in flight', async () => {
+    let releaseDispatch!: () => void;
+    const dispatchOutbox = vi.fn(
+      () =>
+        new Promise(resolve => {
+          releaseDispatch = () => resolve(sampleOutboxDispatchResult(1));
+        }),
+    );
+    const worker = new HarnessChannelOutboxWorker();
+    const deps = createMockDeps();
+    deps.mastra = {
+      getHarnesses: () => ({
+        default: {
+          listChannelBindings: () => [sampleChannelBinding()],
+          _internalGetSessionStorage: () => ({}),
+          channels: { dispatchOutbox },
+        },
+      }),
+    } as any;
+
+    await worker.init(deps);
+    const first = worker.runOnce();
+    await expect(worker.runOnce()).resolves.toBe(0);
+    releaseDispatch();
+    await expect(first).resolves.toBe(1);
+    expect(dispatchOutbox).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues processing later harnesses when one harness dispatch fails', async () => {
+    const failure = new Error('provider unavailable');
+    const badDispatch = vi.fn().mockRejectedValue(failure);
+    const goodDispatch = vi.fn().mockResolvedValue(sampleOutboxDispatchResult(2));
+    const worker = new HarnessChannelOutboxWorker();
+    const deps = createMockDeps();
+    deps.mastra = {
+      getHarnesses: () => ({
+        bad: {
+          listChannelBindings: () => [sampleChannelBinding()],
+          _internalGetSessionStorage: () => ({}),
+          channels: { dispatchOutbox: badDispatch },
+        },
+        good: {
+          listChannelBindings: () => [sampleChannelBinding()],
+          _internalGetSessionStorage: () => ({}),
+          channels: { dispatchOutbox: goodDispatch },
+        },
+      }),
+    } as any;
+
+    await worker.init(deps);
+    await expect(worker.runOnce()).resolves.toBe(2);
+
+    expect(deps._logger.error).toHaveBeenCalledWith(
+      'HarnessChannelOutboxWorker: failed to dispatch harness channel outbox',
+      expect.objectContaining({ harnessName: 'bad', error: failure }),
+    );
+    expect(goodDispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips channel-bound harnesses without storage while dispatching storage-backed harnesses', async () => {
+    const skippedDispatch = vi.fn().mockRejectedValue(new Error('should not dispatch'));
+    const goodDispatch = vi.fn().mockResolvedValue(sampleOutboxDispatchResult(1));
+    const worker = new HarnessChannelOutboxWorker();
+    const deps = createMockDeps();
+    deps.mastra = {
+      getHarnesses: () => ({
+        skipped: {
+          listChannelBindings: () => [sampleChannelBinding()],
+          _internalGetSessionStorage: () => undefined,
+          channels: { dispatchOutbox: skippedDispatch },
+        },
+        good: {
+          listChannelBindings: () => [sampleChannelBinding()],
+          _internalGetSessionStorage: () => ({}),
+          channels: { dispatchOutbox: goodDispatch },
+        },
+      }),
+    } as any;
+
+    await worker.init(deps);
+    await expect(worker.runOnce()).resolves.toBe(1);
+
+    expect(skippedDispatch).not.toHaveBeenCalled();
+    expect(goodDispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns once when channel bindings exist but none have storage', async () => {
+    const worker = new HarnessChannelOutboxWorker();
+    const deps = createMockDeps();
+    deps.mastra = {
+      getHarnesses: () => ({
+        default: {
+          listChannelBindings: () => [sampleChannelBinding()],
+          _internalGetSessionStorage: () => undefined,
+          channels: { dispatchOutbox: vi.fn() },
+        },
+      }),
+    } as any;
+
+    await worker.init(deps);
+    await expect(worker.runOnce()).resolves.toBe(0);
+    await expect(worker.runOnce()).resolves.toBe(0);
+
+    expect(deps._logger.warn).toHaveBeenCalledWith(
+      'HarnessChannelOutboxWorker: no storage-backed Harness channel bindings registered, worker will not dispatch outbox items',
+    );
+    expect(deps._logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns once when no harness channel bindings are registered', async () => {
+    const worker = new HarnessChannelOutboxWorker();
+    const deps = createMockDeps();
+    deps.mastra = {
+      getHarnesses: () => ({
+        default: {
+          listChannelBindings: () => [],
+          channels: { dispatchOutbox: vi.fn() },
+        },
+      }),
+    } as any;
+
+    await worker.init(deps);
+    await expect(worker.runOnce()).resolves.toBe(0);
+    await expect(worker.runOnce()).resolves.toBe(0);
+
+    expect(deps._logger.warn).toHaveBeenCalledWith(
+      'HarnessChannelOutboxWorker: no Harness channel bindings registered, worker will not dispatch outbox items',
+    );
+    expect(deps._logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('auto-registers on Mastra only when Harness channel bindings exist', () => {
+    const channelHarness = {
+      __registerMastra: vi.fn(),
+      _internalGetSessionStorage: () => undefined,
+      listChannelBindings: () => [sampleChannelBinding()],
+      channels: { dispatchOutbox: vi.fn() },
+      shutdown: vi.fn(),
+    };
+    const mastra = new Mastra({
+      logger: false,
+      storage: new InMemoryStore(),
+      harnesses: { default: channelHarness as any },
+    });
+
+    expect(mastra.workers.some(worker => worker.name === 'harnessChannelOutbox')).toBe(true);
+
+    const noChannelHarness = {
+      __registerMastra: vi.fn(),
+      _internalGetSessionStorage: () => undefined,
+      listChannelBindings: () => [],
+      channels: { dispatchOutbox: vi.fn() },
+      shutdown: vi.fn(),
+    };
+    const noChannelMastra = new Mastra({
+      logger: false,
+      storage: new InMemoryStore(),
+      harnesses: { default: noChannelHarness as any },
+    });
+    const disabledMastra = new Mastra({
+      logger: false,
+      storage: new InMemoryStore(),
+      harnessChannelOutbox: { enabled: false },
+      harnesses: { default: channelHarness as any },
+    });
+
+    expect(noChannelMastra.workers.some(worker => worker.name === 'harnessChannelOutbox')).toBe(false);
+    expect(disabledMastra.workers.some(worker => worker.name === 'harnessChannelOutbox')).toBe(false);
+    expect(() => {
+      new Mastra({
+        logger: false,
+        storage: new InMemoryStore(),
+        harnessChannelOutbox: { channels: [''] },
+        harnesses: { default: channelHarness as any },
+      });
+    }).toThrow('channels entries must be non-empty strings');
+    expect(() => {
+      new Mastra({
+        logger: false,
+        storage: new InMemoryStore(),
+        harnessChannelOutbox: { harnesses: 'default' as any },
+        harnesses: { default: channelHarness as any },
+      });
+    }).toThrow('harnesses must be an array');
   });
 });
 

--- a/packages/core/src/worker/worker.ts
+++ b/packages/core/src/worker/worker.ts
@@ -22,6 +22,7 @@ export interface WorkerDeps {
  * - SchedulerWorker: fires cron-based workflow schedules
  * - BackgroundTaskWorker: manages background tool execution
  * - HarnessWakeupWorker: admits durable Harness wakeups into sessions
+ * - HarnessChannelOutboxWorker: dispatches durable Harness channel outbox rows
  *
  * Workers are registered on a Mastra instance and run inline by default.
  * They can also be launched standalone via the CLI for separate deployment.

--- a/packages/core/src/worker/workers/harness-channel-outbox-worker.ts
+++ b/packages/core/src/worker/workers/harness-channel-outbox-worker.ts
@@ -1,0 +1,234 @@
+import type {
+  ChannelOutboxDispatchOptions,
+  ChannelOutboxDispatchResult,
+  HarnessChannelBinding,
+} from '../../harness/v1';
+import { MastraWorker } from '../worker';
+import type { WorkerDeps } from '../worker';
+
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+
+type OutboxHarness = {
+  listChannelBindings?: () => HarnessChannelBinding[];
+  _internalGetSessionStorage?: () => unknown;
+  channels?: {
+    dispatchOutbox?: (opts?: ChannelOutboxDispatchOptions) => Promise<ChannelOutboxDispatchResult>;
+  };
+};
+
+type OutboxMastra = {
+  getHarnesses?: () => Record<string, OutboxHarness>;
+};
+
+export interface HarnessChannelOutboxWorkerConfig {
+  enabled?: boolean;
+  batchSize?: number;
+  pollIntervalMs?: number;
+  harnesses?: readonly string[];
+  channels?: readonly string[];
+}
+
+export class HarnessChannelOutboxWorker extends MastraWorker {
+  readonly name = 'harnessChannelOutbox';
+
+  #config: {
+    enabled: boolean;
+    batchSize?: number;
+    pollIntervalMs: number;
+    harnesses?: ReadonlySet<string>;
+    channels?: ReadonlySet<string>;
+  };
+  #running = false;
+  #timer?: ReturnType<typeof setTimeout>;
+  #tickInFlight = false;
+  #pollGeneration = 0;
+  #warnedNoHarnesses = false;
+  #warnedNoBindings = false;
+  #warnedNoStorage = false;
+
+  constructor(config: HarnessChannelOutboxWorkerConfig = {}) {
+    super();
+    this.#config = {
+      enabled: config.enabled === undefined ? true : booleanConfig('enabled', config.enabled),
+      ...(config.batchSize !== undefined ? { batchSize: positiveIntegerConfig('batchSize', config.batchSize) } : {}),
+      pollIntervalMs: positiveIntegerConfig('pollIntervalMs', config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS),
+      ...(config.harnesses !== undefined ? { harnesses: stringSetConfig('harnesses', config.harnesses) } : {}),
+      ...(config.channels !== undefined ? { channels: stringSetConfig('channels', config.channels) } : {}),
+    };
+  }
+
+  async init(deps: WorkerDeps): Promise<void> {
+    await super.init(deps);
+  }
+
+  async start(): Promise<void> {
+    if (this.#running || !this.#config.enabled) return;
+    if (!this.deps) throw new Error('HarnessChannelOutboxWorker: call init() before start()');
+    this.#running = true;
+    this.#pollGeneration += 1;
+    this.#scheduleNextTick(0);
+  }
+
+  async stop(): Promise<void> {
+    if (!this.#running) return;
+    this.#running = false;
+    this.#pollGeneration += 1;
+    if (this.#timer) {
+      clearTimeout(this.#timer);
+      this.#timer = undefined;
+    }
+  }
+
+  get isRunning(): boolean {
+    return this.#running;
+  }
+
+  async runOnce(): Promise<number> {
+    if (!this.#config.enabled || this.#tickInFlight) return 0;
+    this.#tickInFlight = true;
+    try {
+      return await this.#dispatchPendingOutbox();
+    } finally {
+      this.#tickInFlight = false;
+    }
+  }
+
+  #scheduleNextTick(delayMs: number, generation = this.#pollGeneration): void {
+    if (!this.#running || generation !== this.#pollGeneration) return;
+    this.#timer = setTimeout(() => {
+      this.#timer = undefined;
+      void this.runOnce()
+        .catch(error => this.deps?.logger?.error?.('HarnessChannelOutboxWorker: tick failed', error))
+        .finally(() => this.#scheduleNextTick(this.#config.pollIntervalMs, generation));
+    }, delayMs);
+    this.#timer.unref?.();
+  }
+
+  async #dispatchPendingOutbox(): Promise<number> {
+    const deps = this.deps;
+    const mastra = deps?.mastra as OutboxMastra | undefined;
+    const harnesses = mastra?.getHarnesses?.() ?? {};
+    const entries = Object.entries(harnesses).filter(([name]) => this.#config.harnesses?.has(name) ?? true);
+    if (entries.length === 0) {
+      if (!this.#warnedNoHarnesses) {
+        deps?.logger?.warn?.(
+          'HarnessChannelOutboxWorker: no Harness instances registered, worker will not dispatch outbox items',
+        );
+        this.#warnedNoHarnesses = true;
+      }
+      return 0;
+    }
+
+    let claimed = 0;
+    let sawDispatchableBinding = false;
+    let sawStorageBackedBinding = false;
+    const hasGlobalHarnessStorage = Boolean(
+      (deps?.storage as { stores?: { harness?: unknown } } | undefined)?.stores?.harness,
+    );
+    for (const [harnessName, harness] of entries) {
+      const bindings = this.#dispatchableBindings(harness);
+      if (bindings.length === 0) continue;
+      sawDispatchableBinding = true;
+      if (!this.#hasHarnessStorage(harness, hasGlobalHarnessStorage)) continue;
+      sawStorageBackedBinding = true;
+      try {
+        claimed += await this.#dispatchHarnessOutbox({ harnessName, harness, bindings });
+      } catch (error) {
+        deps?.logger?.error?.('HarnessChannelOutboxWorker: failed to dispatch harness channel outbox', {
+          harnessName,
+          error,
+        });
+      }
+    }
+
+    if (!sawDispatchableBinding && !this.#warnedNoBindings) {
+      deps?.logger?.warn?.(
+        'HarnessChannelOutboxWorker: no Harness channel bindings registered, worker will not dispatch outbox items',
+      );
+      this.#warnedNoBindings = true;
+    }
+    if (sawDispatchableBinding && !sawStorageBackedBinding && !this.#warnedNoStorage) {
+      deps?.logger?.warn?.(
+        'HarnessChannelOutboxWorker: no storage-backed Harness channel bindings registered, worker will not dispatch outbox items',
+      );
+      this.#warnedNoStorage = true;
+    }
+    return claimed;
+  }
+
+  #dispatchableBindings(harness: OutboxHarness): HarnessChannelBinding[] {
+    const bindings = harness.listChannelBindings?.() ?? [];
+    const channelFilter = this.#config.channels;
+    if (!channelFilter) return bindings;
+    return bindings.filter(binding => channelFilter.has(binding.channelId));
+  }
+
+  #hasHarnessStorage(harness: OutboxHarness, hasGlobalHarnessStorage: boolean): boolean {
+    return hasGlobalHarnessStorage || harness._internalGetSessionStorage?.() !== undefined;
+  }
+
+  async #dispatchHarnessOutbox({
+    harnessName,
+    harness,
+    bindings,
+  }: {
+    harnessName: string;
+    harness: OutboxHarness;
+    bindings: HarnessChannelBinding[];
+  }): Promise<number> {
+    const dispatchOutbox = harness.channels?.dispatchOutbox;
+    if (typeof dispatchOutbox !== 'function') {
+      this.deps?.logger?.warn?.('HarnessChannelOutboxWorker: Harness channel outbox dispatch is unavailable', {
+        harnessName,
+      });
+      return 0;
+    }
+
+    const baseOptions = this.#config.batchSize !== undefined ? { limit: this.#config.batchSize } : {};
+    if (!this.#config.channels) {
+      const result = await dispatchOutbox(baseOptions);
+      return result.claimed;
+    }
+
+    let claimed = 0;
+    for (const channelId of new Set(bindings.map(binding => binding.channelId))) {
+      try {
+        const result = await dispatchOutbox({ ...baseOptions, channelId });
+        claimed += result.claimed;
+      } catch (error) {
+        this.deps?.logger?.error?.('HarnessChannelOutboxWorker: failed to dispatch harness channel outbox', {
+          harnessName,
+          channelId,
+          error,
+        });
+      }
+    }
+    return claimed;
+  }
+}
+
+function booleanConfig(name: string, value: boolean): boolean {
+  if (typeof value !== 'boolean') {
+    throw new Error(`HarnessChannelOutboxWorker: ${name} must be a boolean`);
+  }
+  return value;
+}
+
+function positiveIntegerConfig(name: string, value: number): number {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`HarnessChannelOutboxWorker: ${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function stringSetConfig(name: string, values: readonly string[]): ReadonlySet<string> {
+  if (!Array.isArray(values)) {
+    throw new Error(`HarnessChannelOutboxWorker: ${name} must be an array`);
+  }
+  for (const value of values) {
+    if (typeof value !== 'string' || value.length === 0) {
+      throw new Error(`HarnessChannelOutboxWorker: ${name} entries must be non-empty strings`);
+    }
+  }
+  return new Set(values);
+}


### PR DESCRIPTION
## Summary

- Adds `HarnessChannelOutboxWorker` for durable Harness channel outbox dispatch.
- Auto-registers the worker only when Mastra has Harness instances with channel bindings and storage.
- Keeps provider delivery, claim, retry, and reconciliation semantics inside `harness.channels.dispatchOutbox()`.

## Scope

In scope:
- one dispatch call per storage-backed Harness by default
- explicit per-channel dispatch only when `harnessChannelOutbox.channels` is configured
- worker config validation for enabled/batch/poll/harness/channel filters
- reentrancy guard for overlapping ticks
- Mastra auto-registration/start behavior when storage or Harnesses become available
- focused worker tests

Out of scope:
- inbound HTTP ingress routes
- provider callback/action routes
- new storage schema or storage adapter changes
- production deployment, secrets, release, or publish actions

## Source And Coordination Evidence

Linear MCP was unavailable in this session with `auth_revoked`, so I could not update PF-372 directly. Evidence used locally:

- `harness-spec-brainstorming/IMPLEMENTATION_READINESS.md`
- `harness-spec-brainstorming/sections/13-mastra-server-integration/02-auto-mounted-routes.md`
- `harness-spec-brainstorming/sections/14-channels/02-durable-ingress.md`
- `harness-spec-brainstorming/sections/14-channels/05-approval-and-inbox-bridge.md`
- `packages/core/src/harness/v1/harness.ts`
- `packages/core/src/worker/workers/harness-wakeup-worker.ts`
- `packages/core/src/mastra/index.ts`

Open PR overlap check before implementation found no same-file conflict with the current open Harness PRs. The closest related work was PF-348 request-context forwarding and PF-364 SSE replay coverage, which touch different files/contracts.

## Review Evidence

- Agy plan review: incorporated feedback to avoid per-channel N+1 dispatch by default, keep claim renewal inside Harness dispatch, auto-enable only when channel bindings and storage exist, and add reentrancy/storage tests.
- Claude plan review: incorporated feedback to gate on real channel bindings/storage, keep this slice to the worker, and avoid provider/route expansion.
- CodeRabbit CLI: no findings.
- Codex review pass 1: fixed config validation and mixed-storage auto-registration issues.
- Codex review pass 2: fixed worker docs and staged the new worker implementation.
- Final staged Codex review: no findings.

## Validation

- `pnpm --filter ./packages/core test src/worker/worker.test.ts`
- `pnpm --filter ./packages/core check`
- `pnpm -C /tmp/mbenhamd-mastra-pf-372-channel-outbox-worker prettier:changed`
- `git diff --check`
- `pnpm build:core`
- `git diff --cached --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a background "mail carrier" that periodically finds and sends unsent Harness channel messages stored durably and only runs when channels and storage are actually present, so messages are delivered reliably across restarts.

## Overview

Adds HarnessChannelOutboxWorker to durably poll Harness instances and dispatch channel outbox entries via the existing harness.channels.dispatchOutbox(), ensuring reliable delivery across restarts while keeping claim/retry/delivery semantics inside the Harness runtime.

## Key Changes

- New worker: HarnessChannelOutboxWorker
  - Periodic polling with configurable pollIntervalMs and batchSize
  - Optional allowlists: harnesses and channels (validated as arrays of non-empty strings)
  - In-flight guard to prevent overlapping ticks and a generation counter to avoid stale reschedules
  - Validation helpers for positive integers and booleans
  - runOnce() returns total claimed count; init/start/stop lifecycle with idempotency and sequencing checks
  - Dispatch modes:
    - Default: one dispatchOutbox call per storage-backed Harness (batchSize → dispatch limit)
    - Per-channel: when channels allowlist configured, iterates unique channelIds and dispatches per-channel, summing claimed counts
  - Emits one-time warnings for “no registered harnesses”, “no channel bindings”, and “no storage-backed bindings”
  - Logs and isolates per-harness failures so one harness error doesn’t abort others

- Mastra integration
  - Added Config.harnessChannelOutbox?: HarnessChannelOutboxWorkerConfig
  - Mastra auto-registers the worker only when:
    - auto-creation is not explicitly disabled
    - there are Harness instances with channel bindings
    - session storage is available (global harness store or per-harness session storage)
  - `#ensureHarnessChannelOutboxWorker()` applies harness/channel allowlist filtering and validates config; `setStorage()` retries setup if storage is attached later

- Public surface
  - Re-exported HarnessChannelOutboxWorker and HarnessChannelOutboxWorkerConfig from packages/core/src/worker/index.ts
  - Changeset added documenting the new worker (.changeset/pf-372-channel-outbox-worker.md)

- Tests
  - New focused tests in packages/core/src/worker/worker.test.ts covering:
    - config validation (batchSize, pollIntervalMs, enabled, harnesses/channels)
    - lifecycle ordering and idempotency
    - dispatch semantics (default per-harness vs per-channel)
    - concurrency guard (skip overlapping runOnce)
    - failure isolation (per-harness errors)
    - storage-aware skipping and one-time warning emission
    - Mastra auto-registration behavior and invalid config rejection

## Dispatch Semantics

- Default: one dispatchOutbox call per storage-backed Harness instance (batchSize limits applied)
- Optional: when channels allowlist is configured, dispatch runs per-matching channel and sums claimed counts
- All claim/retry/provider delivery logic remains inside harness.channels.dispatchOutbox(); the worker orchestrates when/how to call it
- Harnesses lacking storage-backed bindings are skipped; appropriate one-time warnings are emitted
- Errors in one harness dispatch are logged but do not prevent dispatch for other harnesses

## Scope Notes

In-scope: durable dispatch worker, config validation, auto-registration based on bindings/storage, reentrancy guard, focused tests.  
Out-of-scope: inbound HTTP routes, provider callback/action routes, storage schema/adapter changes, production deployment/release/publishing steps.

## Validation

Local validation performed as listed in the PR: unit tests for core worker, core checks, prettier, and core build commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->