### PR TITLE
[PF-745] Add Harness v1 canonical contracts

### DIFF
--- a/.changeset/pf-745-harness-contracts.md
+++ b/.changeset/pf-745-harness-contracts.md
@@ -2,7 +2,7 @@
 '@mastra/core': minor
 ---
 
-Added type-safe Harness v1 work-unit contracts under `@mastra/core/harness/v1`.
+Added type-safe Harness v1 work-unit types under `@mastra/core/harness/v1`.
 
 Developers can now use shared types for tasks, runs, evidence, and pending interactions when building Harness integrations. This release adds types only; it does not change runtime behavior.
 

--- a/.changeset/pf-745-harness-contracts.md
+++ b/.changeset/pf-745-harness-contracts.md
@@ -1,0 +1,19 @@
+---
+'@mastra/core': minor
+---
+
+Added type-safe Harness v1 work-unit contracts under `@mastra/core/harness/v1`.
+
+Developers can now use shared types for tasks, runs, evidence, and pending interactions when building Harness integrations. This release adds types only; it does not change runtime behavior.
+
+```ts
+import type { HarnessEvidence, HarnessTask } from '@mastra/core/harness/v1';
+
+function taskLabel(task: HarnessTask) {
+  return `${task.origin}:${task.status}`;
+}
+
+function evidenceId(evidence: HarnessEvidence) {
+  return evidence.evidenceKind === 'workspace-action' ? evidence.entry.id : undefined;
+}
+```

--- a/packages/core/src/harness/v1/contracts.test-d.ts
+++ b/packages/core/src/harness/v1/contracts.test-d.ts
@@ -1,0 +1,19 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
+import type { HarnessAdmissionEvidence, PendingInteraction } from './contracts';
+
+type HasKey<T, K extends PropertyKey> = K extends keyof T ? true : false;
+type QueueAdmissionPublicEvidence = Extract<HarnessAdmissionEvidence, { queuedItemId: string }>;
+
+describe('Harness v1 canonical contract types', () => {
+  it('PendingInteraction does not expose runtime recovery fields', () => {
+    expectTypeOf<HasKey<PendingInteraction, 'runtimeDependencies'>>().toEqualTypeOf<false>();
+    expectTypeOf<HasKey<PendingInteraction, 'resumedAt'>>().toEqualTypeOf<false>();
+    expectTypeOf<HasKey<PendingInteraction, 'approvedTransitionModeId'>>().toEqualTypeOf<false>();
+    expectTypeOf<HasKey<PendingInteraction, 'modeTransitionAppliedAt'>>().toEqualTypeOf<false>();
+  });
+
+  it('HarnessAdmissionEvidence does not expose queue runtime dependencies', () => {
+    expectTypeOf<HasKey<QueueAdmissionPublicEvidence, 'runtimeDependencies'>>().toEqualTypeOf<false>();
+  });
+});

