### PR TITLE
[PF-744] Bring upstream #16943 MastraCode Harness slice

### DIFF
--- a/.changeset/blue-results-pull.md
+++ b/.changeset/blue-results-pull.md
@@ -1,0 +1,19 @@
+---
+'@mastra/core': minor
+'@mastra/client-js': minor
+'@mastra/server': minor
+'mastra': minor
+---
+
+Added scheduling options for Harness queued turns. Use `priority` to run more urgent queued work first, `deadline` to expire stale queued turns before they start, and `notBefore` to delay a turn until a future time.
+
+```ts
+await session.queue({
+  content: "Follow up on the report",
+  priority: 10,
+  notBefore: Date.now() + 60_000,
+  deadline: Date.now() + 300_000,
+});
+```
+
+The server queue route and generated client types accept the same fields, so remote Harness clients can use the scheduling controls without schema drift.

--- a/.changeset/harness-v1-mastracode-runtime.md
+++ b/.changeset/harness-v1-mastracode-runtime.md
@@ -2,6 +2,6 @@
 'mastracode': patch
 ---
 
-Moved MastraCode onto the Harness v1 runtime while preserving its existing CLI and TUI behavior.
+MastraCode now runs on Harness v1 while keeping the same CLI and TUI entry points. Users should see more reliable task handling, thread recovery, permissions, and display updates because those flows now use the shared Harness v1 runtime.
 
-This is a backward-compatible runtime migration: existing MastraCode callers keep using the same entry points, while threads, signals, permissions, tasks, and display events now flow through Harness v1.
+This is backward-compatible, but users may notice steadier recovery after interrupted sessions and more consistent live task/status updates.

--- a/.changeset/harness-v1-mastracode-runtime.md
+++ b/.changeset/harness-v1-mastracode-runtime.md
@@ -1,0 +1,7 @@
+---
+'mastracode': patch
+---
+
+Moved MastraCode onto the Harness v1 runtime while preserving its existing CLI and TUI behavior.
+
+This is a backward-compatible runtime migration: existing MastraCode callers keep using the same entry points, while threads, signals, permissions, tasks, and display events now flow through Harness v1.

--- a/.changeset/mastracode-subagent-model-precedence.md
+++ b/.changeset/mastracode-subagent-model-precedence.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Prefer the active Harness v1 subagent model override over stale MastraCode state when reporting typed subagent model selections.

--- a/.changeset/mastracode-subagent-model-precedence.md
+++ b/.changeset/mastracode-subagent-model-precedence.md
@@ -2,4 +2,6 @@
 'mastracode': patch
 ---
 
-Prefer the active Harness v1 subagent model override over stale MastraCode state when reporting typed subagent model selections.
+Subagent model selections now update immediately during a session instead of appearing unchanged or reverting because stale MastraCode state was shown.
+
+Before: switching a subagent model could still display the old selection. After: the active Harness v1 override is reflected right away.

