### PR TITLE
[PF-735] Persist Harness token usage across rehydration

### DIFF
--- a/.changeset/pf-735-harness-store-evidence-metadata.md
+++ b/.changeset/pf-735-harness-store-evidence-metadata.md
@@ -1,0 +1,6 @@
+---
+'@mastra/libsql': patch
+'@mastra/pg': patch
+---
+
+Fixed Harness message result storage to preserve mode and model metadata for duplicate message recovery.

--- a/.changeset/pf-735-token-usage-durability.md
+++ b/.changeset/pf-735-token-usage-durability.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed token usage tracking so counts persist across restarts, session evictions, interruptions, and background operations. Token totals are now calculated automatically when providers omit them.

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -695,6 +695,7 @@ export class Harness {
   private readonly _sessionEventBridges = new Map<string, HarnessEventUnsubscribe>();
   /** In-process close de-dupe by any session id currently covered by a close tree. */
   private readonly _closePromises = new Map<string, Promise<void>>();
+  private readonly _shutdownEvictedSessionIds = new Set<string>();
   /** Workspace registry — owns lifecycle across `shared`/`per-resource`/`per-session`. */
   readonly _workspaceRegistry: WorkspaceRegistry;
   /** Snapshot of the workspace kind for fast read paths. `undefined` when not configured. */
@@ -2908,7 +2909,7 @@ export class Harness {
    * Drain in-flight work and release every held lease. After `shutdown`,
    * `session()` rejects. Idempotent.
    */
-  async shutdown(_opts?: ShutdownOptions): Promise<void> {
+  async shutdown(opts?: ShutdownOptions): Promise<void> {
     if (this._shutdown) return;
     this._shutdown = true;
 
@@ -2935,18 +2936,64 @@ export class Harness {
     // Release every held lease. We keep the records active in storage —
     // shutdown is not a close.
     const sessions = Array.from(this._liveSessions.values());
+    for (const session of sessions) {
+      session._beginClosing();
+    }
+    const drainTimeoutMs = opts?.drainTimeoutMs ?? this._closeTimeoutMs;
+    const drainDeadlineAt = Date.now() + drainTimeoutMs;
     let eventPersistenceError: { sessionId: string; error: unknown } | undefined;
     for (const session of sessions) {
-      // Surface eviction to harness-level subscribers BEFORE we tear down
-      // the bridge so the event still propagates, and persist it before lease
-      // handoff so a fast new owner resumes from the correct event sequence.
-      session._emit({ type: 'session_evicted', reason: 'shutdown' });
+      try {
+        await session._waitForShutdownDrain(drainDeadlineAt);
+      } catch (err) {
+        eventPersistenceError ??= { sessionId: session.id, error: err };
+        continue;
+      }
+      try {
+        await session._internalPersistTokenUsageForShutdown({ deadlineAt: drainDeadlineAt });
+        await session._internalAwaitFlushChain({ deadlineAt: drainDeadlineAt });
+      } catch (err) {
+        eventPersistenceError ??= { sessionId: session.id, error: err };
+        continue;
+      }
       try {
         await session._flushEventPersistence();
       } catch (err) {
         eventPersistenceError ??= { sessionId: session.id, error: err };
+        continue;
       }
+    }
+    if (eventPersistenceError !== undefined) {
+      for (const session of sessions) {
+        session._restoreLiveAfterFailedClose();
+      }
+      this._shutdown = false;
+      throw new HarnessStorageError(eventPersistenceError.sessionId, 'flush', eventPersistenceError.error);
+    }
 
+    for (const session of sessions) {
+      // Surface eviction to harness-level subscribers after admitted turn work
+      // drains so replay observes terminal turn events before the handoff marker.
+      if (!this._shutdownEvictedSessionIds.has(session.id)) {
+        session._emit({ type: 'session_evicted', reason: 'shutdown' });
+        this._shutdownEvictedSessionIds.add(session.id);
+      }
+      try {
+        await session._flushEventPersistence();
+      } catch (err) {
+        eventPersistenceError ??= { sessionId: session.id, error: err };
+        continue;
+      }
+    }
+    if (eventPersistenceError !== undefined) {
+      for (const session of sessions) {
+        session._restoreLiveAfterFailedClose();
+      }
+      this._shutdown = false;
+      throw new HarnessStorageError(eventPersistenceError.sessionId, 'flush', eventPersistenceError.error);
+    }
+
+    for (const session of sessions) {
       try {
         await storage.releaseSessionLease({
           harnessName: session.getRecord().harnessName,
@@ -2962,8 +3009,10 @@ export class Harness {
         bridge();
         this._sessionEventBridges.delete(session.id);
       }
+      this._liveSessions.delete(session.id);
     }
     this._liveSessions.clear();
+    this._shutdownEvictedSessionIds.clear();
 
     // Tear down every provisioned workspace (shared + per-resource + per-session).
     try {
@@ -2972,9 +3021,6 @@ export class Harness {
       // Best-effort: errors surface through the workspace_error event.
     }
     this._untrackBoundStorage();
-    if (eventPersistenceError !== undefined) {
-      throw new HarnessStorageError(eventPersistenceError.sessionId, 'flush', eventPersistenceError.error);
-    }
   }
 
   // -------------------------------------------------------------------------

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -152,6 +152,7 @@ type Deferred<T> = {
 type MessageAdmissionStart = {
   admissionHash: string;
   modeId: string;
+  modelId: string;
   promise: Promise<AgentSignalResultEvidence | OperationAdmissionTombstone>;
 };
 
@@ -690,7 +691,13 @@ export class Session {
   private readonly _activeTools = new Map<string, ActiveToolState>();
   private readonly _toolInputBuffers = new Map<string, { toolName: string; text: string }>();
   private readonly _activeSubagents = new Map<string, ActiveSubagentState>();
-  /** Cumulative usage for the session's thread. Updated on `agent_end`. */
+  /**
+   * Cumulative usage for the session's thread. Live counter, single source of
+   * truth in-process. Seeded from `internals.record.tokenUsage` in the
+   * constructor so reopens carry the persisted aggregate; flushed back into
+   * `_record.tokenUsage` on every `_flushUpdate` so the next reopen sees the
+   * latest value.
+   */
   private _tokenUsage: TokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
   /**
    * Outstanding `waitForIdle()` callers. On close/evict each waiter is
@@ -786,9 +793,19 @@ export class Session {
     string,
     { ok: true; full: FullOutput<unknown> } | { ok: false; err: unknown }
   >();
+  /**
+   * Message admission retries can observe `_completedRuns` before the original
+   * message continuation has accounted usage. Track run ids accounted through
+   * either path so the retry can persist before writing evidence without the
+   * original continuation double-counting later.
+   */
+  private readonly _messageTokenAccountedRunIds = new Set<string>();
+  private readonly _messageTokenAccountingRunIds = new Set<string>();
+  private readonly _messageTokenAccountingReservations = new Map<string, Deferred<void>>();
   private readonly _messageAdmissionStarts = new Map<string, MessageAdmissionStart>();
   private _eventPersistenceTail: Promise<void> = Promise.resolve();
   private _eventPersistenceError: unknown;
+  private readonly _backgroundTurnCompletions = new Set<Promise<unknown>>();
 
   /** @internal — constructed by the Harness, not directly. */
   constructor(internals: SessionInternals) {
@@ -800,6 +817,41 @@ export class Session {
     this.createdAt = internals.record.createdAt;
 
     this._record = internals.record;
+    // Seed the live token-usage counter from the persisted aggregate so reopens
+    // (after eviction / process restart) continue accumulating instead of
+    // restarting at zero. Accept only non-negative integer fields because rows
+    // written before tokenUsage durability shipped may carry partially-populated
+    // or malformed objects; a bad component would otherwise poison the
+    // aggregate.
+    {
+      const persisted = internals.record.tokenUsage as Partial<TokenUsage> | undefined;
+      const promptTokens =
+        typeof persisted?.promptTokens === 'number' &&
+        Number.isInteger(persisted.promptTokens) &&
+        persisted.promptTokens >= 0
+          ? persisted.promptTokens
+          : 0;
+      const completionTokens =
+        typeof persisted?.completionTokens === 'number' &&
+        Number.isInteger(persisted.completionTokens) &&
+        persisted.completionTokens >= 0
+          ? persisted.completionTokens
+          : 0;
+      const derivedTotalTokens = promptTokens + completionTokens;
+      const totalTokens =
+        typeof persisted?.totalTokens === 'number' &&
+        Number.isInteger(persisted.totalTokens) &&
+        persisted.totalTokens >= 0
+          ? persisted.totalTokens < derivedTotalTokens
+            ? derivedTotalTokens
+            : persisted.totalTokens
+          : derivedTotalTokens;
+      this._tokenUsage = {
+        promptTokens,
+        completionTokens,
+        totalTokens,
+      };
+    }
     if (this._record.closedAt !== undefined) {
       this._state = 'closed';
     } else if (this._record.closingAt !== undefined) {
@@ -1089,6 +1141,16 @@ export class Session {
     return activeTurnWaiter ? Promise.race([promise, activeTurnWaiter]) : promise;
   }
 
+  private _trackBackgroundTurnCompletion<T>(promise: Promise<T>): Promise<T> {
+    this._backgroundTurnCompletions.add(promise);
+    void promise
+      .finally(() => {
+        this._backgroundTurnCompletions.delete(promise);
+      })
+      .catch(() => {});
+    return promise;
+  }
+
   private _shouldWriteTurnFailureEvidence(err: unknown): boolean {
     return this._state !== 'deleted' && !(err instanceof HarnessSessionDeletedError);
   }
@@ -1103,15 +1165,15 @@ export class Session {
     }
   }
 
-  /**
-   * Fold the `FullOutput` from a completed (or suspended) agent run into the
-   * session's transient display state: capture `runId` if not yet set and
-   * accumulate token usage. Called from every site that has the full output.
-   */
-  private _recordTurnCompletion(full: FullOutput<unknown>): void {
+  /** Capture the first run id for the active turn display state. */
+  private _captureTurnRunId(full: FullOutput<unknown>): void {
+    if (this._currentTurnAbortController === undefined) return;
     if (full.runId && this._currentRunId === undefined) {
       this._currentRunId = full.runId;
     }
+  }
+
+  private _tokenUsageDeltaFromFullOutput(full: FullOutput<unknown>): TokenUsage | undefined {
     const usage = (full as { totalUsage?: unknown; usage?: unknown }).totalUsage ?? (full as { usage?: unknown }).usage;
     if (usage && typeof usage === 'object') {
       const u = usage as {
@@ -1123,11 +1185,352 @@ export class Session {
       };
       const prompt = u.promptTokens ?? u.inputTokens;
       const completion = u.completionTokens ?? u.outputTokens;
-      if (typeof prompt === 'number') this._tokenUsage.promptTokens += prompt;
-      if (typeof completion === 'number') this._tokenUsage.completionTokens += completion;
-      if (typeof u.totalTokens === 'number') this._tokenUsage.totalTokens += u.totalTokens;
+      const promptNumber = typeof prompt === 'number' && Number.isInteger(prompt) && prompt >= 0 ? prompt : undefined;
+      const completionNumber =
+        typeof completion === 'number' && Number.isInteger(completion) && completion >= 0 ? completion : undefined;
+      const delta: TokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+      const incremented =
+        promptNumber !== undefined ||
+        completionNumber !== undefined ||
+        (typeof u.totalTokens === 'number' && Number.isInteger(u.totalTokens) && u.totalTokens >= 0);
+      if (promptNumber !== undefined) delta.promptTokens += promptNumber;
+      if (completionNumber !== undefined) delta.completionTokens += completionNumber;
+      const derivedTotalTokens = (promptNumber ?? 0) + (completionNumber ?? 0);
+      if (typeof u.totalTokens === 'number' && Number.isInteger(u.totalTokens) && u.totalTokens >= 0) {
+        delta.totalTokens += u.totalTokens < derivedTotalTokens ? derivedTotalTokens : u.totalTokens;
+      } else if (promptNumber !== undefined || completionNumber !== undefined) {
+        // Providers that only emit `inputTokens`/`outputTokens` leave `totalTokens`
+        // off; derive it so the aggregate stays consistent with its parts.
+        delta.totalTokens += derivedTotalTokens;
+      }
+      return incremented ? delta : undefined;
+    }
+    return undefined;
+  }
+
+  private _applyTokenUsageDelta(delta: TokenUsage | undefined): void {
+    if (delta === undefined) return;
+    this._tokenUsage = {
+      promptTokens: this._tokenUsage.promptTokens + delta.promptTokens,
+      completionTokens: this._tokenUsage.completionTokens + delta.completionTokens,
+      totalTokens: this._tokenUsage.totalTokens + delta.totalTokens,
+    };
+  }
+
+  private _clearPendingTokenUsageFlushErrorIfSaved(tokenUsage: TokenUsage | undefined): void {
+    if (
+      tokenUsage !== undefined &&
+      tokenUsage.promptTokens === this._tokenUsage.promptTokens &&
+      tokenUsage.completionTokens === this._tokenUsage.completionTokens &&
+      tokenUsage.totalTokens === this._tokenUsage.totalTokens
+    ) {
+      this._pendingTokenUsageFlushError = undefined;
+      if (this._pendingDurableTurnFlushError?.pendingResume === undefined) {
+        this._pendingDurableTurnFlushError = undefined;
+      }
     }
   }
+
+  private _latchDurableTurnFlushError(err: unknown, full?: FullOutput<unknown>): void {
+    if (!this._isExpectedFlushLifecycleError(err)) {
+      this._pendingDurableTurnFlushError ??= { error: err, pendingResume: this._pendingResumeKeyFromOutput(full) };
+    }
+  }
+
+  private _pendingResumeKeyFromOutput(
+    full: FullOutput<unknown> | undefined,
+  ): { runId: string; toolCallId: string } | undefined {
+    if (!full?.runId || full.finishReason !== 'suspended') return undefined;
+    const payload = full.suspendPayload as { toolCallId?: unknown } | undefined;
+    return typeof payload?.toolCallId === 'string' ? { runId: full.runId, toolCallId: payload.toolCallId } : undefined;
+  }
+
+  private _clearPendingDurableTurnFlushErrorIfRepaired(full?: FullOutput<unknown>): void {
+    const latched = this._pendingDurableTurnFlushError;
+    if (latched === undefined) return;
+    const latchedPending = latched.pendingResume;
+    if (latchedPending === undefined) {
+      this._pendingDurableTurnFlushError = undefined;
+      return;
+    }
+    const repairedPending = this._pendingResumeKeyFromOutput(full);
+    if (
+      repairedPending?.runId === latchedPending.runId &&
+      repairedPending.toolCallId === latchedPending.toolCallId &&
+      this._record.pendingResume?.runId === latchedPending.runId &&
+      this._record.pendingResume.toolCallId === latchedPending.toolCallId
+    ) {
+      this._pendingDurableTurnFlushError = undefined;
+    }
+  }
+
+  private _recordTokenUsageMatchesLive(opts: { tolerateInvalidZero?: boolean } = {}): boolean {
+    const stored = this._record.tokenUsage;
+    const liveIsZero =
+      this._tokenUsage.promptTokens === 0 && this._tokenUsage.completionTokens === 0 && this._tokenUsage.totalTokens === 0;
+    if (
+      stored === undefined ||
+      !this._isValidTokenCount(stored.promptTokens) ||
+      !this._isValidTokenCount(stored.completionTokens) ||
+      !this._isValidTokenCount(stored.totalTokens)
+    ) {
+      return opts.tolerateInvalidZero === true && liveIsZero;
+    }
+    return (
+      stored.promptTokens === this._tokenUsage.promptTokens &&
+      stored.completionTokens === this._tokenUsage.completionTokens &&
+      stored.totalTokens === this._tokenUsage.totalTokens
+    );
+  }
+
+  private _isValidTokenCount(value: unknown): value is number {
+    return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+  }
+
+  private _recordTurnCompletion(full: FullOutput<unknown>, opts: { persist?: boolean } = {}): TokenUsage | undefined {
+    this._captureTurnRunId(full);
+    const delta = this._tokenUsageDeltaFromFullOutput(full);
+    this._applyTokenUsageDelta(delta);
+    if (delta !== undefined && opts.persist !== false) this._schedulePersistTokenUsage();
+    return delta;
+  }
+
+  private _recordMessageTurnCompletion(
+    full: FullOutput<unknown>,
+    opts: { persist?: boolean } = {},
+  ): { tokenUsageDelta?: TokenUsage; tokenUsageAccounted: boolean } {
+    this._captureTurnRunId(full);
+    if (full.runId && this._messageTokenAccountedRunIds.has(full.runId)) {
+      return { tokenUsageAccounted: true };
+    }
+    const tokenUsageDelta = this._tokenUsageDeltaFromFullOutput(full);
+    this._applyTokenUsageDelta(tokenUsageDelta);
+    if (tokenUsageDelta !== undefined) {
+      if (full.runId) this._messageTokenAccountedRunIds.add(full.runId);
+      if (opts.persist !== false) this._schedulePersistTokenUsage();
+      return { tokenUsageDelta, tokenUsageAccounted: true };
+    }
+    return { tokenUsageAccounted: false };
+  }
+
+  private _messageSuspendedTokenUsageDelta(full: FullOutput<unknown>): TokenUsage | undefined {
+    if (
+      full.runId &&
+      (this._messageTokenAccountedRunIds.has(full.runId) || this._messageTokenAccountingRunIds.has(full.runId))
+    ) {
+      return undefined;
+    }
+    return this._tokenUsageDeltaFromFullOutput(full);
+  }
+
+  private _reserveMessageSuspendedTokenUsage(full: FullOutput<unknown>): {
+    tokenUsageDelta?: TokenUsage;
+    reservedRunId?: string;
+    reservation?: Deferred<void>;
+  } {
+    const tokenUsageDelta = this._messageSuspendedTokenUsageDelta(full);
+    if (tokenUsageDelta !== undefined && full.runId) {
+      const reservation = createDeferred<void>();
+      this._messageTokenAccountingRunIds.add(full.runId);
+      this._messageTokenAccountingReservations.set(full.runId, reservation);
+      void reservation.promise.catch(() => {});
+      return { tokenUsageDelta, reservedRunId: full.runId, reservation };
+    }
+    return { tokenUsageDelta };
+  }
+
+  private _commitMessageSuspendedTokenUsage(
+    full: FullOutput<unknown>,
+    reservation: { tokenUsageDelta?: TokenUsage; reservedRunId?: string; reservation?: Deferred<void> },
+  ): void {
+    if (reservation.reservedRunId !== undefined) {
+      this._messageTokenAccountingRunIds.delete(reservation.reservedRunId);
+      if (this._messageTokenAccountingReservations.get(reservation.reservedRunId) === reservation.reservation) {
+        this._messageTokenAccountingReservations.delete(reservation.reservedRunId);
+      }
+      this._messageTokenAccountedRunIds.add(reservation.reservedRunId);
+      reservation.reservation?.resolve();
+    } else if (reservation.tokenUsageDelta !== undefined && full.runId) {
+      this._messageTokenAccountedRunIds.add(full.runId);
+    }
+  }
+
+  private _rollbackMessageSuspendedTokenUsage(reservation: {
+    reservedRunId?: string;
+    reservation?: Deferred<void>;
+  }): void {
+    if (reservation.reservedRunId !== undefined) {
+      this._messageTokenAccountingRunIds.delete(reservation.reservedRunId);
+      if (this._messageTokenAccountingReservations.get(reservation.reservedRunId) === reservation.reservation) {
+        this._messageTokenAccountingReservations.delete(reservation.reservedRunId);
+      }
+      reservation.reservation?.resolve();
+    }
+  }
+
+  private async _waitForMessageSuspendedTokenUsageOwner(
+    full: FullOutput<unknown>,
+    activeTurnWaiter?: Promise<never>,
+  ): Promise<void> {
+    if (!full.runId) return;
+    while (!this._messageTokenAccountedRunIds.has(full.runId)) {
+      const reservation = this._messageTokenAccountingReservations.get(full.runId);
+      if (reservation === undefined) return;
+      await this._raceActiveTurnWaiter(reservation.promise, activeTurnWaiter);
+    }
+  }
+
+  private async _captureMessageSuspendWithTokenUsage(
+    full: FullOutput<unknown>,
+    queuedItemId: string | undefined,
+    modeId: string,
+    modelId: string,
+    activeTurnWaiter?: Promise<never>,
+  ): Promise<void> {
+    await this._waitForMessageSuspendedTokenUsageOwner(full, activeTurnWaiter);
+    const reservation = this._reserveMessageSuspendedTokenUsage(full);
+    try {
+      await this._raceActiveTurnWaiter(
+        this._maybeCaptureSuspend(full, queuedItemId, modeId, modelId, {
+          tokenUsageDelta: reservation.tokenUsageDelta,
+        }),
+        activeTurnWaiter,
+      );
+      this._commitMessageSuspendedTokenUsage(full, reservation);
+    } catch (err) {
+      this._rollbackMessageSuspendedTokenUsage(reservation);
+      throw err;
+    }
+  }
+
+  /**
+   * Trigger a no-op `_flushUpdate` so the latest `_tokenUsage` is overlaid into
+   * `SessionRecord.tokenUsage` on disk. Fire-and-forget — serialized via
+   * `_flushChain` so it never races concurrent setters, and skipped when the
+   * session is no longer in a state that accepts writes. Non-lifecycle storage
+   * failures are latched onto `_pendingTokenUsageFlushError` so
+   * `_internalAwaitFlushChain()` can surface them to shutdown/test callers.
+   */
+  private _schedulePersistTokenUsage(): void {
+    if (this._state !== 'live' && this._state !== 'closing') return;
+    void this._persistTokenUsageOrLatch().catch(err => {
+      if (this._isExpectedFlushLifecycleError(err)) return;
+      this._pendingTokenUsageFlushError ??= err;
+    });
+  }
+
+  private _persistTokenUsage(): Promise<void> {
+    if (this._state !== 'live' && this._state !== 'closing') return Promise.resolve();
+    return this._flushUpdate(prev => prev);
+  }
+
+  private async _persistTokenUsageOrLatch(): Promise<void> {
+    try {
+      await this._persistTokenUsage();
+    } catch (err) {
+      if (!this._isExpectedFlushLifecycleError(err)) this._pendingTokenUsageFlushError ??= err;
+      throw err;
+    }
+  }
+
+  async _internalPersistTokenUsageForShutdown(opts: { deadlineAt?: number } = {}): Promise<void> {
+    const timeoutMs = opts.deadlineAt === undefined ? undefined : Math.max(0, opts.deadlineAt - Date.now());
+    if (
+      this._pendingTokenUsageFlushError === undefined &&
+      this._recordTokenUsageMatchesLive({ tolerateInvalidZero: timeoutMs === 0 })
+    ) {
+      return;
+    }
+    const persist = this._persistTokenUsageOrLatch();
+    void persist.catch(() => {});
+    if (timeoutMs === undefined) {
+      await persist;
+      return;
+    }
+    if (timeoutMs === 0) {
+      throw new HarnessValidationError('shutdown()', 'Session token usage did not flush before shutdown deadline');
+    }
+    const timedOut = Symbol('harness-token-usage-timeout');
+    const result = await Promise.race([persist.then(() => undefined), delay(timeoutMs).then(() => timedOut)]);
+    if (result === timedOut) {
+      throw new HarnessValidationError('shutdown()', 'Session token usage did not flush before shutdown deadline');
+    }
+  }
+
+  private _persistTokenUsageDelta(delta: TokenUsage | undefined): Promise<void> {
+    if (delta === undefined) return Promise.resolve();
+    if (this._state !== 'live' && this._state !== 'closing') return Promise.resolve();
+    return this._flushUpdate(prev => prev, { tokenUsageDelta: delta });
+  }
+
+  private _isExpectedFlushLifecycleError(err: unknown): boolean {
+    return (
+      err instanceof HarnessSessionClosedError ||
+      err instanceof HarnessSessionDeletedError ||
+      err instanceof HarnessStateConflictError
+    );
+  }
+
+  /**
+   * Wait for any in-flight `_flushUpdate` writes (including the trailing
+   * persist scheduled by `_recordTurnCompletion`) to settle. Throws if a
+   * scheduled token-usage flush hit a non-lifecycle storage error so shutdown
+   * and tests surface durability gaps instead of silently dropping them.
+   *
+   * @internal
+   */
+  async _internalAwaitFlushChain(opts: { deadlineAt?: number } = {}): Promise<void> {
+    const waitUntilDeadline = async (promise: Promise<unknown>): Promise<boolean> => {
+      if (opts.deadlineAt === undefined) {
+        await promise;
+        return true;
+      }
+      const timeoutMs = Math.max(0, opts.deadlineAt - Date.now());
+      const timedOut = Symbol('harness-flush-timeout');
+      const result = await Promise.race([promise.then(() => undefined), delay(timeoutMs).then(() => timedOut)]);
+      return result !== timedOut;
+    };
+
+    while (true) {
+      const backgroundTurnCompletions = Array.from(this._backgroundTurnCompletions);
+      if (backgroundTurnCompletions.length > 0) {
+        const completed = await waitUntilDeadline(Promise.allSettled(backgroundTurnCompletions));
+        if (!completed) {
+          throw new HarnessValidationError('shutdown()', 'Session background work did not flush before shutdown deadline');
+        }
+      }
+      const chain = this._flushChain;
+      const completed = await waitUntilDeadline(chain);
+      if (!completed) {
+        throw new HarnessValidationError('shutdown()', 'Session storage writes did not flush before shutdown deadline');
+      }
+      if (this._flushChain === chain && this._backgroundTurnCompletions.size === 0) break;
+    }
+    const latched = this._pendingTokenUsageFlushError;
+    if (latched !== undefined) {
+      this._pendingTokenUsageFlushError = undefined;
+      throw latched;
+    }
+    const durableTurnLatched = this._pendingDurableTurnFlushError;
+    if (durableTurnLatched !== undefined) {
+      if (
+        durableTurnLatched.pendingResume !== undefined &&
+        this._record.pendingResume?.runId === durableTurnLatched.pendingResume.runId &&
+        this._record.pendingResume.toolCallId === durableTurnLatched.pendingResume.toolCallId
+      ) {
+        this._pendingDurableTurnFlushError = undefined;
+        return;
+      }
+      throw durableTurnLatched.error;
+    }
+  }
+
+  /** Latched storage error from a scheduled token-usage persist; surfaced by
+   * `_internalAwaitFlushChain()` so shutdown and tests can act on it. */
+  private _pendingTokenUsageFlushError: unknown;
+  private _pendingDurableTurnFlushError:
+    | { error: unknown; pendingResume?: { runId: string; toolCallId: string } }
+    | undefined;
 
   /**
    * True while a turn (message or queued) is in flight against the agent.
@@ -1160,6 +1563,14 @@ export class Session {
     return false;
   }
 
+  private _isShutdownDrainBusy(): boolean {
+    if (this._currentTurnAbortController !== undefined) return true;
+    if (this._record.pendingResume !== undefined) return false;
+    if (this._draining) return true;
+    if (this._currentQueuedItemId !== undefined) return true;
+    return (this._record.pendingQueue?.length ?? 0) > 0;
+  }
+
   /**
    * Number of items currently waiting in `pendingQueue` (excluding any
    * queued item already drained into a live turn — that one is tracked
@@ -1174,10 +1585,10 @@ export class Session {
    * completed turn (manual or queued). Returns a fresh shallow copy so
    * callers can't mutate the running aggregate.
    *
-   * Note: this is **not** persisted across rehydration — token counts
-   * reset to zero when a closed/evicted session is hydrated from storage.
-   * Callers that need cross-process aggregates should sum from message
-   * history themselves.
+   * Durable across rehydration: counters are persisted into
+   * `SessionRecord.tokenUsage` on every save and seeded from there on
+   * construction, so reopens after eviction or process restart carry the
+   * accumulated value instead of resetting to zero.
    */
   getTokenUsage(): TokenUsage {
     return { ...this._tokenUsage };
@@ -1230,14 +1641,13 @@ export class Session {
   }
 
   /**
-   * Re-check `isBusy()` and resolve every `waitForIdle()` waiter whose
-   * predicate is now satisfied. Cheap when there are no waiters (common
-   * case). Called from every state transition that might tip the session
-   * idle: `_endTurn`, queue drain shutdown, queued-turn settlement.
+   * Re-check every idle/drain waiter whose predicate is now satisfied. Cheap
+   * when there are no waiters (common case). Called from every state
+   * transition that might tip the session idle or durably parked: `_endTurn`,
+   * queue drain shutdown, queued-turn settlement, suspension parking.
    */
   private _notifyMaybeIdle(): void {
     if (this._idleWaiters.size === 0) return;
-    if (this.isBusy()) return;
     const waiters = Array.from(this._idleWaiters);
     for (const w of waiters) w.check();
   }
@@ -1285,6 +1695,54 @@ export class Session {
           timer = undefined;
           this.abort({ reason: 'session_close_timeout' });
           resolveAfter(this._failPendingQueueForClose(new HarnessSessionClosingError(this.id)));
+        }, timeoutMs);
+      }
+    });
+  }
+
+  /** @internal — shutdown waits for admitted work without turning queued items into close failures. */
+  _waitForShutdownDrain(drainDeadlineAt: number): Promise<void> {
+    void this._maybeDrainQueue();
+    if (!this._isShutdownDrainBusy()) return Promise.resolve();
+    const timeoutMs = Math.max(0, drainDeadlineAt - Date.now());
+
+    return new Promise<void>((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      let waiter!: IdleWaiter;
+      const cleanup = () => {
+        if (timer !== undefined) clearTimeout(timer);
+        this._idleWaiters.delete(waiter);
+      };
+      const resolveAfter = () => {
+        cleanup();
+        resolve();
+      };
+      waiter = {
+        check: () => {
+          if (!this._isShutdownDrainBusy()) {
+            resolveAfter();
+            return true;
+          }
+          return false;
+        },
+        reject: () => {
+          resolveAfter();
+        },
+        cleanup,
+      };
+      this._idleWaiters.add(waiter);
+      if (waiter.check()) return;
+      const rejectAfterTimeout = () => {
+        this.abort({ reason: 'session_shutdown_timeout' });
+        cleanup();
+        reject(new HarnessValidationError('shutdown()', 'Session did not drain before shutdown deadline'));
+      };
+      if (timeoutMs === 0) {
+        rejectAfterTimeout();
+      } else {
+        timer = setTimeout(() => {
+          timer = undefined;
+          rejectAfterTimeout();
         }, timeoutMs);
       }
     });
@@ -2727,6 +3185,9 @@ export class Session {
       const oldest = this._completedRuns.keys().next().value;
       if (oldest === undefined) return;
       this._completedRuns.delete(oldest);
+      this._messageTokenAccountedRunIds.delete(oldest);
+      this._messageTokenAccountingRunIds.delete(oldest);
+      this._messageTokenAccountingReservations.delete(oldest);
     }
   }
 
@@ -2976,6 +3437,7 @@ export class Session {
       this._messageAdmissionStarts.set(opts.admissionId!, {
         admissionHash,
         modeId: effectiveModeId,
+        modelId: effectiveModelId,
         promise: admissionStart.promise,
       });
     }
@@ -3044,11 +3506,20 @@ export class Session {
           activeTurnWaiter.promise,
         ]);
         const full = result as FullOutput<unknown>;
-        this._recordTurnCompletion(full);
-        await Promise.race([
-          this._maybeCaptureSuspend(full, undefined, effectiveModeId, effectiveModelId),
-          activeTurnWaiter.promise,
-        ]);
+        if (full.finishReason === 'suspended') {
+          await this._captureMessageSuspendWithTokenUsage(
+            full,
+            undefined,
+            effectiveModeId,
+            effectiveModelId,
+            activeTurnWaiter.promise,
+          );
+        } else {
+          const tokenUsageDelta = this._recordTurnCompletion(full, { persist: false });
+          if (tokenUsageDelta !== undefined) {
+            await Promise.race([this._persistTokenUsageOrLatch(), activeTurnWaiter.promise]);
+          }
+        }
         this._emitTurnEvent({
           type: 'agent_end',
           reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
@@ -3087,6 +3558,8 @@ export class Session {
               status: 'pending',
               signalId: admissionIdentity.signalId,
               runId: admissionIdentity.runId,
+              modeId: effectiveModeId,
+              modelId: effectiveModelId,
               admissionId: opts.admissionId!,
               admissionHash,
             },
@@ -3147,6 +3620,8 @@ export class Session {
                 status: 'failed',
                 signalId: admissionIdentity.signalId,
                 runId: admissionIdentity.runId,
+                modeId: effectiveModeId,
+                modelId: effectiveModelId,
                 admissionId: opts.admissionId!,
                 admissionHash,
                 error: projectHarnessPublicError(err),
@@ -3188,6 +3663,8 @@ export class Session {
         threadId: this.threadId,
         signalId: signal.signal.id,
         runId: signal.runId,
+        modeId: effectiveModeId,
+        modelId: effectiveModelId,
         admissionId: opts.admissionId!,
         admissionHash,
         createdAt: now,
@@ -3207,6 +3684,8 @@ export class Session {
               status: 'pending',
               signalId: signal.signal.id,
               runId: signal.runId,
+              modeId: effectiveModeId,
+              modelId: effectiveModelId,
               ...(opts.admissionId !== undefined ? { admissionId: opts.admissionId } : {}),
               ...(admissionHash !== undefined ? { admissionHash } : {}),
             },
@@ -3230,6 +3709,8 @@ export class Session {
             status: 'failed',
             signalId: signal.signal.id,
             runId: signal.runId,
+            modeId: effectiveModeId,
+            modelId: effectiveModelId,
             error: projectHarnessPublicError(err),
             admissionId: opts.admissionId!,
             admissionHash: admissionHash!,
@@ -3283,6 +3764,8 @@ export class Session {
                 status: 'failed',
                 signalId: signal.signal.id,
                 runId: signal.runId,
+                modeId: effectiveModeId,
+                modelId: effectiveModelId,
                 error: projectHarnessPublicError(err),
                 admissionId: opts.admissionId!,
                 admissionHash: admissionHash!,
@@ -3309,9 +3792,27 @@ export class Session {
         throw err;
       }
       let streamCompletedEvidenceWriteFailed = false;
-      void Promise.race([completion, activeTurnWaiter.promise])
+      const streamBookkeeping = Promise.race([completion, activeTurnWaiter.promise])
         .then(async full => {
-          this._recordTurnCompletion(full);
+          try {
+            if (full.finishReason === 'suspended') {
+              await this._captureMessageSuspendWithTokenUsage(
+                full,
+                undefined,
+                effectiveModeId,
+                effectiveModelId,
+                activeTurnWaiter.promise,
+              );
+            } else {
+              const { tokenUsageAccounted } = this._recordMessageTurnCompletion(full, { persist: false });
+              if (tokenUsageAccounted) {
+                await Promise.race([this._persistTokenUsageOrLatch(), activeTurnWaiter.promise]);
+              }
+            }
+          } catch (err) {
+            this._latchDurableTurnFlushError(err, full);
+            throw err;
+          }
           if (admissionIdentity === undefined) return full;
           await Promise.race([
             this._writeMessageResultEvidence(
@@ -3319,6 +3820,8 @@ export class Session {
                 status: 'completed',
                 signalId: signal.signal.id,
                 runId: signal.runId,
+                modeId: effectiveModeId,
+                modelId: effectiveModelId,
                 result: full,
                 admissionId: opts.admissionId!,
                 admissionHash: admissionHash!,
@@ -3333,10 +3836,6 @@ export class Session {
           return full;
         })
         .then(async full => {
-          await Promise.race([
-            this._maybeCaptureSuspend(full, undefined, effectiveModeId, effectiveModelId),
-            activeTurnWaiter.promise,
-          ]);
           this._emitTurnEvent({
             type: 'agent_end',
             reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
@@ -3355,6 +3854,8 @@ export class Session {
                 status: 'failed',
                 signalId: signal.signal.id,
                 runId: signal.runId,
+                modeId: effectiveModeId,
+                modelId: effectiveModelId,
                 error: projectHarnessPublicError(err),
                 admissionId: opts.admissionId!,
                 admissionHash: admissionHash!,
@@ -3369,6 +3870,7 @@ export class Session {
           finishOwnedMessageTurn();
           void this._maybeDrainQueue();
         });
+      void this._trackBackgroundTurnCompletion(streamBookkeeping);
       return out;
     }
 
@@ -3387,32 +3889,45 @@ export class Session {
         streamStarted = true;
       }
       const full = await Promise.race([completion, activeTurnWaiter.promise]);
-      this._recordTurnCompletion(full);
-      if (admissionIdentity !== undefined) {
-        try {
+      try {
+        if (full.finishReason === 'suspended') {
+          await this._captureMessageSuspendWithTokenUsage(
+            full,
+            undefined,
+            effectiveModeId,
+            effectiveModelId,
+            activeTurnWaiter.promise,
+          );
+        } else {
+          const { tokenUsageAccounted } = this._recordMessageTurnCompletion(full, { persist: false });
+          if (tokenUsageAccounted) {
+            await Promise.race([this._persistTokenUsageOrLatch(), activeTurnWaiter.promise]);
+          }
+        }
+        if (admissionIdentity !== undefined) {
           await Promise.race([
             this._writeMessageResultEvidenceBestEffort(
               {
                 status: 'completed',
                 signalId: signal.signal.id,
                 runId: signal.runId,
+                modeId: effectiveModeId,
+                modelId: effectiveModelId,
                 result: full,
                 admissionId: opts.admissionId!,
                 admissionHash: admissionHash!,
               },
               { compatibleAdmissionHashes },
-            ),
+            ).catch(err => {
+              completedEvidenceWriteFailed = true;
+              throw err;
+            }),
             activeTurnWaiter.promise,
           ]);
-        } catch (err) {
-          completedEvidenceWriteFailed = true;
-          throw err;
         }
+      } catch (err) {
+        throw err;
       }
-      await Promise.race([
-        this._maybeCaptureSuspend(full, undefined, effectiveModeId, effectiveModelId),
-        activeTurnWaiter.promise,
-      ]);
       this._emitTurnEvent({
         type: 'agent_end',
         reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
@@ -3439,6 +3954,8 @@ export class Session {
               status: 'failed',
               signalId: signal.signal.id,
               runId: signal.runId,
+              modeId: effectiveModeId,
+              modelId: effectiveModelId,
               error: projectHarnessPublicError(err),
               admissionId: opts.admissionId!,
               admissionHash: admissionHash!,
@@ -3627,16 +4144,21 @@ export class Session {
       if ('status' in evidence) {
         if (opts.stream === true) {
           if (evidence.status === 'pending') {
-            const agent = this._harness.getAgentForMode(this._messageDuplicateModeId(evidence, opts));
+            const duplicateModeId = this._messageDuplicateModeId(evidence, opts);
+            const duplicateModelId = this._messageDuplicateModelId(evidence, opts);
+            const agent = this._harness.getAgentForMode(duplicateModeId);
             await this._raceActiveTurnWaiter(this._ensureThreadSubscription(agent), activeDeleted);
             const runId = await this._pendingMessageRunId(evidence);
             if (runId && this._completedRuns.has(runId)) {
               const cached = this._completedRuns.get(runId);
               if (cached?.ok && evidence.admissionId !== undefined && evidence.admissionHash !== undefined) {
+                await this._prepareCachedDuplicateMessageCompletion(cached.full, evidence, opts, activeDeleted);
                 await this._writeMessageResultEvidenceBestEffort({
                   status: 'completed',
                   signalId: evidence.signalId,
                   runId,
+                  modeId: duplicateModeId,
+                  modelId: duplicateModelId,
                   result: cached.full,
                   admissionId: evidence.admissionId,
                   admissionHash: evidence.admissionHash,
@@ -3688,16 +4210,21 @@ export class Session {
         if (evidence.status === 'failed') throw publicErrorProjectionToError(evidence.error);
         const runId = await this._pendingMessageRunId(evidence);
         if (runId) {
-          const agent = this._harness.getAgentForMode(this._messageDuplicateModeId(evidence, opts));
+          const duplicateModeId = this._messageDuplicateModeId(evidence, opts);
+          const duplicateModelId = this._messageDuplicateModelId(evidence, opts);
+          const agent = this._harness.getAgentForMode(duplicateModeId);
           await this._raceActiveTurnWaiter(this._ensureThreadSubscription(agent), activeDeleted);
           const cached = this._completedRuns.get(runId);
           if (cached) {
             if (!cached.ok) throw cached.err;
             if (evidence.admissionId !== undefined && evidence.admissionHash !== undefined) {
+              await this._prepareCachedDuplicateMessageCompletion(cached.full, evidence, opts, activeDeleted);
               await this._writeMessageResultEvidenceBestEffort({
                 status: 'completed',
                 signalId: evidence.signalId,
                 runId,
+                modeId: duplicateModeId,
+                modelId: duplicateModelId,
                 result: cached.full,
                 admissionId: evidence.admissionId,
                 admissionHash: evidence.admissionHash,
@@ -3715,6 +4242,29 @@ export class Session {
     });
   }
 
+  private async _prepareCachedDuplicateMessageCompletion(
+    full: FullOutput<unknown>,
+    evidence: AgentSignalResultEvidence,
+    opts: MessageOptions,
+    activeDeleted?: Promise<never>,
+  ): Promise<void> {
+    if (full.finishReason === 'suspended') {
+      await this._captureMessageSuspendWithTokenUsage(
+        full,
+        undefined,
+        this._messageDuplicateModeId(evidence, opts),
+        this._messageDuplicateModelId(evidence, opts),
+        activeDeleted,
+      );
+      return;
+    }
+
+    const { tokenUsageAccounted } = this._recordMessageTurnCompletion(full, { persist: false });
+    if (tokenUsageAccounted) {
+      await this._raceActiveTurnWaiter(this._persistTokenUsageOrLatch(), activeDeleted);
+    }
+  }
+
   private async _pendingMessageRunId(evidence: AgentSignalResultEvidence): Promise<string | undefined> {
     if (evidence.status !== 'pending') return evidence.runId;
     const starting = evidence.admissionId ? this._messageAdmissionStarts.get(evidence.admissionId) : undefined;
@@ -3729,7 +4279,12 @@ export class Session {
 
   private _messageDuplicateModeId(evidence: AgentSignalResultEvidence, opts: MessageOptions): string {
     const starting = evidence.admissionId ? this._messageAdmissionStarts.get(evidence.admissionId) : undefined;
-    return starting?.modeId ?? opts.mode ?? this._record.modeId;
+    return starting?.modeId ?? evidence.modeId ?? opts.mode ?? this._record.modeId;
+  }
+
+  private _messageDuplicateModelId(evidence: AgentSignalResultEvidence, opts: MessageOptions): string {
+    const starting = evidence.admissionId ? this._messageAdmissionStarts.get(evidence.admissionId) : undefined;
+    return starting?.modelId ?? evidence.modelId ?? opts.model ?? this._record.modelId;
   }
 
   private _hasLiveMessageRun(agent: Agent, runId: string): boolean {
@@ -4038,25 +4593,44 @@ export class Session {
 
       // Background continuation runs the post-turn bookkeeping so the
       // caller's `result` promise resolves with the final AgentResult.
-      const result: Promise<AgentResult> = completionOrDelete
-        .then(async full => {
-          this._recordTurnCompletion(full);
-          await Promise.race([
-            this._maybeCaptureSuspend(full, undefined, effectiveModeId, this._record.modelId),
-            activeTurnWaiter.promise,
-          ]);
-          this._emitTurnEvent({
-            type: 'agent_end',
-            reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
-            runId: full.runId,
-          });
-          await Promise.race([this._runGoalJudge(full, false), activeTurnWaiter.promise]);
-          return full as AgentResult;
-        })
-        .finally(() => {
-          finishOwnedSignalTurn();
-          void this._maybeDrainQueue();
-        });
+      const result: Promise<AgentResult> = this._trackBackgroundTurnCompletion(
+        completionOrDelete
+          .then(async full => {
+            const tokenUsageDelta =
+              full.finishReason === 'suspended'
+                ? this._tokenUsageDeltaFromFullOutput(full)
+                : this._recordTurnCompletion(full, { persist: false });
+            await Promise.race([
+              this._maybeCaptureSuspend(full, undefined, effectiveModeId, this._record.modelId, {
+                tokenUsageDelta: full.finishReason === 'suspended' ? tokenUsageDelta : undefined,
+              }).catch(err => {
+                this._latchDurableTurnFlushError(err, full);
+                throw err;
+              }),
+              activeTurnWaiter.promise,
+            ]);
+            if (tokenUsageDelta !== undefined && full.finishReason !== 'suspended') {
+              await Promise.race([
+                this._persistTokenUsageOrLatch().catch(err => {
+                  if (!this._isExpectedFlushLifecycleError(err)) this._pendingTokenUsageFlushError ??= err;
+                  throw err;
+                }),
+                activeTurnWaiter.promise,
+              ]);
+            }
+            this._emitTurnEvent({
+              type: 'agent_end',
+              reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
+              runId: full.runId,
+            });
+            await Promise.race([this._runGoalJudge(full, false), activeTurnWaiter.promise]);
+            return full as AgentResult;
+          })
+          .finally(() => {
+            finishOwnedSignalTurn();
+            void this._maybeDrainQueue();
+          }),
+      );
 
       // Swallow `result` rejections at the inner level so the
       // background continuation doesn't surface as an unhandled
@@ -4192,24 +4766,43 @@ export class Session {
 
       const completion = this._awaitRunCompletion(dispatched.runId);
       const completionOrDelete = Promise.race([completion, activeTurnWaiter.promise]);
-      const result = completionOrDelete
-        .then(async full => {
-          this._recordTurnCompletion(full);
-          await Promise.race([
-            this._maybeCaptureSuspend(full, undefined, effectiveModeId, this._record.modelId),
-            activeTurnWaiter.promise,
-          ]);
-          this._emitTurnEvent({
-            type: 'agent_end',
-            reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
-            runId: full.runId,
-          });
-          await Promise.race([this._runGoalJudge(full, false), activeTurnWaiter.promise]);
-        })
-        .finally(() => {
-          finishOwnedReminderTurn();
-          void this._maybeDrainQueue();
-        });
+      const result = this._trackBackgroundTurnCompletion(
+        completionOrDelete
+          .then(async full => {
+            const tokenUsageDelta =
+              full.finishReason === 'suspended'
+                ? this._tokenUsageDeltaFromFullOutput(full)
+                : this._recordTurnCompletion(full, { persist: false });
+            await Promise.race([
+              this._maybeCaptureSuspend(full, undefined, effectiveModeId, this._record.modelId, {
+                tokenUsageDelta: full.finishReason === 'suspended' ? tokenUsageDelta : undefined,
+              }).catch(err => {
+                this._latchDurableTurnFlushError(err, full);
+                throw err;
+              }),
+              activeTurnWaiter.promise,
+            ]);
+            if (tokenUsageDelta !== undefined && full.finishReason !== 'suspended') {
+              await Promise.race([
+                this._persistTokenUsageOrLatch().catch(err => {
+                  if (!this._isExpectedFlushLifecycleError(err)) this._pendingTokenUsageFlushError ??= err;
+                  throw err;
+                }),
+                activeTurnWaiter.promise,
+              ]);
+            }
+            this._emitTurnEvent({
+              type: 'agent_end',
+              reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
+              runId: full.runId,
+            });
+            await Promise.race([this._runGoalJudge(full, false), activeTurnWaiter.promise]);
+          })
+          .finally(() => {
+            finishOwnedReminderTurn();
+            void this._maybeDrainQueue();
+          }),
+      );
       void result.catch(() => {});
 
       return {
@@ -4264,23 +4857,56 @@ export class Session {
     queuedItemId = this._currentQueuedItemId,
     modeId = this._record.modeId,
     modelId = this._modelIdForQueuedItem(queuedItemId),
+    opts: { tokenUsageDelta?: TokenUsage } = {},
   ): Promise<void> {
     if (full.finishReason !== 'suspended') return;
+    this._captureTurnRunId(full);
     const payload = full.suspendPayload as
       | { toolCallId: string; toolName: string; args?: unknown; suspendPayload?: unknown }
       | undefined;
-    if (!payload || !full.runId) return;
+    if (!payload || !full.runId) {
+      await this._persistTokenUsageDelta(opts.tokenUsageDelta);
+      this._clearPendingDurableTurnFlushErrorIfRepaired(full);
+      return;
+    }
 
-    const kind = this._classifyResumeKind(payload);
+    const pending = this._pendingResumeFromSuspendedOutput(full, payload, queuedItemId, modeId, modelId);
+    if (pending === undefined) return;
     const existing = this._record.pendingResume;
     if (
       existing &&
-      existing.kind === kind &&
+      existing.kind === pending.kind &&
       existing.runId === full.runId &&
       existing.toolCallId === payload.toolCallId
     ) {
+      await this._flushUpdate(prev => prev, { tokenUsageDelta: opts.tokenUsageDelta });
+      this._clearPendingDurableTurnFlushErrorIfRepaired(full);
       return;
     }
+    await this._flushUpdate(prev => ({ ...prev, pendingResume: pending }), { tokenUsageDelta: opts.tokenUsageDelta });
+    this._clearPendingDurableTurnFlushErrorIfRepaired(full);
+
+    // Emit suspension_required AFTER the durable-parking barrier (§5.4) so
+    // any subscriber observing this event can reconstruct the pending state
+    // from storage.
+    this._emitTurnEvent({
+      type: 'suspension_required',
+      kind: pending.kind,
+      toolCallId: pending.toolCallId,
+      toolName: pending.toolName,
+      runId: pending.runId,
+    });
+  }
+
+  private _pendingResumeFromSuspendedOutput(
+    full: FullOutput<unknown>,
+    payload: { toolCallId: string; toolName: string; args?: unknown; suspendPayload?: unknown },
+    queuedItemId = this._currentQueuedItemId,
+    modeId = this._record.modeId,
+    modelId = this._modelIdForQueuedItem(queuedItemId),
+  ): PendingResume | undefined {
+    if (!full.runId) return undefined;
+    const kind = this._classifyResumeKind(payload);
     const pending: PendingResume = {
       kind,
       itemId: `${kind}:${payload.toolCallId}`,
@@ -4299,19 +4925,7 @@ export class Session {
       const mode = this._harness._getMode(modeId);
       if (mode.transitionsTo) pending.transitionModeId = mode.transitionsTo;
     }
-
-    await this._flushUpdate(prev => ({ ...prev, pendingResume: pending }));
-
-    // Emit suspension_required AFTER the durable-parking barrier (§5.4) so
-    // any subscriber observing this event can reconstruct the pending state
-    // from storage.
-    this._emitTurnEvent({
-      type: 'suspension_required',
-      kind,
-      toolCallId: pending.toolCallId,
-      toolName: pending.toolName,
-      runId: pending.runId,
-    });
+    return pending;
   }
 
   private _classifyResumeKind(payload: { toolName: string; suspendPayload?: unknown }): PendingResume['kind'] {
@@ -5695,6 +6309,26 @@ export class Session {
     // accepted".
     const completingQueuedItemId = full.finishReason !== 'suspended' ? pendingQueuedItemId : undefined;
     try {
+      const suspendedPayload =
+        full.finishReason === 'suspended'
+          ? (full.suspendPayload as
+              | { toolCallId: string; toolName: string; args?: unknown; suspendPayload?: unknown }
+              | undefined)
+          : undefined;
+      const suspendedPending =
+        suspendedPayload !== undefined
+          ? this._pendingResumeFromSuspendedOutput(
+              full,
+              suspendedPayload,
+              pendingQueuedItemId,
+              resumeModeId,
+              resumeRuntimeDependencies.modelId,
+            )
+          : undefined;
+      const suspendedTokenUsageDelta =
+        full.finishReason === 'suspended' ? this._tokenUsageDeltaFromFullOutput(full) : undefined;
+      if (full.finishReason === 'suspended') this._captureTurnRunId(full);
+      let alreadyAccounted = false;
       if (completingQueuedItemId !== undefined) {
         if (modeFlipTarget && modeFlipTarget !== previousModeId) {
           await Promise.race([
@@ -5704,56 +6338,75 @@ export class Session {
         }
         const queuedItem = this._record.pendingQueue.find(item => item.id === completingQueuedItemId);
         if (queuedItem) {
+          let tokenUsageDelta: TokenUsage | undefined;
           try {
-            await Promise.race([this._markQueuedPostRunFinalized(completingQueuedItemId), activeTurnWaiter.promise]);
+            this._captureTurnRunId(full);
+            tokenUsageDelta = this._tokenUsageDeltaFromFullOutput(full);
+            alreadyAccounted = true;
+            await Promise.race([
+              this._markQueuedPostRunFinalized(completingQueuedItemId, { tokenUsageDelta }),
+              activeTurnWaiter.promise,
+            ]);
           } catch (err) {
             if (err instanceof HarnessSessionDeletedError) throw err;
             throw new QueuePostRunFinalizationPendingError(Date.now() + QUEUE_POST_RUN_FINALIZATION_RETRY_MS, err);
           }
         }
-        this._recordTurnCompletion(full);
-      } else {
-        this._recordTurnCompletion(full);
+        if (!alreadyAccounted) this._recordTurnCompletion(full, { persist: false });
+      } else if (full.finishReason !== 'suspended') {
+        this._recordTurnCompletion(full, { persist: false });
       }
       const queueCompletedAt = Date.now();
       const responseAppliedAt = queueCompletedAt;
       await Promise.race([
-        this._flushUpdate(prev => {
-          const next: SessionRecord = { ...prev };
-          delete next.pendingResume;
-          const receipt =
-            responseId !== undefined ? getOwnRecordValue(prev.inboxResponseReceipts, responseId) : undefined;
-          if (receipt) {
-            next.inboxResponseReceipts = {
-              ...(prev.inboxResponseReceipts ?? {}),
-              [receipt.responseId]: {
-                ...receipt,
-                status: 'applied',
-                result: full,
-                appliedAt: receipt.appliedAt ?? responseAppliedAt,
-                updatedAt: responseAppliedAt,
-              },
-            };
-          }
-          if (modeFlipTarget) next.modeId = modeFlipTarget;
-          if (completingQueuedItemId !== undefined) {
-            next.pendingQueue = (prev.pendingQueue ?? []).filter(x => x.id !== completingQueuedItemId);
-            const receipt = prev.queueAdmissionReceipts?.[completingQueuedItemId];
+        this._flushUpdate(
+          prev => {
+            const next: SessionRecord = { ...prev };
+            if (full.finishReason === 'suspended' && suspendedPending !== undefined) {
+              next.pendingResume = suspendedPending;
+            } else {
+              delete next.pendingResume;
+            }
+            const receipt =
+              responseId !== undefined ? getOwnRecordValue(prev.inboxResponseReceipts, responseId) : undefined;
             if (receipt) {
-              next.queueAdmissionReceipts = {
-                ...(prev.queueAdmissionReceipts ?? {}),
-                [completingQueuedItemId]: {
+              next.inboxResponseReceipts = {
+                ...(prev.inboxResponseReceipts ?? {}),
+                [receipt.responseId]: {
                   ...receipt,
-                  status: 'completed',
+                  status: 'applied',
                   result: full,
-                  completedAt: receipt.completedAt ?? queueCompletedAt,
-                  updatedAt: queueCompletedAt,
+                  appliedAt: receipt.appliedAt ?? responseAppliedAt,
+                  updatedAt: responseAppliedAt,
                 },
               };
             }
-          }
-          return next;
-        }),
+            if (modeFlipTarget) next.modeId = modeFlipTarget;
+            if (completingQueuedItemId !== undefined) {
+              next.pendingQueue = (prev.pendingQueue ?? []).filter(x => x.id !== completingQueuedItemId);
+              const receipt = prev.queueAdmissionReceipts?.[completingQueuedItemId];
+              if (receipt) {
+                next.queueAdmissionReceipts = {
+                  ...(prev.queueAdmissionReceipts ?? {}),
+                  [completingQueuedItemId]: {
+                    ...receipt,
+                    status: 'completed',
+                    result: full,
+                    completedAt: receipt.completedAt ?? queueCompletedAt,
+                    updatedAt: queueCompletedAt,
+                  },
+                };
+              }
+            }
+            return next;
+          },
+          {
+            tokenUsageDelta:
+              full.finishReason === 'suspended' && suspendedTokenUsageDelta !== undefined
+                ? suspendedTokenUsageDelta
+                : undefined,
+          },
+        ),
         activeTurnWaiter.promise,
       ]);
 
@@ -5773,13 +6426,15 @@ export class Session {
         });
       }
 
-      // The resumed run can itself suspend again (multi-step approval chains).
-      // Mirror message()'s post-run hook so the next respond* call sees the
-      // new pending record.
-      await Promise.race([
-        this._maybeCaptureSuspend(full, pendingQueuedItemId, resumeModeId, resumeRuntimeDependencies.modelId),
-        activeTurnWaiter.promise,
-      ]);
+      if (suspendedPending !== undefined) {
+        this._emitTurnEvent({
+          type: 'suspension_required',
+          kind: suspendedPending.kind,
+          toolCallId: suspendedPending.toolCallId,
+          toolName: suspendedPending.toolName,
+          runId: suspendedPending.runId,
+        });
+      }
 
       // If the resumed run did NOT suspend again, the turn is complete from
       // the harness's perspective. Surface that to subscribers via agent_end.
@@ -6093,9 +6748,15 @@ export class Session {
     if (currentReceipt?.status === 'completed') {
       const queuedItem = this._record.pendingQueue.find(item => item.id === queuedItemId);
       const shouldRunPostRunSideEffects = queuedItem !== undefined && currentReceipt.postRunFinalizedAt === undefined;
+      let alreadyAccounted = false;
       if (shouldRunPostRunSideEffects) {
+        let tokenUsageDelta: TokenUsage | undefined;
         try {
-          await this._markQueuedPostRunFinalized(queuedItemId);
+          const full = currentReceipt.result as FullOutput<unknown>;
+          this._captureTurnRunId(full);
+          tokenUsageDelta = this._tokenUsageDeltaFromFullOutput(full);
+          alreadyAccounted = true;
+          await this._markQueuedPostRunFinalized(queuedItemId, { tokenUsageDelta });
         } catch (err) {
           this._deferQueuedTurnRetry(
             new QueuePostRunFinalizationPendingError(Date.now() + QUEUE_POST_RUN_FINALIZATION_RETRY_MS, err),
@@ -6125,6 +6786,8 @@ export class Session {
           queuedItem,
           currentReceipt.result as FullOutput<unknown>,
           pending.modeId ?? currentReceipt.modeId ?? queuedItem.mode ?? this._record.modeId,
+          undefined,
+          { skipTokenAccounting: alreadyAccounted },
         );
       }
       this._currentQueuedItemId = undefined;
@@ -7068,18 +7731,30 @@ export class Session {
     modeId: string,
     activeTurnWaiter?: Promise<never>,
   ): Promise<void> {
+    let alreadyAccounted = false;
     if (this._record.queueAdmissionReceipts?.[item.id]?.postRunFinalizedAt === undefined) {
-      // Mark before running non-idempotent post-run side effects. Recovery may
-      // retry a failed marker write, but must not replay goal continuations,
-      // token accounting, or terminal turn events after the marker persists.
+      // Account for the turn's tokens BEFORE writing the no-replay marker so
+      // the marker's CAS save piggybacks the live `_tokenUsage` via the
+      // `_flushUpdate` overlay. Without this ordering, a
+      // crash between the marker save and a later scheduled token persist
+      // would resume with `postRunFinalizedAt` set and never re-account.
+      let tokenUsageDelta: TokenUsage | undefined;
       try {
-        await this._raceActiveTurnWaiter(this._markQueuedPostRunFinalized(item.id), activeTurnWaiter);
+        this._captureTurnRunId(full);
+        tokenUsageDelta = this._tokenUsageDeltaFromFullOutput(full);
+        alreadyAccounted = true;
+        await this._raceActiveTurnWaiter(
+          this._markQueuedPostRunFinalized(item.id, { tokenUsageDelta }),
+          activeTurnWaiter,
+        );
       } catch (err) {
         if (err instanceof HarnessSessionDeletedError) throw err;
         throw new QueuePostRunFinalizationPendingError(Date.now() + QUEUE_POST_RUN_FINALIZATION_RETRY_MS, err);
       }
     }
-    await this._finalizeQueuedRunCompletion(item, full, modeId, activeTurnWaiter);
+    await this._finalizeQueuedRunCompletion(item, full, modeId, activeTurnWaiter, {
+      skipTokenAccounting: alreadyAccounted,
+    });
   }
 
   private async _markQueuedTurnCompleted(
@@ -7124,12 +7799,22 @@ export class Session {
     full: FullOutput<unknown>,
     modeId?: string,
     activeTurnWaiter?: Promise<never>,
+    opts: { skipTokenAccounting?: boolean } = {},
   ): Promise<FullOutput<unknown>> {
-    this._recordTurnCompletion(full);
+    const tokenUsageDelta = opts.skipTokenAccounting
+      ? undefined
+      : full.finishReason === 'suspended'
+        ? this._tokenUsageDeltaFromFullOutput(full)
+        : this._recordTurnCompletion(full, { persist: false });
     await this._raceActiveTurnWaiter(
-      this._maybeCaptureSuspend(full, item.id, modeId ?? item.mode ?? this._record.modeId),
+      this._maybeCaptureSuspend(full, item.id, modeId ?? item.mode ?? this._record.modeId, undefined, {
+        tokenUsageDelta: full.finishReason === 'suspended' ? tokenUsageDelta : undefined,
+      }),
       activeTurnWaiter,
     );
+    if (tokenUsageDelta !== undefined && full.finishReason !== 'suspended') {
+      await this._raceActiveTurnWaiter(this._persistTokenUsageOrLatch(), activeTurnWaiter);
+    }
     this._emitTurnEvent({
       type: 'agent_end',
       reason: full.finishReason === 'suspended' ? 'suspended' : full.finishReason === 'error' ? 'error' : 'complete',
@@ -7139,15 +7824,34 @@ export class Session {
     return full;
   }
 
-  private async _markQueuedPostRunFinalized(queuedItemId: string): Promise<void> {
-    await this._updateQueueAdmissionReceipt(queuedItemId, (receipt, now) =>
-      receipt.postRunFinalizedAt !== undefined
-        ? receipt
-        : {
-            ...receipt,
-            postRunFinalizedAt: now,
-            updatedAt: now,
+  private async _markQueuedPostRunFinalized(
+    queuedItemId: string,
+    opts: { tokenUsageDelta?: TokenUsage } = {},
+  ): Promise<void> {
+    let tokenUsageDeltaToPersist: TokenUsage | undefined;
+    await this._flushUpdate(
+      prev => {
+        const current = prev.queueAdmissionReceipts?.[queuedItemId];
+        if (!current) return prev;
+        const now = Date.now();
+        const nextReceipt =
+          current.postRunFinalizedAt !== undefined
+            ? current
+            : {
+                ...current,
+                postRunFinalizedAt: now,
+                updatedAt: now,
+              };
+        if (current.postRunFinalizedAt === undefined) tokenUsageDeltaToPersist = opts.tokenUsageDelta;
+        return {
+          ...prev,
+          queueAdmissionReceipts: {
+            ...(prev.queueAdmissionReceipts ?? {}),
+            [queuedItemId]: nextReceipt,
           },
+        };
+      },
+      { tokenUsageDelta: () => tokenUsageDeltaToPersist },
     );
   }
 
@@ -7603,7 +8307,11 @@ export class Session {
    */
   private _flushUpdate(
     update: (prev: SessionRecord) => SessionRecord,
-    opts?: { attachmentReferences?: SaveAttachmentReferenceInput[]; ifVersion?: number },
+    opts?: {
+      attachmentReferences?: SaveAttachmentReferenceInput[];
+      ifVersion?: number;
+      tokenUsageDelta?: TokenUsage | (() => TokenUsage | undefined);
+    },
   ): Promise<void> {
     if (this._state === 'closed') {
       return Promise.reject(new HarnessSessionClosedError(this.id));
@@ -7618,8 +8326,25 @@ export class Session {
       if (opts?.ifVersion !== undefined && this._record.version !== opts.ifVersion) {
         throw new HarnessStateConflictError(this.id, opts.ifVersion, this._record.version);
       }
+      const updated = update(this._record);
+      const tokenUsageDelta =
+        typeof opts?.tokenUsageDelta === 'function' ? opts.tokenUsageDelta() : opts?.tokenUsageDelta;
+      const tokenUsageForSave =
+        tokenUsageDelta !== undefined
+          ? {
+              promptTokens: this._tokenUsage.promptTokens + tokenUsageDelta.promptTokens,
+              completionTokens: this._tokenUsage.completionTokens + tokenUsageDelta.completionTokens,
+              totalTokens: this._tokenUsage.totalTokens + tokenUsageDelta.totalTokens,
+            }
+          : this._tokenUsage;
       const next: SessionRecord = {
-        ...update(this._record),
+        ...updated,
+        // Overlay the live token-usage counter so every CAS write persists the
+        // latest aggregate. Updaters never need to thread `tokenUsage` through
+        // their closures, and `_recordTurnCompletion` mutations between save
+        // construction and post-save assignment are not lost — we re-overlay
+        // from the live counter below.
+        tokenUsage: { ...tokenUsageForSave },
         lastActivityAt: Date.now(),
       };
       const saveOpts = {
@@ -7631,7 +8356,9 @@ export class Session {
         opts?.attachmentReferences && opts.attachmentReferences.length > 0
           ? await this._storage.saveSessionWithAttachmentReferences(next, saveOpts, opts.attachmentReferences)
           : await this._storage.saveSession(next, saveOpts);
-      this._record = { ...next, version: saved.version };
+      this._applyTokenUsageDelta(tokenUsageDelta);
+      this._clearPendingTokenUsageFlushErrorIfSaved(next.tokenUsage);
+      this._record = { ...next, tokenUsage: { ...this._tokenUsage }, version: saved.version };
     };
     // Chain so concurrent callers serialize against the latest in-memory
     // version. Swallow chain-link errors so one caller's failure doesn't
@@ -7797,6 +8524,7 @@ export class Session {
         ...this._record,
         closingAt,
         closeDeadlineAt,
+        tokenUsage: { ...this._tokenUsage },
         lastActivityAt: Date.now(),
       };
       const saved = await this._storage.saveSession(next, {
@@ -7823,6 +8551,7 @@ export class Session {
       }
       const next: SessionRecord = {
         ...this._record,
+        tokenUsage: { ...this._tokenUsage },
         lastActivityAt: closedAt,
         closedAt,
       };

--- a/packages/core/src/harness/v1/token-usage.test.ts
+++ b/packages/core/src/harness/v1/token-usage.test.ts
@@ -1,0 +1,1173 @@
+/**
+ * Tests for `Session.getTokenUsage()` durability.
+ *
+ * Three regressions guarded here:
+ *   1. Rehydration: a fresh `Session` instance built from a persisted record
+ *      seeds `_tokenUsage` from `SessionRecord.tokenUsage`, so a process
+ *      restart / eviction does not reset the cumulative counter to zero.
+ *   2. Persistence: increments accumulated during a turn flow into the next
+ *      `saveSession` write via the `_flushUpdate` overlay, with no setter
+ *      having to thread `tokenUsage` through its closure.
+ *   3. `totalTokens` derivation: providers that only emit
+ *      `inputTokens`/`outputTokens` still produce a consistent
+ *      `totalTokens` aggregate.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SessionRecord } from '../../storage/domains/harness/types';
+import type { FullOutput } from '../../stream/base/output';
+import { setupHarness } from './__test-utils__/setup';
+import type { Session } from './session';
+
+interface TokenUsageInternals {
+  _tokenUsage: { promptTokens: number; completionTokens: number; totalTokens: number };
+  _recordTurnCompletion(
+    full: FullOutput<unknown>,
+  ): { promptTokens: number; completionTokens: number; totalTokens: number } | undefined;
+  _recordMessageTurnCompletion(
+    full: FullOutput<unknown>,
+    opts?: { persist?: boolean },
+  ): {
+    tokenUsageDelta?: { promptTokens: number; completionTokens: number; totalTokens: number };
+    tokenUsageAccounted: boolean;
+  };
+}
+
+type LegacyMissingTokenUsageRecord = Omit<SessionRecord, 'tokenUsage'> & { tokenUsage?: undefined };
+
+function asInternals(session: Session): TokenUsageInternals {
+  return session as unknown as TokenUsageInternals;
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(res => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('Session token usage — durability', () => {
+  it('seeds the live counter from the persisted record on construction', async () => {
+    const { harness, agent } = setupHarness();
+    agent.enqueueRun({ runId: 'r1', finishReason: 'stop' });
+
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'one' });
+
+    // MockAgent emits `{ inputTokens: 1, outputTokens: 1, totalTokens: 2 }` per
+    // run, so after one turn the live counter and the persisted record agree.
+    const before = session.getTokenUsage();
+    expect(before.promptTokens).toBeGreaterThan(0);
+    expect(before.completionTokens).toBeGreaterThan(0);
+    expect(before.totalTokens).toBeGreaterThanOrEqual(before.promptTokens + before.completionTokens);
+
+    const persisted = session.getRecord().tokenUsage;
+    expect(persisted).toEqual(before);
+  });
+
+  it('derives missing persisted totals from legacy prompt and completion counters', async () => {
+    const { harness, storage } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: 't-legacy-partial-usage' });
+    const record = session.getRecord();
+    await storage.saveSession(
+      {
+        ...record,
+        tokenUsage: { promptTokens: 3, completionTokens: 4 } as SessionRecord['tokenUsage'],
+      },
+      { harnessName: record.harnessName, ownerId: harness.ownerId, ifVersion: record.version },
+    );
+
+    await harness.shutdown();
+    const { harness: harness2 } = setupHarness({ sessions: { storage } });
+    const rehydrated = await harness2.session({ resourceId: 'u', threadId: 't-legacy-partial-usage' });
+
+    expect(rehydrated.getTokenUsage()).toEqual({ promptTokens: 3, completionTokens: 4, totalTokens: 7 });
+  });
+
+  it('repairs stale zero persisted totals when prompt and completion counters are present', async () => {
+    const { harness, storage } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: 't-legacy-zero-total-usage' });
+    const record = session.getRecord();
+    await storage.saveSession(
+      {
+        ...record,
+        tokenUsage: { promptTokens: 5, completionTokens: 6, totalTokens: 0 },
+      },
+      { harnessName: record.harnessName, ownerId: harness.ownerId, ifVersion: record.version },
+    );
+
+    await harness.shutdown();
+    const { harness: harness2 } = setupHarness({ sessions: { storage } });
+    const rehydrated = await harness2.session({ resourceId: 'u', threadId: 't-legacy-zero-total-usage' });
+
+    expect(rehydrated.getTokenUsage()).toEqual({ promptTokens: 5, completionTokens: 6, totalTokens: 11 });
+  });
+
+  it('repairs stale low persisted totals when prompt and completion counters are present', async () => {
+    const { harness, storage } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: 't-legacy-low-total-usage' });
+    const record = session.getRecord();
+    await storage.saveSession(
+      {
+        ...record,
+        tokenUsage: { promptTokens: 5, completionTokens: 6, totalTokens: 7 },
+      },
+      { harnessName: record.harnessName, ownerId: harness.ownerId, ifVersion: record.version },
+    );
+
+    await harness.shutdown();
+    const { harness: harness2 } = setupHarness({ sessions: { storage } });
+    const rehydrated = await harness2.session({ resourceId: 'u', threadId: 't-legacy-low-total-usage' });
+
+    expect(rehydrated.getTokenUsage()).toEqual({ promptTokens: 5, completionTokens: 6, totalTokens: 11 });
+  });
+
+  it('ignores non-finite persisted counters during rehydration', async () => {
+    const { harness, storage } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: 't-legacy-non-finite-usage' });
+    const record = session.getRecord();
+    await storage.saveSession(
+      {
+        ...record,
+        tokenUsage: {
+          promptTokens: Number.NaN,
+          completionTokens: Number.POSITIVE_INFINITY,
+          totalTokens: Number.NEGATIVE_INFINITY,
+        },
+      },
+      { harnessName: record.harnessName, ownerId: harness.ownerId, ifVersion: record.version },
+    );
+
+    await harness.shutdown();
+    const { harness: harness2 } = setupHarness({ sessions: { storage } });
+    const rehydrated = await harness2.session({ resourceId: 'u', threadId: 't-legacy-non-finite-usage' });
+
+    expect(rehydrated.getTokenUsage()).toEqual({ promptTokens: 0, completionTokens: 0, totalTokens: 0 });
+  });
+
+  it('ignores negative and fractional persisted counters during rehydration', async () => {
+    const { harness, storage } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: 't-legacy-invalid-usage' });
+    const record = session.getRecord();
+    await storage.saveSession(
+      {
+        ...record,
+        tokenUsage: {
+          promptTokens: -1,
+          completionTokens: 1.5,
+          totalTokens: -2,
+        },
+      },
+      { harnessName: record.harnessName, ownerId: harness.ownerId, ifVersion: record.version },
+    );
+
+    await harness.shutdown();
+    const { harness: harness2 } = setupHarness({ sessions: { storage } });
+    const rehydrated = await harness2.session({ resourceId: 'u', threadId: 't-legacy-invalid-usage' });
+
+    expect(rehydrated.getTokenUsage()).toEqual({ promptTokens: 0, completionTokens: 0, totalTokens: 0 });
+  });
+
+  it('persists counters across rehydration via a new Harness instance', async () => {
+    const { harness, agent, storage } = setupHarness();
+    agent.enqueueRuns([
+      { runId: 'r1', finishReason: 'stop' },
+      { runId: 'r2', finishReason: 'stop' },
+    ]);
+
+    const original = await harness.session({ threadId: 't-token', resourceId: 'u' });
+    const originalId = original.id;
+    await original.message({ content: 'one' });
+    await original.message({ content: 'two' });
+    const before = original.getTokenUsage();
+    expect(before.totalTokens).toBeGreaterThan(0);
+
+    // Simulate a process restart: shut down the live harness (releases the
+    // session lease) and resolve the same `(threadId, resourceId)` against a
+    // fresh harness pointed at the same storage.
+    await harness.shutdown();
+    const { harness: harness2 } = setupHarness({ sessions: { storage } });
+    const rehydrated = await harness2.session({ threadId: 't-token', resourceId: 'u' });
+    expect(rehydrated.id).toBe(originalId);
+    expect(rehydrated).not.toBe(original);
+    expect(rehydrated.getTokenUsage()).toEqual(before);
+  });
+
+  it('persists cached duplicate message token usage before completed evidence without double-counting', async () => {
+    const { harness, storage } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const full = {
+      text: 'cached duplicate',
+      finishReason: 'stop',
+      runId: 'duplicate-token-run',
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    } as unknown as FullOutput<unknown>;
+    const evidenceTokenUsage: Array<SessionRecord['tokenUsage']> = [];
+    const writeMessageResultEvidence = storage.writeMessageResultEvidence.bind(storage);
+    vi.spyOn(storage, 'writeMessageResultEvidence').mockImplementation(async record => {
+      if (record.admissionId === 'duplicate-token-race' && record.status === 'completed') {
+        evidenceTokenUsage.push(session.getRecord().tokenUsage);
+      }
+      return writeMessageResultEvidence(record);
+    });
+    (session as unknown as { _completedRuns: Map<string, { ok: true; full: FullOutput<unknown> }> })._completedRuns.set(
+      'duplicate-token-run',
+      { ok: true, full },
+    );
+    expect(session.getDisplayState().currentRunId).toBeUndefined();
+
+    const duplicate = await (session as unknown as {
+      _returnDuplicateMessageResult(evidence: unknown, opts: unknown): Promise<unknown>;
+    })._returnDuplicateMessageResult(
+      {
+        status: 'pending',
+        signalId: 'duplicate-token-signal',
+        runId: 'duplicate-token-run',
+        admissionId: 'duplicate-token-race',
+        admissionHash: 'duplicate-token-hash',
+      },
+      { content: 'hi' },
+    );
+
+    expect(duplicate).toBe(full);
+    expect(evidenceTokenUsage).toEqual([{ promptTokens: 1, completionTokens: 1, totalTokens: 2 }]);
+    expect(session.getTokenUsage()).toEqual({ promptTokens: 1, completionTokens: 1, totalTokens: 2 });
+    expect(session.getDisplayState().currentRunId).toBeUndefined();
+    asInternals(session)._recordMessageTurnCompletion(full, { persist: false });
+    expect(session.getTokenUsage()).toEqual({ promptTokens: 1, completionTokens: 1, totalTokens: 2 });
+  });
+
+  it('persists cached suspended duplicate message token usage and pending resume before completed evidence', async () => {
+    const { harness, storage } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const full = {
+      text: 'cached suspended duplicate',
+      finishReason: 'suspended',
+      runId: 'duplicate-suspend-token-run',
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      suspendPayload: { toolCallId: 'tc-duplicate-suspend', toolName: 'shell', args: { cmd: 'ls' } },
+    } as unknown as FullOutput<unknown>;
+    const completedEvidenceSnapshots: Array<{
+      tokenUsage: SessionRecord['tokenUsage'];
+      pendingToolCallId?: string;
+      modeId?: string;
+      modelId?: string;
+    }> = [];
+    const defaultModeId = session.getRecord().modeId;
+    const writeMessageResultEvidence = storage.writeMessageResultEvidence.bind(storage);
+    vi.spyOn(storage, 'writeMessageResultEvidence').mockImplementation(async record => {
+      if (record.admissionId === 'duplicate-suspend-token-race' && record.status === 'completed') {
+        completedEvidenceSnapshots.push({
+          tokenUsage: session.getRecord().tokenUsage,
+          pendingToolCallId: session.getRecord().pendingResume?.toolCallId,
+          modeId: record.modeId,
+          modelId: record.modelId,
+        });
+      }
+      return writeMessageResultEvidence(record);
+    });
+    (session as unknown as { _completedRuns: Map<string, { ok: true; full: FullOutput<unknown> }> })._completedRuns.set(
+      'duplicate-suspend-token-run',
+      { ok: true, full },
+    );
+    const evidence = {
+      status: 'pending',
+      signalId: 'duplicate-suspend-token-signal',
+      runId: 'duplicate-suspend-token-run',
+      admissionId: 'duplicate-suspend-token-race',
+      admissionHash: 'duplicate-suspend-token-hash',
+    };
+
+    const duplicate = await (session as unknown as {
+      _returnDuplicateMessageResult(evidence: unknown, opts: unknown): Promise<unknown>;
+    })._returnDuplicateMessageResult(evidence, { content: 'hi', model: 'duplicate-dispatched-model' });
+
+    expect(duplicate).toBe(full);
+    expect(completedEvidenceSnapshots).toEqual([
+      {
+        tokenUsage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        pendingToolCallId: 'tc-duplicate-suspend',
+        modeId: defaultModeId,
+        modelId: 'duplicate-dispatched-model',
+      },
+    ]);
+    expect(session.getTokenUsage()).toEqual({ promptTokens: 1, completionTokens: 1, totalTokens: 2 });
+    expect(session.getRecord().pendingResume?.toolCallId).toBe('tc-duplicate-suspend');
+    expect(session.getRecord().pendingResume?.runtimeDependencies?.modelId).toBe('duplicate-dispatched-model');
+    expect(session.getDisplayState().currentRunId).toBeUndefined();
+
+    const replay = await (session as unknown as {
+      _returnDuplicateMessageResult(evidence: unknown, opts: unknown): Promise<unknown>;
+    })._returnDuplicateMessageResult(evidence, { content: 'hi', model: 'duplicate-dispatched-model' });
+    expect(replay).toBe(full);
+    expect(session.getTokenUsage()).toEqual({ promptTokens: 1, completionTokens: 1, totalTokens: 2 });
+  });
+
+  it('retries suspended duplicate message token accounting when an in-flight owner rolls back', async () => {
+    const { harness, storage } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const full = {
+      text: 'cached suspended duplicate retry',
+      finishReason: 'suspended',
+      runId: 'duplicate-suspend-token-retry-run',
+      usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
+      totalUsage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
+      suspendPayload: { toolCallId: 'tc-duplicate-suspend-retry', toolName: 'shell', args: { cmd: 'ls' } },
+    } as unknown as FullOutput<unknown>;
+    const saveSession = storage.saveSession.bind(storage);
+    const firstSave = deferred();
+    let pendingResumeSaveCount = 0;
+    vi.spyOn(storage, 'saveSession').mockImplementation(async (record, opts) => {
+      if (record.pendingResume?.toolCallId === 'tc-duplicate-suspend-retry') {
+        pendingResumeSaveCount += 1;
+        if (pendingResumeSaveCount === 1) {
+          await firstSave.promise;
+          throw new Error('first duplicate suspend persist failed');
+        }
+      }
+      return saveSession(record, opts);
+    });
+
+    const capture = (session as unknown as {
+      _captureMessageSuspendWithTokenUsage(
+        full: FullOutput<unknown>,
+        queuedItemId: string | undefined,
+        modeId: string,
+        modelId: string,
+      ): Promise<void>;
+    })._captureMessageSuspendWithTokenUsage.bind(session);
+    const first = capture(full, undefined, session.getRecord().modeId, session.getRecord().modelId);
+    await vi.waitFor(() => expect(pendingResumeSaveCount).toBe(1));
+    const second = capture(full, undefined, session.getRecord().modeId, session.getRecord().modelId);
+
+    firstSave.resolve();
+    await expect(first).rejects.toThrow('first duplicate suspend persist failed');
+    await expect(second).resolves.toBeUndefined();
+
+    expect(pendingResumeSaveCount).toBe(2);
+    expect(session.getTokenUsage()).toEqual({ promptTokens: 2, completionTokens: 3, totalTokens: 5 });
+    expect(session.getRecord().pendingResume?.toolCallId).toBe('tc-duplicate-suspend-retry');
+  });
+
+  it('persists queued-turn token usage in the same write as the no-replay marker', async () => {
+    // Regression guard for the ordering bug surfaced during review:
+    // `_finalizeCompletedQueuedTurn` previously wrote `postRunFinalizedAt`
+    // before accounting tokens, so a crash between marker and accumulator
+    // would resume with the marker set and never re-record the turn's usage.
+    const { harness, agent } = setupHarness();
+    agent.enqueueRun({ runId: 'q1', finishReason: 'stop' });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.queue({ content: 'queued' });
+    const persisted = session.getRecord().tokenUsage;
+    const receipt = Object.values(session.getRecord().queueAdmissionReceipts ?? {})[0];
+    expect(receipt?.postRunFinalizedAt).toBeDefined();
+    expect(persisted.totalTokens).toBeGreaterThan(0);
+    expect(session.getTokenUsage()).toEqual(persisted);
+  });
+
+  it('does not write queued-turn token usage before the no-replay marker', async () => {
+    const { harness, agent, storage } = setupHarness();
+    const writes: SessionRecord[] = [];
+    const saveSession = storage.saveSession.bind(storage);
+    vi.spyOn(storage, 'saveSession').mockImplementation(async (record, opts) => {
+      writes.push(JSON.parse(JSON.stringify(record)) as SessionRecord);
+      return saveSession(record, opts);
+    });
+
+    agent.enqueueRun({ runId: 'q-no-token-gap', finishReason: 'stop' });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.queue({ content: 'queued' });
+
+    const receiptId = Object.keys(session.getRecord().queueAdmissionReceipts ?? {})[0];
+    expect(receiptId).toBeDefined();
+    const tokenOnlyWrites = writes.filter(record => {
+      if ((record.tokenUsage?.totalTokens ?? 0) <= 0) return false;
+      const receipt = record.queueAdmissionReceipts?.[receiptId!];
+      return receipt !== undefined && receipt.postRunFinalizedAt === undefined;
+    });
+    expect(tokenOnlyWrites).toEqual([]);
+    expect(
+      writes.some(record => {
+        const receipt = record.queueAdmissionReceipts?.[receiptId!];
+        return (record.tokenUsage?.totalTokens ?? 0) > 0 && receipt?.postRunFinalizedAt !== undefined;
+      }),
+    ).toBe(true);
+  });
+
+  it('rolls back queued-turn token usage when the no-replay marker write retries', async () => {
+    vi.useFakeTimers();
+    try {
+      const { harness, agent, storage } = setupHarness();
+      const saveSession = storage.saveSession.bind(storage);
+      let failedMarkerOnce = false;
+      vi.spyOn(storage, 'saveSession').mockImplementation(async (record, opts) => {
+        const receipt = Object.values(record.queueAdmissionReceipts ?? {})[0];
+        if (
+          !failedMarkerOnce &&
+          receipt?.postRunFinalizedAt !== undefined &&
+          (record.tokenUsage?.totalTokens ?? 0) > 0
+        ) {
+          failedMarkerOnce = true;
+          throw new Error('marker write failed once');
+        }
+        return saveSession(record, opts);
+      });
+
+      agent.enqueueRun({ runId: 'q-marker-retry', finishReason: 'stop' });
+      const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+      const queued = session.queue({ content: 'queued' });
+
+      for (let i = 0; i < 10 && !failedMarkerOnce; i += 1) {
+        await vi.advanceTimersByTimeAsync(0);
+      }
+      expect(failedMarkerOnce).toBe(true);
+      expect(session.getTokenUsage()).toEqual({ promptTokens: 0, completionTokens: 0, totalTokens: 0 });
+
+      await vi.advanceTimersByTimeAsync(1_001);
+      await queued;
+
+      expect(session.getTokenUsage()).toEqual({ promptTokens: 1, completionTokens: 1, totalTokens: 2 });
+      const receipt = Object.values(session.getRecord().queueAdmissionReceipts ?? {})[0];
+      expect(receipt?.postRunFinalizedAt).toBeDefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('persists admitted message token usage before completed result evidence', async () => {
+    const { harness, agent, storage } = setupHarness();
+    const events: string[] = [];
+    const saveSession = storage.saveSession.bind(storage);
+    vi.spyOn(storage, 'saveSession').mockImplementation(async (record, opts) => {
+      if ((record.tokenUsage?.totalTokens ?? 0) > 0) events.push('token-save');
+      return saveSession(record, opts);
+    });
+    const writeEvidence = storage.writeMessageResultEvidence.bind(storage);
+    vi.spyOn(storage, 'writeMessageResultEvidence').mockImplementation(async record => {
+      if (record.status === 'completed') events.push('completed-evidence');
+      return writeEvidence(record);
+    });
+
+    agent.enqueueRun({ runId: 'msg-token-order', finishReason: 'stop' });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'one', admissionId: 'msg-token-order' });
+
+    expect(events).toContain('token-save');
+    expect(events).toContain('completed-evidence');
+    expect(events.indexOf('token-save')).toBeLessThan(events.indexOf('completed-evidence'));
+  });
+
+  it('writes failed evidence when admitted stream token persistence fails before completion evidence', async () => {
+    const { harness, agent, storage } = setupHarness();
+    const evidenceStatuses: string[] = [];
+    const saveSession = storage.saveSession.bind(storage);
+    let failedTokenSave = false;
+    vi.spyOn(storage, 'saveSession').mockImplementation(async (record, opts) => {
+      if (!failedTokenSave && (record.tokenUsage?.totalTokens ?? 0) > 0) {
+        failedTokenSave = true;
+        throw new Error('token persist failed');
+      }
+      return saveSession(record, opts);
+    });
+    const writeEvidence = storage.writeMessageResultEvidence.bind(storage);
+    vi.spyOn(storage, 'writeMessageResultEvidence').mockImplementation(async record => {
+      if (record.admissionId === 'stream-token-persist-failure') evidenceStatuses.push(record.status);
+      return writeEvidence(record);
+    });
+
+    agent.enqueueRun({ runId: 'stream-token-persist-failure', finishReason: 'stop' });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const stream = await session.message({
+      content: 'one',
+      admissionId: 'stream-token-persist-failure',
+      stream: true,
+    });
+    await (stream as { getFullOutput(): Promise<FullOutput<unknown>> }).getFullOutput();
+    await session.waitForIdle({ timeoutMs: 1_000 });
+
+    expect(failedTokenSave).toBe(true);
+    expect(evidenceStatuses).toContain('pending');
+    expect(evidenceStatuses).toContain('failed');
+    expect(evidenceStatuses).not.toContain('completed');
+  });
+
+  it('does not release the lease when suspended stream parking fails before pending resume persists', async () => {
+    const { harness, agent, storage } = setupHarness();
+    const releaseSessionLease = vi.spyOn(storage, 'releaseSessionLease');
+    const saveSession = storage.saveSession.bind(storage);
+    let failedPendingResumeSave = false;
+    vi.spyOn(storage, 'saveSession').mockImplementation(async (record, opts) => {
+      if (!failedPendingResumeSave && record.pendingResume?.toolCallId === 'tc-stream-suspend-persist-failure') {
+        failedPendingResumeSave = true;
+        throw new Error('stream suspend persist failed');
+      }
+      return saveSession(record, opts);
+    });
+
+    const suspendedFull = {
+      runId: 'stream-suspend-persist-failure',
+      finishReason: 'suspended',
+      suspendPayload: { toolCallId: 'tc-stream-suspend-persist-failure', toolName: 'shell', args: { cmd: 'ls' } },
+    } as unknown as FullOutput<unknown>;
+    agent.enqueueRun(suspendedFull);
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const stream = await session.message({ content: 'suspend', stream: true });
+    await (stream as { getFullOutput(): Promise<FullOutput<unknown>> }).getFullOutput();
+    await session.waitForIdle({ timeoutMs: 1_000 });
+
+    expect(failedPendingResumeSave).toBe(true);
+    expect(session.getRecord().pendingResume).toBeUndefined();
+    await expect(harness.shutdown()).rejects.toMatchObject({
+      name: 'HarnessStorageError',
+      cause: expect.objectContaining({ message: 'stream suspend persist failed' }),
+    });
+    expect(releaseSessionLease).not.toHaveBeenCalled();
+
+    await (session as unknown as {
+      _captureMessageSuspendWithTokenUsage(
+        full: FullOutput<unknown>,
+        queuedItemId: string | undefined,
+        modeId: string,
+        modelId: string,
+      ): Promise<void>;
+    })._captureMessageSuspendWithTokenUsage(suspendedFull, undefined, session.getRecord().modeId, session.getRecord().modelId);
+    await expect(harness.shutdown()).resolves.toBeUndefined();
+    expect(releaseSessionLease).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not clear a durable-turn latch for an unrelated pending resume', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const pending = {
+      kind: 'tool-approval',
+      itemId: 'tool-approval:tc-existing',
+      runId: 'existing-run',
+      toolCallId: 'tc-existing',
+      toolName: 'shell',
+      source: 'parent',
+      requestedAt: Date.now(),
+    } satisfies NonNullable<SessionRecord['pendingResume']>;
+    (session as unknown as { _record: SessionRecord })._record = {
+      ...session.getRecord(),
+      pendingResume: pending,
+    };
+    (session as unknown as {
+      _pendingDurableTurnFlushError?: { error: unknown; pendingResume?: { runId: string; toolCallId: string } };
+    })._pendingDurableTurnFlushError = {
+      error: new Error('different suspend persist failed'),
+      pendingResume: { runId: 'latched-run', toolCallId: 'tc-latched' },
+    };
+
+    await (session as unknown as {
+      _maybeCaptureSuspend(
+        full: FullOutput<unknown>,
+        queuedItemId: string | undefined,
+        modeId: string,
+        modelId: string,
+      ): Promise<void>;
+    })._maybeCaptureSuspend(
+      {
+        finishReason: 'suspended',
+        runId: 'unrelated-run',
+        suspendPayload: { toolCallId: 'tc-unrelated', toolName: 'shell', args: { cmd: 'pwd' } },
+      } as unknown as FullOutput<unknown>,
+      undefined,
+      session.getRecord().modeId,
+      session.getRecord().modelId,
+    );
+    expect(session.getRecord().pendingResume?.toolCallId).toBe('tc-unrelated');
+    await expect(
+      (session as unknown as { _internalAwaitFlushChain(): Promise<void> })._internalAwaitFlushChain(),
+    ).rejects.toThrow('different suspend persist failed');
+
+    (session as unknown as { _record: SessionRecord })._record = {
+      ...session.getRecord(),
+      pendingResume: { ...pending, runId: 'latched-run', toolCallId: 'tc-latched' },
+    };
+    await expect(
+      (session as unknown as { _internalAwaitFlushChain(): Promise<void> })._internalAwaitFlushChain(),
+    ).resolves.toBeUndefined();
+  });
+
+  it('clears an unkeyed durable-turn latch after token usage is repaired', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    asInternals(session)._tokenUsage = { promptTokens: 1, completionTokens: 2, totalTokens: 3 };
+    (session as unknown as {
+      _pendingDurableTurnFlushError?: { error: unknown; pendingResume?: { runId: string; toolCallId: string } };
+    })._pendingDurableTurnFlushError = {
+      error: new Error('unkeyed durable persist failed'),
+    };
+
+    await (session as unknown as { _persistTokenUsage(): Promise<void> })._persistTokenUsage();
+
+    await expect(
+      (session as unknown as { _internalAwaitFlushChain(): Promise<void> })._internalAwaitFlushChain(),
+    ).resolves.toBeUndefined();
+  });
+
+  it('repairs foreground message token persistence on shutdown before releasing the lease', async () => {
+    const { harness, agent, storage } = setupHarness();
+    const releaseSessionLease = vi.spyOn(storage, 'releaseSessionLease');
+    const saveSession = storage.saveSession.bind(storage);
+    let failedTokenSave = false;
+    vi.spyOn(storage, 'saveSession').mockImplementation(async (record, opts) => {
+      if (!failedTokenSave && (record.tokenUsage?.totalTokens ?? 0) > 0) {
+        failedTokenSave = true;
+        throw new Error('foreground token persist failed');
+      }
+      return saveSession(record, opts);
+    });
+
+    agent.enqueueRun({ runId: 'foreground-token-persist-failure', finishReason: 'stop' });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await expect(session.message({ content: 'one', admissionId: 'foreground-token-persist-failure' })).rejects.toThrow(
+      'foreground token persist failed',
+    );
+    expect(failedTokenSave).toBe(true);
+
+    await expect(harness.shutdown()).resolves.toBeUndefined();
+    expect(releaseSessionLease).toHaveBeenCalledTimes(1);
+  });
+
+  it('repairs owned system-reminder token persistence on shutdown before releasing the lease', async () => {
+    const { harness, agent, storage } = setupHarness();
+    const hold = deferred();
+    const releaseSessionLease = vi.spyOn(storage, 'releaseSessionLease');
+    const saveSession = storage.saveSession.bind(storage);
+    let failedTokenSave = false;
+    vi.spyOn(storage, 'saveSession').mockImplementation(async (record, opts) => {
+      if (!failedTokenSave && (record.tokenUsage?.totalTokens ?? 0) > 0) {
+        failedTokenSave = true;
+        throw new Error('reminder token persist failed');
+      }
+      return saveSession(record, opts);
+    });
+
+    agent.enqueueRun({ runId: 'reminder-token-persist-failure', finishReason: 'stop', holdUntil: hold.promise });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.injectSystemReminder('remember this');
+    let shutdownSettled = false;
+    const shutdown = harness.shutdown().finally(() => {
+      shutdownSettled = true;
+    });
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(shutdownSettled).toBe(false);
+    expect(failedTokenSave).toBe(false);
+    hold.resolve();
+    await expect(shutdown).resolves.toBeUndefined();
+    expect(failedTokenSave).toBe(true);
+    expect(releaseSessionLease).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists a dirty live token counter during shutdown before releasing the lease', async () => {
+    const { harness, storage } = setupHarness();
+    let releasedTokenUsage: SessionRecord['tokenUsage'] | undefined;
+    const releaseSessionLease = storage.releaseSessionLease.bind(storage);
+    vi.spyOn(storage, 'releaseSessionLease').mockImplementation(async opts => {
+      const stored = await storage.loadSession({ harnessName: opts.harnessName, sessionId: opts.sessionId });
+      releasedTokenUsage = stored?.tokenUsage;
+      return releaseSessionLease(opts);
+    });
+
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    asInternals(session)._tokenUsage = { promptTokens: 3, completionTokens: 4, totalTokens: 7 };
+
+    await expect(harness.shutdown()).resolves.toBeUndefined();
+    expect(releasedTokenUsage).toEqual({ promptTokens: 3, completionTokens: 4, totalTokens: 7 });
+    const stored = await storage.loadSession({ harnessName: session.getRecord().harnessName, sessionId: session.id });
+    expect(stored?.tokenUsage).toEqual({ promptTokens: 3, completionTokens: 4, totalTokens: 7 });
+  });
+
+  it('does not treat missing zero token usage as dirty under a zero shutdown deadline', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    (session as unknown as { _record: SessionRecord | LegacyMissingTokenUsageRecord })._record = {
+      ...session.getRecord(),
+      tokenUsage: undefined,
+    };
+
+    await expect(harness.shutdown({ drainTimeoutMs: 0 })).resolves.toBeUndefined();
+  });
+
+  it('repairs missing zero token usage during normal shutdown', async () => {
+    const { harness, storage } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    (session as unknown as { _record: SessionRecord | LegacyMissingTokenUsageRecord })._record = {
+      ...session.getRecord(),
+      tokenUsage: undefined,
+    };
+
+    await expect(harness.shutdown()).resolves.toBeUndefined();
+
+    const stored = await storage.loadSession({ harnessName: session.getRecord().harnessName, sessionId: session.id });
+    expect(stored?.tokenUsage).toEqual({ promptTokens: 0, completionTokens: 0, totalTokens: 0 });
+  });
+
+  it('does not release the lease when shutdown event persistence fails', async () => {
+    const { harness, storage } = setupHarness();
+    const releaseSessionLease = vi.spyOn(storage, 'releaseSessionLease');
+    vi.spyOn(storage, 'appendSessionEvent').mockRejectedValueOnce(new Error('event persistence failed'));
+
+    await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await expect(harness.shutdown()).rejects.toMatchObject({
+      name: 'HarnessStorageError',
+      cause: expect.objectContaining({ message: 'event persistence failed' }),
+    });
+    expect(releaseSessionLease).not.toHaveBeenCalled();
+  });
+
+  it('does not partially release earlier session leases when later shutdown event persistence fails', async () => {
+    const { harness, storage } = setupHarness();
+    const releaseSessionLease = vi.spyOn(storage, 'releaseSessionLease');
+    const appendSessionEvent = storage.appendSessionEvent.bind(storage);
+    const evictedSessionIds: string[] = [];
+    harness.subscribe(event => {
+      if (event.type === 'session_evicted') evictedSessionIds.push(event.sessionId);
+    });
+    const first = await harness.session({ resourceId: 'u', threadId: 't-shutdown-partial-release-1' });
+    const second = await harness.session({ resourceId: 'u', threadId: 't-shutdown-partial-release-2' });
+    let failSecondEviction = true;
+    vi.spyOn(storage, 'appendSessionEvent').mockImplementation(async record => {
+      if (failSecondEviction && record.sessionId === second.id) {
+        failSecondEviction = false;
+        throw new Error('second event persistence failed');
+      }
+      return appendSessionEvent(record);
+    });
+
+    await expect(harness.shutdown()).rejects.toMatchObject({
+      name: 'HarnessStorageError',
+      cause: expect.objectContaining({ message: 'second event persistence failed' }),
+    });
+    expect(releaseSessionLease).not.toHaveBeenCalled();
+    await expect(storage.loadSession({ harnessName: first.getRecord().harnessName, sessionId: first.id })).resolves.toMatchObject({
+      ownerId: harness.ownerId,
+    });
+
+    await expect(harness.shutdown()).rejects.toMatchObject({
+      name: 'HarnessStorageError',
+      cause: expect.objectContaining({ message: 'second event persistence failed' }),
+    });
+    expect(releaseSessionLease).not.toHaveBeenCalled();
+    expect(evictedSessionIds.filter(id => id === first.id)).toHaveLength(1);
+    expect(evictedSessionIds.filter(id => id === second.id)).toHaveLength(1);
+  });
+
+  it('rejects new work from held session references while shutdown is releasing leases', async () => {
+    const { harness, storage } = setupHarness();
+    const holdRelease = deferred();
+    let releaseStarted = false;
+    const releaseSessionLease = storage.releaseSessionLease.bind(storage);
+    vi.spyOn(storage, 'releaseSessionLease').mockImplementation(async opts => {
+      releaseStarted = true;
+      await holdRelease.promise;
+      return releaseSessionLease(opts);
+    });
+
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const shutdown = harness.shutdown();
+    await vi.waitFor(() => expect(releaseStarted).toBe(true));
+
+    await expect(session.message({ content: 'too late' })).rejects.toMatchObject({
+      name: 'HarnessSessionClosingError',
+    });
+
+    holdRelease.resolve();
+    await expect(shutdown).resolves.toBeUndefined();
+  });
+
+  it('waits for returned stream token persistence before releasing the lease on shutdown', async () => {
+    const { harness, agent, storage } = setupHarness();
+    const hold = deferred();
+    let releasedTokenUsage: SessionRecord['tokenUsage'] | undefined;
+    const releaseSessionLease = storage.releaseSessionLease.bind(storage);
+    vi.spyOn(storage, 'releaseSessionLease').mockImplementation(async opts => {
+      const stored = await storage.loadSession({ harnessName: opts.harnessName, sessionId: opts.sessionId });
+      releasedTokenUsage = stored?.tokenUsage;
+      return releaseSessionLease(opts);
+    });
+
+    agent.enqueueRun({ runId: 'stream-shutdown-token-usage', finishReason: 'stop', holdUntil: hold.promise });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'stream', stream: true });
+    let shutdownSettled = false;
+    const shutdown = harness.shutdown().finally(() => {
+      shutdownSettled = true;
+    });
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(shutdownSettled).toBe(false);
+    hold.resolve();
+    await expect(shutdown).resolves.toBeUndefined();
+    expect(releasedTokenUsage).toEqual({ promptTokens: 1, completionTokens: 1, totalTokens: 2 });
+  });
+
+  it('waits for foreground message token persistence before releasing the lease on shutdown', async () => {
+    const { harness, agent, storage } = setupHarness();
+    const hold = deferred();
+    let releasedTokenUsage: SessionRecord['tokenUsage'] | undefined;
+    const releaseSessionLease = storage.releaseSessionLease.bind(storage);
+    vi.spyOn(storage, 'releaseSessionLease').mockImplementation(async opts => {
+      const stored = await storage.loadSession({ harnessName: opts.harnessName, sessionId: opts.sessionId });
+      releasedTokenUsage = stored?.tokenUsage;
+      return releaseSessionLease(opts);
+    });
+
+    agent.enqueueRun({ runId: 'foreground-shutdown-token-usage', finishReason: 'stop', holdUntil: hold.promise });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const message = session.message({ content: 'foreground' });
+    await new Promise(resolve => setImmediate(resolve));
+    let shutdownSettled = false;
+    const shutdown = harness.shutdown().finally(() => {
+      shutdownSettled = true;
+    });
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(shutdownSettled).toBe(false);
+    hold.resolve();
+    await expect(message).resolves.toBeDefined();
+    await expect(shutdown).resolves.toBeUndefined();
+    expect(releasedTokenUsage).toEqual({ promptTokens: 1, completionTokens: 1, totalTokens: 2 });
+  });
+
+  it('does not release the lease when shutdown times out before a foreground turn unwinds', async () => {
+    const { harness, agent, storage } = setupHarness();
+    const hold = deferred();
+    const releaseSessionLease = vi.spyOn(storage, 'releaseSessionLease');
+
+    agent.enqueueRun({ runId: 'foreground-shutdown-timeout', finishReason: 'stop', holdUntil: hold.promise });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const message = session.message({ content: 'foreground timeout' });
+    await new Promise(resolve => setImmediate(resolve));
+
+    await expect(harness.shutdown({ drainTimeoutMs: 0 })).rejects.toMatchObject({ name: 'HarnessStorageError' });
+    expect(releaseSessionLease).not.toHaveBeenCalled();
+
+    hold.resolve();
+    await expect(message).resolves.toBeDefined();
+    await expect(harness.shutdown()).resolves.toBeUndefined();
+    expect(releaseSessionLease).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the lease for a durably parked suspended turn on shutdown', async () => {
+    const { harness, agent, storage } = setupHarness();
+    let releasedTokenUsage: SessionRecord['tokenUsage'] | undefined;
+    const releaseSessionLease = storage.releaseSessionLease.bind(storage);
+    vi.spyOn(storage, 'releaseSessionLease').mockImplementation(async opts => {
+      const stored = await storage.loadSession({ harnessName: opts.harnessName, sessionId: opts.sessionId });
+      releasedTokenUsage = stored?.tokenUsage;
+      return releaseSessionLease(opts);
+    });
+
+    agent.enqueueRun({
+      runId: 'suspended-shutdown-token-usage',
+      finishReason: 'suspended',
+      suspendPayload: { toolCallId: 'tc-shutdown-suspend', toolName: 'shell', args: { cmd: 'ls' } },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'suspend' });
+    expect(session.getRecord().pendingResume).toBeDefined();
+
+    await expect(harness.shutdown()).resolves.toBeUndefined();
+    expect(releasedTokenUsage).toEqual({ promptTokens: 1, completionTokens: 1, totalTokens: 2 });
+  });
+
+  it('releases the lease for a durably parked queued suspended turn on shutdown', async () => {
+    const { harness, agent, storage } = setupHarness();
+    const hold = deferred();
+    let releasedTokenUsage: SessionRecord['tokenUsage'] | undefined;
+    const releaseSessionLease = storage.releaseSessionLease.bind(storage);
+    vi.spyOn(storage, 'releaseSessionLease').mockImplementation(async opts => {
+      const stored = await storage.loadSession({ harnessName: opts.harnessName, sessionId: opts.sessionId });
+      releasedTokenUsage = stored?.tokenUsage;
+      return releaseSessionLease(opts);
+    });
+
+    agent.enqueueRun({
+      runId: 'queued-suspended-shutdown-token-usage',
+      finishReason: 'suspended',
+      holdUntil: hold.promise,
+      suspendPayload: { toolCallId: 'tc-queued-shutdown-suspend', toolName: 'shell', args: { cmd: 'ls' } },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const queued = session.queue({ content: 'queued suspend' });
+    void queued.catch(() => {});
+    await new Promise(resolve => setImmediate(resolve));
+    let shutdownSettled = false;
+    const shutdown = harness.shutdown({ drainTimeoutMs: 250 }).finally(() => {
+      shutdownSettled = true;
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    expect(shutdownSettled).toBe(false);
+
+    hold.resolve();
+    await expect(shutdown).resolves.toBeUndefined();
+    expect(session.getRecord().pendingResume?.toolCallId).toBe('tc-queued-shutdown-suspend');
+    expect(session.getRecord().pendingQueue?.length).toBe(1);
+    expect(releasedTokenUsage).toEqual({ promptTokens: 1, completionTokens: 1, totalTokens: 2 });
+  });
+
+  it('waits for queued-turn token persistence before releasing the lease on shutdown', async () => {
+    const { harness, agent, storage } = setupHarness();
+    const hold = deferred();
+    let releasedTokenUsage: SessionRecord['tokenUsage'] | undefined;
+    const releaseSessionLease = storage.releaseSessionLease.bind(storage);
+    vi.spyOn(storage, 'releaseSessionLease').mockImplementation(async opts => {
+      const stored = await storage.loadSession({ harnessName: opts.harnessName, sessionId: opts.sessionId });
+      releasedTokenUsage = stored?.tokenUsage;
+      return releaseSessionLease(opts);
+    });
+
+    agent.enqueueRun({ runId: 'queued-shutdown-token-usage', finishReason: 'stop', holdUntil: hold.promise });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const queued = session.queue({ content: 'queued' });
+    await new Promise(resolve => setImmediate(resolve));
+    let shutdownSettled = false;
+    const shutdown = harness.shutdown().finally(() => {
+      shutdownSettled = true;
+    });
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(shutdownSettled).toBe(false);
+    hold.resolve();
+    await expect(queued).resolves.toBeDefined();
+    await expect(shutdown).resolves.toBeUndefined();
+    expect(releasedTokenUsage).toEqual({ promptTokens: 1, completionTokens: 1, totalTokens: 2 });
+  });
+
+  it('does not write resumed queued-turn token usage before the no-replay marker', async () => {
+    const { harness, agent, storage } = setupHarness();
+    const writes: SessionRecord[] = [];
+    const saveSession = storage.saveSession.bind(storage);
+    vi.spyOn(storage, 'saveSession').mockImplementation(async (record, opts) => {
+      writes.push(JSON.parse(JSON.stringify(record)) as SessionRecord);
+      return saveSession(record, opts);
+    });
+
+    agent.enqueueRun({
+      runId: 'q-suspend-token-gap',
+      finishReason: 'suspended',
+      suspendPayload: { toolCallId: 'tc-token-gap', toolName: 'shell', args: { cmd: 'ls' } },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const queued = session.queue({ content: 'queued' });
+    await new Promise(resolve => setImmediate(resolve));
+
+    const receiptId = Object.keys(session.getRecord().queueAdmissionReceipts ?? {})[0];
+    expect(receiptId).toBeDefined();
+    const beforeResumeTokens = session.getTokenUsage().totalTokens;
+    agent.enqueueRun({ runId: 'q-suspend-token-gap', finishReason: 'stop' });
+    await session.respondToToolApproval({ approved: true });
+    await queued;
+
+    const tokenOnlyWrites = writes.filter(record => {
+      if ((record.tokenUsage?.totalTokens ?? 0) <= beforeResumeTokens) return false;
+      const receipt = record.queueAdmissionReceipts?.[receiptId!];
+      return receipt !== undefined && receipt.postRunFinalizedAt === undefined;
+    });
+    expect(tokenOnlyWrites).toEqual([]);
+    expect(
+      writes.some(record => {
+        const receipt = record.queueAdmissionReceipts?.[receiptId!];
+        return (record.tokenUsage?.totalTokens ?? 0) > beforeResumeTokens && receipt?.postRunFinalizedAt !== undefined;
+      }),
+    ).toBe(true);
+  });
+
+  it('parks suspended message state in the same write as token usage', async () => {
+    const { harness, agent, storage } = setupHarness();
+    const writes: SessionRecord[] = [];
+    const saveSession = storage.saveSession.bind(storage);
+    vi.spyOn(storage, 'saveSession').mockImplementation(async (record, opts) => {
+      writes.push(JSON.parse(JSON.stringify(record)) as SessionRecord);
+      return saveSession(record, opts);
+    });
+
+    agent.enqueueRun({
+      runId: 'msg-suspend-token-gap',
+      finishReason: 'suspended',
+      suspendPayload: { toolCallId: 'tc-msg-token-gap', toolName: 'shell', args: { cmd: 'ls' } },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'needs approval' });
+
+    const tokenOnlyWrites = writes.filter(
+      record => (record.tokenUsage?.totalTokens ?? 0) > 0 && record.pendingResume === undefined,
+    );
+    expect(tokenOnlyWrites).toEqual([]);
+    expect(
+      writes.some(
+        record => (record.tokenUsage?.totalTokens ?? 0) > 0 && record.pendingResume?.toolCallId === 'tc-msg-token-gap',
+      ),
+    ).toBe(true);
+  });
+
+  it('parks resumed suspension state in the same write as token usage', async () => {
+    const { harness, agent, storage } = setupHarness();
+    const writes: SessionRecord[] = [];
+    const saveSession = storage.saveSession.bind(storage);
+    vi.spyOn(storage, 'saveSession').mockImplementation(async (record, opts) => {
+      writes.push(JSON.parse(JSON.stringify(record)) as SessionRecord);
+      return saveSession(record, opts);
+    });
+
+    agent.enqueueRun({
+      runId: 'msg-resuspend-token-gap',
+      finishReason: 'suspended',
+      suspendPayload: { toolCallId: 'tc-resuspend-first', toolName: 'shell', args: { cmd: 'ls' } },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'needs approval' });
+    const beforeResumeTokens = session.getTokenUsage().totalTokens;
+
+    agent.enqueueRun({
+      runId: 'msg-resuspend-token-gap',
+      finishReason: 'suspended',
+      suspendPayload: { toolCallId: 'tc-resuspend-second', toolName: 'shell', args: { cmd: 'pwd' } },
+    });
+    await session.respondToToolApproval({ approved: true });
+
+    const tokenWritesWithoutNewPending = writes.filter(
+      record =>
+        (record.tokenUsage?.totalTokens ?? 0) > beforeResumeTokens &&
+        record.pendingResume?.toolCallId !== 'tc-resuspend-second',
+    );
+    expect(tokenWritesWithoutNewPending).toEqual([]);
+    expect(
+      writes.some(
+        record =>
+          (record.tokenUsage?.totalTokens ?? 0) > beforeResumeTokens &&
+          record.pendingResume?.toolCallId === 'tc-resuspend-second',
+      ),
+    ).toBe(true);
+  });
+
+  it('continues accumulating after rehydration instead of restarting at zero', async () => {
+    const { harness, agent, storage } = setupHarness();
+    agent.enqueueRun({ runId: 'r1', finishReason: 'stop' });
+    const first = await harness.session({ threadId: 't-cont', resourceId: 'u' });
+    await first.message({ content: 'one' });
+    const afterFirst = first.getTokenUsage();
+    await harness.shutdown();
+
+    const { harness: harness2, agent: agent2 } = setupHarness({ sessions: { storage } });
+    agent2.enqueueRun({ runId: 'r2', finishReason: 'stop' });
+    const second = await harness2.session({ threadId: 't-cont', resourceId: 'u' });
+    expect(second.getTokenUsage()).toEqual(afterFirst);
+    await second.message({ content: 'two' });
+    const afterSecond = second.getTokenUsage();
+    expect(afterSecond.promptTokens).toBeGreaterThan(afterFirst.promptTokens);
+    expect(afterSecond.completionTokens).toBeGreaterThan(afterFirst.completionTokens);
+    expect(afterSecond.totalTokens).toBeGreaterThan(afterFirst.totalTokens);
+  });
+});
+
+describe('Session token usage — totalTokens derivation', () => {
+  it('derives totalTokens from input + output when the provider omits totalTokens', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const internals = asInternals(session);
+    internals._recordTurnCompletion({
+      usage: { inputTokens: 3, outputTokens: 4 },
+    } as unknown as FullOutput<unknown>);
+    expect(internals._tokenUsage).toEqual({ promptTokens: 3, completionTokens: 4, totalTokens: 7 });
+  });
+
+  it('respects an explicit totalTokens when the provider supplies one', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const internals = asInternals(session);
+    internals._recordTurnCompletion({
+      usage: { inputTokens: 2, outputTokens: 5, totalTokens: 9 },
+    } as unknown as FullOutput<unknown>);
+    expect(internals._tokenUsage).toEqual({ promptTokens: 2, completionTokens: 5, totalTokens: 9 });
+  });
+
+  it('repairs stale zero provider totals when component counters are present', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const internals = asInternals(session);
+    internals._recordTurnCompletion({
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 0 },
+    } as unknown as FullOutput<unknown>);
+    expect(internals._tokenUsage).toEqual({ promptTokens: 10, completionTokens: 5, totalTokens: 15 });
+  });
+
+  it('repairs stale low provider totals when component counters are present', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const internals = asInternals(session);
+    internals._recordTurnCompletion({
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 7 },
+    } as unknown as FullOutput<unknown>);
+    expect(internals._tokenUsage).toEqual({ promptTokens: 10, completionTokens: 5, totalTokens: 15 });
+  });
+
+  it('does not double-count when both totalTokens and input/output are present across turns', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const internals = asInternals(session);
+    internals._recordTurnCompletion({
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    } as unknown as FullOutput<unknown>);
+    internals._recordTurnCompletion({
+      usage: { inputTokens: 4, outputTokens: 6 },
+    } as unknown as FullOutput<unknown>);
+    expect(internals._tokenUsage).toEqual({ promptTokens: 5, completionTokens: 7, totalTokens: 12 });
+  });
+
+  it('leaves promptTokens and completionTokens at zero when only totalTokens is provided', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const internals = asInternals(session);
+    internals._recordTurnCompletion({
+      usage: { totalTokens: 5 },
+    } as unknown as FullOutput<unknown>);
+    expect(internals._tokenUsage).toEqual({ promptTokens: 0, completionTokens: 0, totalTokens: 5 });
+  });
+
+  it('derives totalTokens from numeric components only', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const internals = asInternals(session);
+    internals._recordTurnCompletion({
+      usage: { inputTokens: 3, outputTokens: '4' },
+    } as unknown as FullOutput<unknown>);
+    expect(internals._tokenUsage).toEqual({ promptTokens: 3, completionTokens: 0, totalTokens: 3 });
+  });
+
+  it('ignores non-finite provider usage values', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const internals = asInternals(session);
+    internals._recordTurnCompletion({
+      usage: {
+        inputTokens: Number.NaN,
+        outputTokens: Number.POSITIVE_INFINITY,
+        totalTokens: Number.NEGATIVE_INFINITY,
+      },
+    } as unknown as FullOutput<unknown>);
+    expect(internals._tokenUsage).toEqual({ promptTokens: 0, completionTokens: 0, totalTokens: 0 });
+  });
+
+  it('ignores negative and fractional provider usage values', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const internals = asInternals(session);
+    internals._recordTurnCompletion({
+      usage: {
+        inputTokens: -3,
+        outputTokens: 1.5,
+        totalTokens: -2,
+      },
+    } as unknown as FullOutput<unknown>);
+    expect(internals._tokenUsage).toEqual({ promptTokens: 0, completionTokens: 0, totalTokens: 0 });
+  });
+});

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -744,6 +744,8 @@ export const TABLE_SCHEMAS: Record<TABLE_NAMES, Record<string, StorageColumn>> =
     thread_id: { type: 'text', nullable: false },
     signal_id: { type: 'text', nullable: false },
     run_id: { type: 'text', nullable: true },
+    mode_id: { type: 'text', nullable: true },
+    model_id: { type: 'text', nullable: true },
     admission_id: { type: 'text', nullable: true },
     admission_hash: { type: 'text', nullable: true },
     status: { type: 'text', nullable: false },

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -386,9 +386,14 @@ export interface HarnessStoredPublicError {
 }
 
 export type AgentSignalResultStatus =
-  | { status: 'pending'; signalId: string; runId?: string }
-  | { status: 'completed'; signalId: string; runId: string; result: unknown }
-  | { status: 'failed'; signalId: string; runId?: string; error: HarnessStoredPublicError };
+  (
+    | { status: 'pending'; signalId: string; runId?: string }
+    | { status: 'completed'; signalId: string; runId: string; result: unknown }
+    | { status: 'failed'; signalId: string; runId?: string; error: HarnessStoredPublicError }
+  ) & {
+    modeId?: string;
+    modelId?: string;
+  };
 
 export interface AgentSignalAccepted {
   runId: string;

--- a/stores/libsql/src/storage/domains/harness/index.test.ts
+++ b/stores/libsql/src/storage/domains/harness/index.test.ts
@@ -1109,6 +1109,8 @@ describe('HarnessLibSQL message result evidence', () => {
         threadId: 'thread-1',
         signalId: 'signal-1',
         runId: 'run-1',
+        modeId: 'mode-1',
+        modelId: 'model-1',
         admissionId: 'admission-1',
         admissionHash: 'hash-1',
         status: 'completed',
@@ -1126,6 +1128,8 @@ describe('HarnessLibSQL message result evidence', () => {
         threadId: 'thread-1',
         signalId: 'signal-1',
         runId: 'run-1',
+        modeId: 'mode-1',
+        modelId: 'model-1',
         admissionId: 'admission-1',
         admissionHash: 'hash-1',
         status: 'completed',
@@ -1164,7 +1168,12 @@ describe('HarnessLibSQL message result evidence', () => {
         threadId: 'thread-1',
         signalId: 'signal-1',
       }),
-    ).resolves.toMatchObject({ status: 'completed', result: { text: 'done' } });
+    ).resolves.toMatchObject({
+      status: 'completed',
+      modeId: 'mode-1',
+      modelId: 'model-1',
+      result: { text: 'done' },
+    });
     await expect(
       storage.resolveOperationAdmissionEvidence({
         sessionId: 'session-1',

--- a/stores/libsql/src/storage/domains/harness/index.ts
+++ b/stores/libsql/src/storage/domains/harness/index.ts
@@ -1328,14 +1328,18 @@ export class HarnessLibSQL extends HarnessStorage {
         }
         const updated = {
           ...namespacedRecord,
+          modeId: namespacedRecord.modeId ?? current.modeId,
+          modelId: namespacedRecord.modelId ?? current.modelId,
           createdAt: current.createdAt,
         };
         await tx.execute({
           sql: `UPDATE ${TABLE_HARNESS_MESSAGE_RESULTS}
-                SET run_id = ?, status = ?, result = ?, error = ?, updated_at = ?
+                SET run_id = ?, mode_id = ?, model_id = ?, status = ?, result = ?, error = ?, updated_at = ?
                 WHERE id = ?`,
           args: [
             namespacedRecord.runId ?? null,
+            updated.modeId ?? null,
+            updated.modelId ?? null,
             namespacedRecord.status,
             'result' in namespacedRecord ? JSON.stringify(namespacedRecord.result) : null,
             'error' in namespacedRecord ? JSON.stringify(namespacedRecord.error) : null,
@@ -1349,9 +1353,9 @@ export class HarnessLibSQL extends HarnessStorage {
         created = true;
         await tx.execute({
           sql: `INSERT INTO ${TABLE_HARNESS_MESSAGE_RESULTS}
-                (id, harness_name, session_id, resource_id, thread_id, signal_id, run_id,
+                (id, harness_name, session_id, resource_id, thread_id, signal_id, run_id, mode_id, model_id,
                  admission_id, admission_hash, status, result, error, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
           args: [
             id,
             namespacedRecord.harnessName,
@@ -1360,6 +1364,8 @@ export class HarnessLibSQL extends HarnessStorage {
             namespacedRecord.threadId,
             namespacedRecord.signalId,
             namespacedRecord.runId ?? null,
+            namespacedRecord.modeId ?? null,
+            namespacedRecord.modelId ?? null,
             namespacedRecord.admissionId ?? null,
             namespacedRecord.admissionHash ?? null,
             namespacedRecord.status,
@@ -3827,6 +3833,11 @@ export class HarnessLibSQL extends HarnessStorage {
       schema: TABLE_SCHEMAS[TABLE_HARNESS_MESSAGE_RESULTS],
       compositePrimaryKey: messageResultsConfig?.compositePrimaryKey,
     });
+    await this.#db.alterTable({
+      tableName: TABLE_HARNESS_MESSAGE_RESULTS,
+      schema: TABLE_SCHEMAS[TABLE_HARNESS_MESSAGE_RESULTS],
+      ifNotExists: ['mode_id', 'model_id'],
+    });
   }
 
   async #ensureOperationTombstonesTable(): Promise<void> {
@@ -5230,6 +5241,8 @@ function rowToMessageResultEvidence(row: Record<string, unknown>): AgentSignalRe
     threadId: String(row.thread_id),
     signalId: String(row.signal_id),
     ...(row.run_id == null ? {} : { runId: String(row.run_id) }),
+    ...(row.mode_id == null ? {} : { modeId: String(row.mode_id) }),
+    ...(row.model_id == null ? {} : { modelId: String(row.model_id) }),
     ...(row.admission_id == null ? {} : { admissionId: String(row.admission_id) }),
     ...(row.admission_hash == null ? {} : { admissionHash: String(row.admission_hash) }),
     createdAt: Number(row.created_at),

--- a/stores/pg/src/storage/domains/harness/index.test.ts
+++ b/stores/pg/src/storage/domains/harness/index.test.ts
@@ -712,6 +712,8 @@ describe('HarnessPG', () => {
       threadId: 'thread-1',
       signalId: 'signal-1',
       runId: 'run-1',
+      modeId: 'mode-1',
+      modelId: 'model-1',
       admissionId: 'admission-1',
       admissionHash: 'hash-1',
       status: 'completed',
@@ -727,7 +729,13 @@ describe('HarnessPG', () => {
         threadId: 'thread-1',
         signalId: 'signal-1',
       }),
-    ).resolves.toMatchObject({ status: 'completed', runId: 'run-1', result: { ok: true } });
+    ).resolves.toMatchObject({
+      status: 'completed',
+      runId: 'run-1',
+      modeId: 'mode-1',
+      modelId: 'model-1',
+      result: { ok: true },
+    });
 
     await harness!.withThreadDeleteFence({ threadId: 'thread-1', ownerId: 'deleter', ttlMs: 30_000 }, async () => {
       await expect(

--- a/stores/pg/src/storage/domains/harness/index.ts
+++ b/stores/pg/src/storage/domains/harness/index.ts
@@ -1669,14 +1669,18 @@ export class HarnessPG extends HarnessStorage {
         }
         const updated = {
           ...namespacedRecord,
+          modeId: namespacedRecord.modeId ?? current.modeId,
+          modelId: namespacedRecord.modelId ?? current.modelId,
           createdAt: current.createdAt,
         };
         await tx.execute({
           sql: `UPDATE ${TABLE_HARNESS_MESSAGE_RESULTS}
-                SET run_id = ?, status = ?, result = ?, error = ?, updated_at = ?
+                SET run_id = ?, mode_id = ?, model_id = ?, status = ?, result = ?, error = ?, updated_at = ?
                 WHERE id = ?`,
           args: [
             namespacedRecord.runId ?? null,
+            updated.modeId ?? null,
+            updated.modelId ?? null,
             namespacedRecord.status,
             'result' in namespacedRecord ? JSON.stringify(namespacedRecord.result) : null,
             'error' in namespacedRecord ? JSON.stringify(namespacedRecord.error) : null,
@@ -1690,9 +1694,9 @@ export class HarnessPG extends HarnessStorage {
         created = true;
         await tx.execute({
           sql: `INSERT INTO ${TABLE_HARNESS_MESSAGE_RESULTS}
-                (id, harness_name, session_id, resource_id, thread_id, signal_id, run_id,
+                (id, harness_name, session_id, resource_id, thread_id, signal_id, run_id, mode_id, model_id,
                  admission_id, admission_hash, status, result, error, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
           args: [
             id,
             namespacedRecord.harnessName,
@@ -1701,6 +1705,8 @@ export class HarnessPG extends HarnessStorage {
             namespacedRecord.threadId,
             namespacedRecord.signalId,
             namespacedRecord.runId ?? null,
+            namespacedRecord.modeId ?? null,
+            namespacedRecord.modelId ?? null,
             namespacedRecord.admissionId ?? null,
             namespacedRecord.admissionHash ?? null,
             namespacedRecord.status,
@@ -3742,6 +3748,11 @@ export class HarnessPG extends HarnessStorage {
       schema: TABLE_SCHEMAS[TABLE_HARNESS_MESSAGE_RESULTS],
       compositePrimaryKey: messageResultsConfig?.compositePrimaryKey,
     });
+    await this.#db.alterTable({
+      tableName: TABLE_HARNESS_MESSAGE_RESULTS,
+      schema: TABLE_SCHEMAS[TABLE_HARNESS_MESSAGE_RESULTS],
+      ifNotExists: ['mode_id', 'model_id'],
+    });
   }
 
   async #ensureOperationTombstonesTable(): Promise<void> {
@@ -4925,6 +4936,8 @@ function rowToMessageResultEvidence(row: Record<string, unknown>): AgentSignalRe
     threadId: String(row.thread_id),
     signalId: String(row.signal_id),
     ...(row.run_id == null ? {} : { runId: String(row.run_id) }),
+    ...(row.mode_id == null ? {} : { modeId: String(row.mode_id) }),
+    ...(row.model_id == null ? {} : { modelId: String(row.model_id) }),
     ...(row.admission_id == null ? {} : { admissionId: String(row.admission_id) }),
     ...(row.admission_hash == null ? {} : { admissionHash: String(row.admission_hash) }),
     createdAt: Number(row.created_at),


### PR DESCRIPTION
## Summary

PF-735 adapts the token-usage durability slice from official `mastra-ai/mastra#16912` into the `mbenhamd/mastra` fork without wholesale-merging the whole upstream PR.

- Verified latest official PR head on 2026-05-24: `cdfdc1e8c8b289805fdf8d80e1869efe7bd855a4`.
- Source token-usage commit adapted: `44fb7e656c7857fc2bd1e93cded4944f119c1fed`.
- Later upstream commits after `44fb7e6` are intentionally not merged here. The latest official delta adds permission grants, per-call permission resolver args, subagent profile binding, and sandbox-access request APIs; those are useful Mastra-native primitives for later PF-742/PF-723-style work, not part of this token durability slice.

## Changes

- Rehydrate and repair Harness session token usage from persisted session records.
- Persist token usage through background completions, duplicate suspended message recovery, eviction, shutdown, and restart paths.
- Latch and surface token/durable-turn flush failures instead of silently dropping durability failures.
- Preserve message result `modeId` and `modelId` evidence in Harness storage and SQL adapters.
- Add lazy SQL column migration for `mode_id` and `model_id` in LibSQL and Postgres.
- Harden shutdown so live sessions reject new work during drain, use one global drain deadline, restore live state if preflight fails, and do not release leases before event persistence succeeds.
- Write failed message evidence when admitted token persistence fails before completion evidence can be durably recorded.

## Architecture Notes

This keeps Mastra responsible for runtime mechanics: Harness sessions, storage, replay/durability, shutdown, and message evidence. It does not add Doxa/PapersFlow compatibility layers or port old Doxa/VPS mechanics. Downstream PapersFlow policy/projections should stay outside this fork package slice.

PF-740 remains a sequencing concern downstream: Convex epoch/source type alignment should be fixed before relying on replay, subscriptions, or HITL recovery.

## Related PRs

Open fork PR checked before opening this PR:

- `#185` / PF-733: touches `packages/core/src/storage/domains/harness/types.ts` and Harness workspace restore exports. This PR overlaps only in `types.ts`, with additive message evidence metadata fields. There is no semantic dependency, but whichever PR merges second should rebase and re-run focused Harness checks.

## Validation

Passed:

- `pnpm --filter ./packages/core test:unit src/harness/v1/token-usage.test.ts --reporter=dot` — 45 tests passed, no type errors.
- `pnpm --filter ./packages/core check`
- `pnpm --dir packages/core exec eslint --no-warn-ignored src/harness/v1/harness.ts src/harness/v1/session.ts src/harness/v1/token-usage.test.ts src/storage/constants.ts src/storage/domains/harness/types.ts`
- `pnpm build:core`
- `pnpm --dir stores/libsql exec vitest run src/storage/domains/harness/index.test.ts` — 85 tests passed.
- `pnpm --dir stores/pg exec vitest run src/storage/domains/harness/index.test.ts` — 16 tests passed with local Docker Postgres.
- `pnpm --dir stores/libsql exec eslint --no-warn-ignored src/storage/domains/harness/index.ts src/storage/domains/harness/index.test.ts`
- `pnpm --dir stores/pg exec eslint --no-warn-ignored src/storage/domains/harness/index.ts src/storage/domains/harness/index.test.ts`
- `pnpm --filter @mastra/libsql build:lib`
- `pnpm --filter @mastra/pg build:lib`
- `git diff --cached --check`

Caveats:

- Broad `pnpm --filter @mastra/libsql test -- src/storage/domains/harness/index.test.ts` unexpectedly ran broader tests and hit unrelated local-performance/Harness failures; the focused LibSQL Harness storage test passed.
- Broad `pnpm --dir stores/pg test -- src/storage/domains/harness/index.test.ts` unexpectedly ran broader Postgres tests and hit unrelated performance DB/timestamp failures; the focused Postgres Harness storage test passed with Docker.

## Review Evidence

- Local Codex review pass over the latest delta: no findings.
- Local CodeRabbit findings were checked against source and addressed: changeset package wording, duplicate cached completion mode/model fallback, and failed evidence fallback when token persistence fails before completion evidence.
- No Gemini/opencode council was used for this PR, per user instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR teaches the system to remember how many tokens (basic units of computation) it has used, so that even if the program stops and restarts, it doesn't forget and won't lose track of costs. It also makes sure the system stores which AI mode and model was used with each message, and improves how the system shuts down to make sure nothing gets lost.

---

## Summary of Changes

### Core Functionality

**Token Usage Durability**: Implemented persistent token usage tracking across session restarts and background operations. Token usage is now:
- Initialized from persisted `SessionRecord.tokenUsage` during session construction
- Properly accumulated and persisted through durable write barriers
- Automatically calculated when providers omit total counts
- Recovered and repaired from stale or incomplete persisted records

**Harness Shutdown Improvements**: Significantly hardened shutdown behavior by:
- Adding per-session eviction deduplication to prevent duplicate `session_evicted` events
- Implementing a global drain deadline (`drainTimeoutMs`) for all sessions
- Draining admitted work without converting queued work into failures
- Ensuring token usage is persisted before releasing session leases
- Restoring live state if any persistence or drain step fails
- Latching and surfacing flush failures instead of silently dropping them

### Data Model & Storage

**Message Result Metadata**: Extended `TABLE_HARNESS_MESSAGE_RESULTS` schema with two new columns:
- `mode_id`: text column to store AI mode identifier
- `model_id`: text column to store AI model identifier

**Session-Level Token Accounting**: Refactored `Session` class to:
- Track run-scoped token usage with durable evidence barriers
- Prevent double-counting across message/queue/resume flows
- Use token accounting reservations to avoid counting retries
- Persist token metadata (mode/model) in message evidence
- Support lazy SQL column migrations for both LibSQL and Postgres adapters

### Database Adapters

**LibSQL Adapter (`@mastra/libsql`)**: Updated to:
- Write and update `mode_id` and `model_id` in `TABLE_HARNESS_MESSAGE_RESULTS`
- Read these fields back during message evidence loading
- Bootstrap schema with the new columns via `ALTER TABLE` with existence checks

**Postgres Adapter (`@mastra/pg`)**: Updated to:
- Persist `mode_id` and `model_id` for message-result evidence
- Handle column existence checks during table schema initialization
- Read and return these fields when loading message evidence

### Testing

Added comprehensive `token-usage.test.ts` covering:
- **Durability suite**: Validates token usage survives process restarts, continues accumulation across rehydration, and repairs legacy/stale totals
- **Persistence ordering and atomicity**: Ensures token usage is written correctly relative to queue markers and doesn't leak data during failures
- **Shutdown behavior**: Verifies leases aren't released on persistence failures and token persistence completes before lease release
- **Token derivation**: Tests that `totalTokens` is correctly derived from component counts when providers omit it, and stale/zero totals are repaired upward

### Release Notes

Two changeset entries mark patch releases:
- `@mastra/core`: Fix for token usage persistence across restarts and background operations
- `@mastra/libsql` and `@mastra/pg`: Fix for storing message result mode and model metadata during duplicate recovery

---

## Architecture & Design Notes

The changes maintain clear separation of concerns:
- Runtime responsibilities (sessions, storage, replay/durability, shutdown) remain in Mastra core
- No downstream PapersFlow compatibility or policy projections added
- Lazy SQL migrations avoid forced schema updates, supporting incremental deployment
- Token accounting uses durable evidence barriers to prevent loss across message/queue/resume boundaries
- Shutdown behavior is more robust with per-session tracking and explicit error handling

No exported API signatures changed; all improvements are internal to the Harness system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->