--- a/packages/core/src/harness/v1/contracts.test.ts
+++ b/packages/core/src/harness/v1/contracts.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Harness v1 — canonical Task / Run / Evidence contracts.
+ *
+ * These are type-only public contracts. The tests use small structural
+ * fixtures to pin field names and alias compatibility without adding
+ * runtime behavior.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type {
+  HarnessOperationAdmissionEvidence,
+  InboxResponseReceipt,
+  OperationAdmissionEvidence,
+  PendingResume,
+  QueueAdmissionReceipt,
+  WorkspaceActionJournalEntry,
+} from '../../storage/domains/harness/types';
+import type {
+  HarnessAdmissionEvidence,
+  HarnessEvidence,
+  HarnessEvidenceKind,
+  HarnessRun,
+  HarnessRunFinishReason,
+  HarnessTaskIndexEntry,
+  HarnessTask,
+  HarnessTaskOrigin,
+  HarnessTaskStatus,
+  PendingInteraction,
+} from './contracts';
+import type {
+  HarnessAdmissionEvidence as ExportedHarnessAdmissionEvidence,
+  HarnessEvidence as ExportedHarnessEvidence,
+  HarnessTask as ExportedHarnessTask,
+  PendingInteraction as ExportedPendingInteraction,
+} from './index';
+
+describe('Harness v1 canonical contracts', () => {
+  it('HarnessTask carries the documented field set', () => {
+    const task: HarnessTask = {
+      taskId: 'task-1',
+      origin: 'user',
+      sessionId: 'sess-1',
+      resourceId: 'r-1',
+      threadId: 't-1',
+      createdAt: 0,
+      status: 'pending',
+    };
+
+    expect(task).toMatchObject({
+      taskId: 'task-1',
+      origin: 'user',
+      sessionId: 'sess-1',
+      resourceId: 'r-1',
+      threadId: 't-1',
+      status: 'pending',
+    });
+  });
+
+  it('HarnessTaskOrigin covers the seven entry surfaces', () => {
+    const origins: HarnessTaskOrigin[] = ['user', 'a2a', 'channel', 'cli', 'server', 'subagent-tool', 'system'];
+    expect(origins).toHaveLength(7);
+  });
+
+  it('HarnessTaskStatus covers pending through terminal states', () => {
+    const statuses: HarnessTaskStatus[] = ['pending', 'running', 'paused', 'cancelled', 'succeeded', 'failed'];
+    expect(statuses).toHaveLength(6);
+  });
+
+  it('HarnessRun carries one execution attempt for a task', () => {
+    const run: HarnessRun = {
+      runId: 'run-1',
+      taskId: 'task-1',
+      agentId: 'agent-1',
+      modeId: 'default',
+      startedAt: 0,
+      tokenUsage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 },
+    };
+
+    expect(run.runId).toBe('run-1');
+    expect(run.tokenUsage?.totalTokens).toBe(3);
+  });
+
+  it('HarnessRunFinishReason matches the public terminal vocabulary', () => {
+    const reasons: HarnessRunFinishReason[] = ['complete', 'suspended', 'error', 'aborted', 'budget_exhausted'];
+    expect(reasons).toHaveLength(5);
+  });
+
+  it('HarnessTaskIndexEntry requires task identity and scope fences', () => {
+    const minimal: HarnessTaskIndexEntry = {
+      taskId: 'task-x',
+      sessionId: 'sess-x',
+      resourceId: 'resource-x',
+      threadId: 'thread-x',
+    };
+    const full: HarnessTaskIndexEntry = {
+      taskId: 'task-1',
+      sessionId: 'sess-1',
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      runId: 'run-1',
+      queuedItemId: 'q-1',
+      a2aTaskId: 'a2a-1',
+    };
+
+    expect(minimal.runId).toBeUndefined();
+    expect(full).toMatchObject({ taskId: 'task-1', queuedItemId: 'q-1' });
+  });
+
+  it('HarnessEvidence narrows on evidenceKind', () => {
+    const admission: HarnessEvidence = {
+      evidenceKind: 'admission',
+      admission: {
+        runId: 'run-1',
+        signalId: 'sig-1',
+        duplicate: false,
+      },
+    };
+    const workspaceEntry: WorkspaceActionJournalEntry = {
+      id: 'wa-1',
+      harnessName: 'h',
+      sessionId: 'sess-1',
+      resourceId: 'r-1',
+      threadId: 't-1',
+      actionKind: 'file',
+      operation: 'read',
+      action: { op: 'read', path: '/tmp/x' },
+      policyDecision: 'allow',
+      policyReasons: [],
+      matchedRules: [],
+      createdAt: 0,
+    };
+    const workspace: HarnessEvidence = { evidenceKind: 'workspace-action', entry: workspaceEntry };
+    const inboxReceipt: InboxResponseReceipt = {
+      responseId: 'resp-1',
+      responseHash: 'hash-1',
+      resumeAttemptId: 'attempt-1',
+      itemId: 'item-1',
+      kind: 'tool-approval',
+      runId: 'run-1',
+      toolCallId: 'tc-1',
+      pendingRequestedAt: 0,
+      response: { approved: true },
+      status: 'accepted',
+      acceptedAt: 0,
+      updatedAt: 0,
+    };
+    const inbox: HarnessEvidence = { evidenceKind: 'inbox-receipt', receipt: inboxReceipt };
+
+    function describeEvidence(evidence: HarnessEvidence): string {
+      switch (evidence.evidenceKind) {
+        case 'admission':
+          return `admission:${evidence.admission.signalId ?? 'n/a'}`;
+        case 'workspace-action':
+          return `workspace:${evidence.entry.id}`;
+        case 'inbox-receipt':
+          return `inbox:${evidence.receipt.responseId}`;
+      }
+    }
+
+    const kinds: HarnessEvidenceKind[] = [admission.evidenceKind, workspace.evidenceKind, inbox.evidenceKind];
+    expect(kinds).toEqual(['admission', 'workspace-action', 'inbox-receipt']);
+    expect(describeEvidence(admission)).toBe('admission:sig-1');
+    expect(describeEvidence(workspace)).toBe('workspace:wa-1');
+    expect(describeEvidence(inbox)).toBe('inbox:resp-1');
+  });
+
+  it('HarnessOperationAdmissionEvidence aliases the existing storage evidence shape', () => {
+    const sample: OperationAdmissionEvidence = { runId: 'r', signalId: 's', duplicate: false };
+    const canonical: HarnessOperationAdmissionEvidence = sample;
+    const legacy: OperationAdmissionEvidence = canonical;
+    expect(legacy).toBe(sample);
+  });
+
+  it('HarnessAdmissionEvidence projects queue runtime dependencies out of public evidence', () => {
+    const queue: QueueAdmissionReceipt = {
+      admissionId: 'admission-1',
+      admissionHash: 'hash-1',
+      queuedItemId: 'queue-1',
+      runtimeDependencies: { modeId: 'mode-1', agentId: 'agent-1' },
+      status: 'queued',
+      attempts: 0,
+      enqueuedAt: 0,
+      updatedAt: 0,
+    };
+    const publicQueue: HarnessAdmissionEvidence = {
+      admissionId: queue.admissionId,
+      admissionHash: queue.admissionHash,
+      queuedItemId: queue.queuedItemId,
+      status: queue.status,
+      attempts: queue.attempts,
+      enqueuedAt: queue.enqueuedAt,
+      updatedAt: queue.updatedAt,
+    };
+
+    expect(publicQueue.queuedItemId).toBe('queue-1');
+  });
+
+  it('PendingInteraction is the public projection of PendingResume', () => {
+    const sample: PendingResume = {
+      kind: 'tool-approval',
+      runId: 'run-1',
+      itemId: 'item-1',
+      toolCallId: 'tc-1',
+      source: 'parent',
+      requestedAt: 0,
+    };
+    const interaction: PendingInteraction = sample;
+    const restored: PendingResume = interaction;
+
+    expect(interaction.kind).toBe('tool-approval');
+    expect(restored.itemId).toBe('item-1');
+  });
+
+  it('exports the canonical contracts from the public v1 entrypoint', () => {
+    const task: ExportedHarnessTask = {
+      taskId: 'task-exported',
+      origin: 'server',
+      sessionId: 'sess',
+      resourceId: 'resource',
+      threadId: 'thread',
+      createdAt: 1,
+      status: 'running',
+    };
+    const admission: ExportedHarnessAdmissionEvidence = {
+      runId: 'run-exported',
+      signalId: 'signal-exported',
+      duplicate: false,
+    };
+    const evidence: ExportedHarnessEvidence = { evidenceKind: 'admission', admission };
+    const pending: ExportedPendingInteraction = {
+      kind: 'question',
+      runId: 'run-exported',
+      itemId: 'item-exported',
+      toolCallId: 'tool-call',
+      source: 'parent',
+      requestedAt: 1,
+    };
+
+    expect(task.taskId).toBe('task-exported');
+    expect(evidence.evidenceKind).toBe('admission');
+    expect(pending.kind).toBe('question');
+  });
+});