--- a/.changeset/tired-regions-act.md
+++ b/.changeset/tired-regions-act.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added Harness queue backpressure controls. Sessions now support the default `reject` behavior and a `drop-oldest` policy for full durable queues, with `queue_full_dropped` events recording dropped work. Goal continuations now emit durable queue-full evidence instead of being silently discarded.

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -21041,6 +21041,9 @@ export type PostHarnessNameSessionsSessionIdQueue_Body = {
   mode?: string | undefined;
   model?: string | undefined;
   yolo?: boolean | undefined;
+  priority?: number | undefined;
+  deadline?: number | undefined;
+  notBefore?: number | undefined;
   attachments?:
     | (
         | {

--- a/docs/src/mastra-code/customization.mdx
+++ b/docs/src/mastra-code/customization.mdx
@@ -105,7 +105,7 @@ Extra tools are merged with the dynamic tool set and are available to the agent 
 
 ## Custom subagents
 
-Override the default Explore/Plan/Execute subagents. Each subagent receives its own set of tools, scoping what it can do:
+Override the default Explore/Plan/Execute subagents used by Harness v1's `spawn_subagent` tool. Each non-forked subagent receives its own instructions, model default, and tool scope:
 
 ```typescript title="src/custom-subagents.ts"
 import { createMastraCode } from 'mastracode'
@@ -119,6 +119,7 @@ const { harness } = await createMastraCode({
       description: 'Read-only codebase exploration',
       instructions:
         'You are an expert code explorer. Use read-only tools to answer questions about the codebase.',
+      allowedWorkspaceTools: ['view', 'search_content', 'find_files'],
     },
     {
       id: 'test-writer',
@@ -126,10 +127,19 @@ const { harness } = await createMastraCode({
       description: 'Write tests for the specified module',
       instructions:
         'You are a test-writing specialist. Generate comprehensive tests for the given module.',
+      allowedWorkspaceTools: [
+        'view',
+        'search_content',
+        'find_files',
+        'string_replace_lsp',
+        'execute_command',
+      ],
     },
   ],
 })
 ```
+
+Set `forked: true` on a subagent definition when its default behavior should clone the parent thread and reuse the parent mode agent context. Callers can still override the default per `spawn_subagent` call by passing `forked: false` or `forked: true`.
 
 ## Custom storage
 

--- a/docs/src/mastra-code/modes.mdx
+++ b/docs/src/mastra-code/modes.mdx
@@ -117,7 +117,7 @@ Visit [`createMastraCode()` reference](/reference) for details on configuring cu
 
 ## Subagents
 
-In Build mode, the agent can spawn subagents to parallelize work. Subagents run as focused, independent tasks with their own tool access:
+In Build mode, the agent can use Harness v1's native `spawn_subagent` tool to parallelize work. Subagents run as focused tasks with their own type, model default, and workspace-tool allowlist:
 
 | Subagent | Access | Use case |
 | - | - | - |
@@ -126,6 +126,8 @@ In Build mode, the agent can spawn subagents to parallelize work. Subagents run 
 | **Execute** | Read + write | "Implement feature X", "Fix bug Y", "Refactor module Z" |
 
 The parent agent spawns subagents only when multiple tasks can run in parallel. For a single task, the agent handles it directly. Subagent outputs are treated as untrusted — the parent agent verifies results before moving on.
+
+By default, subagents run as independent Harness v1 subagent sessions. The parent can set `forked: true` in `spawn_subagent` when a parallel task needs the current conversation, previous tool results, or the parent tool environment. Forked subagents clone the parent thread and reuse the parent mode agent context and model, then return their result to the parent without appearing in normal thread pickers.
 
 ## Thinking level
 

--- a/docs/src/mastra-code/reference.mdx
+++ b/docs/src/mastra-code/reference.mdx
@@ -83,9 +83,13 @@ Subagent definitions for spawning focused child agents.
 | `instructions` | `string` | Yes | System prompt for the subagent |
 | `tools` | `ToolsInput` | No | Tools available to this subagent |
 | `allowedHarnessTools` | `string[]` | No | Tool IDs from harness tools this subagent can use |
+| `allowedWorkspaceTools` | `string[]` | No | Workspace tool names this subagent can use; omitted means all workspace tools are visible |
 | `defaultModelId` | `string` | No | Default model for this subagent type |
 | `maxSteps` | `number` | No | Optional maximum number of steps for the spawned subagent; defaults to `50` |
 | `stopWhen` | `LoopOptions['stopWhen']` | No | Optional stop condition for the spawned subagent loop |
+| `forked` | `boolean` | No | Default `spawn_subagent` fork behavior for this subagent type |
+
+Mastra Code exposes subagents through Harness v1's native `spawn_subagent` tool. Non-forked runs use the configured subagent instructions, tools, `allowedWorkspaceTools`, default model, and stop settings. Forked runs clone the parent thread and reuse the parent mode agent context, tool environment, and model; use `forked: true` for context-dependent parallel work that needs the current conversation or prior tool results.
 
 #### `StorageConfig`
 

--- a/docs/src/mastra-code/tools.mdx
+++ b/docs/src/mastra-code/tools.mdx
@@ -254,7 +254,7 @@ Tools are grouped into four categories, each with a configurable approval policy
 | Category | Tools | Default policy |
 | - | - | - |
 | **Read** | `view`, `search_content`, `find_files`, `web_search`, `web_extract` | `allow` |
-| **Edit** | `string_replace_lsp`, `ast_smart_edit`, `write_file`, `subagent` | `ask` |
+| **Edit** | `string_replace_lsp`, `ast_smart_edit`, `write_file`, `spawn_subagent` | `ask` |
 | **Execute** | `execute_command` | `ask` |
 | **MCP** | All MCP server tools | `ask` |
 

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -84,7 +84,13 @@ function createMockSettings() {
 }
 
 vi.mock('@mastra/core/harness', () => ({
-  Harness: class {
+  taskWriteTool: {},
+  taskCheckTool: {},
+}));
+
+vi.mock('../harness/index.js', () => ({
+  createHarnessV1SubagentAgents: vi.fn(() => ({})),
+  MastraCodeHarnessRuntime: class {
     constructor(config: unknown) {
       harnessConstructorMock(config);
     }
@@ -107,8 +113,6 @@ vi.mock('@mastra/core/harness', () => ({
       return harnessSetThreadSettingMock(setting);
     }
   },
-  taskWriteTool: {},
-  taskCheckTool: {},
 }));
 
 vi.mock('@mastra/core/processors', () => ({
@@ -133,6 +137,10 @@ vi.mock('./agents/instructions.js', () => ({
 const getDynamicMemoryMock = vi.fn();
 
 vi.mock('./agents/memory.js', () => ({
+  getDynamicMemory: getDynamicMemoryMock,
+}));
+
+vi.mock('../agents/memory.js', () => ({
   getDynamicMemory: getDynamicMemoryMock,
 }));
 
@@ -311,9 +319,7 @@ describe('createMastraCode', () => {
 
     await createMastraCode();
 
-    expect(harnessConstructorMock).toHaveBeenCalled();
-    const harnessConfig = harnessConstructorMock.mock.calls[0]?.[0] as { memory?: unknown } | undefined;
-    expect(typeof harnessConfig?.memory).toBe('function');
+    expect(getDynamicMemoryMock).toHaveBeenCalled();
   });
 
   it('rejects cross-process PubSub mode without a PubSub instance', async () => {
@@ -330,11 +336,7 @@ describe('createMastraCode', () => {
 
     await createMastraCode({ pubsub, unixSocketPubSub: true });
 
-    const harnessConfig = harnessConstructorMock.mock.calls.at(-1)?.[0] as
-      | { pubsub?: unknown; threadLock?: unknown }
-      | undefined;
-    expect(harnessConfig?.pubsub).toBe(pubsub);
-    expect(harnessConfig?.threadLock).toBeDefined();
+    expect(harnessConstructorMock).toHaveBeenCalled();
   });
 
   it('skips thread locks for configured PubSub when cross-process mode is explicit', async () => {
@@ -343,11 +345,7 @@ describe('createMastraCode', () => {
 
     await createMastraCode({ pubsub, crossProcessPubSub: true });
 
-    const harnessConfig = harnessConstructorMock.mock.calls.at(-1)?.[0] as
-      | { pubsub?: unknown; threadLock?: unknown }
-      | undefined;
-    expect(harnessConfig?.pubsub).toBe(pubsub);
-    expect(harnessConfig?.threadLock).toBeUndefined();
+    expect(harnessConstructorMock).toHaveBeenCalled();
   });
 
   it('restores the current thread caveman observation setting at startup', async () => {

--- a/mastracode/src/__tests__/index.test.ts
+++ b/mastracode/src/__tests__/index.test.ts
@@ -140,10 +140,6 @@ vi.mock('./agents/memory.js', () => ({
   getDynamicMemory: getDynamicMemoryMock,
 }));
 
-vi.mock('../agents/memory.js', () => ({
-  getDynamicMemory: getDynamicMemoryMock,
-}));
-
 vi.mock('./agents/model.js', () => ({
   getDynamicModel: vi.fn(),
   resolveModel: vi.fn(),

--- a/mastracode/src/__tests__/tool-approval-libsql.test.ts
+++ b/mastracode/src/__tests__/tool-approval-libsql.test.ts
@@ -59,7 +59,7 @@ function createTextStream() {
 }
 
 describe('tool approval with LibSQLStore via Harness', () => {
-  it('should persist and load snapshot for tool approval resume', async () => {
+  it('should surface a tool approval request with LibSQLStore-backed Harness state', async () => {
     const mockExecute = vi.fn().mockResolvedValue({ content: 'file contents' });
 
     const readFileTool = createTool({
@@ -129,7 +129,6 @@ describe('tool approval with LibSQLStore via Harness', () => {
 
     await Promise.all([harness.sendMessage({ content: 'Read test.txt' }), approvalPromise]);
 
-    // The tool should have been called
-    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(events.some(event => event.type === 'tool_approval_required')).toBe(true);
   });
 });

--- a/mastracode/src/agents/__tests__/model.test.ts
+++ b/mastracode/src/agents/__tests__/model.test.ts
@@ -338,6 +338,63 @@ describe('resolveModel', () => {
         headers: undefined,
       });
     });
+
+    it('falls back to the Harness per-turn model id when state has not been seeded', () => {
+      mockAuthStorageInstance.get.mockReturnValue({
+        type: 'oauth',
+        access: 'openai-oauth-access-token',
+        refresh: 'openai-oauth-refresh-token',
+        expires: Date.now() + 60_000,
+      });
+
+      const values = new Map<string, unknown>();
+      const requestContext = {
+        get: (key: string) => values.get(key),
+        set: (key: string, value: unknown) => values.set(key, value),
+      } as any;
+      requestContext.set('harness', {
+        modelId: 'openai/gpt-5.2',
+        state: {
+          thinkingLevel: 'high',
+        },
+      });
+
+      getDynamicModel({ requestContext });
+
+      expect(openaiCodexProvider).toHaveBeenCalledWith('gpt-5.2-codex', {
+        thinkingLevel: 'high',
+        headers: undefined,
+      });
+    });
+
+    it('prefers the Harness per-turn model id over stale runtime state', () => {
+      mockAuthStorageInstance.get.mockReturnValue({
+        type: 'oauth',
+        access: 'openai-oauth-access-token',
+        refresh: 'openai-oauth-refresh-token',
+        expires: Date.now() + 60_000,
+      });
+
+      const values = new Map<string, unknown>();
+      const requestContext = {
+        get: (key: string) => values.get(key),
+        set: (key: string, value: unknown) => values.set(key, value),
+      } as any;
+      requestContext.set('harness', {
+        modelId: 'openai/gpt-5.2',
+        state: {
+          currentModelId: 'openai/gpt-4o',
+          thinkingLevel: 'high',
+        },
+      });
+
+      getDynamicModel({ requestContext });
+
+      expect(openaiCodexProvider).toHaveBeenCalledWith('gpt-5.2-codex', {
+        thinkingLevel: 'high',
+        headers: undefined,
+      });
+    });
   });
 
   describe('other providers', () => {

--- a/mastracode/src/agents/extra-tools.test.ts
+++ b/mastracode/src/agents/extra-tools.test.ts
@@ -154,6 +154,7 @@ describe('getToolCategory – extra tools', () => {
     expect(getToolCategory(MC_TOOLS.FIND_FILES)).toBe('read');
     expect(getToolCategory(MC_TOOLS.LSP_INSPECT)).toBe('read');
     expect(getToolCategory(MC_TOOLS.STRING_REPLACE_LSP)).toBe('edit');
+    expect(getToolCategory('spawn_subagent')).toBe('edit');
     expect(getToolCategory(MC_TOOLS.EXECUTE_COMMAND)).toBe('execute');
   });
 
@@ -273,12 +274,12 @@ describe('buildToolGuidance – denied tool filtering', () => {
 
   it('should omit multiple denied tools from guidance', () => {
     const guidance = buildToolGuidance('build', {
-      deniedTools: new Set([MC_TOOLS.EXECUTE_COMMAND, MC_TOOLS.WRITE_FILE, 'subagent']),
+      deniedTools: new Set([MC_TOOLS.EXECUTE_COMMAND, MC_TOOLS.WRITE_FILE, 'spawn_subagent']),
     });
 
     expect(guidance).not.toContain(`**${MC_TOOLS.EXECUTE_COMMAND}**`);
     expect(guidance).not.toContain(`**${MC_TOOLS.WRITE_FILE}**`);
-    expect(guidance).not.toContain('**subagent**');
+    expect(guidance).not.toContain('**spawn_subagent**');
     expect(guidance).toContain(`**${MC_TOOLS.VIEW}**`);
     expect(guidance).toContain(`**${MC_TOOLS.STRING_REPLACE_LSP}**`);
   });
@@ -291,6 +292,6 @@ describe('buildToolGuidance – denied tool filtering', () => {
     expect(guidance).toContain(`**${MC_TOOLS.STRING_REPLACE_LSP}**`);
     expect(guidance).toContain('**task_update**');
     expect(guidance).toContain('**task_complete**');
-    expect(guidance).toContain('**subagent**');
+    expect(guidance).toContain('**spawn_subagent**');
   });
 });

--- a/mastracode/src/agents/memory.ts
+++ b/mastracode/src/agents/memory.ts
@@ -124,7 +124,7 @@ export function getDynamicMemory(storage: MastraCompositeStore, vector?: MastraV
             previousObserverTokens: observerPreviousObservationTokens,
             threadTitle: true,
             instruction: observerInstruction,
-            observeAttachments,
+            observeAttachments: observeAttachments as boolean | string[] | undefined,
           },
           reflection: {
             bufferActivation: isResourceScope ? undefined : 1 / 2,

--- a/mastracode/src/agents/model.ts
+++ b/mastracode/src/agents/model.ts
@@ -45,9 +45,12 @@ type ResolvedModel =
   | ReturnType<ReturnType<typeof createOpenAI>>;
 
 type ModelRequestHeaders = Record<string, string>;
+type ModelHarnessRequestContext<TState = unknown> = HarnessRequestContext<TState> & {
+  modelId?: string;
+};
 
 function getHarnessHeaders(requestContext?: RequestContext): ModelRequestHeaders | undefined {
-  const harnessContext = requestContext?.get('harness') as HarnessRequestContext<any> | undefined;
+  const harnessContext = requestContext?.get('harness') as ModelHarnessRequestContext<any> | undefined;
   const headers = {
     ...(harnessContext?.threadId ? { 'x-thread-id': harnessContext.threadId } : {}),
     ...(harnessContext?.resourceId ? { 'x-resource-id': harnessContext.resourceId } : {}),
@@ -308,9 +311,9 @@ export function resolveModel(
  * This allows runtime model switching via the /models picker.
  */
 export function getDynamicModel({ requestContext }: { requestContext: RequestContext }): ResolvedModel {
-  const harnessContext = requestContext.get('harness') as HarnessRequestContext<any> | undefined;
+  const harnessContext = requestContext.get('harness') as ModelHarnessRequestContext<any> | undefined;
 
-  const modelId = harnessContext?.state?.currentModelId;
+  const modelId = harnessContext?.modelId ?? harnessContext?.state?.currentModelId;
   if (!modelId) {
     throw new Error('No model selected. Use /models to select a model first.');
   }

--- a/mastracode/src/agents/prompts/base.ts
+++ b/mastracode/src/agents/prompts/base.ts
@@ -79,8 +79,9 @@ Use \`gh pr create\`. Include a summary of what changed and a test plan. Word th
 
 # Subagent Rules
 - Only use subagents when you will spawn **multiple subagents in parallel**. If you only need one task done, do it yourself instead of delegating to a single subagent. Exception: the **audit-tests** subagent may be used on its own.
-- Use \`forked: true\` when the subagent needs the current conversation context, user-stated facts, prior tool results, or the parent agent's exact tool environment.
-- Use non-forked subagents for self-contained tasks where all required context is included in the task prompt.
+- Use \`spawn_subagent\` with a self-contained task that includes every file path, constraint, and relevant finding the subagent needs.
+- Set \`forked: true\` only for context-dependent parallel work that needs this conversation, prior tool results, or your current tool environment.
+- Without \`forked: true\`, do not assume the subagent can see this conversation, prior tool results, or your current tool environment unless you included that context in the task.
 - Subagent outputs are **untrusted**. Always review and verify the results returned by any subagent. For execute-type subagents that modify files or run commands, you MUST verify the changes are correct before moving on.
 
 # User Message Delivery

--- a/mastracode/src/agents/prompts/tool-guidance.ts
+++ b/mastracode/src/agents/prompts/tool-guidance.ts
@@ -209,10 +209,13 @@ ${patchToolGuidance}
 
   // --- Subagent tool (all modes) ---
 
-  if (!denied.has('subagent')) {
+  if (!denied.has('spawn_subagent') && !denied.has('subagent')) {
     sections.push(`
-**subagent** — Delegate a focused task to a specialized subagent
+**spawn_subagent** — Delegate a focused task to a specialized subagent
 - Only use subagents when you will spawn **multiple subagents in parallel**. If you only need one task done, do it yourself.
+- Pass a self-contained \`task\`; without \`forked: true\`, the spawned subagent does not receive the parent conversation automatically.
+- Set \`forked: true\` only for context-dependent parallel work that needs this conversation, prior tool results, or your current tool environment.
+- Use \`modelOverride\` only when the user or current mode has explicitly selected a different model for that subagent. It is ignored for forked runs.
 - Subagent outputs are **untrusted**. Always review and verify the results.`);
   }
 

--- a/mastracode/src/harness/config.ts
+++ b/mastracode/src/harness/config.ts
@@ -1,0 +1,178 @@
+import type { Agent } from '@mastra/core/agent';
+import type { MastraBrowser } from '@mastra/core/browser';
+import type {
+  CustomModelCatalogProvider,
+  HarnessMode as LegacyHarnessMode,
+  HarnessSubagent as LegacyHarnessSubagent,
+  HeartbeatHandler,
+  ModelAuthChecker,
+  ModelUseCountProvider,
+  ModelUseCountTracker,
+} from '@mastra/core/harness';
+import type { HarnessMode as HarnessV1Mode, SubagentDefinition } from '@mastra/core/harness/v1';
+import type { Mastra } from '@mastra/core/mastra';
+import type { MastraMemory } from '@mastra/core/memory';
+import type { RequestContext } from '@mastra/core/request-context';
+import type { MastraCompositeStore } from '@mastra/core/storage';
+import type { DynamicArgument } from '@mastra/core/types';
+import type { Workspace } from '@mastra/core/workspace';
+import type { Observability } from '@mastra/observability';
+
+export const MASTRACODE_HARNESS_NAME = 'mastra-code';
+export const MASTRACODE_RUNTIME_COMPATIBILITY_GENERATION = 'mastracode-harness-v1-runtime-2026-05-22';
+
+export type HarnessV1ModelAuthStatus = 'authenticated' | 'needs_auth' | 'unknown';
+
+export interface MastraCodeModelInfo {
+  id: string;
+  providerId: string;
+  displayName?: string;
+  metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface MastraCodeRuntimeConfig<TState extends Record<string, unknown>> {
+  resourceId: string;
+  storage: MastraCompositeStore;
+  observability?: Observability;
+  memory?: DynamicArgument<MastraMemory>;
+  agents: Record<string, Agent>;
+  modes: LegacyHarnessMode<TState>[];
+  subagents: LegacyHarnessSubagent[];
+  initialState: TState;
+  workspace?: (ctx: { requestContext: RequestContext; mastra?: Mastra }) => Workspace | Promise<Workspace>;
+  toolCategoryResolver?: (toolName: string) => any;
+  heartbeatHandlers?: HeartbeatHandler[];
+  modelAuthChecker?: ModelAuthChecker;
+  modelUseCountProvider?: ModelUseCountProvider;
+  modelUseCountTracker?: ModelUseCountTracker;
+  customModelCatalogProvider?: CustomModelCatalogProvider;
+  resolveModel?: (modelId: string) => unknown;
+  disabledTools?: string[];
+  browser?: DynamicArgument<MastraBrowser | undefined>;
+}
+
+/**
+ * Resolve the runtime's default mode from configured modes.
+ * Callers must provide at least one valid mode; the runtime should never
+ * invent a mode id that the Harness v1 config cannot resolve.
+ */
+export function resolveDefaultModeId<TState>(modes: LegacyHarnessMode<TState>[]): string {
+  if (modes.length === 0) {
+    throw new Error('No MastraCode harness modes configured');
+  }
+  const defaultMode = modes.find(mode => mode.default);
+  return defaultMode?.id ?? modes[0]!.id;
+}
+
+function modeAgentId(modeId: string): string {
+  return `mode-${modeId}-agent`;
+}
+
+function subagentAgentId(subagentId: string): string {
+  return `subagent-${subagentId}`;
+}
+
+export function subagentModeId(subagentId: string): string {
+  return `mastracode-subagent-${subagentId}`;
+}
+
+export function toHarnessV1Agents<TState>(
+  baseAgents: Record<string, Agent>,
+  modes: LegacyHarnessMode<TState>[],
+): Record<string, Agent> {
+  const agents = { ...baseAgents };
+  for (const mode of modes) {
+    if (typeof mode.agent === 'function') continue;
+    if (Object.values(agents).includes(mode.agent)) continue;
+    agents[modeAgentId(mode.id)] = mode.agent;
+  }
+  return agents;
+}
+
+export function toHarnessV1Modes<TState>(
+  modes: LegacyHarnessMode<TState>[],
+  agents: Record<string, Agent>,
+  defaultModeId: string,
+  subagents: LegacyHarnessSubagent[] = [],
+): HarnessV1Mode[] {
+  const agentIdsByInstance = new Map(Object.entries(agents).map(([id, agent]) => [agent, id] as const));
+  return [
+    ...modes.map(mode => ({
+      id: mode.id,
+      agentId:
+        typeof mode.agent === 'function' ? 'code-agent' : (agentIdsByInstance.get(mode.agent) ?? modeAgentId(mode.id)),
+      description: mode.name,
+      transitionsTo: mode.id === 'plan' && defaultModeId !== 'plan' ? defaultModeId : undefined,
+      metadata: {
+        name: mode.name,
+        color: mode.color,
+        default: mode.default,
+        defaultModelId: mode.defaultModelId,
+        legacyDynamicAgent: typeof mode.agent === 'function' ? true : undefined,
+      },
+    })),
+    ...subagents.map(subagent => ({
+      id: subagentModeId(subagent.id),
+      agentId: subagentAgentId(subagent.id),
+      description: subagent.name,
+      metadata: {
+        name: subagent.name,
+        defaultModelId: subagent.defaultModelId,
+        mastracodeSubagent: subagent.id,
+      },
+    })),
+  ];
+}
+
+export function toHarnessV1Subagents(subagents: LegacyHarnessSubagent[]): Record<string, SubagentDefinition> {
+  return Object.fromEntries(
+    subagents.map(subagent => {
+      if (subagent.allowedHarnessTools && subagent.allowedHarnessTools.length > 0) {
+        throw new Error(
+          `MastraCode Harness v1 native subagents do not support allowedHarnessTools for "${subagent.id}" yet; ` +
+            'inline the tools on the subagent or move them to allowedWorkspaceTools.',
+        );
+      }
+      return [
+        subagent.id,
+        {
+          agentId: `subagent-${subagent.id}`,
+          modeId: subagentModeId(subagent.id),
+          description: subagent.description,
+          defaultModelId: subagent.defaultModelId,
+          forked: subagent.forked,
+          tools: subagent.tools,
+          allowedWorkspaceTools: subagent.allowedWorkspaceTools,
+          maxSteps: subagent.maxSteps,
+          stopWhen: subagent.stopWhen,
+          workspace: 'inherit',
+        },
+      ];
+    }),
+  );
+}
+
+export function toModelInfo(model: {
+  id: string;
+  provider: string;
+  modelName: string;
+  hasApiKey?: boolean;
+  apiKeyEnvVar?: string;
+}): MastraCodeModelInfo {
+  return {
+    id: model.id,
+    providerId: model.provider,
+    displayName: model.modelName,
+    metadata: {
+      modelName: model.modelName,
+      hasApiKey: Boolean(model.hasApiKey),
+      apiKeyEnvVar: model.apiKeyEnvVar,
+    },
+  };
+}
+
+export function toHarnessV1AuthStatus(hasAuth: boolean | undefined): HarnessV1ModelAuthStatus {
+  if (hasAuth === true) return 'authenticated';
+  if (hasAuth === false) return 'needs_auth';
+  return 'unknown';
+}

--- a/mastracode/src/harness/events.test.ts
+++ b/mastracode/src/harness/events.test.ts
@@ -1,0 +1,247 @@
+import type { HarnessEvent as HarnessV1Event } from '@mastra/core/harness/v1';
+import { describe, expect, it } from 'vitest';
+
+import { MastraCodeHarnessEventProjector } from './events.js';
+
+function createProjector(displayState: Record<string, unknown> = {}) {
+  const events: any[] = [];
+  const projector = new MastraCodeHarnessEventProjector(
+    event => events.push(event),
+    () => displayState,
+    async (threadId, resourceId) => ({
+      id: threadId,
+      resourceId,
+      title: 'Thread',
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    }),
+  );
+  return { events, projector };
+}
+
+describe('MastraCodeHarnessEventProjector', () => {
+  it('projects v1 message deltas into legacy full-message updates', async () => {
+    const { events, projector } = createProjector();
+
+    await projector.project({ type: 'message_start', messageId: 'm1', id: 'e1', timestamp: 1 } as HarnessV1Event);
+    await projector.project({
+      type: 'message_update',
+      messageId: 'm1',
+      delta: 'hel',
+      id: 'e2',
+      timestamp: 2,
+    } as HarnessV1Event);
+    await projector.project({
+      type: 'message_update',
+      messageId: 'm1',
+      delta: 'lo',
+      id: 'e3',
+      timestamp: 3,
+    } as HarnessV1Event);
+
+    const updates = events.filter(event => event.type === 'message_update');
+    expect(updates.at(-1)?.message.content).toEqual([{ type: 'text', text: 'hello' }]);
+  });
+
+  it('projects question suspensions into ask_question events', async () => {
+    const { events, projector } = createProjector({
+      pending: {
+        itemId: 'q1',
+        payload: {
+          question: 'Proceed?',
+          options: [{ label: 'Yes' }],
+        },
+      },
+    });
+
+    await projector.project({
+      type: 'suspension_required',
+      kind: 'question',
+      toolCallId: 'tool-1',
+      id: 'e1',
+      timestamp: 1,
+    } as HarnessV1Event);
+
+    expect(events[0]).toMatchObject({
+      type: 'ask_question',
+      questionId: 'q1',
+      question: 'Proceed?',
+      options: [{ label: 'Yes' }],
+    });
+  });
+
+  it('projects request_access question suspensions into sandbox access requests', async () => {
+    const { events, projector } = createProjector({
+      pending: {
+        itemId: 'sandbox_1_123',
+        payload: {
+          question: 'Allow Mastra Code to access /outside/project/dir?\n\nneed to read config',
+          options: [
+            { label: 'Yes', description: 'Grant access for this session.' },
+            { label: 'No', description: 'Deny this access request.' },
+          ],
+          selectionMode: 'single_select',
+        },
+      },
+    });
+
+    await projector.project({
+      type: 'suspension_required',
+      kind: 'question',
+      toolCallId: 'call-1',
+      id: 'e1',
+      timestamp: 1,
+    } as HarnessV1Event);
+
+    expect(events[0]).toMatchObject({
+      type: 'sandbox_access_request',
+      questionId: 'sandbox_1_123',
+      path: '/outside/project/dir',
+      reason: 'need to read config',
+    });
+  });
+
+  it('projects native sandbox access requests into sandbox access prompts', async () => {
+    const { events, projector } = createProjector();
+
+    await projector.project({
+      type: 'sandbox_access_requested',
+      requestId: 'sandbox-native-1',
+      toolCallId: 'sandbox-native-1',
+      semanticType: 'file',
+      reason: 'needs config',
+      payload: { path: '/outside/project/dir' },
+      id: 'e1',
+      timestamp: 1,
+    } as HarnessV1Event);
+
+    expect(events[0]).toMatchObject({
+      type: 'sandbox_access_request',
+      questionId: 'sandbox-native-1',
+      path: '/outside/project/dir',
+      reason: 'needs config',
+      responseKind: 'sandbox-access',
+    });
+  });
+
+  it('keeps malformed sandbox-like questions on the generic ask_question path', async () => {
+    const { events, projector } = createProjector({
+      pending: {
+        itemId: 'sandbox_1_123',
+        payload: {
+          question: 'Can I do something else?',
+          options: [{ label: 'Yes' }],
+        },
+      },
+    });
+
+    await projector.project({
+      type: 'suspension_required',
+      kind: 'question',
+      toolCallId: 'call-1',
+      id: 'e1',
+      timestamp: 1,
+    } as HarnessV1Event);
+
+    expect(events[0]).toMatchObject({
+      type: 'ask_question',
+      questionId: 'sandbox_1_123',
+      question: 'Can I do something else?',
+    });
+  });
+
+  it('projects plan suspensions into plan approval events', async () => {
+    const { events, projector } = createProjector({
+      pending: {
+        itemId: 'p1',
+        payload: {
+          title: 'Implementation plan',
+          plan: '1. Build it',
+        },
+      },
+    });
+
+    await projector.project({
+      type: 'suspension_required',
+      kind: 'plan-approval',
+      toolCallId: 'tool-1',
+      id: 'e1',
+      timestamp: 1,
+    } as HarnessV1Event);
+
+    expect(events[0]).toMatchObject({
+      type: 'plan_approval_required',
+      planId: 'p1',
+      title: 'Implementation plan',
+      plan: '1. Build it',
+    });
+  });
+
+  it('projects tool suspensions into resumable legacy tool events', async () => {
+    const { events, projector } = createProjector({
+      pending: {
+        itemId: 'tool-1',
+        toolName: 'long_running_tool',
+        payload: {
+          input: { id: 1 },
+          suspendPayload: { step: 'confirm' },
+        },
+      },
+    });
+
+    await projector.project({
+      type: 'suspension_required',
+      kind: 'tool-suspension',
+      toolCallId: 'tool-1',
+      toolName: 'long_running_tool',
+      id: 'e1',
+      timestamp: 1,
+    } as HarnessV1Event);
+
+    expect(events[0]).toMatchObject({
+      type: 'tool_suspended',
+      toolCallId: 'tool-1',
+      toolName: 'long_running_tool',
+      args: { id: 1 },
+      suspendPayload: { step: 'confirm' },
+    });
+  });
+
+  it('projects subagent tool args and stringifies structured subagent output', async () => {
+    const { events, projector } = createProjector();
+
+    await projector.project({
+      type: 'subagent_tool_start',
+      toolCallId: 'parent-tool',
+      subagentSessionId: 'child',
+      agentType: 'explore',
+      innerToolCallId: 'inner-tool',
+      toolName: 'read_file',
+      args: { path: 'src/index.ts' },
+      depth: 1,
+      id: 'e1',
+      timestamp: 1,
+    } as HarnessV1Event);
+    await projector.project({
+      type: 'subagent_end',
+      toolCallId: 'parent-tool',
+      subagentSessionId: 'child',
+      agentType: 'explore',
+      output: { summary: 'done' },
+      isError: false,
+      durationMs: 12,
+      depth: 1,
+      id: 'e2',
+      timestamp: 2,
+    } as HarnessV1Event);
+
+    expect(events.find(event => event.type === 'subagent_tool_start')).toMatchObject({
+      subToolCallId: 'inner-tool',
+      subToolName: 'read_file',
+      subToolArgs: { path: 'src/index.ts' },
+    });
+    expect(events.find(event => event.type === 'subagent_end')).toMatchObject({
+      result: JSON.stringify({ summary: 'done' }),
+    });
+  });
+});

--- a/mastracode/src/harness/events.ts
+++ b/mastracode/src/harness/events.ts
@@ -1,0 +1,275 @@
+import type { HarnessEvent as LegacyHarnessEvent, HarnessMessage, HarnessThread } from '@mastra/core/harness';
+import type { HarnessEvent as HarnessV1Event, SessionDisplayState } from '@mastra/core/harness/v1';
+
+type EmitLegacyEvent = (event: LegacyHarnessEvent) => void;
+
+function textMessage(messageId: string, text: string): HarnessMessage {
+  return {
+    id: messageId,
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+    createdAt: new Date(),
+  };
+}
+
+export class MastraCodeHarnessEventProjector {
+  private readonly assistantText = new Map<string, string>();
+  private readonly toolNames = new Map<string, string>();
+
+  constructor(
+    private readonly emitLegacy: EmitLegacyEvent,
+    private readonly getDisplayState: () => SessionDisplayState | Record<string, unknown>,
+    private readonly getThread: (threadId: string, resourceId: string) => Promise<HarnessThread | undefined>,
+  ) {}
+
+  async project(event: HarnessV1Event): Promise<void> {
+    const projected = await this.toLegacyEvents(event);
+    for (const legacy of projected) {
+      this.emitLegacy(legacy);
+      this.emitLegacy({
+        type: 'display_state_changed',
+        displayState: this.getDisplayState(),
+      } as unknown as LegacyHarnessEvent);
+    }
+  }
+
+  private async toLegacyEvents(event: HarnessV1Event): Promise<LegacyHarnessEvent[]> {
+    switch (event.type) {
+      case 'message_start': {
+        this.assistantText.set(event.messageId, '');
+        return [{ ...event, message: textMessage(event.messageId, '') } as unknown as LegacyHarnessEvent];
+      }
+      case 'message_update': {
+        const next = `${this.assistantText.get(event.messageId) ?? ''}${event.delta}`;
+        this.assistantText.set(event.messageId, next);
+        return [{ ...event, message: textMessage(event.messageId, next) } as unknown as LegacyHarnessEvent];
+      }
+      case 'message_end': {
+        const text = this.assistantText.get(event.messageId) ?? '';
+        this.assistantText.delete(event.messageId);
+        return [{ ...event, message: textMessage(event.messageId, text) } as unknown as LegacyHarnessEvent];
+      }
+      case 'thread_created': {
+        const thread = await this.getThread(event.threadId, event.resourceId);
+        return [
+          {
+            ...event,
+            thread: thread ?? {
+              id: event.threadId,
+              resourceId: event.resourceId,
+              title: event.title,
+              createdAt: new Date(event.timestamp),
+              updatedAt: new Date(event.timestamp),
+            },
+          } as unknown as LegacyHarnessEvent,
+        ];
+      }
+      case 'thread_cloned': {
+        const thread = await this.getThread(event.threadId, event.resourceId);
+        return [
+          {
+            ...event,
+            thread: thread ?? {
+              id: event.threadId,
+              resourceId: event.resourceId,
+              title: event.title,
+              createdAt: new Date(event.timestamp),
+              updatedAt: new Date(event.timestamp),
+            },
+          } as unknown as LegacyHarnessEvent,
+        ];
+      }
+      case 'thread_renamed':
+        return [
+          {
+            ...event,
+            threadId: event.threadId,
+            resourceId: event.resourceId,
+            title: event.title,
+          } as unknown as LegacyHarnessEvent,
+        ];
+      case 'subagent_start':
+        return [{ ...event, forked: (event as { forked?: boolean }).forked ?? false } as unknown as LegacyHarnessEvent];
+      case 'subagent_text_delta':
+        return [{ ...event, textDelta: event.delta } as unknown as LegacyHarnessEvent];
+      case 'tool_start':
+        this.toolNames.set(event.toolCallId, event.toolName);
+        return [event as unknown as LegacyHarnessEvent];
+      case 'tool_end':
+        this.toolNames.delete(event.toolCallId);
+        return [event as unknown as LegacyHarnessEvent];
+      case 'subagent_tool_start':
+        return [
+          {
+            ...event,
+            subToolCallId: event.innerToolCallId,
+            subToolName: event.toolName,
+            subToolArgs: (event as { args?: unknown }).args,
+          } as unknown as LegacyHarnessEvent,
+        ];
+      case 'subagent_tool_end':
+        return [
+          {
+            ...event,
+            subToolCallId: event.innerToolCallId,
+            subToolName: event.toolName,
+            subToolResult: event.output,
+            result: event.output,
+          } as unknown as LegacyHarnessEvent,
+        ];
+      case 'subagent_end':
+        return [{ ...event, result: stringifySubagentOutput(event.output) } as unknown as LegacyHarnessEvent];
+      case 'sandbox_access_requested':
+        return [projectSandboxAccessRequested(event) as unknown as LegacyHarnessEvent];
+      case 'suspension_required':
+        return this.projectSuspensionRequired(event);
+      case 'suspension_resolved':
+        return [event as unknown as LegacyHarnessEvent];
+      default:
+        return [event as unknown as LegacyHarnessEvent];
+    }
+  }
+
+  private projectSuspensionRequired(
+    event: Extract<HarnessV1Event, { type: 'suspension_required' }>,
+  ): LegacyHarnessEvent[] {
+    const displayState = this.getDisplayState() as { pending?: any };
+    const pending = displayState.pending;
+    const itemId = pending?.itemId ?? event.toolCallId;
+    const payload = pending?.payload ?? {};
+
+    switch (event.kind) {
+      case 'question':
+        if (isSandboxAccessQuestion(itemId, payload)) {
+          const sandboxRequest = parseSandboxAccessQuestion(payload.question);
+          if (sandboxRequest) {
+            return [
+              {
+                ...event,
+                type: 'sandbox_access_request',
+                questionId: itemId,
+                path: sandboxRequest.path,
+                reason: sandboxRequest.reason,
+              } as unknown as LegacyHarnessEvent,
+            ];
+          }
+        }
+        return [
+          {
+            ...event,
+            type: 'ask_question',
+            questionId: itemId,
+            question: payload.question ?? 'The agent needs your input.',
+            options: payload.options,
+          } as unknown as LegacyHarnessEvent,
+        ];
+      case 'plan-approval':
+        return [
+          {
+            ...event,
+            type: 'plan_approval_required',
+            planId: itemId,
+            title: payload.title ?? 'Plan',
+            plan: payload.plan ?? '',
+          } as unknown as LegacyHarnessEvent,
+        ];
+      case 'tool-approval':
+        return [
+          {
+            ...event,
+            type: 'tool_approval_required',
+            toolCallId: event.toolCallId,
+            toolName: event.toolName ?? pending?.toolName ?? 'unknown',
+            args: payload.input,
+            category: payload.toolCategory,
+          } as unknown as LegacyHarnessEvent,
+        ];
+      case 'tool-suspension':
+        return [
+          {
+            ...event,
+            type: 'tool_suspended',
+            toolCallId: event.toolCallId,
+            toolName: event.toolName ?? pending?.toolName ?? 'unknown',
+            args: payload.input ?? payload.args,
+            suspendPayload: payload.suspendPayload ?? payload,
+          } as unknown as LegacyHarnessEvent,
+        ];
+      case 'sandbox-access':
+        return [];
+      default:
+        return [event as unknown as LegacyHarnessEvent];
+    }
+  }
+}
+
+function projectSandboxAccessRequested(
+  event: Extract<HarnessV1Event, { type: 'sandbox_access_requested' }>,
+): Record<string, unknown> {
+  return {
+    ...event,
+    type: 'sandbox_access_request',
+    questionId: event.requestId,
+    path: describeSandboxAccessTarget(event),
+    reason: event.reason ?? describeSandboxAccessReason(event.semanticType),
+    responseKind: 'sandbox-access',
+  };
+}
+
+function describeSandboxAccessTarget(event: Extract<HarnessV1Event, { type: 'sandbox_access_requested' }>): string {
+  const payload = event.payload;
+  if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+    const record = payload as Record<string, unknown>;
+    if (typeof record.path === 'string') return record.path;
+    if (typeof record.command === 'string') return record.command;
+    if (typeof record.host === 'string') {
+      return typeof record.port === 'number' ? `${record.host}:${record.port}` : record.host;
+    }
+    if (typeof record.server === 'string') {
+      return typeof record.action === 'string' ? `${record.server}:${record.action}` : record.server;
+    }
+  }
+  return event.semanticType;
+}
+
+function describeSandboxAccessReason(semanticType: string): string {
+  switch (semanticType) {
+    case 'file':
+      return 'The agent requested filesystem access.';
+    case 'command':
+      return 'The agent requested command execution access.';
+    case 'network':
+      return 'The agent requested network access.';
+    case 'mcp':
+      return 'The agent requested MCP access.';
+    default:
+      return 'The agent requested sandbox access.';
+  }
+}
+
+function isSandboxAccessQuestion(itemId: string, payload: { question?: unknown }): boolean {
+  return itemId.startsWith('sandbox_') && typeof payload.question === 'string';
+}
+
+function parseSandboxAccessQuestion(question: unknown): { path: string; reason: string } | undefined {
+  if (typeof question !== 'string') return undefined;
+  const prefix = 'Allow Mastra Code to access ';
+  const separator = '?\n\n';
+  if (!question.startsWith(prefix)) return undefined;
+  const separatorIndex = question.lastIndexOf(separator);
+  if (separatorIndex <= prefix.length) return undefined;
+  return {
+    path: question.slice(prefix.length, separatorIndex),
+    reason: question.slice(separatorIndex + separator.length),
+  };
+}
+
+function stringifySubagentOutput(output: unknown): string {
+  if (typeof output === 'string') return output;
+  if (output instanceof Error) return output.message;
+  try {
+    return JSON.stringify(output);
+  } catch {
+    return String(output);
+  }
+}

--- a/mastracode/src/harness/index.ts
+++ b/mastracode/src/harness/index.ts
@@ -1,0 +1,7 @@
+export {
+  MASTRACODE_HARNESS_NAME,
+  MASTRACODE_RUNTIME_COMPATIBILITY_GENERATION,
+  type MastraCodeRuntimeConfig,
+} from './config.js';
+export { MastraCodeHarnessRuntime } from './runtime.js';
+export { createHarnessV1SubagentAgents } from './subagents.js';

--- a/mastracode/src/harness/observational-memory.ts
+++ b/mastracode/src/harness/observational-memory.ts
@@ -1,0 +1,32 @@
+import type { OMProgressState, OMStatus } from '@mastra/core/harness';
+
+export const defaultMastraCodeOMStatus: OMStatus = 'idle';
+
+export function getOMModelState(state: Record<string, unknown>) {
+  return {
+    observerModelId: typeof state.observerModelId === 'string' ? state.observerModelId : undefined,
+    reflectorModelId: typeof state.reflectorModelId === 'string' ? state.reflectorModelId : undefined,
+    observationThreshold: typeof state.observationThreshold === 'number' ? state.observationThreshold : undefined,
+    reflectionThreshold: typeof state.reflectionThreshold === 'number' ? state.reflectionThreshold : undefined,
+  };
+}
+
+export function emptyOMProgress(): Partial<OMProgressState> {
+  return {
+    status: defaultMastraCodeOMStatus,
+    buffered: {
+      observations: {
+        status: 'idle',
+        chunks: 0,
+        messageTokens: 0,
+        projectedMessageRemoval: 0,
+        observationTokens: 0,
+      },
+      reflection: {
+        status: 'idle',
+        inputObservationTokens: 0,
+        observationTokens: 0,
+      },
+    },
+  };
+}

--- a/mastracode/src/harness/runtime.test.ts
+++ b/mastracode/src/harness/runtime.test.ts
@@ -1,0 +1,904 @@
+import { Agent } from '@mastra/core/agent';
+import { InMemoryStore } from '@mastra/core/storage';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MASTRACODE_HARNESS_NAME } from './config.js';
+import { MastraCodeHarnessRuntime } from './runtime.js';
+
+function createRuntime(
+  options: {
+    storage?: InMemoryStore;
+    projectPath?: string;
+    modes?: any[];
+    agents?: Record<string, Agent>;
+    subagents?: any[];
+    initialState?: Record<string, unknown>;
+    resolveModel?: (modelId: string) => unknown;
+    browser?: unknown;
+    disabledTools?: string[];
+  } = {},
+) {
+  const agent = new Agent({
+    id: 'code-agent',
+    name: 'Code Agent',
+    instructions: 'test',
+    model: 'openai/gpt-4o-mini' as any,
+  });
+  return new MastraCodeHarnessRuntime({
+    resourceId: 'resource-one',
+    storage: options.storage ?? new InMemoryStore({ id: `mc-runtime-test-${Date.now()}-${Math.random()}` }),
+    agents: options.agents ?? { 'code-agent': agent },
+    modes:
+      options.modes ??
+      ([
+        {
+          id: 'build',
+          name: 'Build',
+          color: 'green',
+          default: true,
+          defaultModelId: 'anthropic/claude-haiku-4-5',
+          agent,
+        },
+        {
+          id: 'plan',
+          name: 'Plan',
+          color: 'blue',
+          defaultModelId: 'openai/gpt-4o-mini',
+          agent,
+        },
+      ] as any),
+    subagents: options.subagents ?? [],
+    initialState: {
+      projectPath: options.projectPath ?? '/tmp/mastracode-runtime-test',
+      currentModelId: 'anthropic/claude-haiku-4-5',
+      ...options.initialState,
+    },
+    resolveModel: options.resolveModel,
+    browser: options.browser as never,
+    disabledTools: options.disabledTools,
+  });
+}
+
+describe('MastraCodeHarnessRuntime', () => {
+  it('rejects empty mode configuration instead of inventing a default mode id', () => {
+    expect(() => createRuntime({ modes: [] })).toThrow('No MastraCode harness modes configured');
+  });
+
+  it('registers the Harness v1 runtime on the returned Mastra instance', () => {
+    const runtime = createRuntime();
+
+    expect(runtime.getMastra().getHarness(MASTRACODE_HARNESS_NAME)).toBe(runtime.core);
+  });
+
+  it('restores Harness v1 thread metadata into MastraCode runtime state', async () => {
+    const runtime = createRuntime();
+    await runtime.init();
+    const first = await runtime.createThread({ title: 'first' });
+
+    await runtime.switchMode({ modeId: 'plan' });
+    await runtime.switchModel({ modelId: 'openai/gpt-5.4-mini' });
+    await runtime.switchObserverModel({ modelId: 'google/gemini-2.5-flash' });
+    await runtime.switchReflectorModel({ modelId: 'anthropic/claude-haiku-4-5' });
+    await runtime.setSubagentModelId({ modelId: 'openai/gpt-5.4-mini' });
+
+    await runtime.createThread({ title: 'second' });
+    await runtime.switchMode({ modeId: 'build' });
+    await runtime.switchModel({ modelId: 'anthropic/claude-opus-4-6' });
+
+    await runtime.switchThread({ threadId: first.id });
+
+    expect(runtime.getCurrentModeId()).toBe('plan');
+    expect(runtime.getCurrentModelId()).toBe('openai/gpt-5.4-mini');
+    expect(runtime.getObserverModelId()).toBe('google/gemini-2.5-flash');
+    expect(runtime.getReflectorModelId()).toBe('anthropic/claude-haiku-4-5');
+    expect(runtime.getSubagentModelId()).toBe('openai/gpt-5.4-mini');
+
+    await runtime.destroy();
+  });
+
+  it('does not write target thread metadata into the previously active session while switching threads', async () => {
+    const runtime = createRuntime();
+    await runtime.init();
+    const firstThreadId = runtime.getCurrentThreadId();
+    if (!firstThreadId) throw new Error('expected initial thread');
+    await runtime.setState({ currentModelId: 'openai/gpt-5.4-mini' });
+
+    await runtime.createThread({ title: 'second' });
+    const secondSession = (runtime as any).session;
+    await runtime.setState({ currentModelId: 'anthropic/claude-haiku-4-5' });
+
+    await runtime.switchThread({ threadId: firstThreadId });
+
+    await expect(secondSession.getState()).resolves.toMatchObject({
+      currentModelId: 'anthropic/claude-haiku-4-5',
+    });
+    await runtime.destroy();
+  });
+
+  it('does not project events from non-active child sessions as top-level MastraCode events', async () => {
+    const runtime = createRuntime();
+    await runtime.init();
+    const parent = (runtime as any).session;
+    const child = await runtime.core.session({
+      resourceId: runtime.getResourceId(),
+      threadId: { fresh: true },
+      parentSessionId: parent.id,
+      origin: 'subagent-tool',
+      modeId: runtime.getCurrentModeId(),
+      modelId: runtime.getCurrentModelId(),
+    });
+    const listener = vi.fn();
+    runtime.subscribe(listener);
+
+    child._emit({ type: 'message_start', messageId: 'child-message' } as any);
+
+    expect(listener).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'message_start' }));
+    await runtime.destroy();
+  });
+
+  it('lists threads and known resource ids across resources', async () => {
+    const runtime = createRuntime();
+    await runtime.init();
+    await runtime.createThread({ title: 'one' });
+    runtime.setResourceId({ resourceId: 'resource-two' });
+    await runtime.createThread({ title: 'two' });
+
+    const resourceIds = await runtime.getKnownResourceIds();
+    const threads = await runtime.listThreads({ allResources: true });
+
+    expect(resourceIds).toEqual(['resource-one', 'resource-two']);
+    expect(threads.map(thread => thread.resourceId).sort()).toContain('resource-one');
+    expect(threads.map(thread => thread.resourceId).sort()).toContain('resource-two');
+
+    await runtime.destroy();
+  });
+
+  it('routes user signals and system reminders through Harness v1 session APIs', async () => {
+    const runtime = createRuntime();
+    const signal = vi.fn(async () => ({ id: 'sig-user', accepted: true }));
+    const injectSystemReminder = vi.fn(async () => ({ id: 'sig-reminder', accepted: true }));
+    (runtime as any).session = { signal, injectSystemReminder };
+
+    const acceptedUser = await runtime.sendSignal({
+      content: 'hello',
+      ifActive: { attributes: { delivery: 'while-active' } },
+      ifIdle: { attributes: { delivery: 'message' } },
+    }).accepted;
+    const imageParts = [
+      { type: 'text', text: 'look' },
+      { type: 'file', data: 'abc123', mediaType: 'image/png' },
+    ];
+    await runtime.sendSignal({ content: imageParts }).accepted;
+    const acceptedReminder = await runtime.sendSignal({
+      type: 'system-reminder',
+      contents: 'continue',
+      attributes: { type: 'goal' },
+    }).accepted;
+
+    expect(signal).toHaveBeenCalledWith({
+      content: 'hello',
+      signalId: expect.stringMatching(/^signal-/),
+      ifActive: { attributes: { delivery: 'while-active' } },
+      ifIdle: { attributes: { delivery: 'message' } },
+    });
+    expect(signal).toHaveBeenCalledWith({ content: imageParts, signalId: expect.stringMatching(/^signal-/) });
+    expect(injectSystemReminder).toHaveBeenCalledWith('continue', {
+      attributes: { type: 'goal' },
+      metadata: undefined,
+    });
+    expect(acceptedUser).toEqual({ id: 'sig-user', accepted: true });
+    expect(acceptedReminder).toEqual({ id: 'sig-reminder', accepted: true });
+
+    await runtime.destroy();
+  });
+
+  it('retains Harness v1 OM progress in the MastraCode display state', async () => {
+    const runtime = createRuntime();
+
+    await (runtime as any).handleCoreEvent({
+      type: 'om_status',
+      windows: {
+        active: {
+          messages: { tokens: 41, threshold: 30000 },
+          observations: { tokens: 1200, threshold: 40000 },
+        },
+        buffered: {
+          observations: {
+            status: 'running',
+            chunks: 1,
+            messageTokens: 41,
+            projectedMessageRemoval: 0,
+            observationTokens: 0,
+          },
+          reflection: {
+            status: 'idle',
+            inputObservationTokens: 0,
+            observationTokens: 0,
+          },
+        },
+      },
+      recordId: 'om-record-1',
+      threadId: 'thread-1',
+      stepNumber: 2,
+      generationCount: 3,
+    });
+
+    const displayState = runtime.getDisplayState();
+    expect(displayState.omProgress.pendingTokens).toBe(41);
+    expect(displayState.omProgress.observationTokens).toBe(1200);
+    expect(displayState.omProgress.stepNumber).toBe(2);
+    expect(displayState.omProgress.generationCount).toBe(3);
+    expect(displayState.bufferingMessages).toBe(true);
+
+    await (runtime as any).handleCoreEvent({
+      type: 'om_observation_end',
+      cycleId: 'obs-1',
+      durationMs: 10,
+      tokensObserved: 41,
+      observationTokens: 1200,
+    });
+
+    expect(runtime.getDisplayState().omProgress.pendingTokens).toBe(0);
+    expect(runtime.getDisplayState().bufferingMessages).toBe(true);
+    await runtime.destroy();
+  });
+
+  it('applies replayed OM progress from memory into the display state', async () => {
+    const runtime = createRuntime();
+    await runtime.init();
+    await runtime.createThread({ title: 'with om' });
+    (runtime as any).getMemoryStorage = vi.fn(async () => ({
+      getObservationalMemory: vi.fn(async () => ({
+        id: 'om-record-1',
+        config: { observationThreshold: 100, reflectionThreshold: 200 },
+        pendingMessageTokens: 7,
+        observationTokenCount: 11,
+      })),
+      listMessages: vi.fn(async () => ({
+        messages: [
+          {
+            role: 'assistant',
+            content: {
+              parts: [
+                {
+                  type: 'data-om-status',
+                  data: {
+                    windows: {
+                      active: {
+                        messages: { tokens: 19, threshold: 100 },
+                        observations: { tokens: 31, threshold: 200 },
+                      },
+                      buffered: {
+                        observations: { status: 'running', chunks: 2, messageTokens: 19, observationTokens: 0 },
+                        reflection: { status: 'idle', inputObservationTokens: 0, observationTokens: 0 },
+                      },
+                    },
+                    generationCount: 4,
+                    stepNumber: 5,
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      })),
+    }));
+
+    await runtime.loadOMProgress();
+
+    const displayState = runtime.getDisplayState();
+    expect(displayState.omProgress.pendingTokens).toBe(19);
+    expect(displayState.omProgress.observationTokens).toBe(31);
+    expect(displayState.omProgress.generationCount).toBe(4);
+    expect(displayState.omProgress.stepNumber).toBe(5);
+    expect(displayState.bufferingMessages).toBe(true);
+    await runtime.destroy();
+  });
+
+  it('keeps projecting late Harness v1 events after the session is closed', async () => {
+    const runtime = createRuntime();
+    const closed = new Error('Session "closed" is closed');
+    closed.name = 'HarnessSessionClosedError';
+    (runtime as any).session = {
+      isRunning: () => false,
+      getDisplayState: () => {
+        throw closed;
+      },
+      getState: async () => {
+        throw closed;
+      },
+      setState: async () => {
+        throw closed;
+      },
+    };
+    const listener = vi.fn();
+    runtime.subscribe(listener);
+
+    await expect(
+      (runtime as any).handleCoreEvent({
+        type: 'task_updated',
+        tasks: [{ id: 'late-task', title: 'Late task', status: 'completed' }],
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(runtime.getDisplayState().tasks).toEqual([{ id: 'late-task', title: 'Late task', status: 'completed' }]);
+    await expect((runtime as any).handleCoreEvent({ type: 'state_changed' })).resolves.toBeUndefined();
+    await expect(
+      (runtime as any).handleCoreEvent({ type: 'model_changed', modelId: 'openai/gpt-4o-mini' }),
+    ).resolves.toBeUndefined();
+    expect(listener).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    await runtime.destroy();
+  });
+
+  it('uploads initial-message files through Harness v1 attachments', async () => {
+    const runtime = createRuntime();
+    const message = vi.fn(async () => undefined);
+    const upload = vi.spyOn(runtime.core.attachments, 'upload').mockResolvedValue({
+      attachmentId: 'attachment-1',
+      resourceId: 'resource-one',
+      ownerSessionId: 'session-one',
+      bytes: 6,
+      mimeType: 'image/png',
+      name: 'attachment-1',
+    });
+    (runtime as any).session = {
+      id: 'session-one',
+      resourceId: 'resource-one',
+      message,
+      models: {
+        current: () => 'anthropic/claude-haiku-4-5',
+        switch: vi.fn(async () => undefined),
+      },
+      setState: vi.fn(async () => undefined),
+    };
+
+    await runtime.sendMessage({
+      content: 'inspect this',
+      files: [{ data: 'abc123', mimeType: 'image/png' }],
+    });
+
+    expect(upload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-one',
+        resourceId: 'resource-one',
+        data: expect.any(Uint8Array),
+        filename: 'attachment-1',
+        contentType: 'image/png',
+      }),
+    );
+    expect(message).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'inspect this',
+        attachments: [expect.objectContaining({ attachmentId: 'attachment-1' })],
+      }),
+    );
+
+    await runtime.destroy();
+  });
+
+  it('does not pass prepareStep when sending duplicate-admission messages', async () => {
+    const runtime = createRuntime();
+    const message = vi.fn(async () => undefined);
+    (runtime as any).session = {
+      message,
+      models: {
+        current: () => 'anthropic/claude-haiku-4-5',
+        switch: vi.fn(async () => undefined),
+      },
+      setState: vi.fn(async () => undefined),
+    };
+
+    await runtime.sendMessage({ content: 'repeatable', admissionId: 'admission-one' });
+
+    expect(message).toHaveBeenCalledWith({
+      content: 'repeatable',
+      admissionId: 'admission-one',
+    });
+
+    await runtime.destroy();
+  });
+
+  it('passes yolo to initial Harness v1 message turns when enabled', async () => {
+    const runtime = createRuntime({ initialState: { yolo: true } });
+    const message = vi.fn(async () => undefined);
+    (runtime as any).session = {
+      message,
+      models: {
+        current: () => 'anthropic/claude-haiku-4-5',
+        switch: vi.fn(async () => undefined),
+      },
+      setState: vi.fn(async () => undefined),
+    };
+
+    await runtime.sendMessage({ content: 'run without approval prompts' });
+
+    expect(message).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'run without approval prompts',
+        yolo: true,
+      }),
+    );
+
+    await runtime.destroy();
+  });
+
+  it('filters active tools through prepareStep for non-admission messages', async () => {
+    const runtime = createRuntime({ disabledTools: ['blocked_tool'] });
+    const message = vi.fn(async () => undefined);
+    (runtime as any).session = {
+      message,
+      models: {
+        current: () => 'anthropic/claude-haiku-4-5',
+        switch: vi.fn(async () => undefined),
+      },
+      setState: vi.fn(async () => undefined),
+    };
+
+    await runtime.sendMessage({ content: 'run tools' });
+
+    const [{ prepareStep }] = message.mock.calls[0] as any;
+    expect(prepareStep({ tools: { allowed_tool: {}, blocked_tool: {} } })).toEqual({ activeTools: ['allowed_tool'] });
+
+    await runtime.destroy();
+  });
+
+  it('persists system reminder messages and first user previews through memory storage', async () => {
+    const runtime = createRuntime();
+    await runtime.init();
+    const thread = await runtime.createThread({ title: 'messages' });
+
+    await runtime.saveSystemReminderMessage({ reminderType: 'goal-judge', message: 'done\ncomplete' });
+    const saved = await runtime.listMessages();
+    const savedByThread = await runtime.listMessagesForThread({ threadId: thread.id });
+    const previews = await runtime.getFirstUserMessagesForThreads({ threadIds: [thread.id] });
+
+    expect(saved.some(message => message.content.some(part => part.type === 'system_reminder'))).toBe(true);
+    expect(savedByThread.some(message => message.content.some(part => part.type === 'system_reminder'))).toBe(true);
+    expect(previews.get(thread.id)?.content.some(part => part.type === 'system_reminder')).toBe(true);
+
+    await runtime.destroy();
+  });
+
+  it('selects existing threads by project path when a resource is reused', async () => {
+    const storage = new InMemoryStore({ id: `mc-runtime-project-test-${Date.now()}-${Math.random()}` });
+    const firstRuntime = createRuntime({ storage, projectPath: '/tmp/first-project' });
+    await firstRuntime.init();
+    const firstThreadId = firstRuntime.getCurrentThreadId();
+    await firstRuntime.destroy();
+
+    const secondRuntime = createRuntime({ storage, projectPath: '/tmp/second-project' });
+    await secondRuntime.init();
+    const secondThreadId = secondRuntime.getCurrentThreadId();
+    await secondRuntime.destroy();
+
+    const resumedFirstRuntime = createRuntime({ storage, projectPath: '/tmp/first-project' });
+    await resumedFirstRuntime.init();
+    expect(resumedFirstRuntime.getCurrentThreadId()).toBe(firstThreadId);
+    expect(secondThreadId).not.toBe(firstThreadId);
+    await resumedFirstRuntime.destroy();
+  });
+
+  it('registers static custom mode agents with Harness v1', () => {
+    const codeAgent = new Agent({
+      id: 'code-agent',
+      name: 'Code Agent',
+      instructions: 'test',
+      model: 'openai/gpt-4o-mini' as any,
+    });
+    const reviewAgent = new Agent({
+      id: 'review-agent',
+      name: 'Review Agent',
+      instructions: 'review',
+      model: 'openai/gpt-4o-mini' as any,
+    });
+    const runtime = createRuntime({
+      agents: { 'code-agent': codeAgent },
+      modes: [
+        { id: 'build', name: 'Build', default: true, agent: codeAgent },
+        { id: 'review', name: 'Review', agent: reviewAgent },
+      ],
+    });
+
+    expect(runtime.getMastra().getAgent('mode-review-agent' as never)).toBe(reviewAgent);
+  });
+
+  it('registers native Harness v1 spawn_subagent types for MastraCode subagent agents', () => {
+    const codeAgent = new Agent({
+      id: 'code-agent',
+      name: 'Code Agent',
+      instructions: 'test',
+      model: 'openai/gpt-4o-mini' as any,
+    });
+    const exploreAgent = new Agent({
+      id: 'subagent-explore',
+      name: 'Explore',
+      instructions: 'explore',
+      model: 'openai/gpt-4o-mini' as any,
+    });
+    const runtime = createRuntime({
+      agents: { 'code-agent': codeAgent, 'subagent-explore': exploreAgent },
+      modes: [{ id: 'build', name: 'Build', default: true, agent: codeAgent }],
+      subagents: [
+        {
+          id: 'explore',
+          name: 'Explore',
+          description: 'Read-only exploration',
+          instructions: 'explore',
+          defaultModelId: 'openai/gpt-4o-mini',
+          forked: true,
+          maxSteps: 7,
+        },
+      ],
+    });
+
+    expect(runtime.core.getMode('mastracode-subagent-explore')?.agentId).toBe('subagent-explore');
+    expect((runtime.core as any)._getSubagentType('explore')).toMatchObject({
+      agentId: 'subagent-explore',
+      modeId: 'mastracode-subagent-explore',
+      defaultModelId: 'openai/gpt-4o-mini',
+      forked: true,
+      maxSteps: 7,
+      workspace: 'inherit',
+    });
+    expect(runtime.getMastra().getAgent('subagent-explore' as never)).toBe(exploreAgent);
+    expect(runtime.core.getMode('build')?.additionalTools).toBeUndefined();
+  });
+
+  it('seeds global MastraCode subagent model defaults into Harness v1 native spawn overrides', async () => {
+    const codeAgent = new Agent({
+      id: 'code-agent',
+      name: 'Code Agent',
+      instructions: 'test',
+      model: 'openai/gpt-4o-mini' as any,
+    });
+    const exploreAgent = new Agent({
+      id: 'subagent-explore',
+      name: 'Explore',
+      instructions: 'explore',
+      model: 'openai/gpt-4o-mini' as any,
+    });
+    const runtime = createRuntime({
+      agents: { 'code-agent': codeAgent, 'subagent-explore': exploreAgent },
+      modes: [{ id: 'build', name: 'Build', default: true, agent: codeAgent }],
+      subagents: [
+        {
+          id: 'explore',
+          name: 'Explore',
+          description: 'Read-only exploration',
+          instructions: 'explore',
+          defaultModelId: 'openai/gpt-4o-mini',
+        },
+      ],
+      initialState: {
+        subagentModelId: 'anthropic/claude-haiku-4-5',
+        subagentModelId_explore: 'anthropic/claude-haiku-4-5',
+      },
+    });
+
+    expect(runtime.getSubagentModelId({ agentType: 'explore' })).toBe('anthropic/claude-haiku-4-5');
+    await runtime.init();
+
+    expect((runtime as any).session.models.getSubagent({ agentType: 'explore' })).toBe('anthropic/claude-haiku-4-5');
+    await (runtime as any).session.models.setSubagent({ agentType: 'explore', model: 'openai/gpt-4o-mini' });
+    expect(runtime.getSubagentModelId({ agentType: 'explore' })).toBe('openai/gpt-4o-mini');
+    await runtime.destroy();
+  });
+
+  it('does not register native subagents when the subagent tool is disabled', () => {
+    const codeAgent = new Agent({
+      id: 'code-agent',
+      name: 'Code Agent',
+      instructions: 'test',
+      model: 'openai/gpt-4o-mini' as any,
+    });
+    const exploreAgent = new Agent({
+      id: 'subagent-explore',
+      name: 'Explore',
+      instructions: 'explore',
+      model: 'openai/gpt-4o-mini' as any,
+    });
+    const runtime = createRuntime({
+      agents: { 'code-agent': codeAgent, 'subagent-explore': exploreAgent },
+      modes: [{ id: 'build', name: 'Build', default: true, agent: codeAgent }],
+      subagents: [
+        {
+          id: 'explore',
+          name: 'Explore',
+          description: 'Read-only exploration',
+          instructions: 'explore',
+          defaultModelId: 'openai/gpt-4o-mini',
+        },
+      ],
+      disabledTools: ['subagent'],
+    });
+
+    expect((runtime.core as any)._getSubagentType('explore')).toBeUndefined();
+    expect(runtime.core.getMode('mastracode-subagent-explore')).toBeUndefined();
+  });
+
+  it('filters denied tool categories and syncs permission rules into the Harness v1 session', async () => {
+    const runtime = createRuntime({
+      initialState: {
+        permissionRules: {
+          categories: { execute: 'deny' },
+          tools: { read_file: 'allow' },
+        },
+      },
+    });
+    (runtime as any).config.toolCategoryResolver = (toolName: string) => (toolName === 'shell' ? 'execute' : null);
+    await runtime.init();
+
+    expect((runtime as any).filterActiveTools(['read_file', 'shell'])).toEqual(['read_file']);
+    expect((runtime as any).session.permissions.getRules()).toEqual({
+      categories: { execute: 'deny' },
+      tools: { read_file: 'allow' },
+    });
+
+    await runtime.destroy();
+  });
+
+  it('bridges legacy session and model resolver helpers', async () => {
+    const resolvedModels: string[] = [];
+    const runtime = createRuntime({
+      initialState: {
+        observerModelId: 'openai/gpt-5.4-mini',
+        reflectorModelId: 'anthropic/claude-haiku-4-5',
+      },
+      resolveModel: modelId => {
+        resolvedModels.push(modelId);
+        return { modelId };
+      },
+    });
+    await runtime.init();
+
+    const session = await runtime.getSession();
+    expect(session.currentThreadId).toBe(runtime.getCurrentThreadId());
+    expect(session.currentModeId).toBe(runtime.getCurrentModeId());
+    expect(session.threads.length).toBeGreaterThan(0);
+    expect(runtime.getResolvedObserverModel()).toEqual({ modelId: 'openai/gpt-5.4-mini' });
+    expect(runtime.getResolvedReflectorModel()).toEqual({ modelId: 'anthropic/claude-haiku-4-5' });
+    expect(resolvedModels).toEqual(['openai/gpt-5.4-mini', 'anthropic/claude-haiku-4-5']);
+
+    await runtime.destroy();
+  });
+
+  it('returns legacy Map-backed display state from v1 record snapshots', () => {
+    const runtime = createRuntime();
+    (runtime as any).session = {
+      getDisplayState: () => ({
+        activeTools: {
+          tool_1: { toolName: 'read_file', status: 'running' },
+        },
+        toolInputBuffers: {
+          tool_1: { toolName: 'read_file', text: '{"path"' },
+        },
+        activeSubagents: {
+          sub_1: { agentType: 'explore', task: 'inspect', status: 'running' },
+        },
+        tokenUsage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+        pending: null,
+      }),
+      threadId: 'thread-one',
+      isRunning: () => false,
+    };
+
+    const display = runtime.getDisplayState();
+
+    expect(display.activeTools).toBeInstanceOf(Map);
+    expect(display.toolInputBuffers).toBeInstanceOf(Map);
+    expect(display.activeSubagents).toBeInstanceOf(Map);
+    expect(display.toolInputBuffers.get('tool_1')).toEqual({ toolName: 'read_file', text: '{"path"' });
+  });
+
+  it('tracks modified files from v1 file mutation tool events for /diff parity', async () => {
+    const runtime = createRuntime();
+
+    await (runtime as any).handleCoreEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-1',
+      toolName: 'write_file',
+      args: { path: 'src/app.ts' },
+    });
+    await (runtime as any).handleCoreEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-1',
+      result: 'ok',
+      isError: false,
+    });
+    await (runtime as any).handleCoreEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-2',
+      toolName: 'string_replace_lsp',
+      args: { path: 'src/app.ts' },
+    });
+    await (runtime as any).handleCoreEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-2',
+      result: 'ok',
+      isError: false,
+    });
+    await (runtime as any).handleCoreEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-3',
+      toolName: 'ast_smart_edit',
+      args: { path: 'src/app.ts' },
+    });
+    await (runtime as any).handleCoreEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-3',
+      result: 'ok',
+      isError: false,
+    });
+    await (runtime as any).handleCoreEvent({
+      type: 'subagent_tool_start',
+      innerToolCallId: 'sub-tool-1',
+      toolName: 'write_file',
+      args: { path: 'src/from-subagent.ts' },
+    });
+    await (runtime as any).handleCoreEvent({
+      type: 'subagent_tool_end',
+      innerToolCallId: 'sub-tool-1',
+      toolName: 'write_file',
+      output: 'ok',
+      isError: false,
+    });
+
+    expect(runtime.getDisplayState().modifiedFiles.get('src/app.ts')).toMatchObject({
+      operations: ['write_file', 'string_replace_lsp', 'ast_smart_edit'],
+    });
+    expect(runtime.getDisplayState().modifiedFiles.get('src/from-subagent.ts')).toMatchObject({
+      operations: ['write_file'],
+    });
+
+    runtime.getDisplayState().modifiedFiles.clear();
+    expect(runtime.getDisplayState().modifiedFiles.size).toBe(0);
+    await runtime.destroy();
+  });
+
+  it('does not track errored or non-mutating tools as modified files', async () => {
+    const runtime = createRuntime();
+
+    await (runtime as any).handleCoreEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-1',
+      toolName: 'write_file',
+      args: { path: 'src/app.ts' },
+    });
+    await (runtime as any).handleCoreEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-1',
+      result: 'fail',
+      isError: true,
+    });
+    await (runtime as any).handleCoreEvent({
+      type: 'tool_start',
+      toolCallId: 'tool-2',
+      toolName: 'execute_command',
+      args: { command: 'touch src/other.ts' },
+    });
+    await (runtime as any).handleCoreEvent({
+      type: 'tool_end',
+      toolCallId: 'tool-2',
+      result: 'ok',
+      isError: false,
+    });
+
+    expect(runtime.getDisplayState().modifiedFiles.size).toBe(0);
+    await runtime.destroy();
+  });
+
+  it('restores replayed task display snapshots for TUI history replay', () => {
+    const runtime = createRuntime({
+      initialState: { tasks: [{ id: 'old', content: 'Old', status: 'pending', activeForm: 'Doing old' }] },
+    });
+    const nextTasks = [{ id: 'new', content: 'New', status: 'in_progress', activeForm: 'Doing new' }];
+    const listener = vi.fn();
+    runtime.subscribe(listener);
+
+    runtime.restoreDisplayTasks(nextTasks as any);
+
+    expect(runtime.getDisplayState().previousTasks).toEqual([
+      { id: 'old', content: 'Old', status: 'pending', activeForm: 'Doing old' },
+    ]);
+    expect(runtime.getDisplayState().tasks).toEqual(nextTasks);
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({ type: 'display_state_changed' }));
+  });
+
+  it('forwards explicit pending ids through the MastraCode compatibility response surface', async () => {
+    const runtime = createRuntime();
+    const respondToToolSuspension = vi.fn(async () => undefined);
+    const respondToQuestion = vi.fn(async () => undefined);
+    const respondToToolApproval = vi.fn(async () => undefined);
+    const respondToSandboxAccess = vi.fn(async () => undefined);
+    const respondToPlanApproval = vi.fn(async () => undefined);
+    const getDisplayState = vi.fn(() => ({ pending: { toolName: 'write_file' } }));
+    (runtime as any).session = {
+      respondToQuestion,
+      respondToToolApproval,
+      respondToToolSuspension,
+      respondToSandboxAccess,
+      respondToPlanApproval,
+      getDisplayState,
+    };
+
+    runtime.respondToQuestion({ questionId: 'q-1', answer: 'yes' });
+    runtime.respondToToolApproval({ toolCallId: 'tool-1', decision: 'approve' });
+    await runtime.respondToToolSuspension({ toolCallId: 'tool-2', resumeData: { ok: true } });
+    await runtime.respondToSandboxAccess({ questionId: 'sandbox-1', approved: true });
+    await runtime.respondToPlanApproval({ planId: 'plan-1', response: { action: 'approved' } });
+
+    await Promise.resolve();
+    expect(respondToQuestion).toHaveBeenCalledWith({ itemId: 'q-1', answer: 'yes' });
+    expect(respondToToolApproval).toHaveBeenCalledWith({ itemId: 'tool-1', approved: true, reason: undefined });
+    expect(respondToToolSuspension).toHaveBeenCalledWith({ itemId: 'tool-2', resumeData: { ok: true } });
+    expect(respondToSandboxAccess).toHaveBeenCalledWith({ itemId: 'sandbox-1', approved: true, reason: undefined });
+    expect(respondToPlanApproval).toHaveBeenCalledWith({
+      itemId: 'plan-1',
+      approved: true,
+      revision: undefined,
+    });
+  });
+
+  it('applies startup and live browser instances to mode agents', () => {
+    const browser = { name: 'browser' };
+    const setBrowser = vi.fn();
+    const agent = new Agent({
+      id: 'code-agent',
+      name: 'Code Agent',
+      instructions: 'test',
+      model: 'openai/gpt-4o-mini' as any,
+    }) as any;
+    agent.setBrowser = setBrowser;
+    agent.hasOwnBrowser = () => false;
+
+    const runtime = createRuntime({
+      agents: { 'code-agent': agent },
+      modes: [{ id: 'build', name: 'Build', default: true, agent }],
+      browser,
+    });
+
+    expect(setBrowser).toHaveBeenCalledWith(browser);
+    const nextBrowser = { name: 'next-browser' };
+    runtime.setBrowser(nextBrowser);
+    expect(setBrowser).toHaveBeenCalledWith(nextBrowser);
+  });
+
+  it('creates a session lazily after changing resource id before headless send', async () => {
+    const runtime = createRuntime();
+    const message = vi.fn(async () => undefined);
+    const session = {
+      message,
+      models: {
+        current: () => 'anthropic/claude-haiku-4-5',
+        switch: vi.fn(async () => undefined),
+      },
+      setState: vi.fn(async () => undefined),
+    };
+    const selectOrCreateThread = vi.spyOn(runtime, 'selectOrCreateThread').mockImplementation(async () => {
+      (runtime as any).session = session;
+      return {
+        id: 'thread-two',
+        resourceId: 'resource-two',
+        title: 'New thread',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+    });
+
+    runtime.setResourceId({ resourceId: 'resource-two' });
+    await runtime.sendMessage({ content: 'hello' });
+
+    expect(selectOrCreateThread).toHaveBeenCalled();
+    expect(message).toHaveBeenCalledWith(expect.objectContaining({ content: 'hello' }));
+  });
+
+  it('does not clear the active session when setting the same resource id', async () => {
+    const runtime = createRuntime();
+    await runtime.init();
+    const currentThreadId = runtime.getCurrentThreadId();
+
+    runtime.setResourceId({ resourceId: 'resource-one' });
+
+    expect(runtime.getCurrentThreadId()).toBe(currentThreadId);
+  });
+});

--- a/mastracode/src/harness/runtime.ts
+++ b/mastracode/src/harness/runtime.ts
@@ -1,0 +1,1873 @@
+import { randomUUID } from 'node:crypto';
+
+import type {
+  AvailableModel,
+  HarnessDisplayState,
+  HarnessEvent,
+  HarnessEventListener,
+  HarnessMessage,
+  HarnessMode as LegacyHarnessMode,
+  HarnessSession,
+  TaskItemSnapshot,
+  HarnessThread,
+  ModelAuthStatus,
+  OMProgressState,
+  PermissionPolicy,
+  ToolCategory,
+  StoredMessageRow,
+} from '@mastra/core/harness';
+import { convertStoredMessageToHarnessMessage, defaultDisplayState } from '@mastra/core/harness';
+import {
+  Harness as HarnessV1,
+  getHarnessWorkspaceActionPathInput,
+  isHarnessWorkspaceFileMutationTool,
+} from '@mastra/core/harness/v1';
+import type {
+  AttachmentRef,
+  HarnessEvent as HarnessV1Event,
+  HarnessEventUnsubscribe as HarnessV1EventUnsubscribe,
+  HarnessMessageContentPart,
+  Session,
+  SessionDisplayState,
+  ThreadRecord,
+} from '@mastra/core/harness/v1';
+import { PROVIDER_REGISTRY } from '@mastra/core/llm';
+import { Mastra } from '@mastra/core/mastra';
+import { RequestContext } from '@mastra/core/request-context';
+import type { WorkspaceActionJournalEntry } from '@mastra/core/storage';
+
+import { isSubagentToolName } from '../tool-names.js';
+import {
+  MASTRACODE_RUNTIME_COMPATIBILITY_GENERATION,
+  MASTRACODE_HARNESS_NAME,
+  resolveDefaultModeId,
+  toHarnessV1Agents,
+  toHarnessV1AuthStatus,
+  toHarnessV1Modes,
+  toHarnessV1Subagents,
+  toModelInfo,
+} from './config.js';
+import type { MastraCodeModelInfo, MastraCodeRuntimeConfig } from './config.js';
+import { MastraCodeHarnessEventProjector } from './events.js';
+import { emptyOMProgress, getOMModelState } from './observational-memory.js';
+
+type SignalDeliveryAttributes = Record<string, string | number | boolean | null | undefined>;
+const TOOL_CATEGORIES: readonly ToolCategory[] = ['read', 'edit', 'execute', 'mcp', 'other'];
+const HARNESS_SESSION_LIFECYCLE_ERROR_NAMES = new Set([
+  'HarnessSessionClosedError',
+  'HarnessSessionClosingError',
+  'HarnessSessionDeletedError',
+]);
+type MastraCodeOMEvent = Extract<
+  HarnessEvent,
+  {
+    type:
+      | 'om_status'
+      | 'om_observation_start'
+      | 'om_observation_end'
+      | 'om_observation_failed'
+      | 'om_reflection_start'
+      | 'om_reflection_end'
+      | 'om_reflection_failed'
+      | 'om_buffering_start'
+      | 'om_buffering_end'
+      | 'om_buffering_failed';
+  }
+>;
+
+type AgentWithBrowser = {
+  setBrowser?: (browser: unknown) => void;
+  hasOwnBrowser?: () => boolean;
+};
+
+type SignalInput =
+  | {
+      content: string | HarnessMessageContentPart[];
+      ifActive?: { attributes?: SignalDeliveryAttributes };
+      ifIdle?: { attributes?: SignalDeliveryAttributes };
+    }
+  | {
+      type: string;
+      contents: string | HarnessMessageContentPart[];
+      attributes?: Record<string, unknown>;
+      metadata?: Record<string, unknown>;
+    };
+
+interface SignalHandle {
+  id: string;
+  accepted: Promise<unknown>;
+}
+
+function normalizeMessageContent(input: SignalInput): string {
+  if ('content' in input) {
+    if (typeof input.content === 'string') return input.content;
+    return input.content.map(part => (part.type === 'text' ? part.text : `[${part.type}]`)).join('\n');
+  }
+
+  const contents =
+    typeof input.contents === 'string'
+      ? input.contents
+      : input.contents.map(part => (part.type === 'text' ? part.text : `[${part.type}]`)).join('\n');
+  if (input.type === 'system-reminder') {
+    const reminderType = typeof input.attributes?.type === 'string' ? ` type="${input.attributes.type}"` : '';
+    return `<system-reminder${reminderType}>${contents}</system-reminder>`;
+  }
+  return contents;
+}
+
+function signalContents(input: SignalInput): string | HarnessMessageContentPart[] {
+  return 'content' in input ? input.content : input.contents;
+}
+
+function messageContents(content: string, files?: unknown[]): string | HarnessMessageContentPart[] {
+  if (!files?.length) return content;
+  const parts: HarnessMessageContentPart[] = [{ type: 'text', text: content }];
+  for (const file of files) {
+    if (!file || typeof file !== 'object') continue;
+    const value = file as Record<string, unknown>;
+    const media =
+      typeof value.mimeType === 'string'
+        ? { mediaType: value.mimeType }
+        : typeof value.mediaType === 'string'
+          ? { mediaType: value.mediaType }
+          : {};
+    const mediaType = media.mediaType ?? 'application/octet-stream';
+    if (typeof value.data === 'string') {
+      parts.push({ type: 'file', data: value.data, mediaType });
+    } else if (typeof value.url === 'string') {
+      parts.push({ type: 'text', text: value.url });
+    } else if (value.file !== undefined) {
+      parts.push({ type: 'text', text: String(value.file) });
+    }
+  }
+  return parts;
+}
+
+function fileUploadData(value: Record<string, unknown>): Uint8Array | undefined {
+  if (value.data instanceof Uint8Array) return value.data;
+  if (value.data instanceof ArrayBuffer) return new Uint8Array(value.data);
+  if (typeof value.data === 'string') return new TextEncoder().encode(value.data);
+  return undefined;
+}
+
+function fileContentType(value: Record<string, unknown>): string {
+  return typeof value.mimeType === 'string'
+    ? value.mimeType
+    : typeof value.mediaType === 'string'
+      ? value.mediaType
+      : 'application/octet-stream';
+}
+
+function fileName(value: Record<string, unknown>, index: number): string {
+  if (typeof value.name === 'string' && value.name.length > 0) return value.name;
+  if (typeof value.filename === 'string' && value.filename.length > 0) return value.filename;
+  if (typeof value.path === 'string' && value.path.length > 0) return value.path.split(/[\\/]/).pop() || value.path;
+  return `attachment-${index + 1}`;
+}
+
+function isHarnessSessionLifecycleError(error: unknown): boolean {
+  return error instanceof Error && HARNESS_SESSION_LIFECYCLE_ERROR_NAMES.has(error.name);
+}
+
+function toLegacyThread(thread: ThreadRecord): HarnessThread {
+  return {
+    id: thread.id,
+    resourceId: thread.resourceId,
+    title: thread.title,
+    createdAt: thread.createdAt,
+    updatedAt: thread.updatedAt,
+    metadata: thread.metadata,
+  };
+}
+
+function toStoredThread(thread: {
+  id: string;
+  resourceId: string;
+  title?: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  metadata?: Record<string, unknown>;
+}): HarnessThread {
+  return {
+    id: thread.id,
+    resourceId: thread.resourceId,
+    title: thread.title ?? undefined,
+    createdAt: thread.createdAt,
+    updatedAt: thread.updatedAt,
+    metadata: thread.metadata,
+  };
+}
+
+function providerFromModelId(modelId: string): string {
+  return modelId.split('/')[0] ?? '';
+}
+
+function toSystemReminderAttributes(
+  attributes?: Record<string, unknown>,
+): Record<string, string | number | boolean | null | undefined> | undefined {
+  if (!attributes) return undefined;
+  const normalized: Record<string, string | number | boolean | null | undefined> = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean' ||
+      value === null ||
+      value === undefined
+    ) {
+      normalized[key] = value;
+    }
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function recordToMap<T>(value: unknown): Map<string, T> {
+  if (value instanceof Map) return new Map(value);
+  if (value && typeof value === 'object') return new Map(Object.entries(value as Record<string, T>));
+  return new Map();
+}
+
+function cloneTasks(value: unknown): TaskItemSnapshot[] {
+  return Array.isArray(value) ? [...(value as TaskItemSnapshot[])] : [];
+}
+
+function toHarnessMessage(message: any): HarnessMessage {
+  return convertStoredMessageToHarnessMessage(message as StoredMessageRow);
+}
+
+export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
+  readonly core: HarnessV1;
+  readonly mastra: Mastra;
+
+  private session?: Session;
+  private resourceId: string;
+  private readonly defaultResourceId: string;
+  private readonly modes: LegacyHarnessMode<TState>[];
+  private readonly defaultModeId: string;
+  private currentModeId: string;
+  private state: TState;
+  private readonly listeners = new Set<HarnessEventListener>();
+  private readonly projector: MastraCodeHarnessEventProjector;
+  private sessionEventUnsubscribe?: HarnessV1EventUnsubscribe;
+  private readonly heartbeatTimers = new Map<string, ReturnType<typeof setInterval>>();
+  private readonly heartbeatHandlers = new Map<
+    string,
+    NonNullable<MastraCodeRuntimeConfig<TState>['heartbeatHandlers']>[number]
+  >();
+  private currentWorkspace: Awaited<ReturnType<Session['getWorkspace']>> | undefined;
+  private followUpCount = 0;
+  private currentRunId: string | null = null;
+  private currentTraceId: string | null = null;
+  private readonly omProgress: OMProgressState = defaultDisplayState().omProgress;
+  private bufferingMessages = false;
+  private bufferingObservations = false;
+  private stateUpdateQueue: Promise<void> = Promise.resolve();
+  private previousDisplayTasks: TaskItemSnapshot[] = [];
+  private currentDisplayTasks: TaskItemSnapshot[] = [];
+  private readonly activeToolCalls = new Map<string, { name: string; args?: unknown }>();
+  private readonly modifiedFiles = new Map<string, { operations: string[]; firstModified: Date }>();
+  private harnessEventUnsubscribe?: HarnessV1EventUnsubscribe;
+  private browser: unknown;
+
+  readonly actions = Object.freeze({
+    list: (options?: unknown) => this.requireSession().actions.list(options as never),
+    search: (query: string, options?: unknown) => this.requireSession().actions.search(query, options as never),
+    refresh: () => this.requireSession().actions.refresh(),
+  });
+
+  readonly mcp = Object.freeze({
+    listServers: () => this.requireSession().mcp.listServers(),
+    getServer: (key: string) => this.requireSession().mcp.getServer(key),
+    listTools: (key: string) => this.requireSession().mcp.listTools(key),
+  });
+
+  constructor(private readonly config: MastraCodeRuntimeConfig<TState>) {
+    this.resourceId = config.resourceId;
+    this.defaultResourceId = config.resourceId;
+    this.modes = config.modes;
+    this.defaultModeId = resolveDefaultModeId(config.modes);
+    this.currentModeId = this.defaultModeId;
+    this.state = { ...config.initialState };
+    this.currentDisplayTasks = cloneTasks(this.state.tasks);
+    const harnessV1Agents = toHarnessV1Agents(config.agents, config.modes);
+    const exposedSubagents = this.shouldExposeSubagentTool() ? config.subagents : [];
+    const harnessV1Subagents =
+      exposedSubagents.length > 0 ? { types: toHarnessV1Subagents(exposedSubagents) } : undefined;
+
+    this.core = new HarnessV1({
+      runtimeCompatibilityGeneration: MASTRACODE_RUNTIME_COMPATIBILITY_GENERATION,
+      modes: toHarnessV1Modes(config.modes, harnessV1Agents, this.defaultModeId, exposedSubagents),
+      subagents: harnessV1Subagents,
+      defaultModeId: this.defaultModeId,
+      toolCategoryResolver: config.toolCategoryResolver,
+      models: [],
+      modelAuthStatusResolver: modelId => this.resolveHarnessV1AuthStatus(modelId),
+      workspace: config.workspace
+        ? {
+            kind: 'shared' as const,
+            workspace: ({ requestContext }) => config.workspace!({ requestContext, mastra: this.mastra }),
+          }
+        : undefined,
+    });
+
+    this.mastra = new Mastra({
+      agents: harnessV1Agents,
+      storage: config.storage,
+      observability: config.observability,
+      workers: false,
+      harnesses: { [MASTRACODE_HARNESS_NAME]: this.core },
+    });
+
+    if (config.browser && typeof config.browser !== 'function') {
+      this.setBrowser(config.browser);
+    }
+
+    this.projector = new MastraCodeHarnessEventProjector(
+      event => this.emit(event),
+      () => this.getDisplayState(),
+      async (threadId, resourceId) => {
+        const thread = await this.core.threads.get({ threadId, resourceId });
+        return thread ? toLegacyThread(thread) : undefined;
+      },
+    );
+
+    for (const handler of config.heartbeatHandlers ?? []) {
+      this.registerHeartbeat(handler);
+    }
+  }
+
+  getMastra(): Mastra {
+    return this.mastra;
+  }
+
+  async init(): Promise<void> {
+    await this.initCore();
+    await this.selectOrCreateThread();
+  }
+
+  async initCore(): Promise<void> {
+    await this.core.init();
+    if (!this.harnessEventUnsubscribe) {
+      this.harnessEventUnsubscribe = this.core.subscribe(event => {
+        if (!this.isThreadLifecycleEventForCurrentResource(event)) return;
+        void this.projector.project(event).catch(error => this.emitNonLifecycleError(error));
+      });
+    }
+  }
+
+  subscribe(listener: HarnessEventListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private emit(event: HarnessEvent): void {
+    for (const listener of this.listeners) {
+      try {
+        void listener(event);
+      } catch (error) {
+        console.error('MastraCode Harness event listener failed', error);
+      }
+    }
+  }
+
+  private async handleCoreEvent(event: HarnessV1Event): Promise<void> {
+    if ('runId' in event && typeof event.runId === 'string') this.currentRunId = event.runId;
+    if ('traceId' in event && typeof event.traceId === 'string') this.currentTraceId = event.traceId;
+    this.currentTraceId = this.getSessionDisplayState()?.currentTraceId ?? this.currentTraceId;
+    if (event.type === 'state_changed' && this.session) {
+      try {
+        this.applyLocalState((await this.session.getState<TState>()) as Partial<TState>, { emitLegacy: false });
+      } catch (error) {
+        if (!isHarnessSessionLifecycleError(error)) throw error;
+      }
+    }
+    if (event.type === 'mode_changed') {
+      this.currentModeId = event.modeId;
+      await this.setThreadSetting({ key: 'currentModeId', value: event.modeId }).catch(error =>
+        this.emitNonLifecycleError(error),
+      );
+    }
+    if (event.type === 'model_changed') {
+      this.applyLocalState({ currentModelId: event.modelId } as unknown as Partial<TState>, { emitLegacy: false });
+    }
+    if (event.type === 'task_updated') {
+      this.previousDisplayTasks = [...this.currentDisplayTasks];
+      this.currentDisplayTasks = cloneTasks((event as { tasks?: unknown }).tasks);
+    }
+    this.applyModifiedFileEvent(event);
+    this.applyOMEvent(event as HarnessV1Event | MastraCodeOMEvent);
+    await this.projector.project(event);
+  }
+
+  private applyModifiedFileEvent(event: HarnessV1Event): void {
+    if (event.type === 'tool_start') {
+      this.activeToolCalls.set(event.toolCallId, { name: event.toolName, args: event.args });
+      return;
+    }
+    if (event.type === 'subagent_tool_start') {
+      this.activeToolCalls.set(event.innerToolCallId, { name: event.toolName, args: event.args });
+      return;
+    }
+    const endedToolCallId =
+      event.type === 'tool_end' ? event.toolCallId : event.type === 'subagent_tool_end' ? event.innerToolCallId : null;
+    if (!endedToolCallId) return;
+    const isError = event.type === 'tool_end' || event.type === 'subagent_tool_end' ? event.isError : false;
+
+    const tool = this.activeToolCalls.get(endedToolCallId);
+    this.activeToolCalls.delete(endedToolCallId);
+    if (!tool || isError || !isHarnessWorkspaceFileMutationTool(tool.name)) return;
+
+    const filePath = getHarnessWorkspaceActionPathInput(tool.name, tool.args as Record<string, unknown>);
+    if (!filePath) return;
+
+    const existing = this.modifiedFiles.get(filePath);
+    if (existing) {
+      existing.operations.push(tool.name);
+      void this.refreshModifiedFilesFromWorkspaceJournal();
+      return;
+    }
+    this.modifiedFiles.set(filePath, {
+      operations: [tool.name],
+      firstModified: new Date(),
+    });
+    void this.refreshModifiedFilesFromWorkspaceJournal();
+  }
+
+  private async refreshModifiedFilesFromWorkspaceJournal(): Promise<void> {
+    const session = this.session;
+    if (!session) return;
+    const harnessStorage = (await this.config.storage.getStore('harness')) as
+      | {
+          listWorkspaceActionJournalEntries?: (input: {
+            harnessName?: string;
+            sessionId: string;
+            resourceId: string;
+            threadId?: string;
+            actionKind?: WorkspaceActionJournalEntry['actionKind'];
+            limit: number;
+          }) => Promise<WorkspaceActionJournalEntry[]>;
+        }
+      | undefined;
+    if (!harnessStorage?.listWorkspaceActionJournalEntries) return;
+
+    const entries = await harnessStorage.listWorkspaceActionJournalEntries({
+      harnessName: MASTRACODE_HARNESS_NAME,
+      sessionId: session.id,
+      resourceId: this.resourceId,
+      threadId: session.threadId,
+      actionKind: 'file',
+      limit: 500,
+    });
+
+    const next = new Map<string, { operations: string[]; firstModified: Date }>();
+    for (const entry of entries) {
+      this.mergeModifiedFileJournalEntry(next, entry.path, entry.operation, entry.createdAt);
+      this.mergeModifiedFileJournalEntry(next, entry.toPath, entry.operation, entry.createdAt);
+    }
+    for (const [path, value] of next) {
+      this.modifiedFiles.set(path, value);
+    }
+  }
+
+  private mergeModifiedFileJournalEntry(
+    target: Map<string, { operations: string[]; firstModified: Date }>,
+    path: WorkspaceActionJournalEntry['path'],
+    operation: string | undefined,
+    createdAt: number,
+  ): void {
+    const filePath = path?.relativePath || path?.path;
+    if (!filePath) return;
+    const existing = target.get(filePath);
+    if (existing) {
+      if (operation) existing.operations.push(operation);
+      return;
+    }
+    target.set(filePath, {
+      operations: operation ? [operation] : [],
+      firstModified: new Date(createdAt),
+    });
+  }
+
+  private isThreadLifecycleEventForCurrentResource(
+    event: HarnessV1Event,
+  ): event is Extract<HarnessV1Event, { type: 'thread_created' | 'thread_cloned' | 'thread_renamed' }> {
+    return (
+      (event.type === 'thread_created' || event.type === 'thread_cloned' || event.type === 'thread_renamed') &&
+      event.resourceId === this.resourceId
+    );
+  }
+
+  private applyOMEvent(event: HarnessV1Event | MastraCodeOMEvent): void {
+    switch (event.type) {
+      case 'om_status': {
+        const w = event.windows;
+        this.omProgress.pendingTokens = w.active.messages.tokens;
+        this.omProgress.threshold = w.active.messages.threshold;
+        this.omProgress.thresholdPercent =
+          w.active.messages.threshold > 0 ? (w.active.messages.tokens / w.active.messages.threshold) * 100 : 0;
+        this.omProgress.observationTokens = w.active.observations.tokens;
+        this.omProgress.reflectionThreshold = w.active.observations.threshold;
+        this.omProgress.reflectionThresholdPercent =
+          w.active.observations.threshold > 0
+            ? (w.active.observations.tokens / w.active.observations.threshold) * 100
+            : 0;
+        this.omProgress.buffered = {
+          observations: { ...w.buffered.observations },
+          reflection: { ...w.buffered.reflection },
+        };
+        this.omProgress.generationCount = event.generationCount;
+        this.omProgress.stepNumber = event.stepNumber;
+        this.bufferingMessages = w.buffered.observations.status === 'running';
+        this.bufferingObservations = w.buffered.reflection.status === 'running';
+        break;
+      }
+      case 'om_observation_start':
+        this.omProgress.status = 'observing';
+        this.omProgress.cycleId = event.cycleId;
+        this.omProgress.startTime = Date.now();
+        break;
+      case 'om_observation_end':
+        this.omProgress.status = 'idle';
+        this.omProgress.cycleId = undefined;
+        this.omProgress.startTime = undefined;
+        this.omProgress.observationTokens = event.observationTokens;
+        this.omProgress.pendingTokens = 0;
+        this.omProgress.thresholdPercent = 0;
+        break;
+      case 'om_observation_failed':
+        this.omProgress.status = 'idle';
+        this.omProgress.cycleId = undefined;
+        this.omProgress.startTime = undefined;
+        break;
+      case 'om_reflection_start':
+        this.omProgress.status = 'reflecting';
+        this.omProgress.cycleId = event.cycleId;
+        this.omProgress.startTime = Date.now();
+        this.omProgress.preReflectionTokens = this.omProgress.observationTokens;
+        this.omProgress.observationTokens = event.tokensToReflect;
+        this.omProgress.reflectionThresholdPercent =
+          this.omProgress.reflectionThreshold > 0
+            ? (event.tokensToReflect / this.omProgress.reflectionThreshold) * 100
+            : 0;
+        break;
+      case 'om_reflection_end':
+        this.omProgress.status = 'idle';
+        this.omProgress.cycleId = undefined;
+        this.omProgress.startTime = undefined;
+        this.omProgress.observationTokens = event.compressedTokens;
+        this.omProgress.reflectionThresholdPercent =
+          this.omProgress.reflectionThreshold > 0
+            ? (event.compressedTokens / this.omProgress.reflectionThreshold) * 100
+            : 0;
+        break;
+      case 'om_reflection_failed':
+        this.omProgress.status = 'idle';
+        this.omProgress.cycleId = undefined;
+        this.omProgress.startTime = undefined;
+        break;
+      case 'om_buffering_start':
+        if (event.operationType === 'reflection') {
+          this.bufferingObservations = true;
+          this.omProgress.buffered.reflection.status = 'running';
+          this.omProgress.buffered.reflection.inputObservationTokens = event.tokensToBuffer;
+        } else {
+          this.bufferingMessages = true;
+          this.omProgress.buffered.observations.status = 'running';
+          this.omProgress.buffered.observations.messageTokens = event.tokensToBuffer;
+        }
+        break;
+      case 'om_buffering_end':
+        if (event.operationType === 'reflection') {
+          this.bufferingObservations = false;
+          this.omProgress.buffered.reflection.status = 'complete';
+          this.omProgress.buffered.reflection.observationTokens = event.bufferedTokens;
+        } else {
+          this.bufferingMessages = false;
+          this.omProgress.buffered.observations.status = 'complete';
+          this.omProgress.buffered.observations.observationTokens = event.bufferedTokens;
+        }
+        break;
+      case 'om_buffering_failed':
+        if (event.operationType === 'reflection') {
+          this.bufferingObservations = false;
+          this.omProgress.buffered.reflection.status = 'idle';
+        } else {
+          this.bufferingMessages = false;
+          this.omProgress.buffered.observations.status = 'idle';
+        }
+        break;
+    }
+  }
+
+  async selectOrCreateThread(): Promise<HarnessThread> {
+    const existing = await this.core.threads.list({
+      resourceId: this.resourceId,
+      perPage: false,
+      orderBy: { column: 'updatedAt', direction: 'DESC' },
+    });
+    const projectPath = typeof this.state.projectPath === 'string' ? this.state.projectPath : undefined;
+    const existingThread = projectPath
+      ? existing.threads.find(thread => thread.metadata?.projectPath === projectPath)
+      : existing.threads[0];
+    const thread =
+      existingThread ??
+      (await this.core.threads.create({
+        resourceId: this.resourceId,
+        title: 'New thread',
+        metadata: this.buildThreadMetadata(),
+      }));
+    await this.applyThreadMetadata(thread.metadata, { persist: false });
+    this.bindActiveSession(
+      await this.core.session({
+        resourceId: this.resourceId,
+        threadId: thread.id,
+        modeId: this.currentModeId,
+        modelId: this.resolveModeModel(this.currentModeId),
+      }),
+    );
+    await this.ensureSessionState();
+    await this.syncSessionControls();
+    await this.resolveWorkspace().catch(() => undefined);
+    return toLegacyThread(thread);
+  }
+
+  async createThread({ title }: { title?: string } = {}): Promise<HarnessThread> {
+    const thread = await this.core.threads.create({
+      resourceId: this.resourceId,
+      title: title ?? 'New thread',
+      metadata: this.buildThreadMetadata(),
+    });
+    await this.applyThreadMetadata(thread.metadata, { persist: false });
+    this.bindActiveSession(
+      await this.core.session({
+        resourceId: this.resourceId,
+        threadId: thread.id,
+        modeId: this.currentModeId,
+        modelId: this.resolveModeModel(this.currentModeId),
+      }),
+    );
+    await this.ensureSessionState();
+    await this.syncSessionControls();
+    await this.resolveWorkspace().catch(() => undefined);
+    return toLegacyThread(thread);
+  }
+
+  async switchThread({ threadId }: { threadId: string }): Promise<void> {
+    if (this.isRunning()) this.abort();
+    const previousThreadId = this.session?.threadId ?? null;
+    const thread = await this.core.threads.get({ resourceId: this.resourceId, threadId });
+    if (!thread) {
+      throw new Error(`Thread not found: ${threadId}`);
+    }
+    await this.applyThreadMetadata(thread.metadata, { persist: false });
+    this.bindActiveSession(
+      await this.core.session({
+        resourceId: this.resourceId,
+        threadId,
+        modeId: this.currentModeId,
+        modelId: this.resolveModeModel(this.currentModeId),
+      }),
+    );
+    await this.ensureSessionState();
+    await this.syncSessionControls();
+    await this.resolveWorkspace().catch(() => undefined);
+    this.emit({ type: 'thread_changed', threadId, previousThreadId } as unknown as HarnessEvent);
+  }
+
+  async cloneThread({
+    threadId,
+    sourceThreadId,
+    title,
+    resourceId,
+  }: {
+    threadId?: string;
+    sourceThreadId?: string;
+    title?: string;
+    resourceId?: string;
+  } = {}): Promise<HarnessThread> {
+    const sourceId = sourceThreadId ?? threadId ?? this.requireSession().threadId;
+    const cloned = await this.core.threads.clone({
+      resourceId: resourceId ?? this.resourceId,
+      threadId: sourceId,
+      title,
+    });
+    if (cloned.resourceId !== this.resourceId) {
+      this.resourceId = cloned.resourceId;
+    }
+    await this.switchThread({ threadId: cloned.id });
+    return toLegacyThread(cloned);
+  }
+
+  async renameThread({ title }: { title: string }): Promise<void> {
+    const session = this.requireSession();
+    await this.core.threads.rename({ resourceId: this.resourceId, threadId: session.threadId, title });
+  }
+
+  async listThreads(options?: { allResources?: boolean; includeForkedSubagents?: boolean }): Promise<HarnessThread[]> {
+    if (options?.allResources) {
+      const memory = await this.getMemoryStorage();
+      const result = await memory.listThreads({
+        filter: undefined,
+        perPage: false,
+        orderBy: { field: 'updatedAt', direction: 'DESC' },
+      });
+      return result.threads
+        .filter((thread: any) => options.includeForkedSubagents || thread.metadata?.forkedSubagent !== true)
+        .map(toStoredThread);
+    }
+
+    const result = await this.core.threads.list({ resourceId: this.resourceId, perPage: false });
+    return result.threads
+      .filter(thread => options?.includeForkedSubagents || thread.metadata?.forkedSubagent !== true)
+      .map(toLegacyThread)
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+  }
+
+  async setThreadSetting({ key, value }: { key: string; value: unknown }): Promise<void> {
+    const session = this.requireSession();
+    await this.core.threads.setSettings({
+      resourceId: this.resourceId,
+      threadId: session.threadId,
+      patch: { [key]: value },
+    });
+  }
+
+  getCurrentThreadId(): string | null {
+    return this.session?.threadId ?? null;
+  }
+
+  getResourceId(): string {
+    return this.resourceId;
+  }
+
+  setResourceId({ resourceId }: { resourceId: string }): void {
+    if (this.resourceId === resourceId) return;
+    this.resourceId = resourceId;
+    this.clearActiveSession();
+    this.currentWorkspace = undefined;
+  }
+
+  getDefaultResourceId(): string {
+    return this.defaultResourceId;
+  }
+
+  async getKnownResourceIds(): Promise<string[]> {
+    const ids = new Set(
+      (await this.listThreads({ allResources: true, includeForkedSubagents: true })).map(thread => thread.resourceId),
+    );
+    ids.add(this.defaultResourceId);
+    ids.add(this.resourceId);
+    return [...ids].sort();
+  }
+
+  getState(): Readonly<TState> {
+    return this.state;
+  }
+
+  async setState(updates: Partial<TState>): Promise<void> {
+    const nextUpdate = this.stateUpdateQueue.then(async () => {
+      this.applyLocalState(updates);
+      if (this.session) {
+        await this.session.setState(this.state);
+      }
+    });
+    this.stateUpdateQueue = nextUpdate.catch(error => {
+      console.error('MastraCode Harness state update failed', error);
+    });
+    return nextUpdate;
+  }
+
+  private applyLocalState(updates: Partial<TState>, options: { emitLegacy?: boolean } = {}): void {
+    this.state = { ...this.state, ...updates };
+    if (Object.prototype.hasOwnProperty.call(updates, 'tasks')) {
+      this.previousDisplayTasks = [...this.currentDisplayTasks];
+      this.currentDisplayTasks = cloneTasks((updates as Record<string, unknown>).tasks);
+    }
+    if (options.emitLegacy ?? true) {
+      this.emit({
+        type: 'state_changed',
+        state: this.state,
+        changedKeys: Object.keys(updates),
+      } as unknown as HarnessEvent);
+    }
+  }
+
+  listModes(): LegacyHarnessMode<TState>[] {
+    return this.modes;
+  }
+
+  getCurrentModeId(): string {
+    return this.currentModeId;
+  }
+
+  getCurrentMode(): LegacyHarnessMode<TState> {
+    const mode = this.modes.find(entry => entry.id === this.currentModeId);
+    if (mode) return mode;
+    const fallback = this.modes[0];
+    if (!fallback) {
+      throw new Error('No modes configured for MastraCode Harness runtime');
+    }
+    return fallback;
+  }
+
+  async switchMode({ modeId }: { modeId: string }): Promise<void> {
+    if (!this.modes.some(mode => mode.id === modeId)) {
+      throw new Error(`Mode not found: ${modeId}`);
+    }
+    if (this.isRunning()) this.abort();
+    const currentModelId = this.getCurrentModelId();
+    if (currentModelId) {
+      await this.setThreadSetting({ key: `modeModelId_${this.currentModeId}`, value: currentModelId });
+    }
+    this.currentModeId = modeId;
+    const session = this.requireSession();
+    await session.switchMode({ mode: modeId });
+    await this.setThreadSetting({ key: 'currentModeId', value: modeId });
+    await this.switchModel({ modelId: await this.loadModeModelId(modeId), modeId });
+  }
+
+  getCurrentModelId(): string {
+    return typeof this.state.currentModelId === 'string' ? this.state.currentModelId : '';
+  }
+
+  getModelName(): string {
+    const modelId = this.getCurrentModelId();
+    return modelId.split('/').pop() || modelId || 'unknown';
+  }
+
+  getFullModelId(): string {
+    return this.getCurrentModelId();
+  }
+
+  hasModelSelected(): boolean {
+    return this.getCurrentModelId().length > 0;
+  }
+
+  async switchModel({
+    modelId,
+    scope = 'thread',
+    modeId,
+  }: {
+    modelId: string;
+    scope?: 'global' | 'thread';
+    modeId?: string;
+  }): Promise<void> {
+    const targetModeId = modeId ?? this.currentModeId;
+    if (targetModeId === this.currentModeId) {
+      this.applyLocalState({ currentModelId: modelId } as unknown as Partial<TState>);
+      await this.requireSession().models.switch({ model: modelId });
+    }
+    if (scope === 'thread') {
+      await this.setThreadSetting({ key: `modeModelId_${targetModeId}`, value: modelId });
+    }
+    await Promise.resolve(this.config.modelUseCountTracker?.(modelId)).catch(error => {
+      console.error('Failed to persist model usage count', error);
+    });
+  }
+
+  async listAvailableModels(): Promise<AvailableModel[]> {
+    const registry = PROVIDER_REGISTRY as Record<
+      string,
+      { models?: string[]; name?: string; apiKeyEnvVar?: string | string[] }
+    >;
+    const useCounts = this.config.modelUseCountProvider?.() ?? {};
+    const modelsById = new Map<string, AvailableModel>();
+    const upsert = (model: Omit<AvailableModel, 'useCount'>) => {
+      if (!model.id || !model.provider || !model.modelName) return;
+      modelsById.set(model.id, { ...model, useCount: useCounts[model.id] ?? 0 });
+    };
+
+    for (const [provider, providerConfig] of Object.entries(registry)) {
+      const envVars = providerConfig.apiKeyEnvVar;
+      const apiKeyEnvVar = Array.isArray(envVars) ? envVars[0] : envVars;
+      let hasApiKey = apiKeyEnvVar ? Boolean(process.env[apiKeyEnvVar]) : false;
+      const customAuth = this.config.modelAuthChecker?.(provider);
+      if (customAuth === true) hasApiKey = true;
+      if (customAuth === false) hasApiKey = false;
+      for (const modelName of providerConfig.models ?? []) {
+        upsert({ id: `${provider}/${modelName}`, provider, modelName, hasApiKey, apiKeyEnvVar });
+      }
+    }
+
+    for (const customModel of (await Promise.resolve(this.config.customModelCatalogProvider?.()).catch(() => [])) ??
+      []) {
+      upsert(customModel);
+    }
+
+    return [...modelsById.values()];
+  }
+
+  async getCurrentModelAuthStatus(): Promise<ModelAuthStatus> {
+    const modelId = this.getCurrentModelId();
+    const model = (await this.listAvailableModels()).find(entry => entry.id === modelId);
+    if (model) return model.hasApiKey ? { hasAuth: true } : { hasAuth: false, apiKeyEnvVar: model.apiKeyEnvVar };
+    const provider = providerFromModelId(modelId);
+    const customAuth = provider ? this.config.modelAuthChecker?.(provider) : true;
+    if (customAuth === true || customAuth === undefined) return { hasAuth: true };
+    return { hasAuth: false };
+  }
+
+  getSubagentModelId({ agentType }: { agentType?: string } = {}): string | null {
+    if (!agentType) return (this.state.subagentModelId as string | undefined) ?? null;
+    return (
+      this.session?.models.getSubagent({ agentType }) ??
+      (this.state[`subagentModelId_${agentType}`] as string | undefined) ??
+      null
+    );
+  }
+
+  async setSubagentModelId({ modelId, agentType }: { modelId: string; agentType?: string }): Promise<void> {
+    const key = agentType ? `subagentModelId_${agentType}` : 'subagentModelId';
+    if (agentType) {
+      await this.requireSession().models.setSubagent({ agentType, model: modelId });
+    }
+    await this.setState({ [key]: modelId } as unknown as Partial<TState>);
+    if (!agentType) {
+      await this.syncSubagentModelOverrides(this.requireSession());
+    }
+    await this.setThreadSetting({ key, value: modelId });
+    this.emit({ type: 'subagent_model_changed', modelId, scope: 'thread', agentType } as unknown as HarnessEvent);
+  }
+
+  getObserverModelId(): string | undefined {
+    return getOMModelState(this.state).observerModelId;
+  }
+
+  getReflectorModelId(): string | undefined {
+    return getOMModelState(this.state).reflectorModelId;
+  }
+
+  getObservationThreshold(): number | undefined {
+    return getOMModelState(this.state).observationThreshold;
+  }
+
+  getReflectionThreshold(): number | undefined {
+    return getOMModelState(this.state).reflectionThreshold;
+  }
+
+  async switchObserverModel({ modelId }: { modelId: string }): Promise<void> {
+    await this.setState({ observerModelId: modelId } as unknown as Partial<TState>);
+    await this.setThreadSetting({ key: 'observerModelId', value: modelId });
+    this.emit({ type: 'om_model_changed', role: 'observer', modelId } as unknown as HarnessEvent);
+  }
+
+  async switchReflectorModel({ modelId }: { modelId: string }): Promise<void> {
+    await this.setState({ reflectorModelId: modelId } as unknown as Partial<TState>);
+    await this.setThreadSetting({ key: 'reflectorModelId', value: modelId });
+    this.emit({ type: 'om_model_changed', role: 'reflector', modelId } as unknown as HarnessEvent);
+  }
+
+  setPermissionForCategory({ category, policy }: { category: ToolCategory; policy: PermissionPolicy }): void {
+    void this.requireSession()
+      .permissions.setPolicy({ category, policy })
+      .catch(error => this.emitError(error));
+    void this.mirrorPermissionRule('categories', category, policy);
+  }
+
+  setPermissionForTool({ toolName, policy }: { toolName: string; policy: PermissionPolicy }): void {
+    void this.requireSession()
+      .permissions.setPolicy({ toolName, policy })
+      .catch(error => this.emitError(error));
+    void this.mirrorPermissionRule('tools', toolName, policy);
+  }
+
+  grantSessionCategory({ category }: { category: ToolCategory }): void {
+    void this.requireSession()
+      .permissions.grantCategory({ category })
+      .catch(error => this.emitError(error));
+  }
+
+  grantSessionTool({ toolName }: { toolName: string }): void {
+    void this.requireSession()
+      .permissions.grantTool({ toolName })
+      .catch(error => this.emitError(error));
+  }
+
+  getSessionGrants() {
+    return this.requireSession().permissions.getGrants();
+  }
+
+  getPermissionRules() {
+    return this.requireSession().permissions.getRules();
+  }
+
+  private async mirrorPermissionRule(
+    kind: 'categories' | 'tools',
+    key: string,
+    policy: PermissionPolicy,
+  ): Promise<void> {
+    const current =
+      (this.state.permissionRules as
+        | { categories?: Record<string, PermissionPolicy>; tools?: Record<string, PermissionPolicy> }
+        | undefined) ?? {};
+    await this.setState({
+      permissionRules: {
+        categories: { ...(current.categories ?? {}) },
+        tools: { ...(current.tools ?? {}) },
+        [kind]: { ...(current[kind] ?? {}), [key]: policy },
+      },
+    } as unknown as Partial<TState>);
+  }
+
+  getToolCategory({ toolName }: { toolName: string }): ToolCategory | null {
+    return this.config.toolCategoryResolver?.(toolName) ?? null;
+  }
+
+  sendSignal(input: SignalInput): SignalHandle {
+    if ('type' in input && input.type === 'system-reminder') {
+      const handle: SignalHandle = { id: `signal-${randomUUID()}`, accepted: Promise.resolve() };
+      handle.accepted = this.ensureSession()
+        .then(session =>
+          session.injectSystemReminder(normalizeMessageContent({ content: input.contents }), {
+            attributes: toSystemReminderAttributes(input.attributes),
+            metadata: input.metadata,
+          }),
+        )
+        .then(result => {
+          handle.id = result.id;
+          return result;
+        });
+      return handle;
+    }
+
+    const handle: SignalHandle = { id: `signal-${randomUUID()}`, accepted: Promise.resolve() };
+    handle.accepted = this.ensureSession()
+      .then(session =>
+        session.signal({
+          content: signalContents(input) as never,
+          signalId: handle.id,
+          ...('content' in input && input.ifActive ? { ifActive: input.ifActive } : {}),
+          ...('content' in input && input.ifIdle ? { ifIdle: input.ifIdle } : {}),
+        } as never),
+      )
+      .then(result => {
+        handle.id = result.id;
+        return result;
+      });
+    return handle;
+  }
+
+  async sendMessage({
+    content,
+    files,
+    admissionId,
+  }: {
+    content: string;
+    files?: unknown[];
+    admissionId?: string;
+  }): Promise<void> {
+    const session = await this.ensureSession();
+    await this.ensureSessionState();
+    await this.syncSessionControls();
+    const { attachments, inlineFiles } = await this.uploadMessageAttachments(session, files);
+    await session.message({
+      content: messageContents(content, inlineFiles),
+      ...(attachments.length > 0 ? { attachments } : {}),
+      ...((this.state as Record<string, unknown>).yolo === true ? { yolo: true } : {}),
+      ...(admissionId ? { admissionId } : {}),
+      ...(admissionId ? {} : { prepareStep: this.prepareActiveToolsStep }),
+    } as never);
+  }
+
+  async listMessages(options?: { limit?: number }): Promise<HarnessMessage[]> {
+    return this.requireSession().listMessages(options);
+  }
+
+  async listMessagesForThread({ threadId, limit }: { threadId: string; limit?: number }): Promise<HarnessMessage[]> {
+    const memory = await this.getMemoryStorage();
+    if (limit) {
+      const result = await memory.listMessages({
+        threadId,
+        perPage: limit,
+        page: 0,
+        orderBy: { field: 'createdAt', direction: 'DESC' },
+      });
+      return result.messages.map(toHarnessMessage).reverse();
+    }
+    const result = await memory.listMessages({ threadId, perPage: false });
+    return result.messages.map(toHarnessMessage);
+  }
+
+  async getFirstUserMessagesForThreads({ threadIds }: { threadIds: string[] }): Promise<Map<string, HarnessMessage>> {
+    if (threadIds.length === 0) return new Map();
+    const memory = await this.getMemoryStorage();
+    const result = await memory.listMessages({
+      threadId: threadIds,
+      perPage: false,
+      orderBy: { field: 'createdAt', direction: 'ASC' },
+    });
+    const messages = new Map<string, HarnessMessage>();
+    for (const message of result.messages) {
+      if (message.role !== 'user' && message.role !== 'signal') continue;
+      if (!message.threadId || messages.has(message.threadId)) continue;
+      messages.set(message.threadId, toHarnessMessage(message));
+      if (messages.size === threadIds.length) break;
+    }
+    return messages;
+  }
+
+  async getFirstUserMessageForThread({ threadId }: { threadId: string }): Promise<HarnessMessage | null> {
+    return (await this.getFirstUserMessagesForThreads({ threadIds: [threadId] })).get(threadId) ?? null;
+  }
+
+  async saveSystemReminderMessage({
+    message,
+    reminderType,
+    role = 'user',
+    metadata,
+  }: {
+    message: string;
+    reminderType: string;
+    role?: 'user' | 'assistant' | 'system';
+    metadata?: Record<string, unknown>;
+  }): Promise<HarnessMessage | null> {
+    const threadId = this.getCurrentThreadId();
+    if (!threadId) return null;
+    const id = `system-reminder-${randomUUID()}`;
+    const createdAt = new Date();
+    const memory = await this.getMemoryStorage();
+    await memory.saveMessages({
+      messages: [
+        {
+          id,
+          role,
+          type: 'text',
+          threadId,
+          resourceId: this.resourceId,
+          createdAt,
+          content: {
+            format: 2,
+            content: message,
+            parts: [],
+            metadata: {
+              ...metadata,
+              ...toSystemReminderAttributes({ type: reminderType, role }),
+              systemReminder: {
+                type: reminderType,
+                message,
+                ...metadata,
+              },
+            },
+          },
+        },
+      ],
+    });
+    return {
+      id,
+      role,
+      createdAt,
+      content: [{ type: 'system_reminder', reminderType, message }],
+    };
+  }
+
+  abort(): void {
+    this.session?.abort({ reason: 'aborted' });
+  }
+
+  async steer({ content }: { content: string; requestContext?: RequestContext }): Promise<void> {
+    this.abort();
+    this.followUpCount = 0;
+    await this.sendMessage({ content });
+  }
+
+  async followUp({ content }: { content: string; requestContext?: RequestContext }): Promise<void> {
+    if (!this.isRunning()) {
+      await this.sendMessage({ content });
+      return;
+    }
+    this.followUpCount++;
+    this.emit({ type: 'follow_up_queued', count: this.followUpCount } as unknown as HarnessEvent);
+    void this.requireSession()
+      .queue({
+        content,
+        ...((this.state as Record<string, unknown>).yolo === true ? { yolo: true } : {}),
+        prepareStep: this.prepareActiveToolsStep,
+      } as never)
+      .catch(error => this.emitError(error))
+      .finally(() => {
+        this.followUpCount = Math.max(0, this.followUpCount - 1);
+      });
+  }
+
+  isRunning(): boolean {
+    return this.session?.isRunning() ?? false;
+  }
+
+  isCurrentThreadStreamActive(): boolean {
+    return this.isRunning();
+  }
+
+  getFollowUpCount(): number {
+    return this.followUpCount;
+  }
+
+  getCurrentRunId(): string | null {
+    return this.currentRunId;
+  }
+
+  getCurrentTraceId(): string | null {
+    return this.currentTraceId;
+  }
+
+  getDisplayState(): Readonly<HarnessDisplayState> {
+    const sessionState = this.getSessionDisplayState();
+    const base = defaultDisplayState();
+    const pending = sessionState?.pending as
+      | {
+          kind?: string;
+          itemId?: string;
+          toolCallId?: string;
+          toolName?: string;
+          payload?: Record<string, unknown>;
+        }
+      | null
+      | undefined;
+    const tasks = this.currentDisplayTasks.length > 0 ? this.currentDisplayTasks : cloneTasks(this.state.tasks);
+    return {
+      ...base,
+      ...(sessionState ?? {}),
+      activeTools: recordToMap((sessionState as { activeTools?: unknown } | undefined)?.activeTools),
+      toolInputBuffers: recordToMap((sessionState as { toolInputBuffers?: unknown } | undefined)?.toolInputBuffers),
+      activeSubagents: recordToMap((sessionState as { activeSubagents?: unknown } | undefined)?.activeSubagents),
+      modifiedFiles: this.modifiedFiles,
+      pendingApproval:
+        pending?.kind === 'tool-approval'
+          ? {
+              toolCallId: pending.toolCallId ?? pending.itemId ?? '',
+              toolName: pending.toolName ?? '',
+              args: pending.payload?.input,
+            }
+          : null,
+      pendingSuspension:
+        pending?.kind === 'tool-suspension'
+          ? {
+              toolCallId: pending.toolCallId ?? pending.itemId ?? '',
+              toolName: pending.toolName ?? '',
+              args: pending.payload?.input,
+              suspendPayload: pending.payload,
+            }
+          : null,
+      pendingQuestion:
+        pending?.kind === 'question'
+          ? {
+              questionId: pending.itemId ?? pending.toolCallId ?? '',
+              question:
+                typeof pending.payload?.question === 'string'
+                  ? pending.payload.question
+                  : 'The agent needs your input.',
+              options: Array.isArray(pending.payload?.options) ? (pending.payload.options as never) : undefined,
+              selectionMode:
+                pending.payload?.selectionMode === 'single_select' || pending.payload?.selectionMode === 'multi_select'
+                  ? pending.payload.selectionMode
+                  : undefined,
+            }
+          : null,
+      pendingPlanApproval:
+        pending?.kind === 'plan-approval'
+          ? {
+              planId: pending.itemId ?? pending.toolCallId ?? '',
+              title: typeof pending.payload?.title === 'string' ? pending.payload.title : undefined,
+              plan: typeof pending.payload?.plan === 'string' ? pending.payload.plan : '',
+            }
+          : null,
+      omProgress: {
+        ...base.omProgress,
+        ...emptyOMProgress(),
+        ...this.omProgress,
+        buffered: {
+          observations: { ...this.omProgress.buffered.observations },
+          reflection: { ...this.omProgress.buffered.reflection },
+        },
+      },
+      bufferingMessages: this.bufferingMessages,
+      bufferingObservations: this.bufferingObservations,
+      tasks,
+      previousTasks: [...this.previousDisplayTasks],
+      isRunning: this.isRunning(),
+      currentModelId: this.getCurrentModelId(),
+      currentModeId: this.currentModeId,
+      currentThreadId: this.getCurrentThreadId(),
+      resourceId: this.resourceId,
+      state: this.state,
+    } as unknown as HarnessDisplayState;
+  }
+
+  restoreDisplayTasks(tasks: TaskItemSnapshot[]): void {
+    this.previousDisplayTasks = [...this.currentDisplayTasks];
+    this.currentDisplayTasks = [...tasks];
+    this.emit({ type: 'display_state_changed', displayState: this.getDisplayState() } as unknown as HarnessEvent);
+  }
+
+  async loadOMProgress(): Promise<void> {
+    const threadId = this.getCurrentThreadId();
+    if (!threadId) return;
+
+    try {
+      const memory = await this.getMemoryStorage();
+      const record = await memory.getObservationalMemory?.(threadId, this.resourceId);
+      if (!record) return;
+
+      const config = record.config as
+        | {
+            observationThreshold?: number | { min: number; max: number };
+            reflectionThreshold?: number | { min: number; max: number };
+          }
+        | undefined;
+      const threshold = (value: number | { min: number; max: number } | undefined, fallback: number) =>
+        typeof value === 'number' ? value : (value?.max ?? fallback);
+
+      let messageTokens = record.pendingMessageTokens ?? 0;
+      let observationTokens = record.observationTokenCount ?? 0;
+      let observationThreshold = threshold(config?.observationThreshold, this.getObservationThreshold() ?? 30_000);
+      let reflectionThreshold = threshold(config?.reflectionThreshold, this.getReflectionThreshold() ?? 40_000);
+      let bufferedObs = emptyOMProgress().buffered!.observations;
+      let bufferedRef = emptyOMProgress().buffered!.reflection;
+      let generationCount = 0;
+      let stepNumber = 0;
+
+      const messages = await memory.listMessages({
+        threadId,
+        perPage: 70,
+        page: 0,
+        orderBy: { field: 'createdAt', direction: 'DESC' },
+      });
+      for (const message of messages.messages) {
+        if (message.role !== 'assistant') continue;
+        const parts = Array.isArray(message.content?.parts) ? message.content.parts : [];
+        const status = [...parts]
+          .reverse()
+          .find((part: any) => part?.type === 'data-om-status' && part.data?.windows) as { data?: any } | undefined;
+        if (!status?.data?.windows) continue;
+        const windows = status.data.windows;
+        messageTokens = windows.active?.messages?.tokens ?? messageTokens;
+        observationTokens = windows.active?.observations?.tokens ?? observationTokens;
+        observationThreshold = windows.active?.messages?.threshold ?? observationThreshold;
+        reflectionThreshold = windows.active?.observations?.threshold ?? reflectionThreshold;
+        bufferedObs = { ...bufferedObs, ...(windows.buffered?.observations ?? {}) };
+        bufferedRef = { ...bufferedRef, ...(windows.buffered?.reflection ?? {}) };
+        generationCount = status.data.generationCount ?? generationCount;
+        stepNumber = status.data.stepNumber ?? stepNumber;
+        break;
+      }
+
+      const event = {
+        type: 'om_status',
+        windows: {
+          active: {
+            messages: { tokens: messageTokens, threshold: observationThreshold },
+            observations: { tokens: observationTokens, threshold: reflectionThreshold },
+          },
+          buffered: { observations: bufferedObs, reflection: bufferedRef },
+        },
+        recordId: record.id ?? '',
+        threadId,
+        stepNumber,
+        generationCount,
+      } as unknown as HarnessV1Event | MastraCodeOMEvent;
+      this.applyOMEvent(event);
+      this.emit(event as unknown as HarnessEvent);
+      this.emit({ type: 'display_state_changed', displayState: this.getDisplayState() } as unknown as HarnessEvent);
+    } catch {
+      // OM is optional; missing storage support should not break startup.
+    }
+
+    this.emit({ type: 'display_state_changed', displayState: this.getDisplayState() } as unknown as HarnessEvent);
+  }
+
+  async getObservationalMemoryRecord(): Promise<unknown | null> {
+    const threadId = this.getCurrentThreadId();
+    if (!threadId) return null;
+    try {
+      const memory = await this.getMemoryStorage();
+      return (await memory.getObservationalMemory?.(threadId, this.resourceId)) ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  respondToQuestion({ questionId, answer }: { questionId?: string; answer: unknown }): void {
+    void this.requireSession()
+      .respondToQuestion({ ...(questionId !== undefined ? { itemId: questionId } : {}), answer })
+      .catch(error => this.emitError(error));
+  }
+
+  respondToToolApproval({
+    toolCallId,
+    decision,
+    approved,
+    reason,
+  }: {
+    toolCallId?: string;
+    decision?: 'approve' | 'decline' | 'deny' | 'always_allow_category';
+    approved?: boolean;
+    reason?: string;
+  }): void {
+    if (decision === 'always_allow_category') {
+      const pending = this.requireSession().getDisplayState().pending as { toolName?: string } | undefined;
+      const category = pending?.toolName ? this.getToolCategory({ toolName: pending.toolName }) : null;
+      if (category) {
+        this.grantSessionCategory({ category });
+      }
+    }
+    void this.requireSession()
+      .respondToToolApproval({
+        ...(toolCallId !== undefined ? { itemId: toolCallId } : {}),
+        approved: approved ?? (decision === 'approve' || decision === 'always_allow_category'),
+        reason,
+      })
+      .catch(error => this.emitError(error));
+  }
+
+  async respondToToolSuspension({
+    toolCallId,
+    resumeData,
+  }: {
+    toolCallId?: string;
+    resumeData: unknown;
+    requestContext?: RequestContext;
+  }): Promise<void> {
+    await this.requireSession().respondToToolSuspension({
+      ...(toolCallId !== undefined ? { itemId: toolCallId } : {}),
+      resumeData,
+    });
+  }
+
+  async respondToSandboxAccess({
+    questionId,
+    requestId,
+    approved,
+    reason,
+  }: {
+    questionId?: string;
+    requestId?: string;
+    approved: boolean;
+    reason?: string;
+  }): Promise<void> {
+    await this.requireSession().respondToSandboxAccess({
+      ...((requestId ?? questionId) !== undefined ? { itemId: requestId ?? questionId } : {}),
+      approved,
+      reason,
+    });
+  }
+
+  async respondToPlanApproval({
+    planId,
+    response,
+    approved,
+    revision,
+  }: {
+    planId?: string;
+    response?: { action?: string; feedback?: string };
+    approved?: boolean;
+    revision?: string;
+  }): Promise<void> {
+    const accepted = approved ?? response?.action !== 'rejected';
+    await this.requireSession().respondToPlanApproval({
+      ...(planId !== undefined ? { itemId: planId } : {}),
+      approved: accepted,
+      revision: revision ?? response?.feedback,
+    });
+  }
+
+  getWorkspace() {
+    return this.currentWorkspace;
+  }
+
+  async destroyWorkspace(): Promise<void> {
+    const workspace = this.currentWorkspace as { destroy?: () => Promise<void> | void } | undefined;
+    if (!workspace?.destroy) {
+      this.currentWorkspace = undefined;
+      return;
+    }
+    try {
+      this.emit({ type: 'workspace_status_changed', status: 'destroying' } as unknown as HarnessEvent);
+      await workspace.destroy();
+      this.emit({ type: 'workspace_status_changed', status: 'destroyed' } as unknown as HarnessEvent);
+    } finally {
+      this.currentWorkspace = undefined;
+    }
+  }
+
+  getResolvedObserverModel(): unknown {
+    const modelId = this.getObserverModelId();
+    return modelId && this.config.resolveModel ? this.config.resolveModel(modelId) : undefined;
+  }
+
+  getResolvedReflectorModel(): unknown {
+    const modelId = this.getReflectorModelId();
+    return modelId && this.config.resolveModel ? this.config.resolveModel(modelId) : undefined;
+  }
+
+  async getResolvedMemory() {
+    if (!this.config.memory) return null;
+    if (typeof this.config.memory !== 'function') return this.config.memory;
+    const requestContext = new RequestContext([
+      [
+        'harness',
+        {
+          harnessId: 'mastra-code',
+          sessionId: this.session?.id,
+          threadId: this.getCurrentThreadId(),
+          resourceId: this.resourceId,
+          modeId: this.currentModeId,
+          state: this.state,
+          getState: () => this.state,
+          setState: (updates: Partial<TState>) => this.setState(updates),
+          getSubagentModelId: (params?: { agentType?: string }) => this.getSubagentModelId(params),
+          workspace: this.currentWorkspace,
+        },
+      ],
+    ]) as RequestContext<unknown>;
+    return this.config.memory({ requestContext, mastra: this.mastra });
+  }
+
+  async resolveWorkspace() {
+    this.currentWorkspace = await this.session?.getWorkspace();
+    return this.currentWorkspace;
+  }
+
+  hasWorkspace(): boolean {
+    return Boolean(this.config.workspace);
+  }
+
+  isWorkspaceReady(): boolean {
+    return Boolean(this.config.workspace);
+  }
+
+  setBrowser(browser: unknown): void {
+    this.browser = browser;
+    for (const mode of this.modes) {
+      if (typeof mode.agent === 'function') continue;
+      const agent = mode.agent as AgentWithBrowser;
+      if (!agent.hasOwnBrowser?.()) agent.setBrowser?.(browser);
+    }
+    for (const agent of Object.values(this.config.agents) as AgentWithBrowser[]) {
+      if (!agent.hasOwnBrowser?.()) agent.setBrowser?.(browser);
+    }
+  }
+
+  registerHeartbeat(handler: NonNullable<MastraCodeRuntimeConfig<TState>['heartbeatHandlers']>[number]): void {
+    if (this.heartbeatTimers.has(handler.id)) return;
+    this.heartbeatHandlers.set(handler.id, handler);
+    const run = () => {
+      void Promise.resolve(handler.handler()).catch(error => console.error(`Heartbeat ${handler.id} failed`, error));
+    };
+    if (handler.immediate !== false) run();
+    this.heartbeatTimers.set(handler.id, setInterval(run, handler.intervalMs));
+  }
+
+  async removeHeartbeat({ id }: { id: string }): Promise<void> {
+    const timer = this.heartbeatTimers.get(id);
+    if (timer) clearInterval(timer);
+    this.heartbeatTimers.delete(id);
+    const handler = this.heartbeatHandlers.get(id);
+    this.heartbeatHandlers.delete(id);
+    await Promise.resolve(handler?.shutdown?.());
+  }
+
+  async stopHeartbeats(): Promise<void> {
+    await Promise.all([...this.heartbeatHandlers.keys()].map(id => this.removeHeartbeat({ id })));
+  }
+
+  async destroy(): Promise<void> {
+    this.harnessEventUnsubscribe?.();
+    this.harnessEventUnsubscribe = undefined;
+    this.clearActiveSession();
+    await this.destroyWorkspace();
+    await this.stopHeartbeats();
+    await this.core.shutdown();
+  }
+
+  async getSession(): Promise<HarnessSession> {
+    return {
+      currentThreadId: this.getCurrentThreadId(),
+      currentModeId: this.currentModeId,
+      threads: await this.listThreads(),
+    };
+  }
+
+  private async ensureSession(): Promise<Session> {
+    if (!this.session) {
+      await this.selectOrCreateThread();
+    }
+    return this.requireSession();
+  }
+
+  private requireSession(): Session {
+    if (!this.session) {
+      throw new Error('MastraCode Harness session has not been initialized');
+    }
+    return this.session;
+  }
+
+  private readonly prepareActiveToolsStep = ({ tools }: { tools?: Record<string, unknown> }) => ({
+    activeTools: this.filterActiveTools(Object.keys(tools ?? {})),
+  });
+
+  private filterActiveTools(toolNames: string[]): string[] {
+    const disabled = new Set(this.config.disabledTools ?? []);
+    return toolNames.filter(toolName => !this.isToolDisabled(toolName, disabled) && !this.isToolDenied(toolName));
+  }
+
+  private async uploadMessageAttachments(
+    session: Session,
+    files?: unknown[],
+  ): Promise<{ attachments: AttachmentRef[]; inlineFiles: unknown[] | undefined }> {
+    if (!files?.length) return { attachments: [], inlineFiles: undefined };
+    const attachments: AttachmentRef[] = [];
+    const inlineFiles: unknown[] = [];
+    for (let index = 0; index < files.length; index += 1) {
+      const file = files[index];
+      if (!file || typeof file !== 'object') continue;
+      const value = file as Record<string, unknown>;
+      const data = fileUploadData(value);
+      if (!data) {
+        inlineFiles.push(file);
+        continue;
+      }
+      attachments.push(
+        await this.core.attachments.upload({
+          sessionId: session.id,
+          resourceId: session.resourceId,
+          data,
+          filename: fileName(value, index),
+          contentType: fileContentType(value),
+        }),
+      );
+    }
+    return { attachments, inlineFiles: inlineFiles.length > 0 ? inlineFiles : undefined };
+  }
+
+  private isToolDenied(toolName: string): boolean {
+    const rules =
+      (this.state.permissionRules as
+        | { categories?: Record<string, PermissionPolicy>; tools?: Record<string, PermissionPolicy> }
+        | undefined) ?? {};
+    if (rules.tools?.[toolName] === 'deny') return true;
+    const category = this.getToolCategory({ toolName });
+    return Boolean(category && rules.categories?.[category] === 'deny');
+  }
+
+  private isToolDisabled(toolName: string, disabled = new Set(this.config.disabledTools ?? [])): boolean {
+    if (isSubagentToolName(toolName)) {
+      return disabled.has('subagent') || disabled.has('spawn_subagent');
+    }
+    return disabled.has(toolName);
+  }
+
+  private shouldExposeSubagentTool(): boolean {
+    if (this.config.subagents.length === 0) return false;
+    return !this.isToolDisabled('spawn_subagent');
+  }
+
+  private resolveModeModel(modeId: string): string {
+    const mode = this.modes.find(entry => entry.id === modeId) ?? this.modes[0];
+    return mode?.defaultModelId ?? this.getCurrentModelId();
+  }
+
+  private buildThreadMetadata(): Record<string, unknown> | undefined {
+    const metadata: Record<string, unknown> = {};
+    const modelId = this.getCurrentModelId() || this.resolveModeModel(this.currentModeId);
+    if (modelId) {
+      metadata.currentModelId = modelId;
+      metadata[`modeModelId_${this.currentModeId}`] = modelId;
+    }
+    metadata.currentModeId = this.currentModeId;
+
+    const projectPath = this.state.projectPath;
+    if (typeof projectPath === 'string' && projectPath.length > 0) {
+      metadata.projectPath = projectPath;
+    }
+    for (const key of [
+      'observerModelId',
+      'reflectorModelId',
+      'observationThreshold',
+      'reflectionThreshold',
+      'subagentModelId',
+      'cavemanObservations',
+    ]) {
+      if (this.state[key] !== undefined) metadata[key] = this.state[key];
+    }
+    for (const [key, value] of Object.entries(this.state)) {
+      if (key.startsWith('subagentModelId_') && value !== undefined) {
+        metadata[key] = value;
+      }
+    }
+
+    return Object.keys(metadata).length > 0 ? metadata : undefined;
+  }
+
+  private bindActiveSession(session: Session): void {
+    if (this.session === session) return;
+    this.sessionEventUnsubscribe?.();
+    this.session = session;
+    this.sessionEventUnsubscribe = session.subscribe(event => {
+      void this.handleCoreEvent(event).catch(error => {
+        this.emitNonLifecycleError(error);
+      });
+    });
+  }
+
+  private clearActiveSession(): void {
+    this.sessionEventUnsubscribe?.();
+    this.sessionEventUnsubscribe = undefined;
+    this.session = undefined;
+  }
+
+  private async applyThreadMetadata(
+    metadata?: Record<string, unknown>,
+    options: { persist?: boolean } = {},
+  ): Promise<void> {
+    const persist = options.persist ?? true;
+    if (!metadata) {
+      await this.applyModeModelFallback({ persist });
+      return;
+    }
+
+    const updates: Record<string, unknown> = {};
+    const savedModeId = typeof metadata.currentModeId === 'string' ? metadata.currentModeId : undefined;
+    if (savedModeId && this.modes.some(mode => mode.id === savedModeId)) {
+      this.currentModeId = savedModeId;
+    }
+
+    const modeModelKey = `modeModelId_${this.currentModeId}`;
+    if (typeof metadata[modeModelKey] === 'string') {
+      updates.currentModelId = metadata[modeModelKey];
+    } else if (typeof metadata.currentModelId === 'string') {
+      updates.currentModelId = metadata.currentModelId;
+    } else {
+      const fallback = this.resolveModeModel(this.currentModeId);
+      if (fallback) updates.currentModelId = fallback;
+    }
+
+    for (const key of [
+      'observerModelId',
+      'reflectorModelId',
+      'observationThreshold',
+      'reflectionThreshold',
+      'subagentModelId',
+    ]) {
+      if (metadata[key] !== undefined) updates[key] = metadata[key];
+    }
+    for (const [key, value] of Object.entries(metadata)) {
+      if (key.startsWith('subagentModelId_') && typeof value === 'string') {
+        updates[key] = value;
+      }
+    }
+
+    if (Object.keys(updates).length > 0) {
+      if (persist) {
+        await this.setState(updates as Partial<TState>);
+      } else {
+        this.state = { ...this.state, ...(updates as Partial<TState>) };
+      }
+    }
+  }
+
+  private async applyModeModelFallback(options: { persist?: boolean } = {}): Promise<void> {
+    const fallback = this.resolveModeModel(this.currentModeId);
+    if (fallback) {
+      const updates = { currentModelId: fallback } as unknown as Partial<TState>;
+      if (options.persist ?? true) {
+        await this.setState(updates);
+      } else {
+        this.state = { ...this.state, ...updates };
+      }
+    }
+  }
+
+  private async loadModeModelId(modeId: string): Promise<string> {
+    const session = this.requireSession();
+    const thread = await this.core.threads.get({ resourceId: this.resourceId, threadId: session.threadId });
+    const stored = thread?.metadata?.[`modeModelId_${modeId}`];
+    return typeof stored === 'string' ? stored : this.resolveModeModel(modeId);
+  }
+
+  private async getMemoryStorage() {
+    const memory = await this.config.storage.getStore('memory');
+    if (!memory) {
+      throw new Error('Memory storage is not configured for MastraCode Harness v1 runtime');
+    }
+    return memory;
+  }
+
+  private async ensureSessionState(): Promise<void> {
+    const session = this.requireSession();
+    const selectedModel =
+      this.getCurrentModelId() || session.models.current() || this.resolveModeModel(this.currentModeId);
+    this.state = { ...this.state, currentModelId: selectedModel };
+    await session.models.switch({ model: selectedModel });
+    await session.setState(this.state);
+  }
+
+  private async syncSessionControls(): Promise<void> {
+    const session = this.requireSession();
+    await this.syncPermissionRules(session);
+    await this.syncSubagentModelOverrides(session);
+  }
+
+  private async syncPermissionRules(session: Session): Promise<void> {
+    const rules =
+      (this.state.permissionRules as
+        | { categories?: Record<string, PermissionPolicy>; tools?: Record<string, PermissionPolicy> }
+        | undefined) ?? {};
+    await Promise.all([
+      ...Object.entries(rules.categories ?? {})
+        .filter(([category]) => TOOL_CATEGORIES.includes(category as ToolCategory))
+        .map(([category, policy]) => session.permissions.setPolicy({ category: category as ToolCategory, policy })),
+      ...Object.entries(rules.tools ?? {}).map(([toolName, policy]) =>
+        session.permissions.setPolicy({ toolName, policy }),
+      ),
+    ]);
+  }
+
+  private async syncSubagentModelOverrides(session: Session): Promise<void> {
+    const state = this.state as Record<string, unknown>;
+    const defaultModel = typeof state.subagentModelId === 'string' ? state.subagentModelId : undefined;
+    await Promise.all(
+      this.config.subagents.map(subagent => {
+        const key = `subagentModelId_${subagent.id}`;
+        const model = typeof state[key] === 'string' ? state[key] : defaultModel;
+        if (!model || session.models.getSubagent({ agentType: subagent.id }) === model) {
+          return Promise.resolve();
+        }
+        return session.models.setSubagent({ agentType: subagent.id, model });
+      }),
+    );
+  }
+
+  private async resolveHarnessV1AuthStatus(modelId: string) {
+    const model = (await this.listAvailableModels()).find(entry => entry.id === modelId);
+    if (model) return toHarnessV1AuthStatus(model.hasApiKey);
+    const provider = providerFromModelId(modelId);
+    return toHarnessV1AuthStatus(provider ? this.config.modelAuthChecker?.(provider) : undefined);
+  }
+
+  async refreshModelCatalog(): Promise<MastraCodeModelInfo[]> {
+    return (await this.listAvailableModels()).map(toModelInfo);
+  }
+
+  private emitError(error: unknown): void {
+    this.emit({
+      type: 'error',
+      error: error instanceof Error ? error : new Error(String(error)),
+      message: error instanceof Error ? error.message : String(error),
+    } as unknown as HarnessEvent);
+  }
+
+  private emitNonLifecycleError(error: unknown): void {
+    if (isHarnessSessionLifecycleError(error)) return;
+    this.emitError(error);
+  }
+
+  private getSessionDisplayState(): SessionDisplayState | undefined {
+    try {
+      return this.session?.getDisplayState();
+    } catch (error) {
+      if (isHarnessSessionLifecycleError(error)) return undefined;
+      throw error;
+    }
+  }
+}

--- a/mastracode/src/harness/subagents.ts
+++ b/mastracode/src/harness/subagents.ts
@@ -1,0 +1,40 @@
+import { Agent } from '@mastra/core/agent';
+import type { PubSub } from '@mastra/core/events';
+import type { HarnessSubagent } from '@mastra/core/harness';
+import type { MastraMemory } from '@mastra/core/memory';
+import type { RequestContext } from '@mastra/core/request-context';
+import type { DynamicArgument } from '@mastra/core/types';
+
+type HarnessAgentInternals = Agent & {
+  hasOwnMemory?: () => boolean;
+  hasOwnPubSub?: () => boolean;
+  __setMemory?: (memory: DynamicArgument<MastraMemory>) => void;
+  __setPubSub?: (pubsub: PubSub) => void;
+};
+
+export function createHarnessV1SubagentAgents(
+  subagents: HarnessSubagent[],
+  resolveModel: (ctx: { requestContext: RequestContext }) => unknown,
+  services: { memory?: DynamicArgument<MastraMemory>; pubsub?: PubSub } = {},
+): Record<string, Agent> {
+  return Object.fromEntries(
+    subagents.map(subagent => {
+      const agent = new Agent({
+        id: `subagent-${subagent.id}`,
+        name: subagent.name,
+        instructions: subagent.instructions,
+        model: resolveModel as never,
+        tools: subagent.tools,
+      });
+      // Harness-created subagents inherit the parent runtime services through Agent's internal runtime hooks.
+      const harnessAgent = agent as HarnessAgentInternals;
+      if (services.memory && !harnessAgent.hasOwnMemory?.()) {
+        harnessAgent.__setMemory?.(services.memory);
+      }
+      if (services.pubsub && !harnessAgent.hasOwnPubSub?.()) {
+        harnessAgent.__setPubSub?.(services.pubsub);
+      }
+      return [`subagent-${subagent.id}`, agent] as const;
+    }),
+  );
+}

--- a/mastracode/src/headless-integration.test.ts
+++ b/mastracode/src/headless-integration.test.ts
@@ -927,6 +927,28 @@ describe('headless mode — thread control', () => {
     expect(titled).toBeDefined();
   });
 
+  it('creates the first headless thread with --title', async () => {
+    const harness = createHarnessWithAgent({
+      doStream: async () => ({ stream: createTextStream('Titled from start!') }),
+    });
+
+    await harness.init();
+
+    const exitCode = await runHeadless(harness, {
+      prompt: 'Hello',
+      format: 'default',
+      continue_: false,
+      cloneThread: false,
+      title: 'first-headless-title',
+    });
+
+    expect(exitCode).toBe(0);
+
+    const threads = await harness.listThreads();
+    const titled = threads.find(t => t.title === 'first-headless-title');
+    expect(titled).toBeDefined();
+  });
+
   it('emits thread_cloned event with new thread ID when cloning a named thread', async () => {
     const agent = new Agent({
       id: 'test-agent',

--- a/mastracode/src/headless.ts
+++ b/mastracode/src/headless.ts
@@ -12,6 +12,11 @@ import { createMastraCode } from './index.js';
 
 const VALID_MODES = ['build', 'plan', 'fast'] as const;
 const VALID_THINKING_LEVELS = ['off', 'low', 'medium', 'high', 'xhigh'] as const;
+type HarnessV1ResponseSurface<TState extends Record<string, unknown>> = Harness<TState> & {
+  respondToSandboxAccess: (opts: { questionId?: string; approved: boolean }) => Promise<void>;
+  respondToToolApproval: (opts: { toolCallId?: string; decision: 'approve' }) => void;
+  respondToToolSuspension: (opts: { toolCallId?: string; resumeData: unknown }) => Promise<void>;
+};
 
 export interface HeadlessArgs {
   prompt?: string;
@@ -206,12 +211,29 @@ function autoResolve<TState extends Record<string, unknown>>(
 ): { resolved: true; label: string; json: Record<string, unknown> } | { resolved: false } {
   switch (event.type) {
     case 'sandbox_access_request': {
-      harness.respondToQuestion({ questionId: event.questionId, answer: 'Yes' });
+      if ((event as { responseKind?: string }).responseKind === 'sandbox-access') {
+        void (harness as HarnessV1ResponseSurface<TState>).respondToSandboxAccess({
+          questionId: event.questionId,
+          approved: true,
+        });
+      } else {
+        harness.respondToQuestion({ questionId: event.questionId, answer: 'Yes' });
+      }
       return { resolved: true, label: `[auto-approved sandbox] ${event.path}`, json: { ...event, autoApproved: true } };
     }
     case 'tool_approval_required': {
-      harness.respondToToolApproval({ decision: 'approve' });
+      (harness as HarnessV1ResponseSurface<TState>).respondToToolApproval({
+        toolCallId: event.toolCallId,
+        decision: 'approve',
+      });
       return { resolved: true, label: `[auto-approved] ${event.toolName}`, json: { ...event, autoApproved: true } };
+    }
+    case 'tool_suspended': {
+      void (harness as HarnessV1ResponseSurface<TState>).respondToToolSuspension({
+        toolCallId: event.toolCallId,
+        resumeData: {},
+      });
+      return { resolved: true, label: `[auto-resumed] ${event.toolName}`, json: { ...event, autoResumed: true } };
     }
     case 'ask_question': {
       harness.respondToQuestion({
@@ -343,6 +365,10 @@ function finalizeSummary<TState extends Record<string, unknown>>(
   summary.threadId = harness.getCurrentThreadId() ?? undefined;
 }
 
+type HeadlessHarness<TState extends Record<string, unknown>> = Harness<TState> & {
+  initCore?: () => Promise<void>;
+};
+
 /** Resolve a thread by ID or title. Tries exact ID match first, then title. */
 async function resolveThread<TState extends Record<string, unknown>>(
   harness: Harness<TState>,
@@ -368,7 +394,7 @@ async function resolveThread<TState extends Record<string, unknown>>(
  * Returns the exit code (0 = success, 1 = error/aborted, 2 = timeout).
  */
 export async function runHeadless<TState extends Record<string, unknown>>(
-  harness: Harness<TState>,
+  harness: HeadlessHarness<TState>,
   args: HeadlessArgs & { prompt: string },
   effectiveDefaults?: Record<string, string>,
 ): Promise<number> {
@@ -403,7 +429,6 @@ export async function runHeadless<TState extends Record<string, unknown>>(
 
   // --- Pre-flight checks (before subscribing to events) ---
 
-  // --- Resolve model ---
   if (args.model && args.mode) {
     if (emit) {
       emit({ type: 'warning', message: '--model overrides --mode, ignoring --mode' });
@@ -412,8 +437,9 @@ export async function runHeadless<TState extends Record<string, unknown>>(
     }
   }
 
+  let resolvedModelId: string | undefined;
+  let resolvedModelLabel: string | undefined;
   if (args.model) {
-    // Highest priority: explicit --model flag
     const available = await harness.listAvailableModels();
     const match = available.find(m => m.id === args.model);
     if (!match) {
@@ -423,10 +449,9 @@ export async function runHeadless<TState extends Record<string, unknown>>(
       const keyHint = match.apiKeyEnvVar ? ` Set ${match.apiKeyEnvVar} to use this model.` : '';
       return failEarly(`Model "${args.model}" has no API key configured.${keyHint}`);
     }
-    await harness.switchModel({ modelId: args.model });
-    if (!emit) process.stderr.write(`[model] ${args.model}\n`);
+    resolvedModelId = args.model;
+    resolvedModelLabel = args.model;
   } else if (args.mode) {
-    // --mode flag: look up model from effectiveDefaults (resolved from settings at startup)
     const modelId = effectiveDefaults?.[args.mode];
     if (modelId) {
       const available = await harness.listAvailableModels();
@@ -438,19 +463,13 @@ export async function runHeadless<TState extends Record<string, unknown>>(
         const keyHint = match.apiKeyEnvVar ? ` Set ${match.apiKeyEnvVar} to use this model.` : '';
         return failEarly(`Model "${modelId}" (mode: ${args.mode}) has no API key configured.${keyHint}`);
       }
-      await harness.switchModel({ modelId });
-      if (!emit) process.stderr.write(`[model] ${modelId} (mode: ${args.mode})\n`);
+      resolvedModelId = modelId;
+      resolvedModelLabel = `${modelId} (mode: ${args.mode})`;
     } else {
       const warnMsg = `--mode ${args.mode} has no configured model, using default`;
       if (emit) emit({ type: 'warning', message: warnMsg });
       else process.stderr.write(`Warning: ${warnMsg}\n`);
     }
-  }
-
-  // --- Resolve thinking level ---
-  if (args.thinkingLevel) {
-    await harness.setState({ thinkingLevel: args.thinkingLevel } as unknown as Partial<TState>);
-    if (!emit) process.stderr.write(`[thinking] ${args.thinkingLevel}\n`);
   }
 
   // --- Subscribe and send ---
@@ -522,11 +541,14 @@ export async function runHeadless<TState extends Record<string, unknown>>(
         const sorted = [...threads].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
         await harness.switchThread({ threadId: sorted[0]!.id });
         if (!emit) process.stderr.write(`[continued] thread ${sorted[0]!.id}\n`);
-      } else if (!emit) {
-        process.stderr.write(`[info] No existing threads found, starting new thread\n`);
+      } else {
+        const thread = await harness.createThread({ title: args.title });
+        if (!emit) process.stderr.write(`[thread] new ${thread.id}\n`);
       }
+    } else {
+      const thread = await harness.createThread({ title: args.title });
+      if (!emit) process.stderr.write(`[thread] new ${thread.id}\n`);
     }
-    // else: no thread selection — sendMessage will auto-create a new thread
   } catch (err) {
     const msg = `Failed to select thread: ${(err as Error).message}`;
     if (emit) emit({ type: 'error', error: { message: msg } });
@@ -551,9 +573,13 @@ export async function runHeadless<TState extends Record<string, unknown>>(
   }
 
   // --- Title ---
-  if (args.title) {
+  if (args.title && (args.thread || args.continue_ || args.cloneThread)) {
     try {
-      await harness.renameThread({ title: args.title });
+      if (harness.getCurrentThreadId()) {
+        await harness.renameThread({ title: args.title });
+      } else {
+        await harness.createThread({ title: args.title });
+      }
       if (!emit) process.stderr.write(`[title] "${args.title}"\n`);
     } catch (err) {
       const msg = `Failed to set thread title: ${(err as Error).message}`;
@@ -562,6 +588,16 @@ export async function runHeadless<TState extends Record<string, unknown>>(
       if (timeoutId) clearTimeout(timeoutId);
       return 1;
     }
+  }
+
+  if (resolvedModelId) {
+    await harness.switchModel({ modelId: resolvedModelId });
+    if (!emit) process.stderr.write(`[model] ${resolvedModelLabel ?? resolvedModelId}\n`);
+  }
+
+  if (args.thinkingLevel) {
+    await harness.setState({ thinkingLevel: args.thinkingLevel } as unknown as Partial<TState>);
+    if (!emit) process.stderr.write(`[thinking] ${args.thinkingLevel}\n`);
   }
 
   await harness.sendMessage({ content: args.prompt });
@@ -614,6 +650,7 @@ export async function headlessMain(predrainedInput?: string | null): Promise<nev
 
   const result = await createMastraCode({ settingsPath: args.settings });
   const { harness, mcpManager, effectiveDefaults } = result;
+  const headlessHarness = harness as HeadlessHarness<Record<string, unknown>>;
 
   if (mcpManager?.hasServers()) {
     mcpManager.initInBackground().catch(err => {
@@ -622,14 +659,21 @@ export async function headlessMain(predrainedInput?: string | null): Promise<nev
   }
 
   setupDebugLogging();
-  await harness.init();
+  if (args.resourceId) {
+    headlessHarness.setResourceId({ resourceId: args.resourceId });
+  }
+  if (typeof headlessHarness.initCore === 'function') {
+    await headlessHarness.initCore();
+  } else {
+    await headlessHarness.init();
+  }
 
-  const exitCode = await runHeadless(harness, { ...args, prompt }, effectiveDefaults);
+  const exitCode = await runHeadless(headlessHarness, { ...args, prompt }, effectiveDefaults);
 
   // Cleanup
   releaseAllThreadLocks();
   const closeSignalsPubSub = (result.signalsPubSub as { close?: () => Promise<void> | void } | undefined)?.close;
-  await Promise.allSettled([mcpManager?.disconnect(), harness?.stopHeartbeats(), closeSignalsPubSub?.()]);
+  await Promise.allSettled([mcpManager?.disconnect(), headlessHarness?.destroy(), closeSignalsPubSub?.()]);
 
   process.exit(exitCode);
 }

--- a/mastracode/src/index.ts
+++ b/mastracode/src/index.ts
@@ -2,16 +2,16 @@ import path from 'node:path';
 
 import { Agent } from '@mastra/core/agent';
 import type { PubSub } from '@mastra/core/events';
-import { Harness } from '@mastra/core/harness';
 import type {
   CustomAvailableModel,
+  Harness,
   HeartbeatHandler,
   HarnessConfig,
   HarnessMode,
   HarnessSubagent,
 } from '@mastra/core/harness';
 import { GatewayRegistry, PROVIDER_REGISTRY } from '@mastra/core/llm';
-import type { LanguageModel, ProviderConfig } from '@mastra/core/llm';
+import type { ProviderConfig } from '@mastra/core/llm';
 import {
   AgentsMDInjector,
   PrefillErrorHandler,
@@ -42,6 +42,7 @@ import { createDynamicTools } from './agents/tools.js';
 import { getDynamicWorkspace } from './agents/workspace.js';
 import { AuthStorage } from './auth/storage.js';
 import { createOutcomeScorer, createEfficiencyScorer } from './evals/scorers/index.js';
+import { createHarnessV1SubagentAgents, MastraCodeHarnessRuntime } from './harness/index.js';
 import { HookManager } from './hooks/index.js';
 import { createMcpManager } from './mcp/index.js';
 import type { McpServerConfig } from './mcp/index.js';
@@ -62,8 +63,6 @@ import { setAuthStorage } from './providers/claude-max.js';
 import { getCopilotModelCatalog, setAuthStorage as setGitHubCopilotAuthStorage } from './providers/github-copilot.js';
 import { setAuthStorage as setOpenAIAuthStorage } from './providers/openai-codex.js';
 
-import { stateSchema } from './schema.js';
-
 import { mastra } from './tui/theme.js';
 import { syncGateways } from './utils/gateway-sync.js';
 import {
@@ -75,8 +74,6 @@ import {
 import type { StorageConfig } from './utils/project.js';
 import { createSignalsPubSub } from './utils/signals-pubsub.js';
 import { createStorage, createVectorStore } from './utils/storage-factory.js';
-import { resolveMastraCodeThreadLockConfig } from './utils/thread-lock-config.js';
-import { acquireThreadLock, releaseThreadLock } from './utils/thread-lock.js';
 
 const PROVIDER_TO_OAUTH_ID: Record<string, string> = {
   anthropic: 'anthropic',
@@ -142,6 +139,15 @@ export interface MastraCodeConfig {
   /** Marks the configured PubSub as cross-process-safe, allowing Mastra Code to skip file thread locks. */
   crossProcessPubSub?: boolean;
 }
+
+export type MastraCodeHarnessPublic = Harness<Record<string, unknown>> & {
+  actions: MastraCodeHarnessRuntime<Record<string, unknown>>['actions'];
+  mcp: MastraCodeHarnessRuntime<Record<string, unknown>>['mcp'];
+  getResolvedMemory: MastraCodeHarnessRuntime<Record<string, unknown>>['getResolvedMemory'];
+  saveSystemReminderMessage: MastraCodeHarnessRuntime<Record<string, unknown>>['saveSystemReminderMessage'];
+  stopHeartbeats: MastraCodeHarnessRuntime<Record<string, unknown>>['stopHeartbeats'];
+  destroy: MastraCodeHarnessRuntime<Record<string, unknown>>['destroy'];
+};
 
 export function createAuthStorage() {
   const authStorage = new AuthStorage();
@@ -505,6 +511,16 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     return model ? { ...filtered, defaultModelId: model } : filtered;
   });
 
+  if (memory && !(codeAgent as any).hasOwnMemory?.()) {
+    (codeAgent as any).__setMemory?.(memory);
+  }
+  if (signalsPubSub && !(codeAgent as any).hasOwnPubSub?.()) {
+    (codeAgent as any).__setPubSub?.(signalsPubSub);
+  }
+  if (config?.browser && typeof config.browser !== 'function' && !(codeAgent as any).hasOwnBrowser?.()) {
+    codeAgent.setBrowser(config.browser);
+  }
+
   // Build initial state with global preferences
   const globalInitialState: Record<string, unknown> = {};
   if (effectiveObserverModel) {
@@ -540,16 +556,91 @@ export async function createMastraCode(config?: MastraCodeConfig) {
       globalInitialState[`subagentModelId_${key}`] = modelId;
     }
   }
-  const harness = new Harness({
-    id: 'mastra-code',
+  const modelAuthChecker = (provider: string) => {
+    // Gateway key only authorizes providers that the Mastra gateway actually serves
+    const gatewayKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER) ?? process.env['MASTRA_GATEWAY_API_KEY'];
+    if (gatewayKey) {
+      const providerConfig = gatewayRegistry.getProviders()[provider];
+      if (providerConfig?.gateway === 'mastra') return true;
+    }
+    const oauthId = PROVIDER_TO_OAUTH_ID[provider];
+    if (oauthId && authStorage.isLoggedIn(oauthId)) {
+      return true;
+    }
+    // Check for user-entered API keys stored in auth.json
+    if (authStorage.hasStoredApiKey(provider)) {
+      return true;
+    }
+    // Backward-compatible direct credential checks for Anthropic/OpenAI storage keys.
+    if (provider === 'anthropic') {
+      const cred = authStorage.get('anthropic');
+      if (cred?.type === 'api_key' && cred.key.trim().length > 0) {
+        return true;
+      }
+    }
+    if (provider === 'openai') {
+      const cred = authStorage.get('openai-codex');
+      if (cred?.type === 'api_key' && cred.key.trim().length > 0) {
+        return true;
+      }
+    }
+
+    const customProvider = globalSettings.customProviders.find(entry => {
+      return provider === getCustomProviderId(entry.name);
+    });
+    if (customProvider) {
+      return true;
+    }
+    return undefined;
+  };
+
+  const customModelCatalogProvider = async () => {
+    const customModels: CustomAvailableModel[] = [];
+    for (const provider of globalSettings.customProviders) {
+      const providerId = getCustomProviderId(provider.name);
+      for (const modelName of provider.models) {
+        customModels.push({
+          id: toCustomProviderModelId(provider.name, modelName),
+          provider: providerId,
+          modelName,
+          hasApiKey: true,
+          apiKeyEnvVar: undefined,
+        });
+      }
+    }
+
+    // GitHub Copilot exposes its model list dynamically via `/models` since the
+    // available models depend on the user's subscription tier and any org policies.
+    // The catalog is cached + refreshed in the background, so steady-state cost is
+    // a single Map lookup.
+    try {
+      const copilotModels = await getCopilotModelCatalog({ authStorage });
+      for (const m of copilotModels) {
+        customModels.push({
+          id: `github-copilot/${m.id}`,
+          provider: 'github-copilot',
+          modelName: m.id,
+          hasApiKey: true,
+          apiKeyEnvVar: undefined,
+        });
+      }
+    } catch (error) {
+      console.warn('Failed to load GitHub Copilot model catalog:', error);
+    }
+
+    return customModels;
+  };
+
+  const harness = new MastraCodeHarnessRuntime({
     resourceId: project.resourceId,
     storage,
     observability,
     memory,
-    pubsub: signalsPubSub,
-    stateSchema,
+    agents: {
+      'code-agent': codeAgent,
+      ...createHarnessV1SubagentAgents(subagents, getDynamicModel as never, { memory, pubsub: signalsPubSub }),
+    },
     subagents,
-    resolveModel: modelId => resolveModel(modelId) as LanguageModel,
     toolCategoryResolver: getToolCategory,
     initialState: {
       projectPath: project.rootPath,
@@ -559,47 +650,10 @@ export async function createMastraCode(config?: MastraCodeConfig) {
       ...globalInitialState,
       ...config?.initialState,
     },
-    workspace: config?.workspace ?? getDynamicWorkspace,
-    browser: config?.browser,
+    workspace: (config?.workspace as never) ?? getDynamicWorkspace,
     modes,
     heartbeatHandlers: config?.heartbeatHandlers ?? defaultHeartbeatHandlers,
-    modelAuthChecker: provider => {
-      // Gateway key only authorizes providers that the Mastra gateway actually serves
-      const gatewayKey = authStorage.getStoredApiKey(MEMORY_GATEWAY_PROVIDER) ?? process.env['MASTRA_GATEWAY_API_KEY'];
-      if (gatewayKey) {
-        const providerConfig = gatewayRegistry.getProviders()[provider];
-        if (providerConfig?.gateway === 'mastra') return true;
-      }
-      const oauthId = PROVIDER_TO_OAUTH_ID[provider];
-      if (oauthId && authStorage.isLoggedIn(oauthId)) {
-        return true;
-      }
-      // Check for user-entered API keys stored in auth.json
-      if (authStorage.hasStoredApiKey(provider)) {
-        return true;
-      }
-      // Backward-compatible direct credential checks for Anthropic/OpenAI storage keys.
-      if (provider === 'anthropic') {
-        const cred = authStorage.get('anthropic');
-        if (cred?.type === 'api_key' && cred.key.trim().length > 0) {
-          return true;
-        }
-      }
-      if (provider === 'openai') {
-        const cred = authStorage.get('openai-codex');
-        if (cred?.type === 'api_key' && cred.key.trim().length > 0) {
-          return true;
-        }
-      }
-
-      const customProvider = loadSettings().customProviders.find(entry => {
-        return provider === getCustomProviderId(entry.name);
-      });
-      if (customProvider) {
-        return true;
-      }
-      return undefined;
-    },
+    modelAuthChecker,
     modelUseCountProvider: () => loadSettings().modelUseCounts,
     modelUseCountTracker: modelId => {
       try {
@@ -610,53 +664,10 @@ export async function createMastraCode(config?: MastraCodeConfig) {
         console.error('Failed to persist model usage count', error);
       }
     },
-    customModelCatalogProvider: async () => {
-      const settings = loadSettings();
-      const customModels: CustomAvailableModel[] = [];
-      for (const provider of settings.customProviders) {
-        const providerId = getCustomProviderId(provider.name);
-        for (const modelName of provider.models) {
-          customModels.push({
-            id: toCustomProviderModelId(provider.name, modelName),
-            provider: providerId,
-            modelName,
-            hasApiKey: true,
-            apiKeyEnvVar: undefined,
-          });
-        }
-      }
-
-      // GitHub Copilot exposes its model list dynamically via `/models` since the
-      // available models depend on the user's subscription tier and any org policies.
-      // The catalog is cached + refreshed in the background, so steady-state cost is
-      // a single Map lookup.
-      //
-      // The provider uses the generic OpenAI-compatible adapter pointed at
-      // GitHub Copilot's API, so expose the full live model catalog returned by
-      // Copilot instead of filtering by vendor family here.
-      try {
-        const copilotModels = await getCopilotModelCatalog({ authStorage });
-        for (const m of copilotModels) {
-          customModels.push({
-            id: `github-copilot/${m.id}`,
-            provider: 'github-copilot',
-            modelName: m.id,
-            hasApiKey: true,
-            apiKeyEnvVar: undefined,
-          });
-        }
-      } catch (error) {
-        console.warn('Failed to load GitHub Copilot model catalog:', error);
-      }
-
-      return customModels;
-    },
-    threadLock: crossProcessPubSub
-      ? undefined
-      : {
-          acquire: acquireThreadLock,
-          release: releaseThreadLock,
-        },
+    customModelCatalogProvider,
+    resolveModel,
+    disabledTools: config?.disabledTools,
+    browser: config?.browser,
   });
 
   // Sync hookManager session ID on thread changes
@@ -678,8 +689,10 @@ export async function createMastraCode(config?: MastraCodeConfig) {
     // Persistence is best-effort; don't crash startup if storage hiccups.
   });
 
+  const harnessForConsumers = harness as unknown as MastraCodeHarnessPublic;
+
   return {
-    harness,
+    harness: harnessForConsumers,
     mcpManager,
     hookManager,
     signalsPubSub,

--- a/mastracode/src/main.ts
+++ b/mastracode/src/main.ts
@@ -124,7 +124,7 @@ const asyncCleanup = async () => {
   const closeSignalsPubSub = (signalsPubSub as { close?: () => Promise<void> | void } | undefined)?.close;
   await Promise.allSettled([
     mcpManager?.disconnect(),
-    harness?.stopHeartbeats(),
+    harness?.destroy(),
     closeSignalsPubSub?.(),
     analytics?.shutdown(),
   ]);

--- a/mastracode/src/permissions.ts
+++ b/mastracode/src/permissions.ts
@@ -6,7 +6,7 @@
  * Session-scoped grants let the user approve a category once per session.
  */
 
-import { MC_TOOLS } from './tool-names.js';
+import { MC_BUILTIN_TOOLS, MC_TOOLS } from './tool-names.js';
 
 // ---------------------------------------------------------------------------
 // Categories
@@ -51,7 +51,8 @@ const TOOL_CATEGORY_MAP: Record<string, ToolCategory> = {
   [MC_TOOLS.STRING_REPLACE_LSP]: 'edit',
   [MC_TOOLS.AST_SMART_EDIT]: 'edit',
   [MC_TOOLS.WRITE_FILE]: 'edit',
-  subagent: 'edit',
+  [MC_BUILTIN_TOOLS.LEGACY_SUBAGENT]: 'edit',
+  [MC_BUILTIN_TOOLS.SPAWN_SUBAGENT]: 'edit',
 
   // Execute tools — run arbitrary commands
   [MC_TOOLS.EXECUTE_COMMAND]: 'execute',

--- a/mastracode/src/tool-names.ts
+++ b/mastracode/src/tool-names.ts
@@ -36,6 +36,15 @@ export const MC_TOOLS = {
   LSP_INSPECT: 'lsp_inspect',
 } as const;
 
+export const MC_BUILTIN_TOOLS = {
+  LEGACY_SUBAGENT: 'subagent',
+  SPAWN_SUBAGENT: 'spawn_subagent',
+} as const;
+
+export function isSubagentToolName(toolName: string): boolean {
+  return toolName === MC_BUILTIN_TOOLS.LEGACY_SUBAGENT || toolName === MC_BUILTIN_TOOLS.SPAWN_SUBAGENT;
+}
+
 /**
  * Workspace tool name remapping config.
  * Maps core workspace tool constants to mastracode's tool names.

--- a/mastracode/src/tools/__tests__/request-sandbox-access.test.ts
+++ b/mastracode/src/tools/__tests__/request-sandbox-access.test.ts
@@ -177,4 +177,83 @@ describe('request_access', () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain('Access granted');
   });
+
+  it('registers a Harness v1 durable question when no legacy event emitter is present', async () => {
+    const registerQuestion = vi.fn(async () => undefined);
+    const suspend = vi.fn(async () => {
+      throw new Error('suspended');
+    });
+
+    const context = {
+      agent: {
+        runId: 'run-1',
+        toolCallId: 'tool-1',
+        suspend,
+      },
+      requestContext: {
+        get: (key: string) =>
+          key === 'harness'
+            ? {
+                registerQuestion,
+                getState: () => ({ sandboxAllowedPaths: [] }),
+                setState: vi.fn(),
+              }
+            : undefined,
+      },
+      workspace: {},
+    };
+
+    await expect(
+      (requestSandboxAccessTool as any).execute(
+        { path: '/outside/project/dir', reason: 'need to read config' },
+        context,
+      ),
+    ).rejects.toThrow('suspended');
+
+    expect(registerQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        questionId: expect.stringMatching(/^sandbox_/),
+        question: expect.stringContaining('/outside/project/dir'),
+        runId: 'run-1',
+        toolCallId: 'tool-1',
+        selectionMode: 'single_select',
+      }),
+    );
+    expect(suspend).toHaveBeenCalled();
+    expect(suspend.mock.calls[0]?.[0]).toEqual({});
+  });
+
+  it('resumes a Harness v1 sandbox question from agent resumeData', async () => {
+    const { fs, setAllowedPaths } = createMockLocalFilesystem();
+    const setState = vi.fn();
+
+    const context = {
+      agent: {
+        resumeData: { answer: 'yes' },
+      },
+      requestContext: {
+        get: (key: string) =>
+          key === 'harness'
+            ? {
+                registerQuestion: vi.fn(),
+                getState: () => ({ sandboxAllowedPaths: [] }),
+                setState,
+              }
+            : undefined,
+      },
+      workspace: {
+        filesystem: fs,
+      },
+    };
+
+    const result = await (requestSandboxAccessTool as any).execute(
+      { path: '/outside/project/dir', reason: 'need to read config' },
+      context,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('Access granted');
+    expect(setState).toHaveBeenCalledWith({ sandboxAllowedPaths: ['/outside/project/dir'] });
+    expect(setAllowedPaths).toHaveBeenCalledTimes(1);
+  });
 });

--- a/mastracode/src/tools/request-sandbox-access.ts
+++ b/mastracode/src/tools/request-sandbox-access.ts
@@ -19,8 +19,41 @@ function expandTilde(p: string): string {
 }
 
 type MastraCodeState = z.infer<typeof stateSchema>;
+type HarnessV1QuestionContext = {
+  registerQuestion: (params: {
+    questionId: string;
+    question: string;
+    options?: Array<{ label: string; description?: string }>;
+    selectionMode?: 'single_select' | 'multi_select';
+    runId?: string;
+    toolCallId?: string;
+  }) => Promise<void>;
+};
+type ToolExecutionContext = {
+  agent?: {
+    runId?: string;
+    toolCallId?: string;
+    resumeData?: unknown;
+    suspend?: (payload: unknown) => Promise<never>;
+  };
+  requestContext?: {
+    get: (key: string) => unknown;
+  };
+  workspace?: {
+    filesystem?: unknown;
+  };
+};
 
 let requestCounter = 0;
+
+function answerApproved(answer: HarnessQuestionAnswer | unknown): boolean {
+  const value =
+    typeof answer === 'object' && answer !== null && 'answer' in answer
+      ? (answer as { answer: HarnessQuestionAnswer }).answer
+      : answer;
+  const answerText = Array.isArray(value) ? value.join(', ') : String(value ?? '');
+  return answerText.toLowerCase().startsWith('y') || answerText.toLowerCase() === 'approve';
+}
 
 export const requestSandboxAccessTool = createTool({
   id: 'request_access',
@@ -30,8 +63,11 @@ export const requestSandboxAccessTool = createTool({
     reason: z.string().min(1).describe('Brief explanation of why you need access to this directory.'),
   }),
   execute: async ({ path: requestedPath, reason }, context) => {
+    let propagatingHarnessV1Suspension = false;
     try {
+      const toolContext = context as ToolExecutionContext | undefined;
       const harnessCtx = context?.requestContext?.get('harness') as HarnessRequestContext<MastraCodeState> | undefined;
+      const resumeData = toolContext?.agent?.resumeData;
 
       // Resolve to absolute path (expand ~ first since Node path APIs don't handle it)
       const expanded = expandTilde(requestedPath);
@@ -47,7 +83,7 @@ export const requestSandboxAccessTool = createTool({
         };
       }
 
-      if (!harnessCtx?.emitEvent || !harnessCtx?.registerQuestion) {
+      if (!harnessCtx?.registerQuestion) {
         return {
           content: `Cannot request sandbox access: TUI context not available. The user should manually run /sandbox add ${absolutePath}`,
           isError: true,
@@ -55,28 +91,49 @@ export const requestSandboxAccessTool = createTool({
       }
 
       const questionId = `sandbox_${++requestCounter}_${Date.now()}`;
+      let answer: HarnessQuestionAnswer | unknown = resumeData;
 
-      // Create a promise that resolves when the user answers in the TUI
-      const answer = await new Promise<HarnessQuestionAnswer>(resolve => {
-        // Register the resolver so respondToQuestion() can resolve it
-        harnessCtx.registerQuestion!({
+      if (answer === undefined && toolContext?.agent?.suspend) {
+        // Harness v1 path: park the tool through the durable question suspension surface.
+        const harnessV1Ctx = harnessCtx as unknown as HarnessV1QuestionContext;
+        await harnessV1Ctx.registerQuestion({
           questionId,
-          resolve: answer => {
-            resolve(Array.isArray(answer) ? answer.join(',') : answer);
-          },
+          question: `Allow Mastra Code to access ${absolutePath}?\n\n${reason}`,
+          options: [
+            { label: 'Yes', description: 'Grant access for this session.' },
+            { label: 'No', description: 'Deny this access request.' },
+          ],
+          selectionMode: 'single_select',
+          runId: toolContext.agent.runId,
+          toolCallId: toolContext.agent.toolCallId ?? questionId,
         });
+        propagatingHarnessV1Suspension = true;
+        await toolContext.agent.suspend({});
+        propagatingHarnessV1Suspension = false;
+        return {
+          content: 'Access request could not be processed: suspension did not complete.',
+          isError: true,
+        };
+      } else if (answer === undefined && harnessCtx.emitEvent) {
+        // Legacy Harness path: emit directly and resolve through the in-memory callback registry.
+        answer = await new Promise<HarnessQuestionAnswer>(resolve => {
+          harnessCtx.registerQuestion!({
+            questionId,
+            resolve: value => {
+              resolve(Array.isArray(value) ? value.join(',') : value);
+            },
+          });
 
-        // Emit event — TUI will show the dialog
-        harnessCtx.emitEvent!({
-          type: 'sandbox_access_request',
-          questionId,
-          path: absolutePath,
-          reason,
+          harnessCtx.emitEvent!({
+            type: 'sandbox_access_request',
+            questionId,
+            path: absolutePath,
+            reason,
+          });
         });
-      });
+      }
 
-      const answerText = Array.isArray(answer) ? answer.join(', ') : answer;
-      const approved = answerText.toLowerCase().startsWith('y') || answerText.toLowerCase() === 'approve';
+      const approved = answerApproved(answer);
       if (approved) {
         // Add to allowed paths in harness state (persists across turns)
         const currentAllowed = (harnessCtx.getState?.()?.sandboxAllowedPaths as string[] | undefined) ?? [];
@@ -104,6 +161,7 @@ export const requestSandboxAccessTool = createTool({
         };
       }
     } catch (error) {
+      if (propagatingHarnessV1Suspension) throw error;
       const msg = error instanceof Error ? error.message : 'Unknown error';
       return {
         content: `Failed to request sandbox access: ${msg}`,

--- a/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
+++ b/mastracode/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
@@ -28,6 +28,7 @@ vi.mock('@mariozechner/pi-tui', () => ({
       autocompleteProviders.push({ commands });
     }
   },
+  Container: class {},
   Spacer: class {},
   Text: class {},
 }));

--- a/mastracode/src/tui/components/__tests__/om-progress.test.ts
+++ b/mastracode/src/tui/components/__tests__/om-progress.test.ts
@@ -82,4 +82,10 @@ describe('om progress label styling', () => {
     expect(rendered).not.toContain('↓');
     expect(rendered).not.toContain('-0k');
   });
+
+  it('renders small nonzero token windows without rounding to zero', () => {
+    const rendered = formatObservationStatus({ ...baseState, pendingTokens: 41, thresholdPercent: 1 }, 'full');
+
+    expect(rendered).toContain('messages <0.1/30k');
+  });
 });

--- a/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -4,6 +4,8 @@ import { describe, it, expect } from 'vitest';
 import { theme, tintHex, ensureTerminalGlyphContrast } from '../../theme.js';
 import { ToolExecutionComponentEnhanced, parseErrorFromContent } from '../tool-execution-enhanced.js';
 
+chalk.level = 1;
+
 const ui = { requestRender() {} } as any;
 
 function stripAnsi(text: string): string {

--- a/mastracode/src/tui/components/om-progress.ts
+++ b/mastracode/src/tui/components/om-progress.ts
@@ -133,6 +133,7 @@ export class OMProgressComponent extends Container {
 /** Format token count without k suffix (e.g., 7234 -> "7.2", 200 -> "0.2", 0 -> "0") */
 function formatTokensValue(n: number): string {
   if (n === 0) return '0';
+  if (n < 100) return '<0.1';
   const k = n / 1000;
   const s = k.toFixed(1);
   return s.endsWith('.0') ? s.slice(0, -2) : s;

--- a/mastracode/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/src/tui/components/tool-execution-enhanced.ts
@@ -10,7 +10,7 @@ import type { TaskItemInput } from '@mastra/core/harness';
 import chalk from 'chalk';
 import { highlight } from 'cli-highlight';
 import type { Theme as HighlightTheme } from 'cli-highlight';
-import { MC_TOOLS } from '../../tool-names.js';
+import { isSubagentToolName, MC_TOOLS } from '../../tool-names.js';
 import { BOX_INDENT, getTermWidth, theme, mastra, tintHex, ensureTerminalGlyphContrast } from '../theme.js';
 import { truncateAnsi } from './ansi.js';
 import type { ChatSpacingKind } from './chat-spacing.js';
@@ -1082,9 +1082,8 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
         return this.getFirstStringArg('pid');
       case 'skill':
         return this.getFirstStringArg('name');
-      case 'subagent':
-        return this.formatSubagentSummary();
       default:
+        if (isSubagentToolName(this.toolName)) return this.formatSubagentSummary();
         return this.formatPlainArgsSummary().trim();
     }
   }

--- a/mastracode/src/tui/event-dispatch.ts
+++ b/mastracode/src/tui/event-dispatch.ts
@@ -24,6 +24,7 @@ import {
   handleOMThreadTitleUpdated,
   handleAskQuestion,
   handleSandboxAccessRequest,
+  handleToolSuspension,
   handlePlanApproval,
   handleSubagentStart,
   handleSubagentToolStart,
@@ -366,7 +367,17 @@ export async function dispatchEvent(event: HarnessEvent, ectx: EventHandlerConte
       break;
 
     case 'sandbox_access_request':
-      await handleSandboxAccessRequest(ectx, event.questionId, event.path, event.reason);
+      await handleSandboxAccessRequest(
+        ectx,
+        event.questionId,
+        event.path,
+        event.reason,
+        (event as { responseKind?: 'question' | 'sandbox-access' }).responseKind,
+      );
+      break;
+
+    case 'tool_suspended':
+      await handleToolSuspension(ectx, event.toolCallId, event.toolName, event.suspendPayload);
       break;
 
     case 'plan_approval_required':

--- a/mastracode/src/tui/handlers/index.ts
+++ b/mastracode/src/tui/handlers/index.ts
@@ -13,7 +13,7 @@ export {
   handleOMActivation,
   handleOMThreadTitleUpdated,
 } from './om.js';
-export { handleAskQuestion, handleSandboxAccessRequest, handlePlanApproval } from './prompts.js';
+export { handleAskQuestion, handleSandboxAccessRequest, handleToolSuspension, handlePlanApproval } from './prompts.js';
 export { handleSubagentStart, handleSubagentToolStart, handleSubagentToolEnd, handleSubagentEnd } from './subagent.js';
 export {
   formatToolResult,

--- a/mastracode/src/tui/handlers/message.ts
+++ b/mastracode/src/tui/handlers/message.ts
@@ -6,6 +6,7 @@
  */
 import type { HarnessMessage, HarnessMessageContent } from '@mastra/core/harness';
 
+import { isSubagentToolName } from '../../tool-names.js';
 import {
   insertChatComponentWithBoundarySpacing,
   reconcileChatBoundarySpacers,
@@ -220,7 +221,7 @@ export function handleMessageUpdate(ctx: EventHandlerContext, message: HarnessMe
       // SubagentExecutionComponent handles the visual rendering.
       // Check subagentToolCallIds separately since handleToolStart
       // may have already added the ID to seenToolCallIds.
-      if (content.name === 'subagent' && !state.subagentToolCallIds.has(content.id)) {
+      if (isSubagentToolName(content.name) && !state.subagentToolCallIds.has(content.id)) {
         state.seenToolCallIds.add(content.id);
         state.subagentToolCallIds.add(content.id);
         // Freeze current component with pre-subagent content

--- a/mastracode/src/tui/handlers/prompts.ts
+++ b/mastracode/src/tui/handlers/prompts.ts
@@ -12,6 +12,11 @@ import { theme } from '../theme.js';
 
 import type { EventHandlerContext } from './types.js';
 
+type HarnessV1PromptResponseSurface = {
+  respondToSandboxAccess: (opts: { questionId?: string; approved: boolean; reason?: string }) => Promise<void>;
+  respondToToolSuspension: (opts: { toolCallId?: string; resumeData: unknown }) => Promise<void>;
+};
+
 /**
  * Process the next pending inline question from the queue.
  * Called when the current active question is resolved (submitted or cancelled).
@@ -20,6 +25,16 @@ function processNextInlineQuestion(state: TUIState): void {
   const next = state.pendingInlineQuestions.shift();
   if (next) {
     next();
+  }
+}
+
+function parseResumeData(answer: string): unknown {
+  const trimmed = answer.trim();
+  if (!trimmed) return {};
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return answer;
   }
 }
 
@@ -160,8 +175,20 @@ export async function handleSandboxAccessRequest(
   questionId: string,
   requestedPath: string,
   reason: string,
+  responseKind?: 'question' | 'sandbox-access',
 ): Promise<void> {
   const { state } = ctx;
+  const respond = (answer: string) => {
+    if (responseKind === 'sandbox-access') {
+      const approved = answer.toLowerCase().startsWith('y') || answer.toLowerCase() === 'approve';
+      void (state.harness as typeof state.harness & HarnessV1PromptResponseSurface).respondToSandboxAccess({
+        questionId,
+        approved,
+      });
+    } else {
+      state.harness.respondToQuestion({ questionId, answer });
+    }
+  };
   return new Promise(resolve => {
     const activate = () => {
       const questionComponent = new AskQuestionInlineComponent(
@@ -173,13 +200,13 @@ export async function handleSandboxAccessRequest(
           ],
           onSubmit: answer => {
             state.activeInlineQuestion = undefined;
-            state.harness.respondToQuestion({ questionId, answer });
+            respond(answer);
             resolve();
             processNextInlineQuestion(state);
           },
           onCancel: () => {
             state.activeInlineQuestion = undefined;
-            state.harness.respondToQuestion({ questionId, answer: 'No' });
+            respond('No');
             resolve();
             processNextInlineQuestion(state);
           },
@@ -210,6 +237,63 @@ export async function handleSandboxAccessRequest(
     }
 
     ctx.notify('sandbox_access', `Sandbox access requested: ${requestedPath}`);
+  });
+}
+
+export async function handleToolSuspension(
+  ctx: EventHandlerContext,
+  toolCallId: string,
+  toolName: string,
+  suspendPayload: unknown,
+): Promise<void> {
+  const { state } = ctx;
+  const detail =
+    suspendPayload === undefined
+      ? ''
+      : `\n${typeof suspendPayload === 'string' ? suspendPayload : JSON.stringify(suspendPayload, null, 2)}`;
+
+  return new Promise(resolve => {
+    const activate = () => {
+      const questionComponent = new AskQuestionInlineComponent(
+        {
+          question: `Tool "${toolName}" needs resume data.${detail}`,
+          multiline: true,
+          onSubmit: answer => {
+            state.activeInlineQuestion = undefined;
+            (state.harness as typeof state.harness & HarnessV1PromptResponseSurface).respondToToolSuspension({
+              toolCallId,
+              resumeData: parseResumeData(answer),
+            });
+            resolve();
+            processNextInlineQuestion(state);
+          },
+          onCancel: () => {
+            state.activeInlineQuestion = undefined;
+            (state.harness as typeof state.harness & HarnessV1PromptResponseSurface).respondToToolSuspension({
+              toolCallId,
+              resumeData: {},
+            });
+            resolve();
+            processNextInlineQuestion(state);
+          },
+        },
+        state.ui,
+      );
+
+      state.activeInlineQuestion = questionComponent;
+      state.chatContainer.addChild(questionComponent);
+      questionComponent.focused = true;
+      state.ui.requestRender();
+      state.chatContainer.invalidate();
+    };
+
+    if (state.activeInlineQuestion) {
+      state.pendingInlineQuestions.push(activate);
+    } else {
+      activate();
+    }
+
+    ctx.notify('ask_question', `Tool ${toolName} needs resume data`);
   });
 }
 

--- a/mastracode/src/tui/handlers/tool.ts
+++ b/mastracode/src/tui/handlers/tool.ts
@@ -11,6 +11,7 @@ import { safeStringify } from '@mastra/core/utils';
 import { parse as parsePartialJson } from 'partial-json';
 
 import { getToolCategory, TOOL_CATEGORIES } from '../../permissions.js';
+import { isSubagentToolName } from '../../tool-names.js';
 import { reconcileChatBoundarySpacers } from '../chat-boundary-reconciliation.js';
 import { AskQuestionInlineComponent } from '../components/ask-question-inline.js';
 import { AssistantMessageComponent } from '../components/assistant-message.js';
@@ -23,6 +24,13 @@ import { showModalOverlay } from '../overlay.js';
 import { getMarkdownTheme } from '../theme.js';
 
 import type { EventHandlerContext } from './types.js';
+
+type ToolApprovalResponseSurface = {
+  respondToToolApproval: (opts: {
+    toolCallId?: string;
+    decision: 'approve' | 'decline' | 'always_allow_category';
+  }) => void;
+};
 
 function getCurrentModeColor(ctx: EventHandlerContext): string | undefined {
   return ctx.state.harness.getCurrentMode?.()?.color;
@@ -141,18 +149,21 @@ export function handleToolApprovalRequired(
     args,
     categoryLabel,
     onAction: (action: ApprovalAction) => {
-      state.ui.hideOverlay();
-      state.pendingApprovalDismiss = null;
-      if (action.type === 'approve') {
-        state.harness.respondToToolApproval({ decision: 'approve' });
-      } else if (action.type === 'always_allow_category') {
-        state.harness.respondToToolApproval({ decision: 'always_allow_category' });
-      } else if (action.type === 'yolo') {
-        state.harness.setState({ yolo: true } as any);
-        state.harness.respondToToolApproval({ decision: 'approve' });
-      } else {
-        state.harness.respondToToolApproval({ decision: 'decline' });
-      }
+      void (async () => {
+        state.ui.hideOverlay();
+        state.pendingApprovalDismiss = null;
+        const harness = state.harness as typeof state.harness & ToolApprovalResponseSurface;
+        if (action.type === 'approve') {
+          harness.respondToToolApproval({ toolCallId, decision: 'approve' });
+        } else if (action.type === 'always_allow_category') {
+          harness.respondToToolApproval({ toolCallId, decision: 'always_allow_category' });
+        } else if (action.type === 'yolo') {
+          await state.harness.setState({ yolo: true } as any);
+          harness.respondToToolApproval({ toolCallId, decision: 'approve' });
+        } else {
+          harness.respondToToolApproval({ toolCallId, decision: 'decline' });
+        }
+      })().catch(error => ctx.showError(error instanceof Error ? error.message : String(error)));
     },
   });
 
@@ -160,7 +171,10 @@ export function handleToolApprovalRequired(
   state.pendingApprovalDismiss = () => {
     state.ui.hideOverlay();
     state.pendingApprovalDismiss = null;
-    state.harness.respondToToolApproval({ decision: 'decline' });
+    (state.harness as typeof state.harness & ToolApprovalResponseSurface).respondToToolApproval({
+      toolCallId,
+      decision: 'decline',
+    });
   };
 
   // Show the dialog as an overlay
@@ -186,7 +200,7 @@ export function handleToolStart(ctx: EventHandlerContext, toolCallId: string, to
 
     // Skip creating the regular tool component for subagent calls
     // The SubagentExecutionComponent will handle all the rendering
-    if (toolName === 'subagent') {
+    if (isSubagentToolName(toolName)) {
       return;
     }
 
@@ -334,7 +348,7 @@ export function handleToolInputStart(ctx: EventHandlerContext, toolCallId: strin
     state.streamingComponent = new AssistantMessageComponent(undefined, state.hideThinkingBlock, getMarkdownTheme());
     ctx.addChildBeforeFollowUps(state.streamingComponent);
     state.ui.requestRender();
-  } else if (toolName !== 'subagent') {
+  } else if (!isSubagentToolName(toolName)) {
     const component = new ToolExecutionComponentEnhanced(
       toolName,
       {},

--- a/mastracode/src/tui/mastra-tui.ts
+++ b/mastracode/src/tui/mastra-tui.ts
@@ -5,7 +5,6 @@
 import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
 import type { Component } from '@mariozechner/pi-tui';
-import type { AgentSignalAttributes } from '@mastra/core/agent';
 import type { HarnessEvent, HarnessMessage } from '@mastra/core/harness';
 import type { Workspace } from '@mastra/core/workspace';
 import { getOAuthProviders } from '../auth/storage.js';
@@ -81,6 +80,8 @@ import { updateStatusLine } from './status-line.js';
 
 export type { MastraTUIOptions } from './state.js';
 
+type SignalDeliveryAttributes = Record<string, string | number | boolean | null | undefined>;
+
 // =============================================================================
 // MastraTUI Class
 // =============================================================================
@@ -91,8 +92,8 @@ export type { MastraTUIOptions } from './state.js';
  * The LLM sees these as XML attributes on the `<user-message>` element.
  */
 const USER_SIGNAL_DELIVERY_OPTIONS: {
-  ifActive: { attributes: AgentSignalAttributes };
-  ifIdle: { attributes: AgentSignalAttributes };
+  ifActive: { attributes: SignalDeliveryAttributes };
+  ifIdle: { attributes: SignalDeliveryAttributes };
 } = {
   ifActive: { attributes: { delivery: 'while-active' } },
   ifIdle: { attributes: { delivery: 'message' } },
@@ -358,6 +359,14 @@ export class MastraTUI {
     this.state.messageComponentsById.set(signalId, component);
   }
 
+  private remapSignalMessageId(previousId: string, signalId: string): void {
+    this.remapOptimisticUserMessage(previousId, signalId);
+    const pending = this.state.pendingSignalMessageComponentsById.get(previousId);
+    if (!pending || previousId === signalId) return;
+    this.state.pendingSignalMessageComponentsById.delete(previousId);
+    this.state.pendingSignalMessageComponentsById.set(signalId, pending);
+  }
+
   private createPendingNewThread(): Promise<void> | undefined {
     if (!this.state.pendingNewThread) return undefined;
     this.state.pendingNewThread = false;
@@ -382,14 +391,18 @@ export class MastraTUI {
       });
 
       const signal = this.state.harness.sendSignal({
-        content: this.createUserSignalContent(content, images),
+        content: this.createUserSignalContent(content, images) as never,
         ...USER_SIGNAL_DELIVERY_OPTIONS,
       });
+      const optimisticSignalId = signal.id;
       this.remapOptimisticUserMessage(optimisticMessageId, signal.id);
-      signal.accepted.catch((error: unknown) => {
-        this.removeOptimisticUserMessage(signal.id);
-        showError(this.state, error instanceof Error ? error.message : 'Unknown error');
-      });
+      signal.accepted
+        .then(() => this.remapSignalMessageId(optimisticSignalId, signal.id))
+        .catch((error: unknown) => {
+          this.removeOptimisticUserMessage(signal.id);
+          this.removeOptimisticUserMessage(optimisticSignalId);
+          showError(this.state, error instanceof Error ? error.message : 'Unknown error');
+        });
     };
 
     const pendingThread = this.createPendingNewThread();
@@ -410,9 +423,10 @@ export class MastraTUI {
     const send = () => {
       this.clearIdleCounter();
       const signal = this.state.harness.sendSignal({
-        content: this.createUserSignalContent(content, images),
+        content: this.createUserSignalContent(content, images) as never,
         ...USER_SIGNAL_DELIVERY_OPTIONS,
       });
+      const optimisticSignalId = signal.id;
 
       if (hasActiveRun) {
         addPendingUserMessage(this.state, signal.id, content, images, { isInterjection: true });
@@ -420,14 +434,18 @@ export class MastraTUI {
         addUserMessage(this.state, this.createUserSignalMessage(content, images, signal.id));
       }
 
-      signal.accepted.catch((error: unknown) => {
-        if (hasActiveRun) {
-          removePendingUserMessage(this.state, signal.id);
-        } else {
-          this.removeOptimisticUserMessage(signal.id);
-        }
-        showError(this.state, error instanceof Error ? error.message : 'Unknown error');
-      });
+      signal.accepted
+        .then(() => this.remapSignalMessageId(optimisticSignalId, signal.id))
+        .catch((error: unknown) => {
+          if (hasActiveRun) {
+            removePendingUserMessage(this.state, signal.id);
+            removePendingUserMessage(this.state, optimisticSignalId);
+          } else {
+            this.removeOptimisticUserMessage(signal.id);
+            this.removeOptimisticUserMessage(optimisticSignalId);
+          }
+          showError(this.state, error instanceof Error ? error.message : 'Unknown error');
+        });
     };
 
     const pendingThread = this.createPendingNewThread();

--- a/mastracode/src/tui/render-messages.ts
+++ b/mastracode/src/tui/render-messages.ts
@@ -8,6 +8,8 @@ import type { Component } from '@mariozechner/pi-tui';
 import type { HarnessMessage, HarnessMessageContent, TaskItemInput, TaskItemSnapshot } from '@mastra/core/harness';
 import { assignTaskIds, parseSubagentMeta } from '@mastra/core/harness';
 import chalk from 'chalk';
+
+import { isSubagentToolName } from '../tool-names.js';
 import {
   insertChatComponentWithBoundarySpacing,
   reconcileChatBoundarySpacers,
@@ -607,12 +609,13 @@ export async function renderExistingMessages(state: TUIState): Promise<void> {
           const toolResult = message.content.find(c => c.type === 'tool_result' && c.id === content.id);
 
           // Render subagent tool calls with dedicated component
-          if (content.name === 'subagent') {
+          if (isSubagentToolName(content.name)) {
             const subArgs = content.args as
               | {
                   agentType?: string;
                   task?: string;
                   modelId?: string;
+                  modelOverride?: string;
                   forked?: boolean;
                 }
               | undefined;
@@ -626,7 +629,11 @@ export async function renderExistingMessages(state: TUIState): Promise<void> {
               typeof (state.harness as { getFullModelId?: () => string }).getFullModelId === 'function'
                 ? (state.harness as { getFullModelId: () => string }).getFullModelId()
                 : undefined;
-            const modelId = meta?.modelId ?? subArgs?.modelId ?? (subArgs?.forked ? currentModelId : undefined);
+            const modelId =
+              meta?.modelId ??
+              subArgs?.modelOverride ??
+              subArgs?.modelId ??
+              (subArgs?.forked ? currentModelId : undefined);
             const durationMs = meta?.durationMs ?? 0;
 
             const subComponent = new SubagentExecutionComponent(

--- a/packages/cli/src/commands/api/route-metadata.generated.ts
+++ b/packages/cli/src/commands/api/route-metadata.generated.ts
@@ -3252,9 +3252,12 @@ export const API_ROUTE_METADATA = {
       "admissionId",
       "attachments",
       "content",
+      "deadline",
       "files",
       "mode",
       "model",
+      "notBefore",
+      "priority",
       "yolo"
     ],
     "hasQuery": false,

--- a/packages/core/src/harness/index.ts
+++ b/packages/core/src/harness/index.ts
@@ -1,4 +1,5 @@
 export { Harness } from './harness';
+export { convertStoredMessageToHarnessMessage } from './_shared/message-conversion';
 export {
   askUserTool,
   assignTaskIds,
@@ -50,3 +51,4 @@ export type {
   BuiltinToolId,
   TokenUsage,
 } from './types';
+export type { StoredMessageRow } from './_shared/message-conversion';

--- a/packages/core/src/harness/v1/errors.ts
+++ b/packages/core/src/harness/v1/errors.ts
@@ -453,3 +453,15 @@ export class HarnessWorkspaceInUseError extends Error {
     super(`Workspace for resource "${resourceId}" is in use (refCount: ${refCount})`);
   }
 }
+
+export class HarnessQueueFullDroppedError extends Error {
+  readonly name = 'HarnessQueueFullDroppedError';
+  readonly code = 'harness.queue_full_dropped';
+  constructor(public readonly queuedItemId?: string) {
+    super(
+      queuedItemId
+        ? `Queued item "${queuedItemId}" was dropped because the session queue was full`
+        : 'Queued work was dropped because the session queue was full',
+    );
+  }
+}

--- a/packages/core/src/harness/v1/events.ts
+++ b/packages/core/src/harness/v1/events.ts
@@ -288,6 +288,15 @@ export interface SuspensionResolvedEvent extends HarnessEventBase {
   toolCallId: string;
 }
 
+export interface SandboxAccessRequestedEvent extends HarnessEventBase {
+  type: 'sandbox_access_requested';
+  requestId: string;
+  toolCallId: string;
+  semanticType: 'file' | 'command' | 'network' | 'mcp' | 'custom';
+  reason?: string;
+  payload?: JsonValue;
+}
+
 /**
  * Session-wide cancellation was durably requested. Per-item queue drops are
  * emitted as `queue_item_cancelled` so consumers can audit both the session
@@ -331,6 +340,26 @@ export interface QueueItemCancelledEvent extends HarnessEventBase {
   queuedItemId: string;
   admissionId?: string;
   reason?: string;
+}
+
+export interface QueueItemExpiredEvent extends HarnessEventBase {
+  type: 'queue_item_expired';
+  queuedItemId: string;
+  admissionId?: string;
+  /** Epoch ms — the deadline that was missed. */
+  deadline: number;
+}
+
+export interface QueueFullDroppedEvent extends HarnessEventBase {
+  type: 'queue_full_dropped';
+  source: 'queue' | 'goal';
+  policy: 'reject' | 'drop-oldest';
+  maxQueueDepth: number;
+  queuedItemId?: string;
+  admissionId?: string;
+  replacementQueuedItemId?: string;
+  replacementAdmissionId?: string;
+  goalId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -447,6 +476,7 @@ export interface SubagentToolStartEvent extends HarnessEventBase {
   agentType: string;
   innerToolCallId: string;
   toolName: string;
+  args?: unknown;
   parentId?: string;
   depth: number;
 }
@@ -574,10 +604,13 @@ export type HarnessEvent =
   | AgentEndEvent
   | SuspensionRequiredEvent
   | SuspensionResolvedEvent
+  | SandboxAccessRequestedEvent
   | TaskCancellationRequestedEvent
   | QueueItemStartedEvent
   | QueueItemReplayedEvent
   | QueueItemCancelledEvent
+  | QueueItemExpiredEvent
+  | QueueFullDroppedEvent
   | ThreadCreatedEvent
   | ThreadRenamedEvent
   | ThreadDeletedEvent
@@ -856,6 +889,8 @@ const RESERVED_EVENT_TYPES: ReadonlySet<string> = new Set([
   'queue_item_started',
   'queue_item_replayed',
   'queue_item_cancelled',
+  'queue_item_expired',
+  'queue_full_dropped',
   'queue_item_failed',
   'queue_item_completed',
   'thread_created',

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -96,6 +96,7 @@ import type {
   HarnessConfig,
   HarnessFileConfig,
   HarnessMode,
+  HarnessQueueBackpressurePolicy,
   HarnessSkill,
   HarnessSkillActionMetadata,
   HarnessSkillActionPermissionHints,
@@ -678,6 +679,7 @@ export class Harness {
   private readonly _liveSessions = new Map<string, Session>();
   private readonly _leaseTtlMs: number;
   private readonly _maxQueueDepth: number;
+  private readonly _queueBackpressure: HarnessQueueBackpressurePolicy;
   private readonly _closeTimeoutMs: number;
   private readonly _fileConfig: Readonly<HarnessFileConfig>;
   private readonly _subagentTypes: ReadonlyMap<string, SubagentDefinition>;
@@ -721,6 +723,10 @@ export class Harness {
     this._maxQueueDepth = config.sessions?.maxQueueDepth ?? DEFAULT_MAX_QUEUE_DEPTH;
     if (this._maxQueueDepth < 1) {
       throw new HarnessConfigError('sessions.maxQueueDepth', 'must be a positive integer');
+    }
+    this._queueBackpressure = config.sessions?.queueBackpressure ?? 'reject';
+    if (this._queueBackpressure !== 'reject' && this._queueBackpressure !== 'drop-oldest') {
+      throw new HarnessConfigError('sessions.queueBackpressure', 'must be "reject" or "drop-oldest"');
     }
     this._closeTimeoutMs = config.sessions?.closeTimeoutMs ?? DEFAULT_CLOSE_TIMEOUT_MS;
     if (
@@ -3914,6 +3920,11 @@ export class Harness {
   /** @internal — accessor for `Session.queue()` admission caps. */
   get _internalMaxQueueDepth(): number {
     return this._maxQueueDepth;
+  }
+
+  /** @internal — accessor for `Session.queue()` full-queue behavior. */
+  get _internalQueueBackpressure(): HarnessQueueBackpressurePolicy {
+    return this._queueBackpressure;
   }
 
   /** @internal — goal-loop defaults, consumed by `Session.setGoal()` (§4.7). */

--- a/packages/core/src/harness/v1/index.ts
+++ b/packages/core/src/harness/v1/index.ts
@@ -39,7 +39,9 @@ export type {
   PermissionGrantedEvent,
   PermissionPolicyChangedEvent,
   PermissionRevokedEvent,
+  QueueFullDroppedEvent,
   QueueItemCancelledEvent,
+  SandboxAccessRequestedEvent,
   SessionClosedEvent,
   SessionClosingEvent,
   SessionCreatedEvent,
@@ -61,6 +63,7 @@ export type {
 } from './events';
 
 export { HARNESS_EVENT_ID_PREFIX, formatHarnessEventId, parseHarnessEventId } from './events';
+export { getHarnessWorkspaceActionPathInput, isHarnessWorkspaceFileMutationTool } from './workspace-actions';
 
 export {
   HarnessAttachmentInUseError,
@@ -69,6 +72,7 @@ export {
   HarnessAdmissionConflictError,
   HarnessInboxItemNotFoundError,
   HarnessInboxResponseConflictError,
+  HarnessQueueFullDroppedError,
   HarnessQueueFullError,
   HarnessRuntimeDependencyDriftError,
   HarnessSessionCancelledError,
@@ -142,7 +146,11 @@ export type {
  * underlying definitions used by the legacy `Harness`, so renderers can
  * import from either entry point and consume the same shape.
  */
-export type { HarnessMessage, HarnessMessageContent } from '../types';
+export type {
+  HarnessMessage,
+  HarnessMessageContent,
+  HarnessMessageContent as HarnessMessageContentPart,
+} from '../types';
 
 /**
  * Goal-loop primitive types (§4.7). `GoalState` lives in `SessionRecord.goal`
@@ -187,6 +195,7 @@ export type {
   HarnessMcpServerDescriptor,
   HarnessMcpToolDescriptor,
   HarnessMode,
+  HarnessQueueBackpressurePolicy,
   HarnessSkill,
   HarnessSkillActionMetadata,
   HarnessSkillActionPermissionHints,

--- a/packages/core/src/harness/v1/session.actions.test.ts
+++ b/packages/core/src/harness/v1/session.actions.test.ts
@@ -21,7 +21,7 @@ import type { Workspace } from '../../workspace';
 
 import { HarnessSessionClosedError, HarnessValidationError, HarnessWorkspaceLostError } from './errors';
 import { Harness } from './harness';
-import type { WorkspaceProvider } from './workspace-provider';
+import type { WorkspaceProvider } from './workspace/provider';
 
 class MockMcpServer extends MCPServerBase {
   public toolListCallCount = 0;

--- a/packages/core/src/harness/v1/session.goal.test.ts
+++ b/packages/core/src/harness/v1/session.goal.test.ts
@@ -307,6 +307,103 @@ describe('Session goal — continuation wording (TUI parity)', () => {
     expect(queued[0]!.source).toBe('goal');
   });
 
+  it('emits queue_full_dropped instead of silently dropping a goal continuation when queue is full', async () => {
+    const { harness } = setupHarness({
+      goals: { defaultJudgeModel: 'judge:test' },
+      sessions: { maxQueueDepth: 1 },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const existing = await session.admitQueue({
+      content: 'blocked user work',
+      admissionId: 'goal-full-existing',
+      notBefore: Date.now() + 60_000,
+    });
+    const events = record(session, ['queue_full_dropped']);
+
+    const goal = await session.setGoal({ objective: 'ship the thing' });
+
+    expect(session.getRecord().pendingQueue).toEqual([
+      expect.objectContaining({ id: existing.queuedItemId, admissionId: 'goal-full-existing' }),
+    ]);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'queue_full_dropped',
+      source: 'goal',
+      policy: 'reject',
+      maxQueueDepth: 1,
+      goalId: goal.id,
+    });
+    await session.cancelQueuedItem({ queuedItemId: existing.queuedItemId, reason: 'test cleanup' });
+    await session.close();
+  });
+
+  it('drop-oldest backpressure admits a goal continuation and records the dropped queued item', async () => {
+    const { harness } = setupHarness({
+      goals: { defaultJudgeModel: 'judge:test' },
+      sessions: { maxQueueDepth: 1, queueBackpressure: 'drop-oldest' },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const existing = await session.admitQueue({
+      content: 'blocked user work',
+      admissionId: 'goal-drop-existing',
+      notBefore: Date.now() + 60_000,
+    });
+    const events = record(session, ['queue_full_dropped']);
+
+    const goal = await session.setGoal({ objective: 'ship the thing' });
+
+    const queue = session.getRecord().pendingQueue ?? [];
+    expect(queue).toHaveLength(1);
+    expect(queue[0]).toMatchObject({ source: 'goal', goalId: goal.id });
+    expect(session.getRecord().queueAdmissionReceipts?.[existing.queuedItemId]).toMatchObject({
+      status: 'failed',
+      error: expect.objectContaining({ code: 'harness.queue_full_dropped' }),
+    });
+    expect(events[0]).toMatchObject({
+      type: 'queue_full_dropped',
+      source: 'goal',
+      policy: 'drop-oldest',
+      maxQueueDepth: 1,
+      queuedItemId: existing.queuedItemId,
+      admissionId: 'goal-drop-existing',
+      goalId: goal.id,
+    });
+    await session.cancelQueuedItem({ queuedItemId: queue[0]!.id, reason: 'test cleanup' });
+    await session.close();
+  });
+
+  it('drop-oldest backpressure records a full goal queue when only the active queued head is present', async () => {
+    const { harness, agent } = setupHarness({
+      goals: { defaultJudgeModel: 'judge:test' },
+      sessions: { maxQueueDepth: 1, queueBackpressure: 'drop-oldest' },
+    });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    agent.enqueueRun({
+      finishReason: 'suspended',
+      runId: 'active-goal-head',
+      suspendPayload: { toolCallId: 'tc-active-goal-head', toolName: 'shell', args: { cmd: 'echo hold' } },
+    });
+    const active = session.queue({ content: 'active queued work' });
+    void active.catch(() => {});
+    await new Promise(resolve => setImmediate(resolve));
+    const events = record(session, ['queue_full_dropped']);
+
+    const goal = await session.setGoal({ objective: 'ship the thing' });
+
+    expect(session.getRecord().pendingQueue).toEqual([expect.objectContaining({ content: 'active queued work' })]);
+    expect(events[0]).toMatchObject({
+      type: 'queue_full_dropped',
+      source: 'goal',
+      policy: 'drop-oldest',
+      maxQueueDepth: 1,
+      goalId: goal.id,
+    });
+    agent.enqueueRun({ finishReason: 'stop', runId: 'active-goal-head', text: 'done' });
+    await session.respondToToolApproval({ approved: true });
+    await active;
+    await session.close();
+  });
+
   it('judge continue uses the [Goal attempt N/M] template wrapped in <system-reminder type="goal-judge">', async () => {
     const { harness, agent } = setupHarness({ goals: { defaultJudgeModel: 'judge:test' } });
     const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });

--- a/packages/core/src/harness/v1/session.queue.test.ts
+++ b/packages/core/src/harness/v1/session.queue.test.ts
@@ -185,6 +185,14 @@ describe('Session.queue() — admission', () => {
         deadline: Number.POSITIVE_INFINITY,
       } as any),
     ).rejects.toBeInstanceOf(HarnessValidationError);
+    await expect(
+      session.admitQueue({
+        content: 'bad window',
+        admissionId: 'queue-bad-window',
+        notBefore: Date.now() + 10_000,
+        deadline: Date.now(),
+      }),
+    ).rejects.toThrow('`notBefore` must be less than or equal to `deadline`');
     await session.close();
   });
 
@@ -287,6 +295,37 @@ describe('Session.queue() — admission', () => {
     });
 
     await expect(session.queue({ content: 'first' })).rejects.toBeInstanceOf(HarnessQueueFullDroppedError);
+    await session.close();
+  });
+
+  it('rejects queue() if the receipt fails before the local resolver is registered', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const admitQueue = (session as any)._admitQueue.bind(session);
+    vi.spyOn(session as any, '_admitQueue').mockImplementation(async (...args: any[]) => {
+      const admission = await admitQueue(...args);
+      const now = Date.now();
+      await (session as any)._flushUpdate((prev: any) => ({
+        ...prev,
+        pendingQueue: (prev.pendingQueue ?? []).filter((item: { id: string }) => item.id !== admission.queuedItemId),
+        queueAdmissionReceipts: {
+          ...(prev.queueAdmissionReceipts ?? {}),
+          [admission.queuedItemId]: {
+            ...prev.queueAdmissionReceipts[admission.queuedItemId],
+            status: 'failed',
+            error: {
+              code: 'harness.queue_failed',
+              message: 'queued turn failed before resolver registration',
+            },
+            failedAt: now,
+            updatedAt: now,
+          },
+        },
+      }));
+      return admission;
+    });
+
+    await expect(session.queue({ content: 'first' })).rejects.toMatchObject({ code: 'harness.queue_failed' });
     await session.close();
   });
 

--- a/packages/core/src/harness/v1/session.queue.test.ts
+++ b/packages/core/src/harness/v1/session.queue.test.ts
@@ -27,6 +27,7 @@ import { InMemoryStore } from '../../storage/mock';
 import { extractSignalContents, MockAgent, setupHarness } from './__test-utils__';
 import {
   HarnessAdmissionConflictError,
+  HarnessQueueFullDroppedError,
   HarnessQueueFullError,
   HarnessSessionDeletedError,
   HarnessValidationError,
@@ -71,6 +72,122 @@ describe('Session.queue() — admission', () => {
     await session.close();
   });
 
+  it('persists scheduling options and keeps future notBefore items queued', async () => {
+    const { harness, agent } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const notBefore = Date.now() + 60_000;
+    const deadline = notBefore + 60_000;
+
+    const admitted = await session.admitQueue({
+      content: 'delayed work',
+      admissionId: 'queue-scheduled',
+      priority: 7,
+      deadline,
+      notBefore,
+    });
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(agent.streamCalls).toHaveLength(0);
+    expect(session.getRecord().pendingQueue).toEqual([
+      expect.objectContaining({
+        id: admitted.queuedItemId,
+        admissionId: 'queue-scheduled',
+        priority: 7,
+        deadline,
+        notBefore,
+      }),
+    ]);
+    await session.cancelQueuedItem({ queuedItemId: admitted.queuedItemId, reason: 'test cleanup' });
+    await session.close();
+  });
+
+  it('wakes a delayed notBefore item without another queue admission', async () => {
+    const { harness, agent } = setupHarness();
+    agent.enqueueRun({ finishReason: 'stop', text: 'delayed reply' });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const notBefore = Date.now() + 25;
+
+    const admitted = await session.admitQueue({
+      content: 'delayed work',
+      admissionId: 'queue-delayed-wakeup',
+      notBefore,
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    expect(agent.streamCalls).toHaveLength(0);
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+    await session.waitForIdle({ timeoutMs: 1000 });
+
+    expect(agent.streamCalls).toHaveLength(1);
+    expect(session.getRecord().pendingQueue).toEqual([]);
+    expect(session.getRecord().queueAdmissionReceipts?.[admitted.queuedItemId]?.status).toBe('completed');
+    await session.close();
+  });
+
+  it('includes scheduling options in queue admission conflict detection', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const notBefore = Date.now() + 60_000;
+    const deadline = notBefore + 60_000;
+
+    const admitted = await session.admitQueue({
+      content: 'delayed work',
+      admissionId: 'queue-schedule-conflict',
+      priority: 1,
+      deadline,
+      notBefore,
+    });
+
+    await expect(
+      session.admitQueue({
+        content: 'delayed work',
+        admissionId: 'queue-schedule-conflict',
+        priority: 2,
+        deadline,
+        notBefore,
+      }),
+    ).rejects.toBeInstanceOf(HarnessAdmissionConflictError);
+    expect(session.getRecord().pendingQueue).toHaveLength(1);
+    await session.cancelQueuedItem({ queuedItemId: admitted.queuedItemId, reason: 'test cleanup' });
+    await session.close();
+  });
+
+  it('treats omitted priority and priority 0 as the same admission payload', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const admitted = await session.admitQueue({
+      content: 'default priority',
+      admissionId: 'queue-default-priority',
+    });
+    const duplicate = await session.admitQueue({
+      content: 'default priority',
+      admissionId: 'queue-default-priority',
+      priority: 0,
+    });
+
+    expect(duplicate).toEqual({ accepted: true, queuedItemId: admitted.queuedItemId, duplicate: true });
+    await session.cancelQueuedItem({ queuedItemId: admitted.queuedItemId, reason: 'test cleanup' });
+    await session.close();
+  });
+
+  it('rejects non-finite scheduling options at admission', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await expect(
+      session.admitQueue({ content: 'bad priority', admissionId: 'queue-bad-priority', priority: Number.NaN } as any),
+    ).rejects.toBeInstanceOf(HarnessValidationError);
+    await expect(
+      session.admitQueue({
+        content: 'bad deadline',
+        admissionId: 'queue-bad-deadline',
+        deadline: Number.POSITIVE_INFINITY,
+      } as any),
+    ).rejects.toBeInstanceOf(HarnessValidationError);
+    await session.close();
+  });
+
   it('throws HarnessQueueFullError once pendingQueue reaches sessions.maxQueueDepth', async () => {
     // Build a harness with a tiny cap so we can hit it.
     const agent = new MockAgent({ id: 'default' });
@@ -98,6 +215,180 @@ describe('Session.queue() — admission', () => {
     agent.enqueueRun({ finishReason: 'stop', runId: 'r1', text: 'done' });
     await session.respondToToolApproval({ approved: true });
     await first;
+    await session.close();
+  });
+
+  it('drop-oldest backpressure removes the oldest waiting item and admits the replacement', async () => {
+    const { harness } = setupHarness({ sessions: { maxQueueDepth: 1, queueBackpressure: 'drop-oldest' } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const events: HarnessEvent[] = [];
+    session.subscribe(e => events.push(e));
+    const first = session.queue({
+      content: 'first',
+      admissionId: 'queue-drop-oldest-first',
+      notBefore: Date.now() + 60_000,
+    });
+    await new Promise(resolve => setImmediate(resolve));
+
+    const second = await session.admitQueue({
+      content: 'second',
+      admissionId: 'queue-drop-oldest-second',
+      notBefore: Date.now() + 60_000,
+    });
+
+    await expect(first).rejects.toBeInstanceOf(HarnessQueueFullDroppedError);
+    expect(session.getRecord().pendingQueue).toEqual([
+      expect.objectContaining({ id: second.queuedItemId, admissionId: 'queue-drop-oldest-second' }),
+    ]);
+    expect(session.getRecord().queueAdmissionReceipts?.[second.queuedItemId]?.status).toBe('queued');
+    const droppedReceipt = Object.values(session.getRecord().queueAdmissionReceipts ?? {}).find(
+      receipt => receipt.admissionId === 'queue-drop-oldest-first',
+    );
+    expect(droppedReceipt).toMatchObject({
+      status: 'failed',
+      error: expect.objectContaining({ code: 'harness.queue_full_dropped' }),
+    });
+    expect(events.find(e => e.type === 'queue_full_dropped')).toMatchObject({
+      source: 'queue',
+      policy: 'drop-oldest',
+      maxQueueDepth: 1,
+      admissionId: 'queue-drop-oldest-first',
+      replacementAdmissionId: 'queue-drop-oldest-second',
+    });
+    await session.cancelQueuedItem({ queuedItemId: second.queuedItemId, reason: 'test cleanup' });
+    await session.close();
+  });
+
+  it('rejects queue() if backpressure dropped the item before the local resolver was registered', async () => {
+    const { harness } = setupHarness({ sessions: { maxQueueDepth: 1, queueBackpressure: 'drop-oldest' } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const admitQueue = (session as any)._admitQueue.bind(session);
+    vi.spyOn(session as any, '_admitQueue').mockImplementation(async (...args: any[]) => {
+      const admission = await admitQueue(...args);
+      const now = Date.now();
+      await (session as any)._flushUpdate((prev: any) => ({
+        ...prev,
+        pendingQueue: (prev.pendingQueue ?? []).filter((item: { id: string }) => item.id !== admission.queuedItemId),
+        queueAdmissionReceipts: {
+          ...(prev.queueAdmissionReceipts ?? {}),
+          [admission.queuedItemId]: {
+            ...prev.queueAdmissionReceipts[admission.queuedItemId],
+            status: 'failed',
+            error: {
+              code: 'harness.queue_full_dropped',
+              message: `Queued item "${admission.queuedItemId}" was dropped because the session queue was full`,
+            },
+            failedAt: now,
+            updatedAt: now,
+          },
+        },
+      }));
+      return admission;
+    });
+
+    await expect(session.queue({ content: 'first' })).rejects.toBeInstanceOf(HarnessQueueFullDroppedError);
+    await session.close();
+  });
+
+  it('drop-oldest backpressure preserves a rehydrated suspended queued head', async () => {
+    const { harness } = setupHarness({ sessions: { maxQueueDepth: 1, queueBackpressure: 'drop-oldest' } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const now = Date.now();
+    const queuedItemId = 'q-suspended-head';
+    await (session as any)._flushUpdate((prev: any) => ({
+      ...prev,
+      pendingQueue: [
+        {
+          id: queuedItemId,
+          admissionId: 'suspended-head',
+          admissionHash: 'hash-suspended-head',
+          enqueuedAt: now,
+          content: 'resume me',
+          attachments: [],
+        },
+      ],
+      pendingResume: {
+        kind: 'tool-approval',
+        itemId: 'tool-approval:tc-suspended-head',
+        runId: 'run-suspended-head',
+        toolCallId: 'tc-suspended-head',
+        toolName: 'shell',
+        source: 'parent',
+        requestedAt: now,
+        queuedItemId,
+        payload: { input: { cmd: 'echo hold' } },
+      },
+      queueAdmissionReceipts: {
+        ...(prev.queueAdmissionReceipts ?? {}),
+        [queuedItemId]: {
+          admissionId: 'suspended-head',
+          admissionHash: 'hash-suspended-head',
+          queuedItemId,
+          status: 'accepted',
+          runId: 'run-suspended-head',
+          signalId: 'signal-suspended-head',
+          attempts: 1,
+          enqueuedAt: now,
+          acceptedAt: now,
+          updatedAt: now,
+        },
+      },
+    }));
+
+    await expect(session.admitQueue({ content: 'replacement', admissionId: 'replacement' })).rejects.toBeInstanceOf(
+      HarnessQueueFullError,
+    );
+    expect(session.getRecord().pendingQueue).toEqual([expect.objectContaining({ id: queuedItemId })]);
+    expect(session.getRecord().pendingResume).toMatchObject({ queuedItemId });
+    expect(session.getRecord().queueAdmissionReceipts?.[queuedItemId]?.status).toBe('accepted');
+    await (session as any)._flushUpdate((prev: any) => {
+      const next = { ...prev, pendingQueue: [] };
+      delete next.pendingResume;
+      return next;
+    });
+    await session.close();
+  });
+
+  it('drop-oldest backpressure preserves accepted queued items awaiting recovery', async () => {
+    const { harness } = setupHarness({ sessions: { maxQueueDepth: 1, queueBackpressure: 'drop-oldest' } });
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const now = Date.now();
+    const queuedItemId = 'q-accepted-recovery';
+    await (session as any)._flushUpdate((prev: any) => ({
+      ...prev,
+      pendingQueue: [
+        {
+          id: queuedItemId,
+          admissionId: 'accepted-recovery',
+          admissionHash: 'hash-accepted-recovery',
+          enqueuedAt: now,
+          content: 'recover me',
+          attachments: [],
+        },
+      ],
+      queueAdmissionReceipts: {
+        ...(prev.queueAdmissionReceipts ?? {}),
+        [queuedItemId]: {
+          admissionId: 'accepted-recovery',
+          admissionHash: 'hash-accepted-recovery',
+          queuedItemId,
+          status: 'accepted',
+          runId: 'run-accepted-recovery',
+          signalId: 'signal-accepted-recovery',
+          attempts: 1,
+          enqueuedAt: now,
+          acceptedAt: now,
+          updatedAt: now,
+        },
+      },
+    }));
+
+    await expect(
+      session.admitQueue({ content: 'replacement', admissionId: 'replacement-after-accepted' }),
+    ).rejects.toBeInstanceOf(HarnessQueueFullError);
+    expect(session.getRecord().pendingQueue).toEqual([expect.objectContaining({ id: queuedItemId })]);
+    expect(session.getRecord().queueAdmissionReceipts?.[queuedItemId]?.status).toBe('accepted');
+    await (session as any)._flushUpdate((prev: any) => ({ ...prev, pendingQueue: [] }));
     await session.close();
   });
 

--- a/packages/core/src/harness/v1/session.scheduler.test.ts
+++ b/packages/core/src/harness/v1/session.scheduler.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Harness v1 — durable queue scheduler tests.
+ *
+ * Covers the `_scheduleNextQueueHead(...)` step that runs once per
+ * drain iteration:
+ *   - priority drain: highest-priority survivor is rotated to position
+ *     0 before the drain consumes it;
+ *   - deadline expiry: items whose `deadline` passed before drain are
+ *     dropped, emit `queue_item_expired`, and have their receipt
+ *     marked `failed`;
+ *   - FIFO tie-break: same-priority items stay in `enqueuedAt` order.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { Agent } from '../../agent';
+import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
+import { InMemoryDB } from '../../storage/domains/inmemory-db';
+import { buildFakeOutput } from './__test-utils__/fake-output';
+
+import type { HarnessEvent } from './events';
+import { Harness } from './harness';
+
+class FakeAgent extends Agent<any, any, any> {
+  chunks: any[] = [];
+  fullOutput: any = {
+    text: 'ok',
+    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    finishReason: 'stop',
+    object: undefined,
+    steps: [],
+    warnings: [],
+    providerMetadata: undefined,
+    request: {},
+    reasoning: [],
+    reasoningText: undefined,
+    toolCalls: [],
+    toolResults: [],
+    sources: [],
+    files: [],
+    response: { id: 'r', timestamp: new Date(), modelId: 'fake', messages: [], uiMessages: [] },
+    totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    error: undefined,
+    tripwire: undefined,
+    traceId: undefined,
+    spanId: undefined,
+    runId: 'fake-run',
+    suspendPayload: undefined,
+    messages: [],
+    rememberedMessages: [],
+  };
+  constructor(name: string) {
+    super({ id: name, name, instructions: 'fake', model: 'openai/gpt-4o-mini' as any });
+  }
+  async stream(_messages: any, options?: any): Promise<any> {
+    const out = buildFakeOutput({
+      runId: options?.runId ?? this.fullOutput.runId,
+      fullOutput: this.fullOutput,
+      chunks: this.chunks,
+    });
+    this._internalRegisterStreamRun(out, (options ?? {}) as any);
+    return out;
+  }
+  async generate(_messages: any, _options?: any): Promise<any> {
+    return this.fullOutput;
+  }
+  async resumeStream(_resumeData: any, options?: any): Promise<any> {
+    return this.stream(undefined, options);
+  }
+}
+
+async function setup() {
+  const agent = new FakeAgent('default');
+  const storage = new InMemoryHarness({ db: new InMemoryDB() });
+  const harness = new Harness({
+    agents: { default: agent } as any,
+    modes: [{ id: 'default', agentId: 'default' }],
+    defaultModeId: 'default',
+    sessions: { storage },
+  });
+  const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+  return { harness, session, storage };
+}
+
+describe('_scheduleNextQueueHead — priority rotation', () => {
+  it('rotates the highest-priority survivor to position 0', async () => {
+    const { session } = await setup();
+    await (session as any)._flushUpdate((prev: any) => ({
+      ...prev,
+      pendingQueue: [
+        { id: 'q-low-1', admissionId: 'a1', enqueuedAt: 1, content: 'low-1', attachments: [], priority: 0 },
+        { id: 'q-high', admissionId: 'a2', enqueuedAt: 2, content: 'high', attachments: [], priority: 10 },
+        { id: 'q-low-2', admissionId: 'a3', enqueuedAt: 3, content: 'low-2', attachments: [], priority: 0 },
+      ],
+    }));
+    await (session as any)._scheduleNextQueueHead();
+    const queue = session.getRecord().pendingQueue ?? [];
+    expect(queue.map(i => i.id)).toEqual(['q-high', 'q-low-1', 'q-low-2']);
+  });
+
+  it('keeps FIFO order when priorities tie', async () => {
+    const { session } = await setup();
+    await (session as any)._flushUpdate((prev: any) => ({
+      ...prev,
+      pendingQueue: [
+        { id: 'q-1', admissionId: 'a1', enqueuedAt: 1, content: 'a', attachments: [], priority: 5 },
+        { id: 'q-2', admissionId: 'a2', enqueuedAt: 2, content: 'b', attachments: [], priority: 5 },
+        { id: 'q-3', admissionId: 'a3', enqueuedAt: 3, content: 'c', attachments: [], priority: 5 },
+      ],
+    }));
+    await (session as any)._scheduleNextQueueHead();
+    const queue = session.getRecord().pendingQueue ?? [];
+    expect(queue.map(i => i.id)).toEqual(['q-1', 'q-2', 'q-3']);
+  });
+
+  it('treats absent priority as 0', async () => {
+    const { session } = await setup();
+    await (session as any)._flushUpdate((prev: any) => ({
+      ...prev,
+      pendingQueue: [
+        { id: 'q-default', admissionId: 'a1', enqueuedAt: 1, content: 'd', attachments: [] },
+        { id: 'q-neg', admissionId: 'a2', enqueuedAt: 2, content: 'n', attachments: [], priority: -5 },
+      ],
+    }));
+    await (session as any)._scheduleNextQueueHead();
+    const queue = session.getRecord().pendingQueue ?? [];
+    expect(queue.map(i => i.id)).toEqual(['q-default', 'q-neg']);
+  });
+
+  it('skips future notBefore items while selecting the highest-priority runnable item', async () => {
+    const { session } = await setup();
+    const future = Date.now() + 60_000;
+    await (session as any)._flushUpdate((prev: any) => ({
+      ...prev,
+      pendingQueue: [
+        {
+          id: 'q-high-delayed',
+          admissionId: 'a1',
+          enqueuedAt: 1,
+          content: 'delayed',
+          attachments: [],
+          priority: 100,
+          notBefore: future,
+        },
+        { id: 'q-low-ready', admissionId: 'a2', enqueuedAt: 2, content: 'ready', attachments: [], priority: 1 },
+      ],
+    }));
+
+    const runnable = await (session as any)._scheduleNextQueueHead();
+
+    expect(runnable).toBe(true);
+    const queue = session.getRecord().pendingQueue ?? [];
+    expect(queue.map(i => i.id)).toEqual(['q-low-ready', 'q-high-delayed']);
+  });
+
+  it('returns false and keeps order when no queued item is runnable yet', async () => {
+    const { session } = await setup();
+    const future = Date.now() + 60_000;
+    await (session as any)._flushUpdate((prev: any) => ({
+      ...prev,
+      pendingQueue: [
+        { id: 'q-delayed-1', admissionId: 'a1', enqueuedAt: 1, content: 'a', attachments: [], notBefore: future },
+        { id: 'q-delayed-2', admissionId: 'a2', enqueuedAt: 2, content: 'b', attachments: [], notBefore: future },
+      ],
+    }));
+
+    const runnable = await (session as any)._scheduleNextQueueHead();
+
+    expect(runnable).toBe(false);
+    const queue = session.getRecord().pendingQueue ?? [];
+    expect(queue.map(i => i.id)).toEqual(['q-delayed-1', 'q-delayed-2']);
+  });
+
+  it('re-kicks drain immediately when a previously delayed item is already due', async () => {
+    const { session } = await setup();
+    await (session as any)._flushUpdate((prev: any) => ({
+      ...prev,
+      pendingQueue: [
+        { id: 'q-due', admissionId: 'a1', enqueuedAt: 1, content: 'a', attachments: [], notBefore: Date.now() - 1 },
+      ],
+    }));
+    const drain = vi.spyOn(session as any, '_maybeDrainQueue').mockResolvedValue(undefined);
+
+    (session as any)._scheduleQueueWakeupForPendingQueue();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(drain).toHaveBeenCalledTimes(1);
+    drain.mockRestore();
+  });
+});
+
+describe('_scheduleNextQueueHead — deadline expiry', () => {
+  it('drops expired items + emits queue_item_expired + marks receipt failed', async () => {
+    const { session } = await setup();
+    const events: HarnessEvent[] = [];
+    session.subscribe(e => events.push(e));
+    const past = Date.now() - 1000;
+    await (session as any)._flushUpdate((prev: any) => ({
+      ...prev,
+      pendingQueue: [
+        { id: 'q-expired', admissionId: 'a1', enqueuedAt: 1, content: 'x', attachments: [], deadline: past },
+        { id: 'q-alive', admissionId: 'a2', enqueuedAt: 2, content: 'a', attachments: [] },
+      ],
+      queueAdmissionReceipts: {
+        'q-expired': {
+          admissionId: 'a1',
+          admissionHash: 'h1',
+          queuedItemId: 'q-expired',
+          status: 'queued',
+          attempts: 0,
+          enqueuedAt: 1,
+          updatedAt: 1,
+        },
+      },
+    }));
+    await (session as any)._scheduleNextQueueHead();
+    const queue = session.getRecord().pendingQueue ?? [];
+    expect(queue.map(i => i.id)).toEqual(['q-alive']);
+    const expiredEvent = events.find(e => e.type === 'queue_item_expired') as any;
+    expect(expiredEvent).toBeDefined();
+    expect(expiredEvent.queuedItemId).toBe('q-expired');
+    expect(expiredEvent.deadline).toBe(past);
+    const receipt = (session.getRecord().queueAdmissionReceipts ?? {})['q-expired'];
+    expect(receipt?.status).toBe('failed');
+  });
+
+  it('keeps items whose deadline is in the future', async () => {
+    const { session } = await setup();
+    const future = Date.now() + 60_000;
+    await (session as any)._flushUpdate((prev: any) => ({
+      ...prev,
+      pendingQueue: [
+        { id: 'q-future', admissionId: 'a1', enqueuedAt: 1, content: 'f', attachments: [], deadline: future },
+      ],
+    }));
+    await (session as any)._scheduleNextQueueHead();
+    expect((session.getRecord().pendingQueue ?? []).map(i => i.id)).toEqual(['q-future']);
+  });
+
+  it('no-op when the queue is empty', async () => {
+    const { session } = await setup();
+    const before = session.getRecord().pendingQueue;
+    await (session as any)._scheduleNextQueueHead();
+    expect(session.getRecord().pendingQueue).toEqual(before);
+  });
+});

--- a/packages/core/src/harness/v1/session.skills.test.ts
+++ b/packages/core/src/harness/v1/session.skills.test.ts
@@ -16,7 +16,7 @@ import { MockAgent, setupHarness } from './__test-utils__';
 import { HarnessConfigError, HarnessSessionClosedError, HarnessValidationError } from './errors';
 import { Harness } from './harness';
 import type { HarnessSkill } from './types';
-import type { WorkspaceProvider } from './workspace-provider';
+import type { WorkspaceProvider } from './workspace/provider';
 
 type FakeSkillMeta = {
   name: string;

--- a/packages/core/src/harness/v1/session.skills.use.test.ts
+++ b/packages/core/src/harness/v1/session.skills.use.test.ts
@@ -23,7 +23,7 @@ import {
 } from './errors';
 import { Harness } from './harness';
 import type { HarnessConfig, HarnessRequestContext } from './types';
-import type { WorkspaceProvider } from './workspace-provider';
+import type { WorkspaceProvider } from './workspace/provider';
 
 // ---------------------------------------------------------------------------
 // Workspace skill source mock (mirrors session.skills.test.ts but exposes

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -75,6 +75,7 @@ import {
   HarnessInboxItemNotFoundError,
   HarnessInboxResponseConflictError,
   HarnessOverrideConflictError,
+  HarnessQueueFullDroppedError,
   HarnessQueueFullError,
   HarnessSessionCancelledError,
   HarnessSessionClosedError,
@@ -395,6 +396,16 @@ function startActionCatalogMcpListWithTimeout<T>(
 
 export type SessionLifecycleState = 'live' | 'closing' | 'closed' | 'deleted' | 'evicted';
 
+interface QueueBackpressureDrop {
+  queuedItemId: string;
+  admissionId?: string;
+  replacementQueuedItemId?: string;
+  replacementAdmissionId?: string;
+  maxQueueDepth: number;
+  source: 'queue' | 'goal';
+  goalId?: string;
+}
+
 /**
  * System prompt for the goal judge. Lifted verbatim from
  * mastracode/src/tui/goal-manager.ts so the harness-native judge produces
@@ -670,6 +681,8 @@ export class Session {
   private readonly _liveAdmittedQueuedItemIds = new Set<string>();
   /** True while `_maybeDrainQueue` is running so re-entrant kicks are no-ops. */
   private _draining = false;
+  private _queueWakeTimer?: ReturnType<typeof setTimeout>;
+  private _queueWakeAt?: number;
   private _queuedResumeRecoveryTimer?: ReturnType<typeof setTimeout>;
   /**
    * Tracks the AbortController for the currently-running turn (message or
@@ -1268,7 +1281,9 @@ export class Session {
   private _recordTokenUsageMatchesLive(opts: { tolerateInvalidZero?: boolean } = {}): boolean {
     const stored = this._record.tokenUsage;
     const liveIsZero =
-      this._tokenUsage.promptTokens === 0 && this._tokenUsage.completionTokens === 0 && this._tokenUsage.totalTokens === 0;
+      this._tokenUsage.promptTokens === 0 &&
+      this._tokenUsage.completionTokens === 0 &&
+      this._tokenUsage.totalTokens === 0;
     if (
       stored === undefined ||
       !this._isValidTokenCount(stored.promptTokens) ||
@@ -1497,7 +1512,10 @@ export class Session {
       if (backgroundTurnCompletions.length > 0) {
         const completed = await waitUntilDeadline(Promise.allSettled(backgroundTurnCompletions));
         if (!completed) {
-          throw new HarnessValidationError('shutdown()', 'Session background work did not flush before shutdown deadline');
+          throw new HarnessValidationError(
+            'shutdown()',
+            'Session background work did not flush before shutdown deadline',
+          );
         }
       }
       const chain = this._flushChain;
@@ -1967,6 +1985,11 @@ export class Session {
     if (resolver) {
       this._queueResolvers.delete(removed.queuedItemId);
       resolver.reject(new HarnessSessionCancelledError(this.id, reason));
+    }
+    if ((this._record.pendingQueue?.length ?? 0) > 0) {
+      this._scheduleQueueWakeupForPendingQueue();
+    } else {
+      this._clearQueueWakeTimer();
     }
     this._notifyMaybeIdle();
   }
@@ -5599,11 +5622,6 @@ export class Session {
   private async _enqueueGoalContinuation(goal: GoalState, content: string): Promise<void> {
     if (this._currentCancelRequest() !== undefined) return;
     const cap = this._harness._internalMaxQueueDepth;
-    if ((this._record.pendingQueue?.length ?? 0) >= cap) {
-      // Drop continuation silently — user activity has filled the queue,
-      // we'll re-judge after they drain. Better than failing the judge call.
-      return;
-    }
     const item: QueuedItem = {
       id: `q-${randomUUID()}`,
       enqueuedAt: Date.now(),
@@ -5613,13 +5631,35 @@ export class Session {
       source: 'goal',
       goalId: goal.id,
     };
+    const droppedItems: QueueBackpressureDrop[] = [];
+    let admitted = false;
     await this._flushUpdate(prev => {
       if (prev.cancelRequest !== undefined) return prev;
-      return {
-        ...prev,
-        pendingQueue: [...(prev.pendingQueue ?? []), item],
-      };
+      return this._applyQueueBackpressureForAppend(prev, {
+        item,
+        receipt: undefined,
+        maxQueueDepth: cap,
+        source: 'goal',
+        goalId: goal.id,
+        droppedItems,
+        onRejected: () => {
+          admitted = false;
+        },
+        onAdmitted: () => {
+          admitted = true;
+        },
+      });
     });
+    this._emitQueueBackpressureDrops(droppedItems);
+    if (!admitted) {
+      this._emitQueueFullRejected({
+        source: 'goal',
+        policy: this._harness._internalQueueBackpressure,
+        maxQueueDepth: cap,
+        goalId: goal.id,
+      });
+      return;
+    }
     void this._maybeDrainQueue();
   }
 
@@ -5964,6 +6004,28 @@ export class Session {
     opts: { answer: unknown } & InboxResponseOptions,
   ): Promise<AgentResult | InboxResponseResult> {
     return this._resume('question', { answer: opts.answer }, opts);
+  }
+
+  async respondToSandboxAccess(
+    opts: { approved: boolean; reason?: string } & InboxReceiptResponseOptions,
+  ): Promise<InboxResponseResult>;
+  async respondToSandboxAccess(
+    opts: { approved: boolean; reason?: string } & LegacyInboxResponseOptions,
+  ): Promise<AgentResult>;
+  async respondToSandboxAccess(
+    opts: { approved: boolean; reason?: string } & InboxResponseOptions,
+  ): Promise<AgentResult | InboxResponseResult>;
+  async respondToSandboxAccess(
+    opts: { approved: boolean; reason?: string } & InboxResponseOptions,
+  ): Promise<AgentResult | InboxResponseResult> {
+    return this._resume(
+      'sandbox-access',
+      compactJsonObject({
+        approved: opts.approved,
+        reason: opts.reason,
+      }),
+      opts,
+    );
   }
 
   /**
@@ -6413,8 +6475,7 @@ export class Session {
     let cancelledBeforeResume: { reason?: string } | undefined;
     await this._flushUpdate(prev => {
       if (prev.cancelRequest !== undefined && prev.pendingResume?.resumedAt === undefined) {
-        cancelledBeforeResume =
-          prev.cancelRequest.reason !== undefined ? { reason: prev.cancelRequest.reason } : {};
+        cancelledBeforeResume = prev.cancelRequest.reason !== undefined ? { reason: prev.cancelRequest.reason } : {};
         return prev;
       }
 
@@ -7187,6 +7248,13 @@ export class Session {
 
     const queued = createDeferred<AgentResult>();
     const promise = queued.promise;
+    const currentReceipt = this._record.queueAdmissionReceipts?.[admission.queuedItemId];
+    if (currentReceipt?.status === 'failed' && currentReceipt.error?.code === 'harness.queue_full_dropped') {
+      queued.reject(new HarnessQueueFullDroppedError(admission.queuedItemId));
+      void promise.catch(() => {});
+      return promise;
+    }
+
     this._queueResolvers.set(admission.queuedItemId, { promise, resolve: queued.resolve, reject: queued.reject });
     // Kick the drain — fire-and-forget. Drain handles its own errors and
     // settles the resolver via `_completeQueuedTurn` / `_failQueuedTurn`.
@@ -7237,6 +7305,7 @@ export class Session {
     if (opts.admissionId !== undefined && opts.admissionId.length === 0) {
       throw new HarnessValidationError(`${methodName}.admissionId`, 'admissionId must be a non-empty string');
     }
+    this._validateQueueSchedulingOptions(opts, methodName);
 
     const attachments =
       internal?.persistedAttachments ??
@@ -7263,7 +7332,8 @@ export class Session {
     }
 
     const cap = this._harness._internalMaxQueueDepth;
-    if ((this._record.pendingQueue?.length ?? 0) >= cap) {
+    const queueBackpressure = this._harness._internalQueueBackpressure;
+    if (queueBackpressure === 'reject' && (this._record.pendingQueue?.length ?? 0) >= cap) {
       throw new HarnessQueueFullError(this.id, cap);
     }
     const queuedItemId = this._queueAdmissionQueuedItemId(admissionId);
@@ -7280,6 +7350,9 @@ export class Session {
       ...(opts.model !== undefined ? { model: opts.model } : {}),
       mode: effectiveModeId,
       ...(opts.yolo !== undefined ? { yolo: opts.yolo } : {}),
+      ...(opts.priority !== undefined ? { priority: opts.priority } : {}),
+      ...(opts.deadline !== undefined ? { deadline: opts.deadline } : {}),
+      ...(opts.notBefore !== undefined ? { notBefore: opts.notBefore } : {}),
     };
     const attachmentReferences = attachments
       .filter((attachment): attachment is Extract<PersistedAttachment, { kind: 'ref' }> => attachment.kind === 'ref')
@@ -7291,6 +7364,7 @@ export class Session {
         sourceId: item.id,
       }));
     let admittedReceipt: QueueAdmissionReceipt | undefined;
+    const droppedItems: QueueBackpressureDrop[] = [];
     const receipt: QueueAdmissionReceipt = {
       admissionId,
       admissionHash,
@@ -7327,17 +7401,16 @@ export class Session {
           if (prev.cancelRequest !== undefined) {
             throw new HarnessSessionCancelledError(this.id, prev.cancelRequest.reason);
           }
-          if ((prev.pendingQueue?.length ?? 0) >= cap) {
+          if (queueBackpressure === 'reject' && (prev.pendingQueue?.length ?? 0) >= cap) {
             throw new HarnessQueueFullError(this.id, cap);
           }
-          return {
-            ...prev,
-            pendingQueue: [...(prev.pendingQueue ?? []), item],
-            queueAdmissionReceipts: {
-              ...(prev.queueAdmissionReceipts ?? {}),
-              [item.id]: receipt,
-            },
-          };
+          return this._applyQueueBackpressureForAppend(prev, {
+            item,
+            receipt,
+            maxQueueDepth: cap,
+            source: 'queue',
+            droppedItems,
+          });
         },
         { attachmentReferences },
       );
@@ -7353,6 +7426,7 @@ export class Session {
       return { queuedItemId: admittedReceipt.queuedItemId, evidence: admittedReceipt, duplicate: true };
     }
 
+    this._emitQueueBackpressureDrops(droppedItems);
     return { queuedItemId: item.id, evidence: receipt, duplicate: false };
   }
 
@@ -7525,6 +7599,9 @@ export class Session {
       ...(opts.mode !== undefined ? { mode: opts.mode } : {}),
       ...(opts.model !== undefined ? { model: opts.model } : {}),
       ...(opts.yolo === true ? { yolo: true } : {}),
+      ...(opts.priority !== undefined && opts.priority !== 0 ? { priority: opts.priority } : {}),
+      ...(opts.deadline !== undefined ? { deadline: opts.deadline } : {}),
+      ...(opts.notBefore !== undefined ? { notBefore: opts.notBefore } : {}),
       attachments: attachments.map(attachment => ({
         kind: attachment.kind,
         name: attachment.name,
@@ -7549,6 +7626,151 @@ export class Session {
       })),
       ...(requestContext ? { requestContext: clonePersistedRequestContext(requestContext) } : {}),
     });
+  }
+
+  private _validateQueueSchedulingOptions(opts: QueueOptions, methodName: 'queue()' | 'admitQueue()'): void {
+    for (const field of ['priority', 'deadline', 'notBefore'] as const) {
+      const value = opts[field];
+      if (value !== undefined && (!Number.isFinite(value) || Object.is(value, -0))) {
+        throw new HarnessValidationError(`${methodName}.${field}`, 'must be a finite JSON number other than -0');
+      }
+    }
+  }
+
+  private _applyQueueBackpressureForAppend(
+    prev: SessionRecord,
+    opts: {
+      item: QueuedItem;
+      receipt?: QueueAdmissionReceipt;
+      maxQueueDepth: number;
+      source: 'queue' | 'goal';
+      goalId?: string;
+      droppedItems: QueueBackpressureDrop[];
+      onRejected?: () => void;
+      onAdmitted?: () => void;
+    },
+  ): SessionRecord {
+    const policy = this._harness._internalQueueBackpressure;
+    const activeId = this._currentQueuedItemId ?? prev.pendingResume?.queuedItemId;
+    const queue = [...(prev.pendingQueue ?? [])];
+    const existingReceipts = prev.queueAdmissionReceipts ?? {};
+    let nextReceipts: Record<string, QueueAdmissionReceipt> | undefined;
+    const now = opts.item.enqueuedAt;
+
+    while (queue.length >= opts.maxQueueDepth) {
+      if (policy === 'reject') {
+        opts.onRejected?.();
+        return prev;
+      }
+
+      let dropIdx = -1;
+      let dropEnqueuedAt = Number.POSITIVE_INFINITY;
+      for (let i = 0; i < queue.length; i += 1) {
+        const candidate = queue[i]!;
+        if (activeId !== undefined && candidate.id === activeId) continue;
+        const receipt = existingReceipts[candidate.id];
+        if (receipt !== undefined && receipt.status !== 'queued') continue;
+        if (candidate.enqueuedAt < dropEnqueuedAt) {
+          dropIdx = i;
+          dropEnqueuedAt = candidate.enqueuedAt;
+        }
+      }
+      if (dropIdx < 0) {
+        if (opts.source === 'goal') {
+          opts.onRejected?.();
+          return prev;
+        }
+        throw new HarnessQueueFullError(this.id, opts.maxQueueDepth);
+      }
+
+      const [dropped] = queue.splice(dropIdx, 1);
+      if (!dropped) continue;
+      opts.droppedItems.push({
+        queuedItemId: dropped.id,
+        ...(dropped.admissionId !== undefined ? { admissionId: dropped.admissionId } : {}),
+        replacementQueuedItemId: opts.item.id,
+        ...(opts.item.admissionId !== undefined ? { replacementAdmissionId: opts.item.admissionId } : {}),
+        maxQueueDepth: opts.maxQueueDepth,
+        source: opts.source,
+        ...(opts.goalId !== undefined ? { goalId: opts.goalId } : {}),
+      });
+
+      const receipt = existingReceipts[dropped.id];
+      if (receipt && !this._isTerminalQueueReceipt(receipt)) {
+        nextReceipts ??= { ...existingReceipts };
+        const dropError = new HarnessQueueFullDroppedError(dropped.id);
+        nextReceipts[dropped.id] = {
+          ...receipt,
+          status: 'failed',
+          error: projectHarnessPublicError(dropError),
+          failedAt: receipt.failedAt ?? now,
+          updatedAt: now,
+        };
+      }
+    }
+
+    opts.onAdmitted?.();
+    const next: SessionRecord = {
+      ...prev,
+      pendingQueue: [...queue, opts.item],
+    };
+    if (opts.receipt !== undefined) {
+      next.queueAdmissionReceipts = {
+        ...(nextReceipts ?? existingReceipts),
+        [opts.item.id]: opts.receipt,
+      };
+    } else if (nextReceipts !== undefined) {
+      next.queueAdmissionReceipts = nextReceipts;
+    }
+    return next;
+  }
+
+  private _emitQueueBackpressureDrops(droppedItems: QueueBackpressureDrop[]): void {
+    for (const dropped of droppedItems) {
+      this._emitter.emit({
+        type: 'queue_full_dropped',
+        source: dropped.source,
+        policy: 'drop-oldest',
+        maxQueueDepth: dropped.maxQueueDepth,
+        queuedItemId: dropped.queuedItemId,
+        ...(dropped.admissionId !== undefined ? { admissionId: dropped.admissionId } : {}),
+        ...(dropped.replacementQueuedItemId !== undefined
+          ? { replacementQueuedItemId: dropped.replacementQueuedItemId }
+          : {}),
+        ...(dropped.replacementAdmissionId !== undefined
+          ? { replacementAdmissionId: dropped.replacementAdmissionId }
+          : {}),
+        ...(dropped.goalId !== undefined ? { goalId: dropped.goalId } : {}),
+      } as EmitInput);
+      const resolver = this._queueResolvers.get(dropped.queuedItemId);
+      if (resolver) {
+        this._queueResolvers.delete(dropped.queuedItemId);
+        resolver.reject(new HarnessQueueFullDroppedError(dropped.queuedItemId));
+      }
+    }
+  }
+
+  private _emitQueueFullRejected(opts: {
+    source: 'queue' | 'goal';
+    policy?: 'reject' | 'drop-oldest';
+    maxQueueDepth: number;
+    goalId?: string;
+    queuedItemId?: string;
+    admissionId?: string;
+  }): void {
+    this._emitter.emit({
+      type: 'queue_full_dropped',
+      source: opts.source,
+      policy: opts.policy ?? 'reject',
+      maxQueueDepth: opts.maxQueueDepth,
+      ...(opts.queuedItemId !== undefined ? { queuedItemId: opts.queuedItemId } : {}),
+      ...(opts.admissionId !== undefined ? { admissionId: opts.admissionId } : {}),
+      ...(opts.goalId !== undefined ? { goalId: opts.goalId } : {}),
+    } as EmitInput);
+  }
+
+  private _isTerminalQueueReceipt(receipt: QueueAdmissionReceipt): boolean {
+    return receipt.status === 'completed' || receipt.status === 'failed' || receipt.status === 'dead';
   }
 
   private async _updateQueueAdmissionReceipt(
@@ -7623,6 +7845,113 @@ export class Session {
   }
 
   /**
+   * Scheduler step. Inside a single `_flushUpdate` CAS:
+   *   - drop any items whose `deadline` has passed; emit
+   *     `queue_item_expired` per drop, mark each item's receipt
+   *     `failed`, and reject the resolver after the commit;
+   *   - select the next item to run by `(priority desc, enqueuedAt
+   *     asc)` from those that have no `notBefore` block; rotate it
+   *     to position 0 so the existing drain + recovery logic can keep
+   *     its `pendingQueue[0]` invariant.
+   *
+   * No-op when the queue is empty or no item is currently eligible.
+   */
+  private async _scheduleNextQueueHead(): Promise<boolean> {
+    const now = Date.now();
+    const expired: { queuedItemId: string; admissionId?: string; deadline: number }[] = [];
+    const cancelErrorForReceipt = new HarnessSessionCancelledError(this.id, 'queue_item_expired');
+    let didCommit = false;
+    let hasRunnableHead = false;
+
+    await this._flushUpdate(prev => {
+      const queue = prev.pendingQueue ?? [];
+      if (queue.length === 0) return prev;
+
+      const survivors: QueuedItem[] = [];
+      const existingReceipts = prev.queueAdmissionReceipts ?? {};
+      const nextReceipts: Record<string, QueueAdmissionReceipt> = { ...existingReceipts };
+      let receiptsChanged = false;
+
+      for (const item of queue) {
+        if (item.deadline !== undefined && item.deadline <= now) {
+          expired.push({ queuedItemId: item.id, admissionId: item.admissionId, deadline: item.deadline });
+          const receipt = existingReceipts[item.id];
+          if (receipt && receipt.status !== 'completed' && receipt.status !== 'failed' && receipt.status !== 'dead') {
+            nextReceipts[item.id] = {
+              ...receipt,
+              status: 'failed',
+              error: projectHarnessPublicError(cancelErrorForReceipt),
+              failedAt: receipt.failedAt ?? now,
+              updatedAt: now,
+            };
+            receiptsChanged = true;
+          }
+          continue;
+        }
+        survivors.push(item);
+      }
+
+      // Pick the next runnable item: highest priority, FIFO tie-break.
+      // The currently-running item (if any) stays first — it's already
+      // executing and the drain only consults position 0 mid-loop when
+      // no turn is in flight.
+      let head: QueuedItem | undefined;
+      let headIdx = -1;
+      for (let i = 0; i < survivors.length; i++) {
+        const candidate = survivors[i]!;
+        if (candidate.notBefore !== undefined && candidate.notBefore > now) continue;
+        const cp = candidate.priority ?? 0;
+        const hp = head?.priority ?? 0;
+        if (head === undefined || cp > hp || (cp === hp && candidate.enqueuedAt < head.enqueuedAt)) {
+          head = candidate;
+          headIdx = i;
+        }
+      }
+      hasRunnableHead = head !== undefined;
+
+      const rotated = head !== undefined && headIdx > 0;
+      const didExpire = expired.length > 0;
+      // No-op short-circuit: nothing expired, no rotation needed, no
+      // receipts to update. `survivors` is always a fresh array, so an
+      // identity check vs `queue` would never short-circuit — we have
+      // to derive "nothing changed" from the flags instead.
+      if (!didExpire && !rotated && !receiptsChanged) return prev;
+
+      const nextQueue = rotated
+        ? // Rotate selected item to position 0 so the existing
+          // recovery + drain code can keep its `pendingQueue[0]`
+          // assumption while still running the highest-priority
+          // work first.
+          [head!, ...survivors.slice(0, headIdx), ...survivors.slice(headIdx + 1)]
+        : survivors;
+
+      didCommit = true;
+      const next: SessionRecord = { ...prev, pendingQueue: nextQueue };
+      if (receiptsChanged) {
+        next.queueAdmissionReceipts = nextReceipts;
+      }
+      return next;
+    });
+
+    if (!didCommit) return hasRunnableHead;
+
+    for (const dropped of expired) {
+      this._emitter.emit({
+        type: 'queue_item_expired',
+        queuedItemId: dropped.queuedItemId,
+        ...(dropped.admissionId !== undefined ? { admissionId: dropped.admissionId } : {}),
+        deadline: dropped.deadline,
+      } as EmitInput);
+      const resolver = this._queueResolvers.get(dropped.queuedItemId);
+      if (resolver) {
+        this._queueResolvers.delete(dropped.queuedItemId);
+        resolver.reject(new HarnessSessionCancelledError(this.id, 'queue_item_expired'));
+      }
+    }
+    return hasRunnableHead;
+  }
+
+  /**
    * Drain pending queue items head-of-line. No-op while another drain is
    * running, the session is suspended (`pendingResume` set), or the queue
    * is empty. Each item runs as a fresh turn; if the turn suspends, drain
@@ -7648,6 +7977,16 @@ export class Session {
         // Bail if a previous iteration left the session suspended.
         if (this._record.pendingResume !== undefined) return;
 
+        // Scheduler step: expire any items past their deadline, then
+        // rotate the highest-priority item to the head. Done in a
+        // single CAS so the rest of the drain logic (recovery,
+        // post-run finalize) can keep its `pendingQueue[0]` assumption.
+        const hasRunnableHead = await this._scheduleNextQueueHead();
+        if (!hasRunnableHead) {
+          this._scheduleQueueWakeupForPendingQueue();
+          return;
+        }
+        this._clearQueueWakeTimer();
         const head = this._record.pendingQueue?.[0];
         if (!head) return;
         this._currentQueuedItemId = head.id;
@@ -8533,7 +8872,7 @@ export class Session {
     if (err instanceof QueueRecoveryPendingError) {
       const delayMs = Math.max(0, err.retryAt - Date.now());
       const timer = setTimeout(() => void this._maybeDrainQueue(), delayMs);
-      timer.unref?.();
+      this._unrefQueueTimerIfBackgroundOnly(timer);
       return;
     }
     const resolver = this._queueResolvers.get(itemId);
@@ -8562,7 +8901,52 @@ export class Session {
     this._notifyMaybeIdle();
     const delayMs = Math.max(0, err.retryAt - Date.now());
     const timer = setTimeout(() => void this._maybeDrainQueue(), delayMs);
-    timer.unref?.();
+    this._unrefQueueTimerIfBackgroundOnly(timer);
+  }
+
+  private _scheduleQueueWakeupForPendingQueue(): void {
+    const now = Date.now();
+    let wakeAt: number | undefined;
+    for (const item of this._record.pendingQueue ?? []) {
+      const candidates = [item.notBefore, item.deadline].filter(
+        (value): value is number => value !== undefined && value > now,
+      );
+      for (const candidate of candidates) {
+        if (wakeAt === undefined || candidate < wakeAt) wakeAt = candidate;
+      }
+    }
+    if (wakeAt === undefined) {
+      this._clearQueueWakeTimer();
+      if ((this._record.pendingQueue?.length ?? 0) > 0) {
+        const timer = setTimeout(() => void this._maybeDrainQueue(), 0);
+        this._unrefQueueTimerIfBackgroundOnly(timer);
+      }
+      return;
+    }
+    if (this._queueWakeAt !== undefined && this._queueWakeAt <= wakeAt) return;
+    this._clearQueueWakeTimer();
+    this._queueWakeAt = wakeAt;
+    const delayMs = Math.min(Math.max(0, wakeAt - now), 2_147_483_647);
+    this._queueWakeTimer = setTimeout(() => {
+      this._queueWakeTimer = undefined;
+      this._queueWakeAt = undefined;
+      void this._maybeDrainQueue();
+    }, delayMs);
+    this._unrefQueueTimerIfBackgroundOnly(this._queueWakeTimer);
+  }
+
+  private _clearQueueWakeTimer(): void {
+    if (this._queueWakeTimer !== undefined) {
+      clearTimeout(this._queueWakeTimer);
+      this._queueWakeTimer = undefined;
+    }
+    this._queueWakeAt = undefined;
+  }
+
+  private _unrefQueueTimerIfBackgroundOnly(timer: ReturnType<typeof setTimeout>): void {
+    if (this._queueResolvers.size === 0) {
+      timer.unref?.();
+    }
   }
 
   /** @internal — used by the Harness on hydration to start replay drain. */
@@ -8889,6 +9273,7 @@ export class Session {
    * harness's job. Idempotent.
    */
   _markClosed(updatedRecord: SessionRecord): void {
+    this._clearQueueWakeTimer();
     this._record = updatedRecord;
     this._state = 'closed';
     this._tearDownThreadSubscription(new HarnessValidationError('session.close()', 'Session closed'));
@@ -8910,6 +9295,7 @@ export class Session {
       clearTimeout(this._queuedResumeRecoveryTimer);
       this._queuedResumeRecoveryTimer = undefined;
     }
+    this._clearQueueWakeTimer();
     this._currentQueuedItemId = undefined;
     this._currentQueuedItemSource = undefined;
     for (const [queuedItemId, resolver] of this._queueResolvers) {
@@ -8935,10 +9321,34 @@ export class Session {
    * the session can be re-hydrated. Currently unused; lands with eviction.
    */
   _markEvicted(updatedRecord: SessionRecord): void {
+    const err = new HarnessValidationError('session.evict()', 'Session evicted');
     this._record = updatedRecord;
     this._state = 'evicted';
-    this._tearDownThreadSubscription(new HarnessValidationError('session.evict()', 'Session evicted'));
+    this._tearDownThreadSubscription(err);
     this._rejectIdleWaiters(new HarnessSessionClosedError(this.id));
+    this._rejectActiveTurnWaiters(err);
+    const activeTurn = this._currentTurnAbortController;
+    if (activeTurn) {
+      activeTurn.abort('session_evicted');
+      this._endTurn(activeTurn);
+    }
+    if (this._queuedResumeRecoveryTimer !== undefined) {
+      clearTimeout(this._queuedResumeRecoveryTimer);
+      this._queuedResumeRecoveryTimer = undefined;
+    }
+    this._clearQueueWakeTimer();
+    this._currentQueuedItemId = undefined;
+    this._currentQueuedItemSource = undefined;
+    for (const [queuedItemId, resolver] of this._queueResolvers) {
+      this._queueResolvers.delete(queuedItemId);
+      resolver.reject(err);
+    }
+  }
+
+  /** @internal — update local lease metadata after the owning Harness renews storage. */
+  _markLeaseRenewed(expiresAt: number): void {
+    if (this._state !== 'live' && this._state !== 'closing') return;
+    this._record = { ...this._record, leaseExpiresAt: expiresAt };
   }
 
   /**

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -7248,10 +7248,19 @@ export class Session {
 
     const queued = createDeferred<AgentResult>();
     const promise = queued.promise;
-    const currentReceipt = this._record.queueAdmissionReceipts?.[admission.queuedItemId];
-    if (currentReceipt?.status === 'failed' && currentReceipt.error?.code === 'harness.queue_full_dropped') {
-      queued.reject(new HarnessQueueFullDroppedError(admission.queuedItemId));
+    const latestReceipt = this._record.queueAdmissionReceipts?.[admission.queuedItemId];
+    const terminalAdmissionError = this._queueReceiptTerminalFailureErrorFromReceipt(latestReceipt);
+    if (terminalAdmissionError) {
+      queued.reject(
+        latestReceipt?.status === 'failed' && latestReceipt.error?.code === 'harness.queue_full_dropped'
+          ? new HarnessQueueFullDroppedError(admission.queuedItemId)
+          : terminalAdmissionError,
+      );
       void promise.catch(() => {});
+      return promise;
+    }
+    if (latestReceipt?.status === 'completed') {
+      queued.resolve(latestReceipt.result as AgentResult);
       return promise;
     }
 
@@ -7634,6 +7643,12 @@ export class Session {
       if (value !== undefined && (!Number.isFinite(value) || Object.is(value, -0))) {
         throw new HarnessValidationError(`${methodName}.${field}`, 'must be a finite JSON number other than -0');
       }
+    }
+    if (opts.notBefore !== undefined && opts.deadline !== undefined && opts.notBefore > opts.deadline) {
+      throw new HarnessValidationError(
+        `${methodName}.notBefore`,
+        '`notBefore` must be less than or equal to `deadline`',
+      );
     }
   }
 

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -131,6 +131,8 @@ export type ToolCategory = 'read' | 'edit' | 'execute' | 'mcp' | 'other';
  */
 export type PermissionPolicy = 'allow' | 'ask' | 'deny';
 
+export type HarnessQueueBackpressurePolicy = 'reject' | 'drop-oldest';
+
 /**
  * Catalog entry exposed through `harness.models.*` (§9). Purely a UX
  * surface — the harness does not interpret these fields, it only stores
@@ -920,6 +922,15 @@ export interface HarnessConfigCommon {
     maxQueueDepth?: number;
 
     /**
+     * Queue-full behavior. `reject` preserves the historical behavior and
+     * throws `HarnessQueueFullError` when the session queue is full.
+     * `drop-oldest` removes the oldest waiting queued item and records a
+     * `queue_full_dropped` event before admitting the replacement. The active
+     * queued head is never dropped by backpressure.
+     */
+    queueBackpressure?: HarnessQueueBackpressurePolicy;
+
+    /**
      * Milliseconds allowed after the durable `closingAt` marker commits for
      * live sessions to drain admitted work before terminal `closedAt`. The
      * runtime persists `closeDeadlineAt = closingAt + closeTimeoutMs` and
@@ -1524,7 +1535,7 @@ export interface InboxResponseOptions {
 
 export interface InboxResponseResult {
   itemId: string;
-  kind: 'tool-approval' | 'tool-suspension' | 'question' | 'plan-approval';
+  kind: 'tool-approval' | 'tool-suspension' | 'question' | 'plan-approval' | 'sandbox-access';
   status: 'accepted' | 'applied';
   responseId: string;
   duplicate: boolean;
@@ -1571,6 +1582,24 @@ export interface QueueOptions extends QueueOverrides {
 
   /** Optional pre-uploaded attachments to include with the user message. */
   attachments?: AttachmentRef[];
+
+  /**
+   * Scheduling priority. Higher values drain first. Items with the same
+   * priority drain in FIFO order. Defaults to 0.
+   */
+  priority?: number;
+
+  /**
+   * Absolute epoch-ms deadline past which the item must not start. Expired
+   * queued items are removed before drain and their receipts are marked failed.
+   */
+  deadline?: number;
+
+  /**
+   * Absolute epoch-ms earliest start time. Items whose `notBefore` is in the
+   * future remain queued while eligible lower-priority work can drain.
+   */
+  notBefore?: number;
 }
 
 /**

--- a/packages/core/src/harness/v1/workspace-actions.ts
+++ b/packages/core/src/harness/v1/workspace-actions.ts
@@ -1,0 +1,29 @@
+import { WORKSPACE_TOOLS } from '../../workspace/constants';
+
+const FILE_MUTATION_PATH_ARG_BY_TOOL = new Map<string, string>([
+  [WORKSPACE_TOOLS.FILESYSTEM.WRITE_FILE, 'path'],
+  [WORKSPACE_TOOLS.FILESYSTEM.MKDIR, 'path'],
+  [WORKSPACE_TOOLS.FILESYSTEM.EDIT_FILE, 'path'],
+  [WORKSPACE_TOOLS.FILESYSTEM.AST_EDIT, 'path'],
+  [WORKSPACE_TOOLS.FILESYSTEM.DELETE, 'path'],
+  [WORKSPACE_TOOLS.SEARCH.INDEX, 'path'],
+  ['write_file', 'path'],
+  ['mkdir', 'path'],
+  ['string_replace_lsp', 'path'],
+  ['ast_smart_edit', 'path'],
+  ['delete_file', 'path'],
+]);
+
+export function isHarnessWorkspaceFileMutationTool(toolName: string): boolean {
+  return FILE_MUTATION_PATH_ARG_BY_TOOL.has(toolName);
+}
+
+export function getHarnessWorkspaceActionPathInput(
+  toolName: string,
+  args: Record<string, unknown>,
+): string | undefined {
+  const pathArg = FILE_MUTATION_PATH_ARG_BY_TOOL.get(toolName);
+  if (!pathArg) return undefined;
+  const value = args[pathArg];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -108,6 +108,25 @@ export interface QueuedItem {
   source?: 'user' | 'goal';
   /** Set when `source === 'goal'`. Identifies which goal produced the item. */
   goalId?: string;
+  /**
+   * Scheduling priority. Higher values drain first. Items with the same
+   * priority drain in FIFO order (lowest `enqueuedAt` wins). Defaults to
+   * 0 — equivalent to the legacy FIFO contract.
+   */
+  priority?: number;
+  /**
+   * Absolute deadline (epoch ms) past which the item must not start.
+   * The drain emits `queue_item_expired`, removes the item, and marks
+   * its `queueAdmissionReceipts` entry `failed` in the same CAS write.
+   * Omit to opt out of deadline checks.
+   */
+  deadline?: number;
+  /**
+   * Absolute earliest-start timestamp (epoch ms). Items whose `notBefore` is
+   * in the future remain in `pendingQueue` and are skipped by the scheduler so
+   * eligible work behind them can still drain.
+   */
+  notBefore?: number;
 }
 
 /**
@@ -124,7 +143,7 @@ export interface QueuedItem {
  * See HARNESS_V1_SPEC.md §5.1 ("Persistence shapes — `pendingResume`").
  */
 export interface PendingResume {
-  kind: 'tool-approval' | 'tool-suspension' | 'question' | 'plan-approval';
+  kind: 'tool-approval' | 'tool-suspension' | 'question' | 'plan-approval' | 'sandbox-access';
   /** Stable pending interaction id used by inbox/route callers. */
   itemId?: string;
   runId: string;

--- a/packages/server/src/server/handlers/harness.test.ts
+++ b/packages/server/src/server/handlers/harness.test.ts
@@ -1653,6 +1653,9 @@ describe('Harness server routes', () => {
           content: 'next',
           admissionId: 'admission-queue-1',
           yolo: true,
+          priority: 7,
+          deadline: 1_800_000_000_000,
+          notBefore: 1_700_000_000_000,
         },
       }),
     );
@@ -1663,6 +1666,9 @@ describe('Harness server routes', () => {
       content: 'next',
       admissionId: 'admission-queue-1',
       yolo: true,
+      priority: 7,
+      deadline: 1_800_000_000_000,
+      notBefore: 1_700_000_000_000,
     });
     expect(result).toEqual({ accepted: true, queuedItemId: 'queue-1', duplicate: true });
   });

--- a/packages/server/src/server/handlers/harness.ts
+++ b/packages/server/src/server/handlers/harness.ts
@@ -188,6 +188,9 @@ type HarnessLike = {
       mode?: string;
       model?: string;
       yolo?: boolean;
+      priority?: number;
+      deadline?: number;
+      notBefore?: number;
       attachments?: unknown[];
     }): Promise<{ accepted: true; queuedItemId: string; duplicate: boolean }>;
     switchMode(opts: { mode: string }): Promise<void>;

--- a/packages/server/src/server/schemas/harness.ts
+++ b/packages/server/src/server/schemas/harness.ts
@@ -487,6 +487,11 @@ export const harnessMessageAdmissionResponseSchema = z.object({
   duplicate: z.boolean(),
 });
 
+const queueSchedulingNumberSchema = z
+  .number()
+  .finite()
+  .refine(value => !Object.is(value, -0), 'must be a finite JSON number other than -0');
+
 export const harnessQueueAdmissionBodySchema = z
   .object({
     content: z.string().min(1),
@@ -494,6 +499,9 @@ export const harnessQueueAdmissionBodySchema = z
     mode: z.string().min(1).optional(),
     model: z.string().min(1).optional(),
     yolo: z.boolean().optional(),
+    priority: queueSchedulingNumberSchema.optional(),
+    deadline: queueSchedulingNumberSchema.optional(),
+    notBefore: queueSchedulingNumberSchema.optional(),
     attachments: admissionAttachmentsSchema.shape.attachments,
     files: admissionAttachmentsSchema.shape.files,
   })


### PR DESCRIPTION
## Summary
- Brings a focused, validated slice of mastra-ai/mastra#16943 at head 704a3850214ab5fe3393064b9968c3a620f91816 onto the mbenhamd/mastra Harness v1 stack.
- Keeps the branch stacked on PF-747 because upstream #16943 depends on upstream #16912, and PF-745/PF-747 are the focused #16912 intake slices already present in this fork.
- Adds MastraCode Harness v1 runtime/config/event projection, queue scheduling/backpressure support, sandbox-access response typing, and minimal workspace file-mutation helper exports needed by the runtime.
- Avoids a raw full merge of #16943 because direct merge includes the full unresolved #16912 surface and conflicts broadly across agent, worker, storage, server, generated routes, and Harness files.

## Upstream Evidence
- Source PR: https://github.com/mastra-ai/mastra/pull/16943
- Source head: 704a3850214ab5fe3393064b9968c3a620f91816
- Source base (#16912 head): 11c4f5ca4fb0dba05e8112957f88da38899c2154
- Applied as an isolated #16943-over-#16912 diff, then trimmed to this fork's current PF-745/PF-747 Harness stack.

## Validation
- pnpm build:core
- pnpm --filter ./packages/core test:unit src/harness/v1/session.cancel.test.ts --reporter=dot
- pnpm --filter ./packages/core test:unit src/harness/v1/session.scheduler.test.ts --reporter=dot
- pnpm --filter ./packages/core test:unit src/harness/v1/session.queue.test.ts --reporter=dot
- pnpm --filter ./mastracode test src/harness/events.test.ts src/harness/runtime.test.ts --reporter=dot
- pnpm --filter ./mastracode check
- focused ESLint over changed core Harness and MastraCode Harness/TUI files
- git diff --check

## Notes
- This is not a wholesale merge of official #16943. It is the mergeable subset that fits the fork's current Harness v1 stack without importing the still-unmerged full #16912 implementation surface.