### PR TITLE
[PF-733] Add workspace restore planning contract

### DIFF
--- a/.changeset/pf-733-workspace-restore-plan.md
+++ b/.changeset/pf-733-workspace-restore-plan.md
@@ -3,3 +3,14 @@
 ---
 
 Added Harness v1 workspace restore planning so callers can build ordered restore plans from workspace action journal entries for a session, turn, or file scope.
+
+Example:
+
+```ts
+import { createWorkspaceRestorePlan } from '@mastra/core/harness/v1';
+
+const plan = createWorkspaceRestorePlan({
+  scope: { kind: 'session' },
+  entries,
+});
+```

--- a/.changeset/pf-733-workspace-restore-plan.md
+++ b/.changeset/pf-733-workspace-restore-plan.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Added Harness v1 workspace restore planning so callers can build ordered restore plans from workspace action journal entries for a session, turn, or file scope.

--- a/packages/core/src/harness/v1/index.ts
+++ b/packages/core/src/harness/v1/index.ts
@@ -106,6 +106,18 @@ export type {
   WorkspaceResolvedPath,
   WorkspaceRootDescriptor,
 } from './workspace-policy';
+export { createWorkspaceRestorePlan, workspaceRestoreEntryMatchesScope } from './workspace-restore';
+export type {
+  CreateWorkspaceRestorePlanOptions,
+  WorkspaceRestoreAffectedPath,
+  WorkspaceRestoreConflict,
+  WorkspaceRestoreConflictStatus,
+  WorkspaceRestorePlan,
+  WorkspaceRestorePlanStep,
+  WorkspaceRestoreScope,
+  WorkspaceRestoreStepKind,
+  WorkspaceRestoreStepStatus,
+} from './workspace-restore';
 
 /**
  * `HarnessMessage` and `HarnessMessageContent` are stable cross-version

--- a/packages/core/src/harness/v1/workspace-restore.test.ts
+++ b/packages/core/src/harness/v1/workspace-restore.test.ts
@@ -269,6 +269,15 @@ describe('workspace restore planner', () => {
     ).toThrow(HarnessValidationError);
   });
 
+  it('rejects file scopes without an affected path selector', () => {
+    expect(() =>
+      createWorkspaceRestorePlan({
+        scope: { kind: 'file', affectedPath: {} },
+        entries: [journalEntry()],
+      }),
+    ).toThrow(HarnessValidationError);
+  });
+
   it('returns cloned plan data', () => {
     const plan = createWorkspaceRestorePlan({
       scope: { kind: 'session' },

--- a/packages/core/src/harness/v1/workspace-restore.test.ts
+++ b/packages/core/src/harness/v1/workspace-restore.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from 'vitest';
+
+import type { WorkspaceActionJournalEntry, WorkspaceActionJournalPath } from '../../storage/domains/harness';
+import { HarnessValidationError } from './errors';
+import { createWorkspaceRestorePlan, workspaceRestoreEntryMatchesScope } from './workspace-restore';
+import type { WorkspaceRestorePlan } from './workspace-restore';
+
+const notesPath = workspacePath('notes.md');
+const oldPath = workspacePath('src/old.ts');
+const newPath = workspacePath('src/new.ts');
+
+describe('workspace restore planner', () => {
+  it('plans session restores in reverse journal order without mutating files', () => {
+    const plan = createWorkspaceRestorePlan({
+      scope: { kind: 'session' },
+      entries: [
+        journalEntry({ id: 'write-notes', createdAt: 1000, result: { before: 'old notes', after: 'new notes' } }),
+        journalEntry({
+          id: 'patch-notes',
+          createdAt: 1100,
+          operation: 'patch',
+          action: { kind: 'file', operation: 'patch', path: 'notes.md' },
+          result: { before: 'new notes', after: 'patched notes' },
+        }),
+        journalEntry({
+          id: 'rename-source',
+          createdAt: 1200,
+          operation: 'rename',
+          action: { kind: 'file', operation: 'rename', path: 'src/old.ts', toPath: 'src/new.ts' },
+          path: oldPath,
+          toPath: newPath,
+          result: { toBefore: null },
+        }),
+      ],
+    });
+
+    expect(plan.truncated).toBe(false);
+    expect(plan.steps.map(step => [step.journalEntryId, step.kind, step.status])).toEqual([
+      ['rename-source', 'move_path', 'planned'],
+      ['patch-notes', 'reverse_patch', 'planned'],
+      ['write-notes', 'restore_file', 'planned'],
+    ]);
+    expect(plan.steps[0]).toMatchObject({ path: newPath, toPath: oldPath, conflict: { status: 'unknown' } });
+    expect(plan.steps[1]).toMatchObject({ path: notesPath, snapshot: 'new notes' });
+    expect(plan.steps[2]).toMatchObject({ path: notesPath, snapshot: 'old notes' });
+    expect(plan.affectedPaths.map(item => item.path.relativePath)).toEqual(['notes.md', 'src/new.ts', 'src/old.ts']);
+  });
+
+  it('uses null before snapshots to plan deletion for files created by a write', () => {
+    const plan = createWorkspaceRestorePlan({
+      scope: { kind: 'turn', requestId: 'turn-1' },
+      entries: [
+        journalEntry({
+          id: 'create-file',
+          requestId: 'turn-1',
+          result: { before: null, after: 'created content' },
+        }),
+        journalEntry({ id: 'other-turn', requestId: 'turn-2', result: { before: 'ignore' } }),
+      ],
+    });
+
+    expect(plan.steps).toEqual([
+      expect.objectContaining({
+        journalEntryId: 'create-file',
+        kind: 'delete_file',
+        status: 'planned',
+        snapshot: null,
+      }),
+    ]);
+  });
+
+  it('marks unsupported, no-op, and missing-evidence rows deterministically', () => {
+    const plan = createWorkspaceRestorePlan({
+      scope: { kind: 'session' },
+      entries: [
+        journalEntry({
+          id: 'read-file',
+          operation: 'read',
+          action: { kind: 'file', operation: 'read', path: 'notes.md' },
+        }),
+        journalEntry({ id: 'denied-write', policyDecision: 'deny', result: { before: 'old' } }),
+        journalEntry({
+          id: 'missing-before',
+          operation: 'delete',
+          action: { kind: 'file', operation: 'delete', path: 'notes.md' },
+          result: undefined,
+        }),
+        journalEntry({
+          id: 'command-run',
+          actionKind: 'command',
+          operation: 'run',
+          action: { kind: 'command', operation: 'run', command: 'pnpm test' },
+          path: undefined,
+        }),
+      ],
+    });
+
+    expect(plan.steps.map(step => [step.journalEntryId, step.status, step.conflict.status])).toEqual([
+      ['read-file', 'skipped', 'no_effect'],
+      ['missing-before', 'blocked', 'missing_before_snapshot'],
+      ['denied-write', 'skipped', 'no_effect'],
+      ['command-run', 'blocked', 'unsupported_operation'],
+    ]);
+  });
+
+  it('handles null before snapshots by operation without inventing restore work', () => {
+    const plan = createWorkspaceRestorePlan({
+      scope: { kind: 'session' },
+      entries: [
+        journalEntry({
+          id: 'delete-missing',
+          operation: 'delete',
+          action: { kind: 'file', operation: 'delete', path: 'notes.md' },
+          result: { before: null },
+        }),
+        journalEntry({
+          id: 'patch-missing',
+          operation: 'patch',
+          action: { kind: 'file', operation: 'patch', path: 'notes.md' },
+          result: { before: null },
+        }),
+      ],
+    });
+
+    expect(plan.steps.map(step => [step.journalEntryId, step.kind, step.status, step.conflict.status])).toEqual([
+      ['patch-missing', 'reverse_patch', 'blocked', 'missing_before_snapshot'],
+      ['delete-missing', 'skip', 'skipped', 'no_effect'],
+    ]);
+  });
+
+  it('blocks rename plans when destination overwrite evidence requires manual review', () => {
+    const plan = createWorkspaceRestorePlan({
+      scope: { kind: 'session' },
+      entries: [
+        journalEntry({
+          id: 'rename-overwrite',
+          operation: 'rename',
+          action: { kind: 'file', operation: 'rename', path: 'src/old.ts', toPath: 'src/new.ts' },
+          path: oldPath,
+          toPath: newPath,
+          result: { toBefore: 'overwritten destination' },
+        }),
+      ],
+    });
+
+    expect(plan.steps).toEqual([
+      expect.objectContaining({
+        journalEntryId: 'rename-overwrite',
+        kind: 'manual_review',
+        status: 'blocked',
+        conflict: expect.objectContaining({ status: 'unsupported_operation' }),
+      }),
+    ]);
+  });
+
+  it('blocks rename plans without explicit destination evidence', () => {
+    const plan = createWorkspaceRestorePlan({
+      scope: { kind: 'session' },
+      entries: [
+        journalEntry({
+          id: 'rename-unknown-destination',
+          operation: 'rename',
+          action: { kind: 'file', operation: 'rename', path: 'src/old.ts', toPath: 'src/new.ts' },
+          path: oldPath,
+          toPath: newPath,
+          result: { status: 'changed' },
+        }),
+      ],
+    });
+
+    expect(plan.steps).toEqual([
+      expect.objectContaining({
+        journalEntryId: 'rename-unknown-destination',
+        kind: 'move_path',
+        status: 'blocked',
+        conflict: expect.objectContaining({ status: 'missing_before_snapshot' }),
+      }),
+    ]);
+  });
+
+  it('matches file scope against destination paths only when requested', () => {
+    const rename = journalEntry({
+      id: 'rename-source',
+      operation: 'rename',
+      action: { kind: 'file', operation: 'rename', path: 'src/old.ts', toPath: 'src/new.ts' },
+      path: oldPath,
+      toPath: newPath,
+    });
+
+    expect(
+      workspaceRestoreEntryMatchesScope(rename, {
+        kind: 'file',
+        affectedPath: { rootId: 'project', relativePath: 'src/new.ts' },
+      }),
+    ).toBe(false);
+    expect(
+      workspaceRestoreEntryMatchesScope(rename, {
+        kind: 'file',
+        affectedPath: { rootId: 'project', relativePath: 'src/new.ts', includeToPath: true },
+      }),
+    ).toBe(true);
+    expect(
+      workspaceRestoreEntryMatchesScope(rename, {
+        kind: 'file',
+        affectedPath: { rootId: 'project', relativePath: 'src/other.ts' },
+      }),
+    ).toBe(false);
+  });
+
+  it('uses the same same-timestamp journal id ordering as storage', () => {
+    const plan = createWorkspaceRestorePlan({
+      scope: { kind: 'session' },
+      entries: [
+        journalEntry({ id: 'a', createdAt: 1000, result: { before: 'lowercase' } }),
+        journalEntry({ id: 'Z', createdAt: 1000, result: { before: 'uppercase' } }),
+      ],
+    });
+
+    expect(plan.steps.map(step => step.journalEntryId)).toEqual(['a', 'Z']);
+  });
+
+  it('does not block denied non-file journal rows', () => {
+    const plan = createWorkspaceRestorePlan({
+      scope: { kind: 'session' },
+      entries: [
+        journalEntry({
+          id: 'denied-command',
+          actionKind: 'command',
+          operation: 'run',
+          policyDecision: 'deny',
+          action: { kind: 'command', operation: 'run', command: 'pnpm test' },
+          path: undefined,
+        }),
+      ],
+    });
+
+    expect(plan.steps).toEqual([
+      expect.objectContaining({
+        journalEntryId: 'denied-command',
+        kind: 'skip',
+        status: 'skipped',
+        conflict: expect.objectContaining({ status: 'no_effect' }),
+      }),
+    ]);
+  });
+
+  it('bounds host-provided entries and reports truncation', () => {
+    const plan = createWorkspaceRestorePlan({
+      scope: { kind: 'session' },
+      limit: 2,
+      entries: [
+        journalEntry({ id: 'a', createdAt: 1000, result: { before: 'a' } }),
+        journalEntry({ id: 'b', createdAt: 1100, result: { before: 'b' } }),
+        journalEntry({ id: 'c', createdAt: 1200, result: { before: 'c' } }),
+      ],
+    });
+
+    expect(plan.truncated).toBe(true);
+    expect(plan.steps.map(step => step.journalEntryId)).toEqual(['c', 'b']);
+  });
+
+  it('rejects invalid limits', () => {
+    expect(() =>
+      createWorkspaceRestorePlan({
+        scope: { kind: 'session' },
+        limit: 0,
+        entries: [journalEntry()],
+      }),
+    ).toThrow(HarnessValidationError);
+  });
+
+  it('returns cloned plan data', () => {
+    const plan = createWorkspaceRestorePlan({
+      scope: { kind: 'session' },
+      entries: [journalEntry({ result: { before: { text: 'old' }, after: { text: 'new' } } })],
+    });
+
+    (plan.steps[0]?.snapshot as Record<string, string>).text = 'mutated';
+    (plan.steps[0]?.path as WorkspaceActionJournalPath).relativePath = 'mutated.md';
+
+    const freshPlan = createWorkspaceRestorePlan({
+      scope: { kind: 'session' },
+      entries: [journalEntry({ result: { before: { text: 'old' }, after: { text: 'new' } } })],
+    });
+
+    expect(firstStep(freshPlan).snapshot).toEqual({ text: 'old' });
+    expect(firstStep(freshPlan).path?.relativePath).toBe('notes.md');
+  });
+});
+
+function firstStep(plan: WorkspaceRestorePlan) {
+  const [step] = plan.steps;
+  if (!step) throw new Error('expected restore step');
+  return step;
+}
+
+function workspacePath(relativePath: string): WorkspaceActionJournalPath {
+  return {
+    rootId: 'project',
+    rootPath: '/workspace/project',
+    path: `/workspace/project/${relativePath}`,
+    relativePath,
+  };
+}
+
+function journalEntry(overrides: Partial<WorkspaceActionJournalEntry> = {}): WorkspaceActionJournalEntry {
+  return {
+    id: 'entry-1',
+    harnessName: 'default',
+    sessionId: 'session-1',
+    resourceId: 'resource-1',
+    threadId: 'thread-1',
+    actionKind: 'file',
+    operation: 'write',
+    action: { kind: 'file', operation: 'write', path: 'notes.md' },
+    policyDecision: 'ask',
+    policyReasons: ['workspace.default_ask'],
+    matchedRules: [],
+    path: notesPath,
+    actor: { type: 'user', id: 'user-1' },
+    requestId: 'turn-1',
+    result: { before: 'old notes', after: 'new notes' },
+    createdAt: 1000,
+    ...overrides,
+  };
+}

--- a/packages/core/src/harness/v1/workspace-restore.test.ts
+++ b/packages/core/src/harness/v1/workspace-restore.test.ts
@@ -78,6 +78,31 @@ describe('workspace restore planner', () => {
           operation: 'read',
           action: { kind: 'file', operation: 'read', path: 'notes.md' },
         }),
+        journalEntry({
+          id: 'stat-file',
+          operation: 'stat',
+          action: { kind: 'file', operation: 'stat', path: 'notes.md' },
+        }),
+        journalEntry({
+          id: 'readfile-file',
+          operation: 'readFile',
+          action: { kind: 'file', operation: 'readFile', path: 'notes.md' },
+        }),
+        journalEntry({
+          id: 'listfiles-file',
+          operation: 'listFiles',
+          action: { kind: 'file', operation: 'listFiles', path: 'src' },
+        }),
+        journalEntry({
+          id: 'grep-file',
+          operation: 'grep',
+          action: { kind: 'file', operation: 'grep', path: 'src' },
+        }),
+        journalEntry({
+          id: 'lspinspect-file',
+          operation: 'lspInspect',
+          action: { kind: 'file', operation: 'lspInspect', path: 'src/index.ts' },
+        }),
         journalEntry({ id: 'denied-write', policyDecision: 'deny', result: { before: 'old' } }),
         journalEntry({
           id: 'missing-before',
@@ -96,10 +121,36 @@ describe('workspace restore planner', () => {
     });
 
     expect(plan.steps.map(step => [step.journalEntryId, step.status, step.conflict.status])).toEqual([
+      ['stat-file', 'skipped', 'no_effect'],
+      ['readfile-file', 'skipped', 'no_effect'],
       ['read-file', 'skipped', 'no_effect'],
       ['missing-before', 'blocked', 'missing_before_snapshot'],
+      ['lspinspect-file', 'skipped', 'no_effect'],
+      ['listfiles-file', 'skipped', 'no_effect'],
+      ['grep-file', 'skipped', 'no_effect'],
       ['denied-write', 'skipped', 'no_effect'],
       ['command-run', 'blocked', 'unsupported_operation'],
+    ]);
+  });
+
+  it('blocks unhandled file mutation audit operations for manual review', () => {
+    const plan = createWorkspaceRestorePlan({
+      scope: { kind: 'session' },
+      entries: ['mkdir', 'rmdir', 'copy', 'move'].map((operation, index) =>
+        journalEntry({
+          id: `unsupported-${operation}`,
+          createdAt: 1000 + index,
+          operation,
+          action: { kind: 'file', operation, path: 'notes.md' },
+        }),
+      ),
+    });
+
+    expect(plan.steps.map(step => [step.journalEntryId, step.kind, step.status, step.conflict.status])).toEqual([
+      ['unsupported-move', 'manual_review', 'blocked', 'unsupported_operation'],
+      ['unsupported-copy', 'manual_review', 'blocked', 'unsupported_operation'],
+      ['unsupported-rmdir', 'manual_review', 'blocked', 'unsupported_operation'],
+      ['unsupported-mkdir', 'manual_review', 'blocked', 'unsupported_operation'],
     ]);
   });
 

--- a/packages/core/src/harness/v1/workspace-restore.test.ts
+++ b/packages/core/src/harness/v1/workspace-restore.test.ts
@@ -258,7 +258,7 @@ describe('workspace restore planner', () => {
     ).toBe(false);
   });
 
-  it('uses the same same-timestamp journal id ordering as storage', () => {
+  it('uses stable journal id ordering for same-timestamp entries', () => {
     const plan = createWorkspaceRestorePlan({
       scope: { kind: 'session' },
       entries: [

--- a/packages/core/src/harness/v1/workspace-restore.ts
+++ b/packages/core/src/harness/v1/workspace-restore.ts
@@ -1,0 +1,312 @@
+import type {
+  JsonValue,
+  WorkspaceActionJournalEntry,
+  WorkspaceActionJournalPath,
+  WorkspaceActionJournalPathFilter,
+} from '../../storage/domains/harness';
+import { HarnessValidationError } from './errors';
+
+export type WorkspaceRestoreScope =
+  | { kind: 'session' }
+  | { kind: 'turn'; requestId: string }
+  /**
+   * File scope follows the storage affected-path filter contract: source
+   * `path` is matched by default, and rename destinations require
+   * `includeToPath: true` on the selector.
+   */
+  | { kind: 'file'; affectedPath: WorkspaceActionJournalPathFilter };
+
+export type WorkspaceRestoreStepKind =
+  | 'restore_file'
+  | 'delete_file'
+  | 'move_path'
+  | 'reverse_patch'
+  | 'skip'
+  | 'manual_review';
+
+export type WorkspaceRestoreStepStatus = 'planned' | 'blocked' | 'skipped';
+
+export type WorkspaceRestoreConflictStatus =
+  | 'unknown'
+  | 'clean'
+  | 'external_change'
+  | 'missing_before_snapshot'
+  | 'unsupported_operation'
+  | 'no_effect';
+
+export interface WorkspaceRestoreConflict {
+  status: WorkspaceRestoreConflictStatus;
+  message?: string;
+}
+
+export interface WorkspaceRestorePlanStep {
+  id: string;
+  journalEntryId: string;
+  actionKind: WorkspaceActionJournalEntry['actionKind'];
+  operation?: string;
+  kind: WorkspaceRestoreStepKind;
+  status: WorkspaceRestoreStepStatus;
+  conflict: WorkspaceRestoreConflict;
+  path?: WorkspaceActionJournalPath;
+  toPath?: WorkspaceActionJournalPath;
+  snapshot?: JsonValue;
+}
+
+export interface WorkspaceRestoreAffectedPath {
+  path: WorkspaceActionJournalPath;
+  lastJournalEntryId: string;
+}
+
+export interface WorkspaceRestorePlan {
+  scope: WorkspaceRestoreScope;
+  steps: WorkspaceRestorePlanStep[];
+  affectedPaths: WorkspaceRestoreAffectedPath[];
+  truncated: boolean;
+}
+
+export interface CreateWorkspaceRestorePlanOptions {
+  scope: WorkspaceRestoreScope;
+  /**
+   * Entries must already be scoped by the host's tenant/session fence
+   * (`harnessName`, `resourceId`, `sessionId`, and optional `threadId`).
+   * The planner is a pure projection and does not perform auth isolation.
+   */
+  entries: readonly WorkspaceActionJournalEntry[];
+  /**
+   * Bounds host-provided input before planning. Use storage pagination for
+   * complete large plans. When truncated, the planner keeps the newest rows so
+   * restore steps still start from the live workspace's latest mutations.
+   */
+  limit?: number;
+}
+
+const DEFAULT_RESTORE_PLAN_LIMIT = 500;
+const FILE_MUTATION_OPERATIONS = new Set(['write', 'delete', 'rename', 'patch']);
+
+export function createWorkspaceRestorePlan({
+  scope,
+  entries,
+  limit = DEFAULT_RESTORE_PLAN_LIMIT,
+}: CreateWorkspaceRestorePlanOptions): WorkspaceRestorePlan {
+  const planLimit = boundRestorePlanLimit(limit);
+  const matchingEntries = [...entries]
+    .filter(entry => workspaceRestoreEntryMatchesScope(entry, scope))
+    .sort(compareWorkspaceRestoreEntries);
+  const selectedEntries = matchingEntries.slice(Math.max(0, matchingEntries.length - planLimit));
+  const steps = [...selectedEntries].reverse().map(projectWorkspaceRestoreStep);
+
+  return {
+    scope: cloneJson(scope),
+    steps: steps.map(step => cloneJson(step)),
+    affectedPaths: collectAffectedPaths(selectedEntries),
+    truncated: matchingEntries.length > selectedEntries.length,
+  };
+}
+
+export function workspaceRestoreEntryMatchesScope(
+  entry: WorkspaceActionJournalEntry,
+  scope: WorkspaceRestoreScope,
+): boolean {
+  if (scope.kind === 'session') return true;
+  if (scope.kind === 'turn') return entry.requestId === scope.requestId;
+  return (
+    workspaceActionPathMatches(entry.path, scope.affectedPath) ||
+    (scope.affectedPath.includeToPath === true && workspaceActionPathMatches(entry.toPath, scope.affectedPath))
+  );
+}
+
+function projectWorkspaceRestoreStep(entry: WorkspaceActionJournalEntry): WorkspaceRestorePlanStep {
+  if (entry.policyDecision === 'deny') {
+    return {
+      ...baseStep(entry, 'skip', 'skipped'),
+      conflict: { status: 'no_effect', message: 'Denied workspace action did not mutate the workspace' },
+    };
+  }
+
+  if (entry.actionKind !== 'file') {
+    return blockedStep(entry, 'manual_review', 'unsupported_operation', 'Only file journal entries can be restored');
+  }
+
+  if (!entry.operation || !FILE_MUTATION_OPERATIONS.has(entry.operation)) {
+    return {
+      ...baseStep(entry, 'skip', 'skipped'),
+      conflict: { status: 'no_effect', message: 'Non-mutating file action does not require restore work' },
+    };
+  }
+
+  if (entry.operation === 'rename') {
+    if (!entry.path || !entry.toPath) {
+      return blockedStep(
+        entry,
+        'move_path',
+        'missing_before_snapshot',
+        'Rename restore requires source and target paths',
+      );
+    }
+    const destinationBefore = getResultSnapshot(entry.result, 'toBefore');
+    if (destinationBefore === undefined) {
+      return blockedStep(
+        entry,
+        'move_path',
+        'missing_before_snapshot',
+        'Rename restore requires explicit result.toBefore destination evidence',
+      );
+    }
+    if (destinationBefore !== undefined && destinationBefore !== null) {
+      return blockedStep(
+        entry,
+        'manual_review',
+        'unsupported_operation',
+        'Rename restore with overwritten destination content requires manual review',
+      );
+    }
+    return {
+      ...baseStep(entry, 'move_path', 'planned'),
+      path: cloneJson(entry.toPath),
+      toPath: cloneJson(entry.path),
+      conflict: { status: 'unknown' },
+    };
+  }
+
+  if (!entry.path) {
+    return blockedStep(entry, 'manual_review', 'unsupported_operation', 'File restore requires a path');
+  }
+
+  const before = getResultSnapshot(entry.result, 'before');
+  if (before === undefined) {
+    return blockedStep(
+      entry,
+      restoreKindForOperation(entry.operation),
+      'missing_before_snapshot',
+      'Restore requires result.before evidence',
+    );
+  }
+
+  if (before === null) {
+    if (entry.operation === 'delete') {
+      return {
+        ...baseStep(entry, 'skip', 'skipped'),
+        conflict: { status: 'no_effect', message: 'Delete action did not remove an existing file' },
+      };
+    }
+    if (entry.operation === 'patch') {
+      return blockedStep(
+        entry,
+        'reverse_patch',
+        'missing_before_snapshot',
+        'Patch restore requires a concrete before snapshot',
+      );
+    }
+    return {
+      ...baseStep(entry, 'delete_file', 'planned'),
+      path: cloneJson(entry.path),
+      snapshot: null,
+      conflict: { status: 'unknown' },
+    };
+  }
+
+  return {
+    ...baseStep(entry, restoreKindForOperation(entry.operation), 'planned'),
+    path: cloneJson(entry.path),
+    snapshot: cloneJson(before),
+    conflict: { status: 'unknown' },
+  };
+}
+
+function restoreKindForOperation(operation: string): WorkspaceRestoreStepKind {
+  if (operation === 'patch') return 'reverse_patch';
+  return 'restore_file';
+}
+
+function baseStep(
+  entry: WorkspaceActionJournalEntry,
+  kind: WorkspaceRestoreStepKind,
+  status: WorkspaceRestoreStepStatus,
+): Omit<WorkspaceRestorePlanStep, 'conflict'> {
+  return {
+    id: `restore:${entry.id}`,
+    journalEntryId: entry.id,
+    actionKind: entry.actionKind,
+    ...(entry.operation ? { operation: entry.operation } : {}),
+    kind,
+    status,
+    ...(entry.path ? { path: cloneJson(entry.path) } : {}),
+    ...(entry.toPath ? { toPath: cloneJson(entry.toPath) } : {}),
+  };
+}
+
+function blockedStep(
+  entry: WorkspaceActionJournalEntry,
+  kind: WorkspaceRestoreStepKind,
+  status: WorkspaceRestoreConflictStatus,
+  message: string,
+): WorkspaceRestorePlanStep {
+  return {
+    ...baseStep(entry, kind, 'blocked'),
+    conflict: { status, message },
+  };
+}
+
+function collectAffectedPaths(entries: readonly WorkspaceActionJournalEntry[]): WorkspaceRestoreAffectedPath[] {
+  const byPath = new Map<string, WorkspaceRestoreAffectedPath>();
+  for (const entry of entries) {
+    for (const affectedPath of [entry.path, entry.toPath]) {
+      if (!affectedPath) continue;
+      byPath.set(workspaceActionPathKey(affectedPath), {
+        path: cloneJson(affectedPath),
+        lastJournalEntryId: entry.id,
+      });
+    }
+  }
+  return [...byPath.values()].sort((left, right) =>
+    workspaceActionPathKey(left.path).localeCompare(workspaceActionPathKey(right.path)),
+  );
+}
+
+function workspaceActionPathMatches(
+  path: WorkspaceActionJournalPath | undefined,
+  filter: WorkspaceActionJournalPathFilter,
+): boolean {
+  if (!path || !workspaceActionPathFilterHasSelector(filter)) return false;
+  if (filter.rootId !== undefined && path.rootId !== filter.rootId) return false;
+  if (filter.path !== undefined && path.path !== filter.path) return false;
+  if (filter.relativePath !== undefined && path.relativePath !== filter.relativePath) return false;
+  return true;
+}
+
+function workspaceActionPathFilterHasSelector(filter: WorkspaceActionJournalPathFilter): boolean {
+  return filter.rootId !== undefined || filter.path !== undefined || filter.relativePath !== undefined;
+}
+
+function workspaceActionPathKey(path: WorkspaceActionJournalPath): string {
+  return `${path.rootId}\0${path.path}\0${path.relativePath}`;
+}
+
+function compareWorkspaceRestoreEntries(left: WorkspaceActionJournalEntry, right: WorkspaceActionJournalEntry): number {
+  return left.createdAt - right.createdAt || compareWorkspaceActionJournalId(left.id, right.id);
+}
+
+function compareWorkspaceActionJournalId(left: string, right: string): number {
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
+}
+
+function getResultSnapshot(result: JsonValue | undefined, key: 'before' | 'toBefore'): JsonValue | undefined {
+  if (!isJsonRecord(result) || !(key in result)) return undefined;
+  return result[key];
+}
+
+function isJsonRecord(value: JsonValue | undefined): value is Record<string, JsonValue> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function boundRestorePlanLimit(limit: number): number {
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
+    throw new HarnessValidationError('limit', 'Workspace restore plan limit must be a positive safe integer');
+  }
+  return limit;
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/packages/core/src/harness/v1/workspace-restore.ts
+++ b/packages/core/src/harness/v1/workspace-restore.ts
@@ -91,6 +91,7 @@ export interface CreateWorkspaceRestorePlanOptions {
 
 const DEFAULT_RESTORE_PLAN_LIMIT = 500;
 const FILE_MUTATION_OPERATIONS = new Set(['write', 'delete', 'rename', 'patch']);
+const FILE_NON_MUTATION_OPERATIONS = new Set(['read', 'readFile', 'listFiles', 'grep', 'stat', 'lspInspect']);
 
 /** Builds an ordered restore plan from already-scoped workspace action journal entries. */
 export function createWorkspaceRestorePlan({
@@ -132,6 +133,7 @@ export function workspaceRestoreEntryMatchesScope(
   );
 }
 
+/** Projects one journal row into host-executable restore work or a review-only step. */
 function projectWorkspaceRestoreStep(entry: WorkspaceActionJournalEntry): WorkspaceRestorePlanStep {
   if (entry.policyDecision === 'deny') {
     return {
@@ -144,11 +146,20 @@ function projectWorkspaceRestoreStep(entry: WorkspaceActionJournalEntry): Worksp
     return blockedStep(entry, 'manual_review', 'unsupported_operation', 'Only file journal entries can be restored');
   }
 
-  if (!entry.operation || !FILE_MUTATION_OPERATIONS.has(entry.operation)) {
+  if (!entry.operation || FILE_NON_MUTATION_OPERATIONS.has(entry.operation)) {
     return {
       ...baseStep(entry, 'skip', 'skipped'),
       conflict: { status: 'no_effect', message: 'Non-mutating file action does not require restore work' },
     };
+  }
+
+  if (!FILE_MUTATION_OPERATIONS.has(entry.operation)) {
+    return blockedStep(
+      entry,
+      'manual_review',
+      'unsupported_operation',
+      'Unsupported file operation requires manual restore review',
+    );
   }
 
   if (entry.operation === 'rename') {
@@ -230,11 +241,13 @@ function projectWorkspaceRestoreStep(entry: WorkspaceActionJournalEntry): Worksp
   };
 }
 
+/** Maps file mutation operations to the restore action kind a host should perform. */
 function restoreKindForOperation(operation: string): WorkspaceRestoreStepKind {
   if (operation === 'patch') return 'reverse_patch';
   return 'restore_file';
 }
 
+/** Copies common journal metadata into a detached restore step shell. */
 function baseStep(
   entry: WorkspaceActionJournalEntry,
   kind: WorkspaceRestoreStepKind,
@@ -252,6 +265,7 @@ function baseStep(
   };
 }
 
+/** Builds a blocked restore step with a typed conflict reason. */
 function blockedStep(
   entry: WorkspaceActionJournalEntry,
   kind: WorkspaceRestoreStepKind,
@@ -264,6 +278,7 @@ function blockedStep(
   };
 }
 
+/** Summarizes distinct source and destination paths touched by selected journal rows. */
 function collectAffectedPaths(entries: readonly WorkspaceActionJournalEntry[]): WorkspaceRestoreAffectedPath[] {
   const byPath = new Map<string, WorkspaceRestoreAffectedPath>();
   for (const entry of entries) {
@@ -280,6 +295,7 @@ function collectAffectedPaths(entries: readonly WorkspaceActionJournalEntry[]): 
   );
 }
 
+/** Applies the journal affected-path selector contract to one resolved workspace path. */
 function workspaceActionPathMatches(
   path: WorkspaceActionJournalPath | undefined,
   filter: WorkspaceActionJournalPathFilter,
@@ -291,32 +307,39 @@ function workspaceActionPathMatches(
   return true;
 }
 
+/** Returns true when a path filter contains at least one concrete selector. */
 function workspaceActionPathFilterHasSelector(filter: WorkspaceActionJournalPathFilter): boolean {
   return filter.rootId !== undefined || filter.path !== undefined || filter.relativePath !== undefined;
 }
 
+/** Builds a deterministic path identity key for de-duplicating affected paths. */
 function workspaceActionPathKey(path: WorkspaceActionJournalPath): string {
   return `${path.rootId}\0${path.path}\0${path.relativePath}`;
 }
 
+/** Orders journal rows the same way storage pagination orders them. */
 function compareWorkspaceRestoreEntries(left: WorkspaceActionJournalEntry, right: WorkspaceActionJournalEntry): number {
   return left.createdAt - right.createdAt || compareWorkspaceActionJournalId(left.id, right.id);
 }
 
+/** Compares journal ids without locale-dependent collation. */
 function compareWorkspaceActionJournalId(left: string, right: string): number {
   if (left === right) return 0;
   return left < right ? -1 : 1;
 }
 
+/** Reads restore evidence from result records while preserving explicit null values. */
 function getResultSnapshot(result: JsonValue | undefined, key: 'before' | 'toBefore'): JsonValue | undefined {
   if (!isJsonRecord(result) || !(key in result)) return undefined;
   return result[key];
 }
 
+/** Narrows JSON values to plain object records. */
 function isJsonRecord(value: JsonValue | undefined): value is Record<string, JsonValue> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+/** Validates and returns the maximum number of journal rows to project. */
 function boundRestorePlanLimit(limit: number): number {
   if (!Number.isSafeInteger(limit) || limit <= 0) {
     throw new HarnessValidationError('limit', 'Workspace restore plan limit must be a positive safe integer');
@@ -324,6 +347,7 @@ function boundRestorePlanLimit(limit: number): number {
   return limit;
 }
 
+/** Produces detached JSON-safe output objects for the public plan DTO. */
 function cloneJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }

--- a/packages/core/src/harness/v1/workspace-restore.ts
+++ b/packages/core/src/harness/v1/workspace-restore.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../storage/domains/harness';
 import { HarnessValidationError } from './errors';
 
+/** Selects which workspace journal entries should be projected into a restore plan. */
 export type WorkspaceRestoreScope =
   | { kind: 'session' }
   | { kind: 'turn'; requestId: string }
@@ -16,6 +17,7 @@ export type WorkspaceRestoreScope =
    */
   | { kind: 'file'; affectedPath: WorkspaceActionJournalPathFilter };
 
+/** Operation the host should perform, or inspect, to reverse a journal entry. */
 export type WorkspaceRestoreStepKind =
   | 'restore_file'
   | 'delete_file'
@@ -24,8 +26,10 @@ export type WorkspaceRestoreStepKind =
   | 'skip'
   | 'manual_review';
 
+/** Whether a restore step is actionable, needs review, or has no effect. */
 export type WorkspaceRestoreStepStatus = 'planned' | 'blocked' | 'skipped';
 
+/** Conflict classification for a projected restore step. */
 export type WorkspaceRestoreConflictStatus =
   | 'unknown'
   | 'clean'
@@ -34,11 +38,13 @@ export type WorkspaceRestoreConflictStatus =
   | 'unsupported_operation'
   | 'no_effect';
 
+/** Human-readable conflict information for a restore step. */
 export interface WorkspaceRestoreConflict {
   status: WorkspaceRestoreConflictStatus;
   message?: string;
 }
 
+/** Planned restore work derived from one workspace action journal entry. */
 export interface WorkspaceRestorePlanStep {
   id: string;
   journalEntryId: string;
@@ -52,11 +58,13 @@ export interface WorkspaceRestorePlanStep {
   snapshot?: JsonValue;
 }
 
+/** A workspace path touched by the selected journal entries. */
 export interface WorkspaceRestoreAffectedPath {
   path: WorkspaceActionJournalPath;
   lastJournalEntryId: string;
 }
 
+/** Ordered restore plan for the selected workspace journal scope. */
 export interface WorkspaceRestorePlan {
   scope: WorkspaceRestoreScope;
   steps: WorkspaceRestorePlanStep[];
@@ -64,6 +72,7 @@ export interface WorkspaceRestorePlan {
   truncated: boolean;
 }
 
+/** Inputs for pure workspace restore planning. */
 export interface CreateWorkspaceRestorePlanOptions {
   scope: WorkspaceRestoreScope;
   /**
@@ -83,6 +92,7 @@ export interface CreateWorkspaceRestorePlanOptions {
 const DEFAULT_RESTORE_PLAN_LIMIT = 500;
 const FILE_MUTATION_OPERATIONS = new Set(['write', 'delete', 'rename', 'patch']);
 
+/** Builds an ordered restore plan from already-scoped workspace action journal entries. */
 export function createWorkspaceRestorePlan({
   scope,
   entries,
@@ -109,6 +119,7 @@ export function createWorkspaceRestorePlan({
   };
 }
 
+/** Returns true when a workspace action journal entry belongs to the requested restore scope. */
 export function workspaceRestoreEntryMatchesScope(
   entry: WorkspaceActionJournalEntry,
   scope: WorkspaceRestoreScope,

--- a/packages/core/src/harness/v1/workspace-restore.ts
+++ b/packages/core/src/harness/v1/workspace-restore.ts
@@ -88,6 +88,12 @@ export function createWorkspaceRestorePlan({
   entries,
   limit = DEFAULT_RESTORE_PLAN_LIMIT,
 }: CreateWorkspaceRestorePlanOptions): WorkspaceRestorePlan {
+  if (scope.kind === 'file' && !workspaceActionPathFilterHasSelector(scope.affectedPath)) {
+    throw new HarnessValidationError(
+      'scope.affectedPath',
+      'File restore scope requires at least one affected path selector',
+    );
+  }
   const planLimit = boundRestorePlanLimit(limit);
   const matchingEntries = [...entries]
     .filter(entry => workspaceRestoreEntryMatchesScope(entry, scope))
@@ -97,7 +103,7 @@ export function createWorkspaceRestorePlan({
 
   return {
     scope: cloneJson(scope),
-    steps: steps.map(step => cloneJson(step)),
+    steps,
     affectedPaths: collectAffectedPaths(selectedEntries),
     truncated: matchingEntries.length > selectedEntries.length,
   };

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -515,6 +515,15 @@ export interface WorkspaceActionJournalEntry {
    */
   traceId?: string;
   spanId?: string;
+  /**
+   * Producer-specific action evidence. Harness restore planning treats
+   * `result.before` as the pre-action file state for file mutations:
+   * `null` means the file did not exist, while an absent key means the
+   * producer did not capture enough evidence for automatic restore planning.
+   * Rename producers must set `result.toBefore` to the pre-action destination
+   * state for automatic restore planning; `null` means the target path did not
+   * exist before the rename.
+   */
   result?: JsonValue;
   createdAt: number;
 }


### PR DESCRIPTION
## Summary

- Adds a pure Harness v1 workspace restore planner over existing workspace action journal rows.
- Exposes restore plan DTOs and scope matching from `@mastra/core/harness/v1`.
- Documents `result.before` / `result.toBefore` restore evidence and adds a changeset.

## Safety / scope

- Read-only projection only: no filesystem mutation, no storage schema changes, no server routes, no auth changes, no production-sensitive paths.
- Restore entries must already be scoped by the host tenant/session fence.
- Rename restore requires explicit destination evidence and blocks unsafe overwrite cases.

## Validation

- `pnpm build:core`
- `pnpm --filter @mastra/core test --run src/harness/v1/workspace-restore.test.ts` (12 tests)
- `pnpm exec prettier --check .changeset/pf-733-workspace-restore-plan.md packages/core/src/harness/v1/index.ts packages/core/src/harness/v1/workspace-restore.ts packages/core/src/harness/v1/workspace-restore.test.ts packages/core/src/storage/domains/harness/types.ts`
- `pnpm --dir packages/core exec eslint --no-warn-ignored src/harness/v1/index.ts src/harness/v1/workspace-restore.ts src/harness/v1/workspace-restore.test.ts src/storage/domains/harness/types.ts`
- `pnpm --filter ./packages/core check`
- `git diff --check`
- agy council review found truncation/restore evidence issues; fixed.
- Local Codex review pass 1: findings fixed, rerun returned no findings.
- Local Codex review pass 2: findings fixed, rerun returned no findings.
- CodeRabbit CLI: one minor changeset wording finding; fixed.

Linear: PF-733


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a read-only planner that looks at recorded workspace changes and produces an ordered plan for how to undo them (restore files, delete created files, move/rename, or flag steps for manual review). It only reports steps, conflicts, and affected paths — it does not change files or runtime behavior.

---

## Changes Overview

Introduces a Harness v1 workspace restore planner in `@mastra/core` (packages/core/src/harness/v1):

- createWorkspaceRestorePlan — takes a scope (session/turn/file) and journal entries, validates/limits input (default limit 500), filters entries by scope, orders rows (createdAt then journal id), truncates to newest relevant rows, projects typed restore steps, reverses for execution order, computes affectedPaths and last-journal-id per path, and returns a deep-cloned plan.
- workspaceRestoreEntryMatchesScope — scope-matching rules for session/turn/file scopes with optional includeToPath to consider rename destinations.
- Public DTOs & utilities exported from packages/core/src/harness/v1 (plan, steps, scope, kinds, statuses, conflicts).
- JSDoc on WorkspaceActionJournalEntry.result documenting evidence semantics: explicit null vs missing key, and rename producers must populate result.toBefore when applicable.
- Changeset documenting the feature and example usage (.changeset/pf-733-workspace-restore-plan.md).

Behavioral and safety notes:
- Pure projection/read-only: no filesystem mutation, no storage schema or server/auth changes.
- Rename restores require explicit destination evidence (result.toBefore). Missing or overwritten destination evidence yields a blocked/manual-review step to avoid unsafe overwrites.
- Delete/patch handling depends on result.before: explicit null indicates file didn’t exist (deletion becomes noop/skip), absent evidence blocks/flags patch restores.
- Non-file or non-mutating actions are skipped or flagged appropriately.
- Deterministic ordering for identical timestamps via journal id tiebreaker.
- Enforces file-scope validation (file scope must include an affected-path selector) and positive safe-integer limits.

---

## Tests & Validation

- Added Vitest coverage (packages/core/src/harness/v1/workspace-restore.test.ts — 12 tests) exercising ordering, null-before behavior, rename evidence/overwrite blocking, scope matching (includeToPath), deterministic ordering, truncation/limit behavior, invalid-limit and invalid-file-scope validation, denied/non-file handling, and cloning of outputs.
- Built and type-checked `@mastra/core`; Prettier and ESLint checks passed for changed files.
- Addressed review feedback (truncation/restore evidence wording; CodeRabbit CLI wording fix).

---

## API / Public Exports

packages/core/src/harness/v1/index.ts now exports:
- Functions: createWorkspaceRestorePlan, workspaceRestoreEntryMatchesScope
- Types: CreateWorkspaceRestorePlanOptions, WorkspaceRestoreAffectedPath, WorkspaceRestoreConflict, WorkspaceRestoreConflictStatus, WorkspaceRestorePlan, WorkspaceRestorePlanStep, WorkspaceRestoreScope, WorkspaceRestoreStepKind, WorkspaceRestoreStepStatus

---

## Docs / Types

- Extended JSDoc in packages/core/src/storage/domains/harness/types.ts to clarify WorkspaceActionJournalEntry.result semantics (explicit null vs missing keys; rename producers must populate result.toBefore).
- Changeset added for a patch release documenting Harness v1 workspace restore planning and example usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->