--- a/packages/core/src/harness/v1/contracts.ts
+++ b/packages/core/src/harness/v1/contracts.ts
@@ -1,0 +1,166 @@
+/**
+ * Harness v1 — canonical work-unit contracts.
+ *
+ * Type-only public contracts shared by every Harness v1 entrypoint:
+ * user calls, A2A, channel ingress, CLI/headless, server routes,
+ * subagent tools, and system continuations. This file intentionally
+ * does not add storage, routing, or runtime behavior; later Harness
+ * slices can produce these shapes without inventing per-surface
+ * vocabulary.
+ */
+
+import type {
+  HarnessOperationAdmissionEvidence,
+  InboxResponseReceipt,
+  JsonValue,
+  PendingResume,
+  QueueAdmissionReceipt,
+  TokenUsage,
+  WorkspaceActionJournalEntry,
+} from '../../storage/domains/harness/types';
+
+// ---------------------------------------------------------------------------
+// Task — what is being attempted.
+// ---------------------------------------------------------------------------
+
+/**
+ * Where a task was admitted from. One task has exactly one origin,
+ * set at admission time and immutable afterwards.
+ */
+export type HarnessTaskOrigin = 'user' | 'a2a' | 'channel' | 'cli' | 'server' | 'subagent-tool' | 'system';
+
+/**
+ * Lifecycle status set for a task. Tasks transition forward only:
+ * `pending -> running -> (paused -> running)* -> terminal`.
+ */
+export type HarnessTaskStatus = 'pending' | 'running' | 'paused' | 'cancelled' | 'succeeded' | 'failed';
+
+/**
+ * The canonical work-unit primitive. One task may produce many runs
+ * through retries, resumes, or continuations. The task is the future
+ * cancellation, accounting, and identity unit; the run is one
+ * execution attempt.
+ */
+export interface HarnessTask {
+  taskId: string;
+  origin: HarnessTaskOrigin;
+  sessionId: string;
+  resourceId: string;
+  threadId: string;
+  /** Set when this task was admitted through the durable queue or signal path. */
+  admissionId?: string;
+  /** Opaque caller-supplied metadata. */
+  metadata?: Record<string, JsonValue>;
+  createdAt: number;
+  status: HarnessTaskStatus;
+}
+
+// ---------------------------------------------------------------------------
+// Run — one execution attempt for a task.
+// ---------------------------------------------------------------------------
+
+/**
+ * Why a run stopped. This is the public contract vocabulary for
+ * terminal run state; runtime persistence is added by later slices.
+ */
+export type HarnessRunFinishReason = 'complete' | 'suspended' | 'error' | 'aborted' | 'budget_exhausted';
+
+/**
+ * One execution attempt for a task. Retries spawn a new run with the
+ * same task id; resumes reattach to the run identified by `runId`.
+ */
+export interface HarnessRun {
+  runId: string;
+  taskId: string;
+  agentId: string;
+  modeId: string;
+  modelId?: string;
+  startedAt: number;
+  completedAt?: number;
+  finishReason?: HarnessRunFinishReason;
+  /** Cumulative token usage observed during this run. */
+  tokenUsage?: TokenUsage;
+}
+
+// ---------------------------------------------------------------------------
+// HarnessTaskIndexEntry — durable mapping rows.
+// ---------------------------------------------------------------------------
+
+/**
+ * The minimum information needed to locate a task across surfaces.
+ * Persistence and lookup APIs are wired by later runtime slices; this
+ * slice only stabilizes the row shape.
+ */
+export interface HarnessTaskIndexEntry {
+  taskId: string;
+  sessionId: string;
+  resourceId: string;
+  threadId: string;
+  runId?: string;
+  queuedItemId?: string;
+  a2aTaskId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Evidence — durable proof of admission, action, approval, completion.
+// ---------------------------------------------------------------------------
+
+/** Discriminator on `HarnessEvidence`. */
+export type HarnessEvidenceKind = 'admission' | 'workspace-action' | 'inbox-receipt';
+
+/**
+ * Public projection of operation admission evidence. Queue receipt recovery
+ * fields stay storage-internal for the same reason `PendingInteraction`
+ * projects out runtime recovery markers.
+ */
+export type HarnessAdmissionEvidence =
+  | Exclude<HarnessOperationAdmissionEvidence, QueueAdmissionReceipt>
+  | Omit<QueueAdmissionReceipt, 'runtimeDependencies'>;
+
+/**
+ * Canonical public union over durable proof rows accumulated during a
+ * Harness v1 session. The wrapper is read-side only; existing storage
+ * rows remain unchanged.
+ */
+export type HarnessEvidence =
+  | { evidenceKind: 'admission'; admission: HarnessAdmissionEvidence }
+  | { evidenceKind: 'workspace-action'; entry: WorkspaceActionJournalEntry }
+  | { evidenceKind: 'inbox-receipt'; receipt: InboxResponseReceipt };
+
+// ---------------------------------------------------------------------------
+// PendingInteraction — durable wait point (public alias).
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical public projection of `PendingResume`, the durable wait point a
+ * Harness v1 session pauses on. In the current fork this covers tool
+ * approval, tool suspension, question, and plan approval pending kinds.
+ * The sandbox-access kind is intentionally not documented here until
+ * PF-746 adds that runtime contract.
+ *
+ * Runtime recovery fields stay storage-internal; public routes already
+ * strip `runtimeDependencies`, and the canonical type keeps that boundary
+ * explicit for future producers.
+ */
+export type PendingInteraction = Omit<
+  PendingResume,
+  'runtimeDependencies' | 'resumedAt' | 'approvedTransitionModeId' | 'modeTransitionAppliedAt'
+>;
+
+/**
+ * Documentation-only type. Maps pre-existing identifiers in the
+ * harness to the canonical primitive they belong to.
+ *
+ * | Existing identifier              | Canonical primitive                         |
+ * | -------------------------------- | ------------------------------------------- |
+ * | `sessionId`                      | `HarnessTask.sessionId`                     |
+ * | `threadId`                       | `HarnessTask.threadId`                      |
+ * | `resourceId`                     | `HarnessTask.resourceId`                    |
+ * | `runId`                          | `HarnessRun.runId`                          |
+ * | `admissionId`                    | `HarnessTask.admissionId`                   |
+ * | `queuedItemId`                   | `HarnessTaskIndexEntry.queuedItemId`        |
+ * | `WorkspaceActionJournalEntry.id` | `HarnessEvidence` workspace-action evidence |
+ * | `PendingResume.itemId`           | `PendingInteraction.itemId`                 |
+ * | A2A `task.id`                    | `HarnessTaskIndexEntry.a2aTaskId`           |
+ */
+export type TaskIdFieldMapping = never;

--- a/packages/core/src/harness/v1/index.ts
+++ b/packages/core/src/harness/v1/index.ts
@@ -119,6 +119,20 @@ export type {
   WorkspaceRestoreStepStatus,
 } from './workspace-restore';
 
+export type {
+  HarnessAdmissionEvidence,
+  HarnessEvidence,
+  HarnessEvidenceKind,
+  HarnessRun,
+  HarnessRunFinishReason,
+  HarnessTask,
+  HarnessTaskIndexEntry,
+  HarnessTaskOrigin,
+  HarnessTaskStatus,
+  PendingInteraction,
+  TaskIdFieldMapping,
+} from './contracts';
+
 /**
  * `HarnessMessage` and `HarnessMessageContent` are stable cross-version
  * interfaces (spec §11.1). They are re-exported from v1 and back the same

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -385,15 +385,14 @@ export interface HarnessStoredPublicError {
   message: string;
 }
 
-export type AgentSignalResultStatus =
-  (
-    | { status: 'pending'; signalId: string; runId?: string }
-    | { status: 'completed'; signalId: string; runId: string; result: unknown }
-    | { status: 'failed'; signalId: string; runId?: string; error: HarnessStoredPublicError }
-  ) & {
-    modeId?: string;
-    modelId?: string;
-  };
+export type AgentSignalResultStatus = (
+  | { status: 'pending'; signalId: string; runId?: string }
+  | { status: 'completed'; signalId: string; runId: string; result: unknown }
+  | { status: 'failed'; signalId: string; runId?: string; error: HarnessStoredPublicError }
+) & {
+  modeId?: string;
+  modelId?: string;
+};
 
 export interface AgentSignalAccepted {
   runId: string;
@@ -987,6 +986,14 @@ export type OperationAdmissionEvidence =
   | AgentSignalResultStatus
   | QueueAdmissionReceipt
   | OperationAdmissionTombstone;
+
+/**
+ * Canonical public name for the evidence rows returned by
+ * `resolveOperationAdmissionEvidence`. Internal storage call sites still use
+ * `OperationAdmissionEvidence`; this alias gives the Harness v1 public
+ * contract a stable name without renaming adapter surfaces.
+ */
+export type HarnessOperationAdmissionEvidence = OperationAdmissionEvidence;
 
 // ---------------------------------------------------------------------------
 // Attachment metadata


### PR DESCRIPTION
## Summary
- Adds type-only Harness v1 work-unit contracts for tasks, runs, task index rows, public evidence, and pending interactions.
- Exports the public contract surface from `@mastra/core/harness/v1`.
- Keeps storage adapter surfaces unchanged; raw storage evidence remains storage-side while public projections omit runtime recovery fields.

## Official branch context
- Compared against latest `mastra-ai/mastra#16912` head `11c4f5ca4fb0dba05e8112957f88da38899c2154`.
- This PR adopts the useful contract slice with local corrections: public pending/admission evidence projections, scoped task index rows, subagent-tool origin, and type-level projection tests.

## Validation
- `pnpm --filter ./packages/core test:unit src/harness/v1/contracts.test.ts --reporter=dot` passed: 11 tests.
- `pnpm --filter ./packages/core exec tsc --noEmit --ignoreConfig --strict --module ES2022 --moduleResolution bundler --target ES2022 --lib ES2023,DOM,DOM.Iterable --skipLibCheck src/harness/v1/contracts.test-d.ts` passed.
- `pnpm --filter ./packages/core exec eslint src/harness/v1/contracts.ts src/harness/v1/contracts.test.ts src/harness/v1/contracts.test-d.ts src/harness/v1/index.ts src/storage/domains/harness/types.ts` passed.
- `git diff --check` passed.
- Local Codex review passes completed; valid findings were patched.
- CodeRabbit CLI rerun completed with no findings.

## Known limitation
- Broad `pnpm --filter ./packages/core check` still fails in this fresh worktree due existing unrelated/internal workspace dependency resolution errors such as `@internal/ai-sdk-v4`, `@internal/ai-sdk-v5`, and `@mastra/schema-compat`. The narrow contract typecheck above passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5

This PR adds a shared set of TypeScript type definitions that describe "what a Harness task, run, evidence, and pending interaction look like" so different parts of the system can speak the same language. It's types-only—no runtime behavior changes.

Overview

Introduces canonical Harness v1 "work-unit" contract types and re-exports them from the public v1 entrypoint. Public projections intentionally omit runtime recovery fields (e.g., runtimeDependencies, resumedAt, approvedTransitionModeId, modeTransitionAppliedAt); storage-side shapes remain unchanged.

Changes

- New canonical contract types (packages/core/src/harness/v1/contracts.ts)
  - HarnessTaskOrigin: 'user' | 'a2a' | 'channel' | 'cli' | 'server' | 'subagent-tool' | 'system'
  - HarnessTaskStatus: 'pending' | 'running' | 'paused' | 'cancelled' | 'succeeded' | 'failed'
  - HarnessTask: taskId, origin, sessionId, resourceId, threadId, admissionId?, metadata?, createdAt, status
  - HarnessRunFinishReason: 'complete' | 'suspended' | 'error' | 'aborted' | 'budget_exhausted'
  - HarnessRun: runId, taskId, agentId, modeId, modelId?, startedAt, completedAt?, finishReason?, tokenUsage?
  - HarnessTaskIndexEntry: taskId, sessionId, resourceId, threadId, optional runId / queuedItemId / a2aTaskId
  - HarnessEvidenceKind: 'admission' | 'workspace-action' | 'inbox-receipt'
  - HarnessAdmissionEvidence: public projection of operation admission evidence (excludes queue runtimeDependencies)
  - HarnessEvidence: discriminated union for admission / workspace-action / inbox-receipt
  - PendingInteraction: Omit<PendingResume, 'runtimeDependencies' | 'resumedAt' | 'approvedTransitionModeId' | 'modeTransitionAppliedAt'>
  - TaskIdFieldMapping = never (documentation-only)

- Public API (packages/core/src/harness/v1/index.ts)
  - Re-exports the new types so they are available from `@mastra/core/harness/v1`

- Storage domain (packages/core/src/storage/domains/harness/types.ts)
  - Added alias: HarnessOperationAdmissionEvidence = OperationAdmissionEvidence
  - Formatting-only change to AgentSignalResultStatus union

Tests

- packages/core/src/harness/v1/contracts.test.ts — runtime-style Vitest assertions validating fixture shapes, discriminator narrowing, enum cardinalities, and that public projections omit runtime fields.
- packages/core/src/harness/v1/contracts.test-d.ts — type-level Vitest assertions ensuring runtime recovery fields are absent from public projections.

Validation

- Unit tests (focused): pnpm --filter ./packages/core test:unit src/harness/v1/contracts.test.ts — passed (11 tests)
- Typecheck (focused): pnpm --filter ./packages/core exec tsc ... src/harness/v1/contracts.test-d.ts — passed
- Lint: eslint on modified files — passed
- git diff --check — passed
- Local code review and CodeRabbit CLI — completed with no findings

Known limitation

Workspace-wide pnpm check fails in this fresh worktree due to unrelated internal workspace dependency resolution errors (e.g., `@internal/ai-sdk-v4`, `@internal/ai-sdk-v5`, `@mastra/schema-compat`). The focused contract typechecks and tests pass independently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->