### PR TITLE
[PF-580] Fix Harness abort lifecycle settlement

### DIFF
--- a/.changeset/pf-747-harness-cancellation.md
+++ b/.changeset/pf-747-harness-cancellation.md
@@ -10,3 +10,5 @@ await session.cancelQueuedItem({ queuedItemId, reason: 'timed_out' });
 ```
 
 `session.cancel()` cancels active and queued work for the session, emits `task_cancellation_requested`, and prevents later turns from being admitted. `session.cancelQueuedItem()` cancels a queued item that has not reached the queue head yet and emits `queue_item_cancelled`.
+
+Improve cancellation reliability by preventing duplicate terminal events and ensuring run state is cleared.

--- a/packages/core/src/harness/__tests__/harness-tool-suspension.test.ts
+++ b/packages/core/src/harness/__tests__/harness-tool-suspension.test.ts
@@ -1,15 +1,13 @@
 /**
- * Tests for harness tool suspension and resumption.
+ * Tests for harness tool suspension, resumption, and direct-resume abort cleanup.
  *
- * When a tool calls suspend() during execution, the harness should:
- *   1. Emit a 'tool_suspended' event to subscribers
- *   2. Report agent_end with reason 'suspended'
- *   3. Allow the caller to resume via respondToToolSuspension()
- *   4. Call agent.resumeStream() and continue processing
+ * Covers the normal suspend/resume path plus abort, stale-run, and follow-up
+ * cleanup behavior around direct resume streams.
  */
 import { describe, it, expect, vi } from 'vitest';
 import z from 'zod';
 import { Agent } from '../../agent';
+import { createSignal } from '../../agent/signals';
 import { Mastra } from '../../mastra';
 import { InMemoryStore } from '../../storage';
 import { MastraLanguageModelV2Mock } from '../../test-utils/llm-mock';
@@ -67,6 +65,45 @@ function createTextStream() {
       controller.close();
     },
   });
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(res => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    if (predicate()) return;
+    await Promise.resolve();
+  }
+  throw new Error('waitFor: predicate never became true');
+}
+
+async function waitForWithTimers(predicate: () => boolean): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    if (predicate()) return;
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+  throw new Error('waitForWithTimers: predicate never became true');
+}
+
+async function settleWithinTicks<T>(
+  promise: Promise<T>,
+  ticks = 10,
+): Promise<{ settled: true; value: T } | { settled: false }> {
+  return Promise.race([
+    promise.then(value => ({ settled: true as const, value })),
+    (async () => {
+      for (let i = 0; i < ticks; i++) {
+        await Promise.resolve();
+      }
+      return { settled: false as const };
+    })(),
+  ]);
 }
 
 describe('Harness: tool suspension and resumption', () => {
@@ -287,6 +324,1706 @@ describe('Harness: tool suspension and resumption', () => {
     // pendingSuspension should be cleared after resume
     const ds = harness.getDisplayState();
     expect(ds.pendingSuspension).toBeNull();
+  });
+
+  it('emits one aborted agent_end when aborting a direct resume stream', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-resume-abort',
+      name: 'Test Agent Resume Abort',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-resume-abort': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-resume-abort');
+
+    const harness = new Harness({
+      id: 'test-harness-resume-abort',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+
+    const events: any[] = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+    events.length = 0;
+
+    const hold = deferred();
+    vi.spyOn(registeredAgent, 'resumeStream').mockResolvedValue({
+      fullStream: (async function* () {
+        yield { type: 'start', runId: 'resume-run-abort' };
+        await hold.promise;
+        yield { type: 'finish', runId: 'resume-run-abort', payload: { stepResult: { reason: 'stop' } } };
+      })(),
+    } as any);
+
+    const resume = harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+    await waitFor(() => harness.getCurrentRunId() === 'resume-run-abort');
+
+    let subscribedRunId: string | null = 'resume-run-abort';
+    (harness as any).agentThreadSubscription = {
+      activeRunId: () => subscribedRunId,
+      abort: () => true,
+      unsubscribe: vi.fn(),
+      stream: (async function* () {})(),
+    };
+
+    harness.abort();
+    harness.abort();
+    subscribedRunId = null;
+
+    await waitFor(() => events.some((event: any) => event.type === 'agent_end' && event.reason === 'aborted'));
+    expect(harness.getCurrentRunId()).toBeNull();
+
+    hold.resolve();
+    await resume;
+
+    const agentEnds = events.filter((event: any) => event.type === 'agent_end');
+    expect(agentEnds).toEqual([expect.objectContaining({ type: 'agent_end', reason: 'aborted' })]);
+  });
+
+  it('classifies direct resume aborts before the first stream chunk as aborted', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-resume-prechunk-abort',
+      name: 'Test Agent Resume Prechunk Abort',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-resume-prechunk-abort': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-resume-prechunk-abort');
+
+    const harness = new Harness({
+      id: 'test-harness-resume-prechunk-abort',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+
+    const events: any[] = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+    events.length = 0;
+
+    const admit = deferred();
+    const hold = deferred();
+    let resumedRunId: string | null = null;
+    vi.spyOn(registeredAgent, 'resumeStream').mockImplementation(async () => {
+      await admit.promise;
+      return {
+        fullStream: (async function* () {
+          await hold.promise;
+          yield { type: 'start', runId: resumedRunId };
+          yield { type: 'finish', runId: resumedRunId, payload: { stepResult: { reason: 'stop' } } };
+        })(),
+      } as any;
+    });
+
+    const suspendedRunId = (harness as any).pendingSuspensionRunId;
+    expect(suspendedRunId).toBeTruthy();
+    resumedRunId = suspendedRunId;
+
+    const resume = harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+    await waitFor(() => harness.getCurrentRunId() === suspendedRunId);
+
+    harness.abort();
+
+    await waitFor(() => events.some((event: any) => event.type === 'agent_end' && event.reason === 'aborted'));
+    expect(harness.getCurrentRunId()).toBeNull();
+
+    admit.resolve();
+    hold.resolve();
+    await resume;
+
+    expect(events.some((event: any) => event.type === 'agent_start' || event.type === 'message_end')).toBe(false);
+    expect((harness as any).agentThreadSubscription).not.toBeNull();
+    const agentEnds = events.filter((event: any) => event.type === 'agent_end');
+    expect(agentEnds).toEqual([expect.objectContaining({ type: 'agent_end', reason: 'aborted' })]);
+  });
+
+  it('closes a partial direct resume message when the resume is aborted', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-resume-partial-abort',
+      name: 'Test Agent Resume Partial Abort',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-resume-partial-abort': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-resume-partial-abort');
+
+    const harness = new Harness({
+      id: 'test-harness-resume-partial-abort',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+
+    const events: any[] = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+    events.length = 0;
+
+    const hold = deferred();
+    const suspendedRunId = (harness as any).pendingSuspensionRunId;
+    expect(suspendedRunId).toBeTruthy();
+    vi.spyOn(registeredAgent, 'resumeStream').mockResolvedValue({
+      fullStream: (async function* () {
+        yield { type: 'start', runId: suspendedRunId };
+        yield { type: 'text-start', runId: suspendedRunId, payload: { id: 'text-1' } };
+        yield { type: 'text-delta', runId: suspendedRunId, payload: { id: 'text-1', text: 'Partial output' } };
+        await hold.promise;
+        yield { type: 'finish', runId: suspendedRunId, payload: { stepResult: { reason: 'stop' } } };
+      })(),
+    } as any);
+
+    const resume = harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+    await waitFor(() => events.some((event: any) => event.type === 'message_update'));
+
+    harness.abort();
+    await waitFor(() => events.some((event: any) => event.type === 'agent_end' && event.reason === 'aborted'));
+
+    (harness as any).pendingSuspensionRunId = 'newer-suspension-run';
+    (harness as any).pendingSuspensionToolCallId = 'newer-tool-call';
+    hold.resolve();
+    await resume;
+
+    expect(events.find((event: any) => event.type === 'message_end')).toMatchObject({
+      message: expect.objectContaining({
+        content: [expect.objectContaining({ type: 'text', text: 'Partial output' })],
+      }),
+    });
+    const agentEnds = events.filter((event: any) => event.type === 'agent_end');
+    expect(agentEnds).toEqual([expect.objectContaining({ type: 'agent_end', reason: 'aborted' })]);
+    expect(events.findIndex((event: any) => event.type === 'message_end')).toBeLessThan(
+      events.findIndex((event: any) => event.type === 'agent_end'),
+    );
+    expect((harness as any).pendingSuspensionRunId).toBe('newer-suspension-run');
+    expect((harness as any).pendingSuspensionToolCallId).toBe('newer-tool-call');
+  });
+
+  it('does not double-close a direct resume message when a message_update listener aborts', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-resume-listener-abort',
+      name: 'Test Agent Resume Listener Abort',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-resume-listener-abort': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-resume-listener-abort');
+
+    const harness = new Harness({
+      id: 'test-harness-resume-listener-abort',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+
+    const events: any[] = [];
+    let abortOnUpdate = false;
+    harness.subscribe(event => {
+      events.push(event);
+      if (abortOnUpdate && event.type === 'message_update') {
+        harness.abort();
+      }
+    });
+
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+    events.length = 0;
+    abortOnUpdate = true;
+
+    const suspendedRunId = (harness as any).pendingSuspensionRunId;
+    vi.spyOn(registeredAgent, 'resumeStream').mockResolvedValue({
+      fullStream: (async function* () {
+        yield { type: 'start', runId: suspendedRunId };
+        yield { type: 'text-start', runId: suspendedRunId, payload: { id: 'text-1' } };
+        yield { type: 'text-delta', runId: suspendedRunId, payload: { id: 'text-1', text: 'Partial output' } };
+        yield { type: 'finish', runId: suspendedRunId, payload: { stepResult: { reason: 'stop' } } };
+      })(),
+    } as any);
+
+    await harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+
+    expect(events.filter((event: any) => event.type === 'message_end')).toHaveLength(1);
+    expect(events.filter((event: any) => event.type === 'agent_end')).toEqual([
+      expect.objectContaining({ reason: 'aborted' }),
+    ]);
+  });
+
+  it('does not double-close a direct resume message when a message_end listener aborts', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-resume-end-listener-abort',
+      name: 'Test Agent Resume End Listener Abort',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-resume-end-listener-abort': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-resume-end-listener-abort');
+
+    const harness = new Harness({
+      id: 'test-harness-resume-end-listener-abort',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+
+    const events: any[] = [];
+    let abortOnEnd = false;
+    harness.subscribe(event => {
+      events.push(event);
+      if (abortOnEnd && event.type === 'message_end') {
+        harness.abort();
+      }
+    });
+
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+    events.length = 0;
+    abortOnEnd = true;
+
+    const suspendedRunId = (harness as any).pendingSuspensionRunId;
+    vi.spyOn(registeredAgent, 'resumeStream').mockResolvedValue({
+      fullStream: (async function* () {
+        yield { type: 'start', runId: suspendedRunId };
+        yield { type: 'text-start', runId: suspendedRunId, payload: { id: 'text-1' } };
+        yield { type: 'text-delta', runId: suspendedRunId, payload: { id: 'text-1', text: 'Partial output' } };
+        yield { type: 'finish', runId: suspendedRunId, payload: { stepResult: { reason: 'stop' } } };
+      })(),
+    } as any);
+
+    await harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+
+    expect(events.filter((event: any) => event.type === 'message_end')).toHaveLength(1);
+    expect(events.filter((event: any) => event.type === 'agent_end')).toEqual([
+      expect.objectContaining({ reason: 'aborted' }),
+    ]);
+  });
+
+  it('preserves a same-run suspension emitted while resuming a tool', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-resume-resuspends',
+      name: 'Test Agent Resume Resuspends',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-resume-resuspends': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-resume-resuspends');
+
+    const harness = new Harness({
+      id: 'test-harness-resume-resuspends',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+    const suspendedRunId = (harness as any).pendingSuspensionRunId;
+
+    vi.spyOn(registeredAgent, 'resumeStream').mockResolvedValue({
+      fullStream: (async function* () {
+        yield { type: 'start', runId: suspendedRunId };
+        yield {
+          type: 'tool-call-suspended',
+          runId: suspendedRunId,
+          payload: {
+            toolCallId: 'call-2',
+            toolName: 'confirmAction',
+            args: { action: 'deploy again' },
+            suspendPayload: { action: 'deploy again' },
+          },
+        };
+      })(),
+    } as any);
+
+    await harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+
+    expect((harness as any).pendingSuspensionRunId).toBe(suspendedRunId);
+    expect((harness as any).pendingSuspensionToolCallId).toBe('call-2');
+    expect(harness.getDisplayState().pendingSuspension).toMatchObject({ toolCallId: 'call-2' });
+  });
+
+  it('does not miss a direct resume abort when the first stream chunk retargets the run id', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-resume-retargeted-abort',
+      name: 'Test Agent Resume Retargeted Abort',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-resume-retargeted-abort': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-resume-retargeted-abort');
+
+    const harness = new Harness({
+      id: 'test-harness-resume-retargeted-abort',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+
+    const events: any[] = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+    events.length = 0;
+
+    const hold = deferred();
+    vi.spyOn(registeredAgent, 'resumeStream').mockResolvedValue({
+      fullStream: (async function* () {
+        await hold.promise;
+        yield { type: 'start', runId: 'retargeted-resume-run' };
+        yield { type: 'text-start', runId: 'retargeted-resume-run', payload: { id: 'text-1' } };
+        yield { type: 'text-delta', runId: 'retargeted-resume-run', payload: { id: 'text-1', text: 'Too late' } };
+        yield { type: 'finish', runId: 'retargeted-resume-run', payload: { stepResult: { reason: 'stop' } } };
+      })(),
+    } as any);
+
+    const resume = harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+    await waitFor(() => events.some((event: any) => event.type === 'agent_start'));
+
+    harness.abort();
+    await waitFor(() => events.some((event: any) => event.type === 'agent_end' && event.reason === 'aborted'));
+
+    hold.resolve();
+    await resume;
+
+    expect(events.some((event: any) => event.type === 'message_update')).toBe(false);
+    const agentEnds = events.filter((event: any) => event.type === 'agent_end');
+    expect(agentEnds).toEqual([expect.objectContaining({ type: 'agent_end', reason: 'aborted' })]);
+  });
+
+  it('aborts a direct resume stream after the stream retargets the run id', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-resume-retargeted-active-abort',
+      name: 'Test Agent Resume Retargeted Active Abort',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-resume-retargeted-active-abort': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-resume-retargeted-active-abort');
+
+    const harness = new Harness({
+      id: 'test-harness-resume-retargeted-active-abort',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+
+    const events: any[] = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+    events.length = 0;
+
+    const hold = deferred();
+    vi.spyOn(registeredAgent, 'resumeStream').mockResolvedValue({
+      fullStream: (async function* () {
+        yield { type: 'start', runId: 'retargeted-active-run' };
+        await hold.promise;
+        yield { type: 'text-start', runId: 'retargeted-active-run', payload: { id: 'text-1' } };
+        yield { type: 'text-delta', runId: 'retargeted-active-run', payload: { id: 'text-1', text: 'Too late' } };
+        yield { type: 'finish', runId: 'retargeted-active-run', payload: { stepResult: { reason: 'stop' } } };
+      })(),
+    } as any);
+
+    const resume = harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+    await waitFor(() => harness.getCurrentRunId() === 'retargeted-active-run');
+
+    harness.abort();
+    await waitFor(() => events.some((event: any) => event.type === 'agent_end' && event.reason === 'aborted'));
+
+    hold.resolve();
+    await resume;
+
+    expect(events.some((event: any) => event.type === 'message_update')).toBe(false);
+    const agentEnds = events.filter((event: any) => event.type === 'agent_end');
+    expect(agentEnds).toEqual([expect.objectContaining({ type: 'agent_end', reason: 'aborted' })]);
+    expect(harness.getCurrentRunId()).toBeNull();
+  });
+
+  it('drains queued follow-ups after a direct resume abort without waiting for the stream to finish', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-resume-abort-followup',
+      name: 'Test Agent Resume Abort Follow Up',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-resume-abort-followup': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-resume-abort-followup');
+
+    const harness = new Harness({
+      id: 'test-harness-resume-abort-followup',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+    const suspendedRunId = (harness as any).pendingSuspensionRunId;
+    expect(suspendedRunId).toBeTruthy();
+
+    vi.spyOn(registeredAgent, 'resumeStream').mockResolvedValue({
+      fullStream: (async function* () {
+        await new Promise(() => {});
+      })(),
+    } as any);
+    const sendSignalSpy = vi.spyOn(registeredAgent, 'sendSignal').mockReturnValue({
+      accepted: true,
+      runId: 'follow-up-run',
+      signal: {} as any,
+    });
+    let activeRunId: string | null = suspendedRunId;
+    const subscribeSpy = vi.spyOn(registeredAgent, 'subscribeToThread').mockResolvedValue({
+      stream: (async function* () {})() as any,
+      unsubscribe: vi.fn(),
+      abort: vi.fn(),
+      activeRunId: () => activeRunId,
+    });
+
+    const resume = harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+    await waitFor(() => harness.getCurrentRunId() !== null);
+
+    await harness.followUp({ content: 'continue after abort' });
+    expect(harness.getFollowUpCount()).toBe(1);
+
+    harness.abort();
+
+    await waitFor(() => subscribeSpy.mock.calls.length > 0);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(sendSignalSpy).not.toHaveBeenCalled();
+
+    activeRunId = null;
+    await waitForWithTimers(() => sendSignalSpy.mock.calls.length === 1);
+    expect(harness.getFollowUpCount()).toBe(0);
+    await resume;
+    expect((harness as any).resumingSuspensionRunIds.size).toBe(0);
+    expect((harness as any).directStreamRunIds.size).toBe(0);
+    expect((harness as any).abortFinalizedRunIds.size).toBe(0);
+  });
+
+  it('releases a runtime direct resume run before draining queued follow-ups when the subscription has no active run id', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-resume-abort-followup-null-active',
+      name: 'Test Agent Resume Abort Follow Up Null Active',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-resume-abort-followup-null-active': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-resume-abort-followup-null-active');
+
+    const harness = new Harness({
+      id: 'test-harness-resume-abort-followup-null-active',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+    const suspendedRunId = (harness as any).pendingSuspensionRunId;
+    expect(suspendedRunId).toBeTruthy();
+
+    vi.spyOn(registeredAgent, 'resumeStream').mockResolvedValue({
+      fullStream: (async function* () {
+        await new Promise(() => {});
+      })(),
+    } as any);
+    const abortRunStreamSpy = vi.spyOn(registeredAgent, 'abortRunStream').mockReturnValue(true);
+    const sendSignalSpy = vi.spyOn(registeredAgent, 'sendSignal').mockReturnValue({
+      accepted: true,
+      runId: 'follow-up-run',
+      signal: {} as any,
+    });
+    vi.spyOn(registeredAgent, 'subscribeToThread').mockResolvedValue({
+      stream: (async function* () {})() as any,
+      unsubscribe: vi.fn(),
+      abort: vi.fn(),
+      activeRunId: () => null,
+    });
+
+    const resume = harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+    await waitFor(() => harness.getCurrentRunId() !== null);
+
+    await harness.followUp({ content: 'continue after abort' });
+    harness.abort();
+
+    await waitFor(() => sendSignalSpy.mock.calls.length === 1);
+    expect(abortRunStreamSpy).toHaveBeenCalledWith(suspendedRunId);
+    expect(abortRunStreamSpy.mock.invocationCallOrder[0]).toBeLessThan(sendSignalSpy.mock.invocationCallOrder[0]!);
+    expect(sendSignalSpy.mock.calls[0]?.[1]).toMatchObject({ ifIdle: expect.any(Object) });
+
+    await resume;
+    expect((harness as any).resumingSuspensionRunIds.size).toBe(0);
+    expect((harness as any).directStreamRunIds.size).toBe(0);
+    expect((harness as any).abortFinalizedRunIds.size).toBe(0);
+  });
+
+  it('settles a direct resume abort when resumeStream has not returned yet', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-resume-pending-abort',
+      name: 'Test Agent Resume Pending Abort',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-resume-pending-abort': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-resume-pending-abort');
+
+    const harness = new Harness({
+      id: 'test-harness-resume-pending-abort',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+
+    vi.spyOn(registeredAgent, 'resumeStream').mockReturnValue(new Promise(() => {}) as any);
+
+    const resume = harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+    await waitFor(() => harness.getCurrentRunId() !== null);
+
+    harness.abort();
+    await resume;
+
+    expect((harness as any).resumingSuspensionRunIds.size).toBe(0);
+    expect((harness as any).directStreamRunIds.size).toBe(0);
+    expect((harness as any).abortFinalizedRunIds.size).toBe(0);
+  });
+
+  it('settles a direct resume abort before resumeStream is called', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-resume-context-abort',
+      name: 'Test Agent Resume Context Abort',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-resume-context-abort': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-resume-context-abort');
+
+    const harness = new Harness({
+      id: 'test-harness-resume-context-abort',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+
+    const contextStarted = deferred();
+    vi.spyOn(harness as any, 'buildRequestContext').mockImplementation(async () => {
+      contextStarted.resolve();
+      await new Promise(() => {});
+      return {} as any;
+    });
+    const resumeStreamSpy = vi.spyOn(registeredAgent, 'resumeStream');
+
+    const resume = harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+    await contextStarted.promise;
+
+    harness.abort();
+    await resume;
+
+    expect(resumeStreamSpy).not.toHaveBeenCalled();
+    expect((harness as any).resumingSuspensionRunIds.size).toBe(0);
+    expect((harness as any).directStreamRunIds.size).toBe(0);
+    expect((harness as any).abortFinalizedRunIds.size).toBe(0);
+  });
+
+  it('settles a direct resume abort while waiting for tool approval', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-resume-approval-abort',
+      name: 'Test Agent Resume Approval Abort',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-resume-approval-abort': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-resume-approval-abort');
+
+    const harness = new Harness({
+      id: 'test-harness-resume-approval-abort',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+
+    const events: any[] = [];
+    harness.subscribe(event => events.push(event));
+
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+    await harness.setState({ yolo: false } as any);
+    events.length = 0;
+
+    const suspendedRunId = (harness as any).pendingSuspensionRunId;
+    vi.spyOn(registeredAgent, 'resumeStream').mockResolvedValue({
+      fullStream: (async function* () {
+        yield { type: 'start', runId: suspendedRunId };
+        yield {
+          type: 'tool-call-approval',
+          runId: suspendedRunId,
+          payload: {
+            toolCallId: 'approval-call',
+            toolName: 'confirmAction',
+            args: { action: 'deploy' },
+          },
+        };
+      })(),
+    } as any);
+
+    const resume = harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+    await waitFor(() => (harness as any).pendingApprovalResolve !== null);
+
+    harness.abort();
+    await resume;
+
+    expect(events).toContainEqual(expect.objectContaining({ type: 'tool_approval_required' }));
+    expect(events.filter((event: any) => event.type === 'agent_end')).toEqual([
+      expect.objectContaining({ reason: 'aborted' }),
+    ]);
+    expect((harness as any).pendingApprovalResolve).toBeNull();
+    expect((harness as any).directStreamRunIds.size).toBe(0);
+    expect((harness as any).abortFinalizedRunIds.size).toBe(0);
+  });
+
+  it('settles a subscribed run abort while waiting for tool approval', async () => {
+    const agent = new Agent({
+      id: 'test-agent-subscribed-approval-abort',
+      name: 'Test Agent Subscribed Approval Abort',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock(),
+    });
+    const storage = new InMemoryStore();
+    const harness = new Harness({
+      id: 'test-harness-subscribed-approval-abort',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent }],
+      initialState: { yolo: false } as any,
+    });
+    await harness.init();
+
+    const events: any[] = [];
+    harness.subscribe(event => events.push(event));
+
+    let activeRunId: string | null = 'run-approval';
+    const unsubscribe = vi.fn(() => {
+      activeRunId = null;
+    });
+    vi.spyOn(agent, 'subscribeToThread').mockResolvedValue({
+      stream: (async function* () {
+        yield { type: 'start', runId: 'run-approval', payload: {} };
+        yield {
+          type: 'tool-call-approval',
+          runId: 'run-approval',
+          payload: {
+            toolCallId: 'approval-call',
+            toolName: 'confirmAction',
+            args: { action: 'deploy' },
+          },
+        };
+      })() as any,
+      unsubscribe,
+      abort: vi.fn(),
+      activeRunId: () => activeRunId,
+    });
+    vi.spyOn(agent, 'sendSignal').mockReturnValue({
+      accepted: true,
+      runId: 'run-approval',
+      signal: createSignal({ type: 'user-message', contents: 'Deploy to production' }),
+    });
+    const declineToolCall = vi.spyOn(agent, 'declineToolCall');
+
+    await harness.createThread();
+    const signal = harness.sendSignal({ content: 'Deploy to production' });
+    await signal.accepted;
+    await waitFor(() => (harness as any).pendingApprovalResolve !== null);
+
+    harness.abort();
+
+    await waitFor(
+      () =>
+        events.some(event => event.type === 'agent_end' && event.reason === 'aborted') &&
+        (harness as any).pendingApprovalResolve === null,
+    );
+
+    expect(events).toContainEqual(expect.objectContaining({ type: 'tool_approval_required' }));
+    expect(events.filter((event: any) => event.type === 'agent_end')).toEqual([
+      expect.objectContaining({ reason: 'aborted' }),
+    ]);
+    expect(declineToolCall).not.toHaveBeenCalled();
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  it('does not route a stale approval decision into a newer active run', async () => {
+    const agent = new Agent({
+      id: 'test-agent-stale-approval',
+      name: 'Test Agent Stale Approval',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock(),
+    });
+    const storage = new InMemoryStore();
+    const harness = new Harness({
+      id: 'test-harness-stale-approval',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent }],
+      initialState: { yolo: false } as any,
+    });
+    await harness.init();
+
+    const holdStream = deferred();
+    vi.spyOn(agent, 'subscribeToThread').mockResolvedValue({
+      stream: (async function* () {
+        yield { type: 'start', runId: 'stale-run', payload: {} };
+        yield {
+          type: 'tool-call-approval',
+          runId: 'stale-run',
+          payload: {
+            toolCallId: 'approval-call',
+            toolName: 'confirmAction',
+            args: { action: 'deploy' },
+          },
+        };
+        await holdStream.promise;
+      })() as any,
+      unsubscribe: vi.fn(),
+      abort: vi.fn(),
+      activeRunId: () => 'newer-run',
+    });
+    vi.spyOn(agent, 'sendSignal').mockReturnValue({
+      accepted: true,
+      runId: 'stale-run',
+      signal: createSignal({ type: 'user-message', contents: 'Deploy to production' }),
+    });
+    const approveToolCall = vi.spyOn(agent, 'approveToolCall');
+    const declineToolCall = vi.spyOn(agent, 'declineToolCall');
+
+    await harness.createThread();
+    const signal = harness.sendSignal({ content: 'Deploy to production' });
+    await signal.accepted;
+    await waitFor(() => (harness as any).pendingApprovalResolve !== null);
+
+    (harness as any).currentRunId = 'newer-run';
+    harness.respondToToolApproval({ decision: 'decline' });
+    await Promise.resolve();
+
+    expect(approveToolCall).not.toHaveBeenCalled();
+    expect(declineToolCall).not.toHaveBeenCalled();
+    expect(harness.getCurrentRunId()).toBe('newer-run');
+
+    holdStream.resolve();
+  });
+
+  it('drains multiple queued follow-ups after a direct resume abort', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-resume-abort-serial-followup',
+      name: 'Test Agent Resume Abort Serial Follow Up',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-resume-abort-serial-followup': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-resume-abort-serial-followup');
+
+    const harness = new Harness({
+      id: 'test-harness-resume-abort-serial-followup',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+
+    vi.spyOn(registeredAgent, 'resumeStream').mockResolvedValue({
+      fullStream: (async function* () {
+        await new Promise(() => {});
+      })(),
+    } as any);
+    const sendSignalSpy = vi.spyOn(registeredAgent, 'sendSignal').mockReturnValue({
+      accepted: true,
+      runId: 'first-follow-up-run',
+      signal: {} as any,
+    });
+
+    const resume = harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+    await waitFor(() => harness.getCurrentRunId() !== null);
+
+    await harness.followUp({ content: 'first follow-up' });
+    await harness.followUp({ content: 'second follow-up' });
+    expect(harness.getFollowUpCount()).toBe(2);
+
+    harness.abort();
+
+    await waitFor(() => sendSignalSpy.mock.calls.length === 1);
+    await resume;
+
+    expect(sendSignalSpy).toHaveBeenCalledTimes(2);
+    expect(harness.getFollowUpCount()).toBe(0);
+  });
+
+  it('reschedules queued follow-up draining after a reentrant drain call', async () => {
+    const agent = new Agent({
+      id: 'test-agent-reentrant-followup-drain',
+      name: 'Test Agent Reentrant Follow Up Drain',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createTextStream() }),
+      }),
+    });
+    const storage = new InMemoryStore();
+    const harness = new Harness({
+      id: 'test-harness-reentrant-followup-drain',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent }],
+      initialState: { yolo: true } as any,
+    });
+    const sent: string[] = [];
+    vi.spyOn(harness as any, 'sendMessage').mockImplementation(async ({ content }: { content: string }) => {
+      sent.push(content);
+      await (harness as any).drainFollowUpQueue();
+    });
+    (harness as any).followUpQueue = [{ content: 'first' }, { content: 'second' }];
+
+    await (harness as any).drainFollowUpQueue();
+    await waitFor(() => sent.length === 2);
+
+    expect(sent).toEqual(['first', 'second']);
+    expect(harness.getFollowUpCount()).toBe(0);
+  });
+
+  it('finalizes a subscribed run as subscribed when activeRunId is temporarily null', () => {
+    const agent = new Agent({
+      id: 'test-agent-subscribed-null-active',
+      name: 'Test Agent Subscribed Null Active',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createTextStream() }),
+      }),
+    });
+    const storage = new InMemoryStore();
+    const harness = new Harness({
+      id: 'test-harness-subscribed-null-active',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent }],
+      initialState: { yolo: true } as any,
+    });
+    const events: any[] = [];
+    harness.subscribe(event => events.push(event));
+
+    (harness as any).currentRunId = 'subscribed-run';
+    (harness as any).abortController = new AbortController();
+    (harness as any).agentThreadSubscription = {
+      activeRunId: () => null,
+      abort: vi.fn(),
+      unsubscribe: vi.fn(),
+      stream: (async function* () {})(),
+    };
+
+    harness.abort();
+
+    expect(events).toContainEqual(expect.objectContaining({ type: 'agent_end', reason: 'aborted' }));
+    expect((harness as any).abortFinalizedRunIds.has('subscribed-run')).toBe(false);
+  });
+
+  it('cleans retargeted direct resume state when the stream throws', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-resume-retargeted-error',
+      name: 'Test Agent Resume Retargeted Error',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-resume-retargeted-error': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-resume-retargeted-error');
+
+    const harness = new Harness({
+      id: 'test-harness-resume-retargeted-error',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+
+    const events: any[] = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+    const suspendedRunId = (harness as any).pendingSuspensionRunId;
+    events.length = 0;
+
+    vi.spyOn(registeredAgent, 'resumeStream').mockResolvedValue({
+      fullStream: (async function* () {
+        yield { type: 'start', runId: 'retargeted-error-run' };
+        throw new Error('retargeted stream failed');
+      })(),
+    } as any);
+
+    await harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+
+    expect(events.find((event: any) => event.type === 'error')).toBeDefined();
+    expect(events.find((event: any) => event.type === 'agent_end')).toMatchObject({ reason: 'error' });
+    expect(harness.getCurrentRunId()).toBeNull();
+    expect((harness as any).directStreamRunIds.has(suspendedRunId)).toBe(false);
+    expect((harness as any).directStreamRunIds.has('retargeted-error-run')).toBe(false);
+  });
+
+  it('does not let a stale suspension resume detach a newer active run', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-stale-resume',
+      name: 'Test Agent Stale Resume',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-stale-resume': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-stale-resume');
+
+    const harness = new Harness({
+      id: 'test-harness-stale-resume',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+
+    const events: any[] = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+    events.length = 0;
+
+    const resumeStreamSpy = vi.spyOn(registeredAgent, 'resumeStream');
+    const unsubscribe = vi.fn();
+    (harness as any).currentRunId = 'newer-run';
+    (harness as any).abortController = new AbortController();
+    (harness as any).agentThreadSubscription = {
+      activeRunId: () => 'newer-run',
+      abort: vi.fn(),
+      unsubscribe,
+      stream: (async function* () {})(),
+    };
+
+    await harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+
+    expect(resumeStreamSpy).not.toHaveBeenCalled();
+    expect(unsubscribe).not.toHaveBeenCalled();
+    expect(harness.getCurrentRunId()).toBe('newer-run');
+    expect(events.some((event: any) => event.type === 'error')).toBe(true);
+    expect(events.some((event: any) => event.type === 'agent_end')).toBe(false);
+  });
+
+  it('does not admit duplicate responses while a suspension resume is in flight', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-duplicate-resume',
+      name: 'Test Agent Duplicate Resume',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-duplicate-resume': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-duplicate-resume');
+
+    const harness = new Harness({
+      id: 'test-harness-duplicate-resume',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+
+    const events: any[] = [];
+    harness.subscribe(event => {
+      events.push(event);
+    });
+
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+    events.length = 0;
+
+    const resumeStarted = deferred();
+    const hold = deferred();
+    const resumeStreamSpy = vi.spyOn(registeredAgent, 'resumeStream').mockImplementation(async () => {
+      resumeStarted.resolve();
+      return {
+        fullStream: (async function* () {
+          await hold.promise;
+          yield { type: 'start', runId: (harness as any).pendingSuspensionRunId };
+          yield {
+            type: 'finish',
+            runId: (harness as any).pendingSuspensionRunId,
+            payload: { stepResult: { reason: 'stop' } },
+          };
+        })(),
+      } as any;
+    });
+
+    const first = harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+    await resumeStarted.promise;
+    await waitFor(() => harness.getCurrentRunId() !== null);
+
+    await harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+
+    expect(resumeStreamSpy).toHaveBeenCalledTimes(1);
+    expect(events.some((event: any) => event.type === 'error')).toBe(true);
+
+    hold.resolve();
+    await first;
+  });
+
+  it('does not let a concurrent signal detach an active direct resume stream', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-concurrent-direct-resume',
+      name: 'Test Agent Concurrent Direct Resume',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-concurrent-direct-resume': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-concurrent-direct-resume');
+
+    const harness = new Harness({
+      id: 'test-harness-concurrent-direct-resume',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+
+    const suspendedRunId = (harness as any).pendingSuspensionRunId;
+    expect(suspendedRunId).toBeTruthy();
+
+    const resumeStarted = deferred();
+    const admit = deferred();
+    const hold = deferred();
+    vi.spyOn(registeredAgent, 'resumeStream').mockImplementation(async () => {
+      resumeStarted.resolve();
+      await admit.promise;
+      return {
+        fullStream: (async function* () {
+          await hold.promise;
+          yield { type: 'start', runId: suspendedRunId };
+          yield { type: 'finish', runId: suspendedRunId, payload: { stepResult: { reason: 'stop' } } };
+        })(),
+      } as any;
+    });
+
+    const registered = deferred();
+    const waitForRunOutputSpy = vi.spyOn(registeredAgent, 'waitForRunOutput').mockImplementation(async () => {
+      await registered.promise;
+      return { status: 'running' } as any;
+    });
+    const sendSignalSpy = vi.spyOn(registeredAgent, 'sendSignal').mockReturnValue({
+      accepted: true,
+      runId: suspendedRunId,
+      signal: {} as any,
+    });
+
+    const resume = harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+    await resumeStarted.promise;
+    await waitFor(() => harness.getCurrentRunId() === suspendedRunId);
+
+    const signal = harness.sendSignal({ content: 'still there?' });
+    await Promise.resolve();
+
+    expect(waitForRunOutputSpy).toHaveBeenCalledWith(suspendedRunId, expect.any(Object));
+    expect(sendSignalSpy).not.toHaveBeenCalled();
+    expect(harness.getCurrentRunId()).toBe(suspendedRunId);
+    expect((harness as any).directStreamRunIds.has(suspendedRunId)).toBe(true);
+
+    admit.resolve();
+    registered.resolve();
+    await expect(signal.accepted).resolves.toMatchObject({ accepted: true, runId: suspendedRunId });
+
+    expect(sendSignalSpy).toHaveBeenCalledTimes(1);
+    expect(sendSignalSpy.mock.calls[0]?.[1]).toMatchObject({ runId: suspendedRunId });
+    expect((harness as any).directStreamRunIds.has(suspendedRunId)).toBe(true);
+
+    hold.resolve();
+    await resume;
+    expect(harness.getCurrentRunId()).toBeNull();
+  });
+
+  it('does not wait for direct resume completion after a user message is admitted', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-direct-resume-send-message',
+      name: 'Test Agent Direct Resume Send Message',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-direct-resume-send-message': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-direct-resume-send-message');
+
+    const harness = new Harness({
+      id: 'test-harness-direct-resume-send-message',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+
+    const suspendedRunId = (harness as any).pendingSuspensionRunId;
+    expect(suspendedRunId).toBeTruthy();
+
+    const resumeStarted = deferred();
+    const admit = deferred();
+    const hold = deferred();
+    vi.spyOn(registeredAgent, 'resumeStream').mockImplementation(async () => {
+      resumeStarted.resolve();
+      await admit.promise;
+      return {
+        fullStream: (async function* () {
+          await hold.promise;
+          yield { type: 'start', runId: suspendedRunId };
+          yield { type: 'finish', runId: suspendedRunId, payload: { stepResult: { reason: 'stop' } } };
+        })(),
+      } as any;
+    });
+
+    const registered = deferred();
+    vi.spyOn(registeredAgent, 'waitForRunOutput').mockImplementation(async () => {
+      await registered.promise;
+      return { status: 'running' } as any;
+    });
+    vi.spyOn(registeredAgent, 'sendSignal').mockReturnValue({
+      accepted: true,
+      runId: suspendedRunId,
+      signal: {} as any,
+    });
+
+    const resume = harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+    await resumeStarted.promise;
+    await waitFor(() => harness.getCurrentRunId() === suspendedRunId);
+
+    const message = harness.sendMessage({ content: 'still there?' });
+    await Promise.resolve();
+    expect(await settleWithinTicks(message)).toEqual({ settled: false });
+
+    registered.resolve();
+    await expect(message).resolves.toBeUndefined();
+
+    admit.resolve();
+    hold.resolve();
+    await resume;
+  });
+
+  it('does not attach a fresh signal to a direct resume run that is still shutting down after abort', async () => {
+    const confirmTool = createTool({
+      id: 'confirm-action',
+      description: 'Confirms an action with the user',
+      inputSchema: z.object({ action: z.string() }),
+      execute: async (input: { action: string }, context?: any) => {
+        const suspend = context?.suspend ?? context?.agent?.suspend;
+        if (!suspend) throw new Error('suspend not available in context');
+        await suspend({ action: input.action });
+        return { result: `Action "${input.action}" confirmed` };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'test-agent-aborted-direct-resume-admission',
+      name: 'Test Agent Aborted Direct Resume Admission',
+      instructions: 'You confirm actions.',
+      model: new MastraLanguageModelV2Mock({
+        doStream: async () => ({ stream: createToolCallStream() }),
+      }),
+      tools: { confirmAction: confirmTool },
+    });
+
+    const storage = new InMemoryStore();
+    const mastra = new Mastra({
+      agents: { 'test-agent-aborted-direct-resume-admission': agent },
+      logger: false,
+      storage,
+    });
+    const registeredAgent = mastra.getAgent('test-agent-aborted-direct-resume-admission');
+
+    const harness = new Harness({
+      id: 'test-harness-aborted-direct-resume-admission',
+      storage,
+      modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+      initialState: { yolo: true } as any,
+    });
+    await harness.init();
+    await harness.createThread();
+    await harness.sendMessage({ content: 'Deploy to production' });
+
+    const suspendedRunId = (harness as any).pendingSuspensionRunId;
+    expect(suspendedRunId).toBeTruthy();
+
+    const holdResume = deferred();
+    vi.spyOn(registeredAgent, 'resumeStream').mockResolvedValue({
+      fullStream: (async function* () {
+        yield { type: 'start', runId: suspendedRunId };
+        await holdResume.promise;
+      })(),
+    } as any);
+
+    const resume = harness.respondToToolSuspension({ resumeData: { confirmed: true } });
+    await waitFor(() => harness.getCurrentRunId() === suspendedRunId);
+
+    harness.abort();
+
+    let activeRunId: string | null = suspendedRunId;
+    vi.spyOn(registeredAgent, 'subscribeToThread').mockResolvedValue({
+      stream: (async function* () {})() as any,
+      unsubscribe: vi.fn(),
+      abort: vi.fn(),
+      activeRunId: () => activeRunId,
+    });
+    const sendSignalSpy = vi.spyOn(registeredAgent, 'sendSignal').mockReturnValue({
+      accepted: true,
+      runId: 'fresh-run',
+      signal: createSignal({ type: 'user-message', contents: 'fresh work' }),
+    });
+
+    const signal = harness.sendSignal({ content: 'fresh work' });
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(sendSignalSpy).not.toHaveBeenCalled();
+
+    activeRunId = null;
+    await expect(signal.accepted).resolves.toMatchObject({ accepted: true, runId: 'fresh-run' });
+    expect(sendSignalSpy).toHaveBeenCalledTimes(1);
+    expect(sendSignalSpy.mock.calls[0]?.[1]).toMatchObject({ ifIdle: expect.any(Object) });
+    expect(sendSignalSpy.mock.calls[0]?.[1]).not.toHaveProperty('runId');
+
+    holdResume.resolve();
+    await resume;
   });
 
   it('should forward requireToolApproval=false to resumeStream when harness is in yolo mode', async () => {

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -235,6 +235,12 @@ export class Harness<TState = {}> {
   private abortGeneration = 0;
   private abortWaiters = new Set<() => void>();
   private currentRunId: string | null = null;
+  private abortFinalizedRunIds = new Set<string>();
+  private directStreamRunIds = new Set<string>();
+  private directStreamStates = new Map<string, HarnessStreamState>();
+  private closedDirectStreamMessageRunIds = new Set<string>();
+  private followUpDrainPromise: Promise<void> | null = null;
+  private dispatchingFollowUp = false;
   private currentTraceId: string | null = null;
   private currentOperationId: number = 0;
   private agentThreadSubscription: AgentThreadSubscription<any> | null = null;
@@ -246,6 +252,7 @@ export class Harness<TState = {}> {
   private pendingApprovalToolName: string | null = null;
   private pendingSuspensionRunId: string | null = null;
   private pendingSuspensionToolCallId: string | null = null;
+  private resumingSuspensionRunIds = new Set<string>();
   private pendingQuestions = new Map<string, (answer: HarnessQuestionAnswer) => void>();
   private pendingPlanApprovals = new Map<
     string,
@@ -1582,6 +1589,9 @@ export class Harness<TState = {}> {
     this.agentThreadSubscription?.unsubscribe();
     this.agentThreadSubscription = null;
     this.agentThreadSubscriptionKey = null;
+    this.directStreamRunIds.clear();
+    this.directStreamStates.clear();
+    this.closedDirectStreamMessageRunIds.clear();
     this.currentRunId = null;
     this.currentTraceId = null;
     this.abortController = null;
@@ -1608,16 +1618,61 @@ export class Harness<TState = {}> {
     await this.ensureAgentThreadSubscription(this.getCurrentAgent(), this.currentThreadId);
   }
 
+  private getActiveDirectStreamRunId(): string | null {
+    return this.currentRunId !== null && this.directStreamRunIds.has(this.currentRunId) ? this.currentRunId : null;
+  }
+
   private async drainFollowUpQueue(options?: { tracingContext?: TracingContext; tracingOptions?: TracingOptions }) {
     if (this.followUpQueue.length === 0) return;
+    if (this.followUpDrainPromise) {
+      if (this.dispatchingFollowUp) return;
+      await this.followUpDrainPromise;
+      return;
+    }
 
-    const next = this.followUpQueue.shift()!;
-    await this.sendMessage({
-      content: next.content,
-      requestContext: next.requestContext,
-      tracingContext: options?.tracingContext,
-      tracingOptions: options?.tracingOptions,
-    });
+    const drain = (async () => {
+      const next = this.followUpQueue.shift();
+      if (!next) return;
+      this.dispatchingFollowUp = true;
+      try {
+        await this.sendMessage({
+          content: next.content,
+          requestContext: next.requestContext,
+          tracingContext: options?.tracingContext,
+          tracingOptions: options?.tracingOptions,
+        });
+      } finally {
+        this.dispatchingFollowUp = false;
+      }
+    })();
+    this.followUpDrainPromise = drain;
+    try {
+      await drain;
+    } finally {
+      if (this.followUpDrainPromise === drain) {
+        this.followUpDrainPromise = null;
+      }
+      if (this.followUpQueue.length > 0) {
+        void this.drainFollowUpQueue(options).catch(error => {
+          this.emit({ type: 'error', error: error instanceof Error ? error : new Error(String(error)) });
+        });
+      }
+    }
+  }
+
+  private hasActiveRunOtherThan(runId: string): boolean {
+    const activeSubscriptionRunId = this.agentThreadSubscription?.activeRunId();
+    if (
+      activeSubscriptionRunId !== null &&
+      activeSubscriptionRunId !== undefined &&
+      activeSubscriptionRunId !== runId
+    ) {
+      return true;
+    }
+    if (this.currentRunId !== null && this.currentRunId !== runId) {
+      return true;
+    }
+    return this.abortController !== null && activeSubscriptionRunId !== runId && this.currentRunId !== runId;
   }
 
   private isActiveAgentThreadSubscription(subscription: AgentThreadSubscription<any>): boolean {
@@ -1670,8 +1725,11 @@ export class Harness<TState = {}> {
   }
 
   private async handleSubscribedStreamError(error: unknown): Promise<void> {
+    const activeRunId = this.agentThreadSubscription?.activeRunId() ?? this.currentRunId;
     if (error instanceof Error && error.name === 'AbortError') {
-      this.emit({ type: 'agent_end', reason: 'aborted' });
+      if (activeRunId === null || !this.abortFinalizedRunIds.has(activeRunId)) {
+        this.emit({ type: 'agent_end', reason: 'aborted' });
+      }
     } else {
       this.emit({ type: 'error', error: error instanceof Error ? error : new Error(String(error)) });
       this.emit({ type: 'agent_end', reason: 'error' });
@@ -1786,8 +1844,38 @@ export class Harness<TState = {}> {
       }
 
       const agent = this.getCurrentAgent();
+      const directStreamRunId = this.getActiveDirectStreamRunId();
+      if (directStreamRunId) {
+        if (this.abortController) {
+          await agent.waitForRunOutput(directStreamRunId, { abortSignal: this.abortController.signal });
+        }
+        throwIfAdmissionAborted();
+        if (this.getActiveDirectStreamRunId() === directStreamRunId) {
+          const result = agent.sendSignal(signal, {
+            resourceId: this.resourceId,
+            threadId: this.currentThreadId,
+            runId: directStreamRunId,
+          });
+          return { accepted: result.accepted, runId: result.runId };
+        }
+      }
+
       await this.ensureAgentThreadSubscription(agent, this.currentThreadId);
       throwIfAdmissionAborted();
+
+      const activeSubscriptionRunId = this.agentThreadSubscription?.activeRunId();
+      if (activeSubscriptionRunId) {
+        if (this.abortFinalizedRunIds.has(activeSubscriptionRunId)) {
+          await this.waitForCurrentThreadStreamIdle();
+          throwIfAdmissionAborted();
+        } else {
+          const result = agent.sendSignal(signal, {
+            resourceId: this.resourceId,
+            threadId: this.currentThreadId,
+          });
+          return { accepted: result.accepted, runId: result.runId };
+        }
+      }
 
       if (this.agentThreadSubscription?.activeRunId()) {
         const result = agent.sendSignal(signal, {
@@ -1873,7 +1961,7 @@ export class Harness<TState = {}> {
       } as AgentSignalContents;
     }
 
-    const wasActive = this.isCurrentThreadStreamActive();
+    const wasActive = this.isCurrentThreadStreamActive() || this.getActiveDirectStreamRunId() !== null;
     let emittedAgentEnd = false;
     const unsubscribeAgentEnd = wasActive
       ? undefined
@@ -2005,9 +2093,6 @@ export class Harness<TState = {}> {
     return convertStoredMessageToHarnessMessage(msg);
   }
 
-  /**
-   * Process a stream response (shared between sendMessage and tool approval).
-   */
   private createStreamState(): HarnessStreamState {
     return {
       currentMessage: {
@@ -2030,56 +2115,202 @@ export class Harness<TState = {}> {
     this.abort();
   }
 
+  private cleanupDirectStreamState(streamRunId: string | null, streamAbortController: AbortController | null): void {
+    const ownsCurrentRun = streamRunId !== null && this.currentRunId === streamRunId;
+    const ownsAbortController = streamAbortController !== null && this.abortController === streamAbortController;
+    const noNewRunStarted = this.currentRunId === null && this.abortController === null;
+
+    if (ownsCurrentRun || noNewRunStarted) {
+      this.currentRunId = null;
+      this.currentTraceId = null;
+    }
+    if (ownsAbortController || noNewRunStarted) {
+      this.abortController = null;
+      this.abortRequested = false;
+    }
+    if (streamRunId && this.agentThreadSubscription?.activeRunId() !== streamRunId) {
+      this.directStreamRunIds.delete(streamRunId);
+      this.directStreamStates.delete(streamRunId);
+      this.closedDirectStreamMessageRunIds.delete(streamRunId);
+    }
+  }
+
+  private releaseFinalizedAbortMarker(streamRunId: string | null): void {
+    if (streamRunId !== null) {
+      this.abortFinalizedRunIds.delete(streamRunId);
+    }
+  }
+
+  private clearPendingSuspensionForRun(runId: string): void {
+    if (this.pendingSuspensionRunId === runId) {
+      this.pendingSuspensionRunId = null;
+      this.pendingSuspensionToolCallId = null;
+    }
+  }
+
   private async processStream(
     response: { fullStream: AsyncIterable<any> },
     requestContextInput?: RequestContext,
+    options?: { runId?: string | null; abortController?: AbortController | null },
   ): Promise<{ message: HarnessMessage; suspended?: boolean } | undefined> {
     const state = this.createStreamState();
-    const requestContext = await this.buildRequestContext(requestContextInput);
+    const requestContext = requestContextInput ?? (await this.buildRequestContext());
     this.currentOperationId += 1;
-    this.emit({ type: 'agent_start' });
-
+    let streamRunId: string | null = options?.runId ?? null;
+    const streamAbortController = options?.abortController ?? this.abortController;
+    if (streamRunId) {
+      this.currentRunId = streamRunId;
+      this.directStreamRunIds.add(streamRunId);
+      this.directStreamStates.set(streamRunId, state);
+    }
+    if (streamRunId !== null && this.abortFinalizedRunIds.has(streamRunId)) {
+      this.cleanupDirectStreamState(streamRunId, streamAbortController);
+      try {
+        await this.drainFollowUpQueue();
+      } finally {
+        this.releaseFinalizedAbortMarker(streamRunId);
+      }
+      return undefined;
+    }
     let result: { message: HarnessMessage; suspended?: boolean } | undefined;
     let error = false;
     let aborted = false;
 
-    for await (const chunk of response.fullStream) {
-      result = await this.processStreamChunk(state, chunk, requestContext);
-      if (chunk.type === 'error') {
-        error = true;
+    const iterator = response.fullStream[Symbol.asyncIterator]();
+    const abortWaiter = this.createAbortWaiter(this.abortGeneration);
+    this.emit({ type: 'agent_start' });
+
+    try {
+      while (true) {
+        const nextChunk = iterator.next().then(
+          value => ({ kind: 'chunk' as const, value }),
+          streamError => ({ kind: 'streamError' as const, streamError }),
+        );
+        const next = await Promise.race([nextChunk, abortWaiter.promise.then(() => ({ kind: 'abort' as const }))]);
+        if (next.kind === 'abort') {
+          aborted = true;
+          break;
+        }
+        if (next.kind === 'streamError') {
+          throw next.streamError;
+        }
+        if (next.value.done) {
+          break;
+        }
+        const chunk = next.value.value;
+        if (streamRunId !== null && this.abortFinalizedRunIds.has(streamRunId)) {
+          aborted = true;
+          break;
+        }
+        if ('runId' in chunk && chunk.runId) {
+          const chunkRunId = chunk.runId;
+          if (streamRunId !== null && streamRunId !== chunkRunId) {
+            this.directStreamRunIds.delete(streamRunId);
+            this.directStreamStates.delete(streamRunId);
+          }
+          streamRunId = chunkRunId;
+          this.currentRunId = chunkRunId;
+          this.directStreamRunIds.add(chunkRunId);
+          this.directStreamStates.set(chunkRunId, state);
+        }
+        if (streamRunId !== null && this.abortFinalizedRunIds.has(streamRunId)) {
+          aborted = true;
+          break;
+        }
+        const processed = await Promise.race([
+          this.processStreamChunk(state, chunk, requestContext).then(
+            value => ({ kind: 'processed' as const, value }),
+            chunkError => ({ kind: 'chunkError' as const, chunkError }),
+          ),
+          abortWaiter.promise.then(() => ({ kind: 'abort' as const })),
+        ]);
+        if (processed.kind === 'abort') {
+          aborted = true;
+          break;
+        }
+        if (processed.kind === 'chunkError') {
+          throw processed.chunkError;
+        }
+        result = processed.value;
+        if (chunk.type === 'error') {
+          error = true;
+        }
+        if (chunk.type === 'abort') {
+          aborted = true;
+        }
+        if (
+          result ||
+          chunk.type === 'finish' ||
+          chunk.type === 'error' ||
+          chunk.type === 'abort' ||
+          chunk.type === 'tool-call-suspended' ||
+          this.abortRequested
+        ) {
+          result ??= this.finishDirectStreamStateIfOpen(state, streamRunId);
+          break;
+        }
       }
-      if (chunk.type === 'abort') {
-        aborted = true;
+    } catch (streamError) {
+      const abortAlreadyFinalized = streamRunId !== null && this.abortFinalizedRunIds.has(streamRunId);
+      if (!abortAlreadyFinalized) {
+        this.cleanupDirectStreamState(streamRunId, streamAbortController);
+        throw streamError;
       }
-      if (
-        result ||
-        chunk.type === 'finish' ||
-        chunk.type === 'error' ||
-        chunk.type === 'abort' ||
-        chunk.type === 'tool-call-suspended' ||
-        this.abortRequested
-      ) {
-        result ??= this.finishStreamState(state);
-        break;
+      result ??=
+        streamRunId !== null &&
+        !this.closedDirectStreamMessageRunIds.has(streamRunId) &&
+        state.currentMessage.content.length > 0
+          ? this.finishDirectStreamStateIfOpen(state, streamRunId)
+          : undefined;
+      this.cleanupDirectStreamState(streamRunId, streamAbortController);
+      try {
+        await this.drainFollowUpQueue();
+      } finally {
+        this.releaseFinalizedAbortMarker(streamRunId);
+      }
+      return result;
+    } finally {
+      abortWaiter.cleanup();
+      if (aborted) {
+        const returnPromise = iterator.return?.();
+        void returnPromise?.catch(() => {});
       }
     }
 
-    result ??= this.finishStreamState(state);
-    this.emit({
-      type: 'agent_end',
-      reason: error
-        ? 'error'
-        : result.suspended
-          ? 'suspended'
-          : aborted || this.abortRequested
-            ? 'aborted'
-            : 'complete',
-    });
+    const abortAlreadyFinalized = streamRunId !== null && this.abortFinalizedRunIds.has(streamRunId);
+    if (abortAlreadyFinalized) {
+      result ??=
+        streamRunId !== null &&
+        !this.closedDirectStreamMessageRunIds.has(streamRunId) &&
+        state.currentMessage.content.length > 0
+          ? this.finishDirectStreamStateIfOpen(state, streamRunId)
+          : undefined;
+      this.cleanupDirectStreamState(streamRunId, streamAbortController);
+      try {
+        await this.drainFollowUpQueue();
+      } finally {
+        this.releaseFinalizedAbortMarker(streamRunId);
+      }
+      return result;
+    }
+    result ??= this.finishDirectStreamStateIfOpen(state, streamRunId);
+    if (!abortAlreadyFinalized) {
+      this.emit({
+        type: 'agent_end',
+        reason: error
+          ? 'error'
+          : result.suspended
+            ? 'suspended'
+            : aborted || this.abortRequested
+              ? 'aborted'
+              : 'complete',
+      });
+    }
 
-    this.currentRunId = null;
-    this.currentTraceId = null;
-    this.abortController = null;
-    this.abortRequested = false;
+    this.cleanupDirectStreamState(streamRunId, streamAbortController);
+    if (abortAlreadyFinalized) {
+      this.releaseFinalizedAbortMarker(streamRunId);
+    }
     await this.drainFollowUpQueue();
 
     return result;
@@ -2219,6 +2450,7 @@ export class Harness<TState = {}> {
       case 'tool-call-approval': {
         const toolCallId = chunk.payload.toolCallId;
         const toolName = chunk.payload.toolName;
+        const approvalRunId = 'runId' in chunk && chunk.runId ? chunk.runId : this.currentRunId;
         const approvalTransform = getTransformedToolPayload(chunk.metadata, 'display', 'approval');
         const toolArgs = hasTransformedToolPayload(approvalTransform)
           ? approvalTransform.transformed
@@ -2227,12 +2459,12 @@ export class Harness<TState = {}> {
         const policy = this.resolveToolApproval(toolName);
 
         if (policy === 'allow') {
-          await this.handleToolApprove({ toolCallId, requestContext });
+          await this.handleToolApprove({ runId: approvalRunId, toolCallId, requestContext });
           break;
         }
 
         if (policy === 'deny') {
-          await this.handleToolDecline({ toolCallId, requestContext });
+          await this.handleToolDecline({ runId: approvalRunId, toolCallId, requestContext });
           break;
         }
 
@@ -2246,10 +2478,22 @@ export class Harness<TState = {}> {
         );
         this.pendingApprovalToolName = null;
 
+        if (approvalRunId !== null && this.currentRunId !== approvalRunId) {
+          break;
+        }
+
         if (approval.decision === 'approve') {
-          await this.handleToolApprove({ toolCallId, requestContext: approval.requestContext ?? requestContext });
+          await this.handleToolApprove({
+            runId: approvalRunId,
+            toolCallId,
+            requestContext: approval.requestContext ?? requestContext,
+          });
         } else {
-          await this.handleToolDecline({ toolCallId, requestContext: approval.requestContext ?? requestContext });
+          await this.handleToolDecline({
+            runId: approvalRunId,
+            toolCallId,
+            requestContext: approval.requestContext ?? requestContext,
+          });
         }
         break;
       }
@@ -2589,6 +2833,26 @@ export class Harness<TState = {}> {
     return { message: state.currentMessage, suspended: state.isSuspended || undefined };
   }
 
+  private finishDirectStreamStateIfOpen(
+    state: HarnessStreamState,
+    streamRunId: string | null,
+  ): { message: HarnessMessage; suspended?: boolean } {
+    if (streamRunId !== null) {
+      if (this.closedDirectStreamMessageRunIds.has(streamRunId)) {
+        return { message: state.currentMessage, suspended: state.isSuspended || undefined };
+      }
+      this.closedDirectStreamMessageRunIds.add(streamRunId);
+    }
+    return this.finishStreamState(state);
+  }
+
+  private clearPendingToolApprovalOnAbort(): void {
+    const pendingApprovalResolve = this.pendingApprovalResolve;
+    this.pendingApprovalResolve = null;
+    this.pendingApprovalToolName = null;
+    pendingApprovalResolve?.({ decision: 'decline' });
+  }
+
   // ===========================================================================
   // Control
   // ===========================================================================
@@ -2600,7 +2864,14 @@ export class Harness<TState = {}> {
     this.abortGeneration++;
     this.notifyAbortWaiters();
     const activeSubscription = this.agentThreadSubscription;
-    const wasThreadStreamActive = this.isCurrentThreadStreamActive() || this.currentRunId !== null;
+    const activeSubscriptionRunId = activeSubscription?.activeRunId();
+    const activeDirectStreamRunId =
+      this.currentRunId !== null && this.directStreamRunIds.has(this.currentRunId) ? this.currentRunId : null;
+    const wasThreadStreamActive =
+      activeDirectStreamRunId === null &&
+      activeSubscription !== null &&
+      (this.currentRunId !== null || (activeSubscriptionRunId !== null && activeSubscriptionRunId !== undefined));
+    const directStreamRunId = activeDirectStreamRunId;
     this.abortRequested = true;
     try {
       activeSubscription?.abort();
@@ -2611,7 +2882,27 @@ export class Harness<TState = {}> {
       } catch {}
       this.abortController = null;
     }
+    this.clearPendingToolApprovalOnAbort();
     if (wasThreadStreamActive) {
+      const abortError = new Error('aborted');
+      abortError.name = 'AbortError';
+      void this.handleSubscribedStreamError(abortError).catch(error => {
+        this.emit({ type: 'error', error: error instanceof Error ? error : new Error(String(error)) });
+      });
+    } else if (directStreamRunId) {
+      this.abortFinalizedRunIds.add(directStreamRunId);
+      try {
+        this.getCurrentAgent().abortRunStream(directStreamRunId);
+      } catch {}
+      const directStreamState = this.directStreamStates.get(directStreamRunId);
+      if (
+        directStreamState &&
+        directStreamState.currentMessage.content.length > 0 &&
+        !this.closedDirectStreamMessageRunIds.has(directStreamRunId)
+      ) {
+        this.closedDirectStreamMessageRunIds.add(directStreamRunId);
+        this.finishStreamState(directStreamState);
+      }
       try {
         activeSubscription?.unsubscribe();
       } catch {}
@@ -2621,7 +2912,6 @@ export class Harness<TState = {}> {
       }
       this.currentRunId = null;
       this.currentTraceId = null;
-      this.abortRequested = false;
       this.emit({ type: 'agent_end', reason: 'aborted' });
     }
   }
@@ -2630,8 +2920,8 @@ export class Harness<TState = {}> {
    * Steer the agent mid-stream: aborts current run and sends a new message.
    */
   async steer({ content, requestContext }: { content: string; requestContext?: RequestContext }): Promise<void> {
-    this.abort();
     this.followUpQueue = [];
+    this.abort();
     await this.sendMessage({ content, requestContext });
   }
 
@@ -2759,6 +3049,7 @@ export class Harness<TState = {}> {
       this.pendingApprovalResolve({ decision, requestContext });
     }
     this.pendingApprovalResolve = null;
+    this.pendingApprovalToolName = null;
   }
 
   /**
@@ -2773,7 +3064,23 @@ export class Harness<TState = {}> {
     requestContext?: RequestContext;
   }): Promise<void> {
     if (!this.pendingSuspensionRunId) return;
+    const suspensionRunId = this.pendingSuspensionRunId;
+    if (this.resumingSuspensionRunIds.has(suspensionRunId)) {
+      this.emit({
+        type: 'error',
+        error: new Error('Suspended tool resume is already in flight'),
+      });
+      return;
+    }
+    if (this.hasActiveRunOtherThan(suspensionRunId)) {
+      this.emit({
+        type: 'error',
+        error: new Error('Cannot resume a suspended tool while another run is active'),
+      });
+      return;
+    }
 
+    this.resumingSuspensionRunIds.add(suspensionRunId);
     try {
       await this.handleToolResume({
         resumeData,
@@ -2783,6 +3090,8 @@ export class Harness<TState = {}> {
       const err = error instanceof Error ? error : new Error(String(error));
       this.emit({ type: 'error', error: err });
       this.emit({ type: 'agent_end', reason: 'error' });
+    } finally {
+      this.resumingSuspensionRunIds.delete(suspensionRunId);
     }
   }
 
@@ -2867,61 +3176,73 @@ export class Harness<TState = {}> {
   }
 
   private async handleToolApprove({
+    runId,
     toolCallId,
     requestContext: requestContextInput,
   }: {
+    runId?: string | null;
     toolCallId?: string;
     requestContext?: RequestContext;
   }): Promise<void> {
-    if (!this.currentRunId) {
+    const targetRunId = runId ?? this.currentRunId;
+    if (!targetRunId) {
       throw new Error('No active run to approve tool call for');
     }
+    if (runId !== undefined && this.currentRunId !== targetRunId) return;
 
     const agent = this.getCurrentAgent();
 
-    if (!this.abortController) {
-      this.abortController = new AbortController();
-    }
+    const toolAbortController = this.abortController ?? new AbortController();
+    this.abortController = toolAbortController;
 
     const requestContext = await this.buildRequestContext(requestContextInput);
+    if (runId !== undefined && this.currentRunId !== targetRunId) return;
     const isYolo = (this.state as Record<string, unknown>).yolo === true;
+    const toolsets = await this.buildToolsets(requestContext);
+    if (runId !== undefined && this.currentRunId !== targetRunId) return;
     await agent.approveToolCall({
-      runId: this.currentRunId,
+      runId: targetRunId,
       toolCallId,
       requireToolApproval: !isYolo,
       memory: this.currentThreadId ? { thread: this.currentThreadId, resource: this.resourceId } : undefined,
-      abortSignal: this.abortController.signal,
+      abortSignal: toolAbortController.signal,
       requestContext,
-      toolsets: await this.buildToolsets(requestContext),
+      toolsets,
     });
   }
 
   private async handleToolDecline({
+    runId,
     toolCallId,
     requestContext: requestContextInput,
   }: {
+    runId?: string | null;
     toolCallId?: string;
     requestContext?: RequestContext;
   }): Promise<void> {
-    if (!this.currentRunId) {
+    const targetRunId = runId ?? this.currentRunId;
+    if (!targetRunId) {
       throw new Error('No active run to decline tool call for');
     }
+    if (runId !== undefined && this.currentRunId !== targetRunId) return;
 
     const agent = this.getCurrentAgent();
-    if (!this.abortController) {
-      this.abortController = new AbortController();
-    }
+    const toolAbortController = this.abortController ?? new AbortController();
+    this.abortController = toolAbortController;
 
     const requestContext = await this.buildRequestContext(requestContextInput);
+    if (runId !== undefined && this.currentRunId !== targetRunId) return;
     const isYolo = (this.state as Record<string, unknown>).yolo === true;
+    const toolsets = await this.buildToolsets(requestContext);
+    if (runId !== undefined && this.currentRunId !== targetRunId) return;
     await agent.declineToolCall({
-      runId: this.currentRunId,
+      runId: targetRunId,
       toolCallId,
       requireToolApproval: !isYolo,
       memory: this.currentThreadId ? { thread: this.currentThreadId, resource: this.resourceId } : undefined,
-      abortSignal: this.abortController.signal,
+      abortSignal: toolAbortController.signal,
       requestContext,
-      toolsets: await this.buildToolsets(requestContext),
+      toolsets,
     });
   }
 
@@ -2932,31 +3253,98 @@ export class Harness<TState = {}> {
     resumeData: any;
     requestContext?: RequestContext;
   }): Promise<void> {
-    if (!this.pendingSuspensionRunId) {
+    const resumeRunId = this.pendingSuspensionRunId;
+    if (!resumeRunId) {
       throw new Error('No active suspension to resume');
     }
 
     const agent = this.getCurrentAgent();
 
-    if (!this.abortController) {
-      this.abortController = new AbortController();
+    const resumeAbortController = this.abortController ?? new AbortController();
+    this.abortController = resumeAbortController;
+    this.currentRunId = resumeRunId;
+    this.directStreamRunIds.add(resumeRunId);
+    try {
+      this.agentThreadSubscription?.unsubscribe();
+    } catch {}
+    this.agentThreadSubscription = null;
+    this.agentThreadSubscriptionKey = null;
+
+    const resumeAbortWaiter = this.createAbortWaiter(this.abortGeneration);
+    const finishAbortedResume = async () => {
+      this.cleanupDirectStreamState(resumeRunId, resumeAbortController);
+      this.clearPendingSuspensionForRun(resumeRunId);
+      try {
+        await this.ensureCurrentAgentThreadSubscription();
+        await this.drainFollowUpQueue();
+      } finally {
+        this.releaseFinalizedAbortMarker(resumeRunId);
+      }
+    };
+    const raceResumeAbort = async <T>(promise: Promise<T>): Promise<{ type: 'value'; value: T } | { type: 'abort' }> =>
+      Promise.race([
+        promise.then(value => ({ type: 'value' as const, value })),
+        resumeAbortWaiter.promise.then(() => ({ type: 'abort' as const })),
+      ]);
+
+    try {
+      const requestContextResult = await raceResumeAbort(this.buildRequestContext(requestContextInput));
+      if (requestContextResult.type === 'abort') {
+        await finishAbortedResume();
+        return;
+      }
+      const requestContext = requestContextResult.value;
+      const isYolo = (this.state as Record<string, unknown>).yolo === true;
+      const toolsetsResult = await raceResumeAbort(this.buildToolsets(requestContext));
+      if (toolsetsResult.type === 'abort') {
+        await finishAbortedResume();
+        return;
+      }
+      const resumeStream = agent.resumeStream(resumeData, {
+        runId: resumeRunId,
+        toolCallId: this.pendingSuspensionToolCallId ?? undefined,
+        requireToolApproval: !isYolo,
+        memory: this.currentThreadId ? { thread: this.currentThreadId, resource: this.resourceId } : undefined,
+        abortSignal: resumeAbortController.signal,
+        requestContext,
+        toolsets: toolsetsResult.value,
+      });
+      void resumeStream.catch(() => {});
+      const resumed = await Promise.race([
+        resumeStream.then(output => ({ type: 'output' as const, output })),
+        resumeAbortWaiter.promise.then(() => ({ type: 'abort' as const })),
+      ]);
+      if (resumed.type === 'abort') {
+        await finishAbortedResume();
+        return;
+      }
+      const output = resumed.output;
+      if (this.abortFinalizedRunIds.has(resumeRunId)) {
+        await finishAbortedResume();
+        return;
+      }
+      const result = await this.processStream(output, requestContext, {
+        runId: resumeRunId,
+        abortController: resumeAbortController,
+      });
+      if (result?.suspended) {
+        await this.ensureCurrentAgentThreadSubscription();
+        return;
+      }
+    } catch (error) {
+      const abortAlreadyFinalized = this.abortFinalizedRunIds.has(resumeRunId);
+      this.cleanupDirectStreamState(resumeRunId, resumeAbortController);
+      if (abortAlreadyFinalized) {
+        await finishAbortedResume();
+        return;
+      }
+      throw error;
+    } finally {
+      resumeAbortWaiter.cleanup();
     }
 
-    const requestContext = await this.buildRequestContext(requestContextInput);
-    const isYolo = (this.state as Record<string, unknown>).yolo === true;
-    const output = await agent.resumeStream(resumeData, {
-      runId: this.pendingSuspensionRunId,
-      toolCallId: this.pendingSuspensionToolCallId ?? undefined,
-      requireToolApproval: !isYolo,
-      memory: this.currentThreadId ? { thread: this.currentThreadId, resource: this.resourceId } : undefined,
-      abortSignal: this.abortController.signal,
-      requestContext,
-      toolsets: await this.buildToolsets(requestContext),
-    });
-    await this.processStream(output, requestContext);
-
-    this.pendingSuspensionRunId = null;
-    this.pendingSuspensionToolCallId = null;
+    this.clearPendingSuspensionForRun(resumeRunId);
+    await this.ensureCurrentAgentThreadSubscription();
   }
 
   // ===========================================================================

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -232,6 +232,8 @@ export class Harness<TState = {}> {
   private displayStateSchedulers = new Set<DisplayStateScheduler>();
   private abortController: AbortController | null = null;
   private abortRequested: boolean = false;
+  private abortGeneration = 0;
+  private abortWaiters = new Set<() => void>();
   private currentRunId: string | null = null;
   private currentTraceId: string | null = null;
   private currentOperationId: number = 0;
@@ -1622,6 +1624,33 @@ export class Harness<TState = {}> {
     return this.agentThreadSubscription === subscription;
   }
 
+  private createAbortWaiter(generation: number): { promise: Promise<void>; cleanup: () => void } {
+    let waiter: (() => void) | undefined;
+    const promise = new Promise<void>(resolve => {
+      if (this.abortGeneration !== generation) {
+        resolve();
+        return;
+      }
+      waiter = resolve;
+      this.abortWaiters.add(waiter);
+    });
+    return {
+      promise,
+      cleanup: () => {
+        if (waiter) this.abortWaiters.delete(waiter);
+      },
+    };
+  }
+
+  private notifyAbortWaiters(): void {
+    if (this.abortWaiters.size === 0) return;
+    const waiters = Array.from(this.abortWaiters);
+    this.abortWaiters.clear();
+    for (const waiter of waiters) {
+      waiter();
+    }
+  }
+
   private async finishSubscribedStreamRun({
     suspended,
     error,
@@ -1689,6 +1718,10 @@ export class Harness<TState = {}> {
 
         try {
           const streamResult = await this.processStreamChunk(currentRun, chunk, requestContext);
+          if (!this.isActiveAgentThreadSubscription(subscription)) {
+            subscription.unsubscribe();
+            break;
+          }
           if (
             streamResult ||
             chunk.type === 'finish' ||
@@ -1709,6 +1742,10 @@ export class Harness<TState = {}> {
             currentRun = undefined;
           }
         } catch (error) {
+          if (!this.isActiveAgentThreadSubscription(subscription)) {
+            subscription.unsubscribe();
+            break;
+          }
           await this.handleSubscribedStreamError(error);
           currentRun = undefined;
         }
@@ -1735,6 +1772,13 @@ export class Harness<TState = {}> {
   ): { id: string; type: AgentSignalInput['type']; accepted: Promise<{ accepted: true; runId: string }> } {
     const { tracingContext, tracingOptions, requestContext: requestContextInput } = 'content' in input ? input : {};
     const signal = createSignal('content' in input ? { type: 'user-message', contents: input.content } : input);
+    const abortGeneration = this.abortGeneration;
+    const throwIfAdmissionAborted = () => {
+      if (this.abortGeneration === abortGeneration) return;
+      const err = new Error('aborted');
+      err.name = 'AbortError';
+      throw err;
+    };
     const accepted = Promise.resolve().then(async () => {
       if (!this.currentThreadId) {
         const thread = await this.createThread();
@@ -1743,6 +1787,7 @@ export class Harness<TState = {}> {
 
       const agent = this.getCurrentAgent();
       await this.ensureAgentThreadSubscription(agent, this.currentThreadId);
+      throwIfAdmissionAborted();
 
       if (this.agentThreadSubscription?.activeRunId()) {
         const result = agent.sendSignal(signal, {
@@ -1768,6 +1813,7 @@ export class Harness<TState = {}> {
         ...(tracingOptions && { tracingOptions }),
       };
       streamOptions.toolsets = await this.buildToolsets(requestContext);
+      throwIfAdmissionAborted();
 
       const result = agent.sendSignal(signal, {
         resourceId: this.resourceId,
@@ -1834,20 +1880,32 @@ export class Harness<TState = {}> {
       : this.subscribe(event => {
           if (event.type === 'agent_end') emittedAgentEnd = true;
         });
+    const abortWaiter = this.createAbortWaiter(this.abortGeneration);
     const signal = this.sendSignal({
       content: messageInput,
       tracingContext,
       tracingOptions,
       requestContext: requestContextInput,
     });
-    await signal.accepted;
-    if (!wasActive) {
-      await new Promise(resolve => setTimeout(resolve, 0));
-      await this.waitForCurrentThreadStreamIdle();
-      unsubscribeAgentEnd?.();
-      if (!emittedAgentEnd && !this.pendingSuspensionRunId) {
-        this.emit({ type: 'agent_end', reason: 'complete' });
+    try {
+      await Promise.race([
+        signal.accepted,
+        abortWaiter.promise.then(() => {
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          throw err;
+        }),
+      ]);
+      if (!wasActive) {
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await this.waitForCurrentThreadStreamIdle();
+        if (!emittedAgentEnd && !this.pendingSuspensionRunId) {
+          this.emit({ type: 'agent_end', reason: 'complete' });
+        }
       }
+    } finally {
+      abortWaiter.cleanup();
+      unsubscribeAgentEnd?.();
     }
     return;
   }
@@ -2539,15 +2597,32 @@ export class Harness<TState = {}> {
    * Abort the current operation.
    */
   abort(): void {
+    this.abortGeneration++;
+    this.notifyAbortWaiters();
+    const activeSubscription = this.agentThreadSubscription;
+    const wasThreadStreamActive = this.isCurrentThreadStreamActive() || this.currentRunId !== null;
     this.abortRequested = true;
     try {
-      this.agentThreadSubscription?.abort();
+      activeSubscription?.abort();
     } catch {}
     if (this.abortController) {
       try {
         this.abortController.abort();
       } catch {}
       this.abortController = null;
+    }
+    if (wasThreadStreamActive) {
+      try {
+        activeSubscription?.unsubscribe();
+      } catch {}
+      if (this.agentThreadSubscription === activeSubscription) {
+        this.agentThreadSubscription = null;
+        this.agentThreadSubscriptionKey = null;
+      }
+      this.currentRunId = null;
+      this.currentTraceId = null;
+      this.abortRequested = false;
+      this.emit({ type: 'agent_end', reason: 'aborted' });
     }
   }
 

--- a/packages/core/src/harness/mode-model-persistence.test.ts
+++ b/packages/core/src/harness/mode-model-persistence.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Agent } from '../agent';
+import { createSignal } from '../agent/signals';
 import { InMemoryStore } from '../storage/mock';
 import { Harness } from './harness';
 
@@ -39,6 +40,21 @@ function createHarness(storage: InMemoryStore): Harness<HarnessTestState> {
       },
     ],
   });
+}
+
+async function settleWithinTicks<T>(
+  promise: Promise<T>,
+  ticks = 10,
+): Promise<{ settled: true; value: T } | { settled: false }> {
+  return Promise.race([
+    promise.then(value => ({ settled: true as const, value })),
+    (async () => {
+      for (let i = 0; i < ticks; i++) {
+        await Promise.resolve();
+      }
+      return { settled: false as const };
+    })(),
+  ]);
 }
 
 describe('Harness mode-model persistence across restarts', () => {
@@ -153,5 +169,70 @@ describe('Harness mode-model persistence across restarts', () => {
     expect(controller.signal.aborted).toBe(true);
     expect(session.getCurrentModeId()).toBe('build');
     expect(resolved).toEqual({ action: 'approved' });
+  });
+
+  it('waits for the aborted plan run to go idle before the next signal starts fresh', async () => {
+    const buildAgent = agent();
+    const planAgent = agent();
+    const session = new Harness<HarnessTestState>({
+      id: 'test-harness-plan-approval-idle',
+      storage,
+      modes: [
+        {
+          id: 'build',
+          name: 'Build',
+          default: true,
+          agent: buildAgent,
+        },
+        {
+          id: 'plan',
+          name: 'Plan',
+          agent: planAgent,
+        },
+      ],
+    });
+    await session.init();
+    await session.createThread();
+    await session.switchMode({ modeId: 'plan' });
+
+    let activeRunId: string | null = 'plan-run';
+    vi.spyOn(buildAgent, 'subscribeToThread').mockResolvedValue({
+      stream: (async function* () {})() as any,
+      unsubscribe: vi.fn(),
+      abort: vi.fn(),
+      activeRunId: () => activeRunId,
+    });
+    const sendSignalSpy = vi.spyOn(buildAgent, 'sendSignal').mockReturnValue({
+      accepted: true,
+      runId: 'fresh-run',
+      signal: createSignal({ type: 'user-message', contents: 'continue' }),
+    });
+
+    (session as any).currentRunId = 'plan-run';
+    (session as any).abortController = new AbortController();
+    (session as any).agentThreadSubscription = {
+      activeRunId: () => 'plan-run',
+      abort: vi.fn(),
+      unsubscribe: vi.fn(),
+      stream: (async function* () {})(),
+    };
+    session.registerPlanApproval({
+      planId: 'plan-1',
+      resolve: () => {},
+    });
+
+    const approval = session.respondToPlanApproval({ planId: 'plan-1', response: { action: 'approved' } });
+    await vi.waitFor(() => expect(buildAgent.subscribeToThread).toHaveBeenCalled());
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(await settleWithinTicks(approval)).toEqual({ settled: false });
+
+    activeRunId = null;
+    await approval;
+
+    const signal = session.sendSignal({ content: 'continue' });
+    await expect(signal.accepted).resolves.toMatchObject({ accepted: true, runId: 'fresh-run' });
+    expect(sendSignalSpy).toHaveBeenCalledTimes(1);
+    expect(sendSignalSpy.mock.calls[0]?.[1]).toMatchObject({ ifIdle: expect.any(Object) });
+    expect(sendSignalSpy.mock.calls[0]?.[1]).not.toHaveProperty('runId');
   });
 });

--- a/packages/core/src/harness/v1/session.abort.test.ts
+++ b/packages/core/src/harness/v1/session.abort.test.ts
@@ -123,10 +123,13 @@ describe('Session.abort()', () => {
     await inflight;
     expect(abortReason).toBe('user-cancelled');
     expect(session.isRunning()).toBe(false);
-    expect(events.find(event => (event as { type?: string }).type === 'agent_end')).toMatchObject({
-      type: 'agent_end',
-      reason: 'aborted',
-    });
+    const agentEnds = events.filter(event => (event as { type?: string }).type === 'agent_end');
+    expect(agentEnds).toEqual([
+      expect.objectContaining({
+        type: 'agent_end',
+        reason: 'aborted',
+      }),
+    ]);
 
     // Per-turn signal handed to the agent must have aborted with the same
     // reason that `session.abort()` supplied.
@@ -177,6 +180,29 @@ describe('Session.abort()', () => {
     const turnSignal = agent.streamCalls[0]!.options.abortSignal as AbortSignal;
     expect(turnSignal.aborted).toBe(true);
     expect((turnSignal as { reason?: unknown }).reason).toBe('session_aborted');
+  });
+
+  it('does not let a completed caller abort signal cancel a later turn', async () => {
+    const { harness, agent } = setupHarness();
+    const oldCallerAbort = new AbortController();
+    agent.enqueueRun({ finishReason: 'stop', text: 'first' });
+
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    await session.message({ content: 'first', abortSignal: oldCallerAbort.signal });
+    expect(session.isRunning()).toBe(false);
+
+    const hold = deferred();
+    agent.enqueueRun({ finishReason: 'stop', text: 'second', holdUntil: hold.promise });
+    const second = session.message({ content: 'second' });
+
+    await waitFor(() => session.isRunning());
+    oldCallerAbort.abort('late-old-caller');
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(session.isRunning()).toBe(true);
+
+    hold.resolve();
+    await expect(second).resolves.toBeDefined();
+    expect(session.isRunning()).toBe(false);
   });
 
   it('cancels an in-flight queued turn', async () => {

--- a/packages/core/src/harness/v1/session.abort.test.ts
+++ b/packages/core/src/harness/v1/session.abort.test.ts
@@ -18,7 +18,14 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { setupHarness } from './__test-utils__';
+import { MockAgent, setupHarness } from './__test-utils__';
+import { HarnessSessionCancelledError } from './errors';
+
+class AbortIgnoringMockAgent extends MockAgent {
+  override async stream(messages: any, options?: any): Promise<any> {
+    return super.stream(messages, { ...options, abortSignal: undefined });
+  }
+}
 
 /** Deferred lets a test gate the mock agent on a promise it controls. */
 function deferred() {
@@ -102,6 +109,8 @@ describe('Session.abort()', () => {
     });
 
     const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const events: unknown[] = [];
+    session.subscribe(event => events.push(event));
     const inflight = session.message({ content: 'go' });
 
     await waitFor(() => session.isRunning());
@@ -114,12 +123,43 @@ describe('Session.abort()', () => {
     await inflight;
     expect(abortReason).toBe('user-cancelled');
     expect(session.isRunning()).toBe(false);
+    expect(events.find(event => (event as { type?: string }).type === 'agent_end')).toMatchObject({
+      type: 'agent_end',
+      reason: 'aborted',
+    });
 
     // Per-turn signal handed to the agent must have aborted with the same
     // reason that `session.abort()` supplied.
     const turnSignal = agent.streamCalls[0]!.options.abortSignal as AbortSignal;
     expect(turnSignal.aborted).toBe(true);
     expect((turnSignal as { reason?: unknown }).reason).toBe('user-cancelled');
+  });
+
+  it('settles message() and emits one aborted agent_end when the agent ignores abort', async () => {
+    const agent = new AbortIgnoringMockAgent({ id: 'default' });
+    const hold = deferred();
+    agent.enqueueRun({ finishReason: 'stop', text: 'done', holdUntil: hold.promise, runId: 'run-ignore-abort' });
+    const { harness } = setupHarness({ agents: { default: agent } });
+
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const events: unknown[] = [];
+    session.subscribe(event => events.push(event));
+    const inflight = session.message({ content: 'go' });
+
+    await waitFor(() => session.isRunning());
+    session.abort({ reason: 'user-cancelled' });
+
+    await expect(inflight).rejects.toBeInstanceOf(HarnessSessionCancelledError);
+    expect(session.isRunning()).toBe(false);
+    const agentEnds = events.filter(event => (event as { type?: string }).type === 'agent_end');
+    expect(agentEnds).toEqual([
+      expect.objectContaining({
+        type: 'agent_end',
+        reason: 'aborted',
+      }),
+    ]);
+
+    hold.resolve();
   });
 
   it('uses a default reason when none is supplied', async () => {

--- a/packages/core/src/harness/v1/session.message.test.ts
+++ b/packages/core/src/harness/v1/session.message.test.ts
@@ -209,7 +209,10 @@ function canonicalJsonForTest(value: unknown): string {
     .join(',')}}`;
 }
 
-async function settleWithinTicks<T>(promise: Promise<T>, ticks = 10): Promise<{ settled: true; value: T } | { settled: false }> {
+async function settleWithinTicks<T>(
+  promise: Promise<T>,
+  ticks = 10,
+): Promise<{ settled: true; value: T } | { settled: false }> {
   return Promise.race([
     promise.then(value => ({ settled: true as const, value })),
     (async () => {
@@ -251,29 +254,50 @@ describe('Session.message() — default path', () => {
     });
   });
 
-  it('forwards the caller-supplied abortSignal (chained into the per-turn signal)', async () => {
+  it('mints a per-turn signal for caller-supplied abortSignal', async () => {
     const { harness, agent } = setup();
     const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
     const ac = new AbortController();
     await session.message({ content: 'hi', abortSignal: ac.signal });
-    // Session mints its own per-turn AbortController so `session.abort()` can
-    // also cancel the run. Caller's signal is linked into it, so aborting the
-    // caller's controller must abort the signal handed to the agent.
+    // Session mints its own per-turn AbortController so `session.abort()` can also cancel the run.
     const turnSignal = agent.calls[0]!.options.abortSignal as AbortSignal;
     expect(turnSignal).toBeInstanceOf(AbortSignal);
     expect(turnSignal).not.toBe(ac.signal);
     expect(turnSignal.aborted).toBe(false);
   });
 
-  it('aborting the caller signal aborts the per-turn signal handed to the agent', async () => {
+  it('forwards a live caller abort into the per-turn signal', async () => {
+    const agent = new LiveStreamFakeAgent('default');
+    const storage = new InMemoryHarness({ db: new InMemoryDB() });
+    const harness = new Harness({
+      agents: { default: agent } as any,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      sessions: { storage },
+    });
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+    const ac = new AbortController();
+    const pending = session.message({ content: 'hi', abortSignal: ac.signal, stream: true });
+    await vi.waitFor(() => expect(agent.calls).toHaveLength(1));
+
+    const turnSignal = agent.calls[0]!.options.abortSignal as AbortSignal;
+    expect(turnSignal.aborted).toBe(false);
+    ac.abort('caller-cancelled');
+    expect(turnSignal.aborted).toBe(true);
+    expect((turnSignal as { reason?: unknown }).reason).toBe('caller-cancelled');
+
+    agent.releaseStream?.();
+    await pending.catch(() => undefined);
+  });
+
+  it('does not let the caller signal abort the per-turn signal after the turn completes', async () => {
     const { harness, agent } = setup();
     const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
     const ac = new AbortController();
     await session.message({ content: 'hi', abortSignal: ac.signal });
     const turnSignal = agent.calls[0]!.options.abortSignal as AbortSignal;
     ac.abort('caller-cancelled');
-    expect(turnSignal.aborted).toBe(true);
-    expect((turnSignal as { reason?: unknown }).reason).toBe('caller-cancelled');
+    expect(turnSignal.aborted).toBe(false);
   });
 
   it('deduplicates an exact admissionId retry without accepting a second signal', async () => {

--- a/packages/core/src/harness/v1/session.queue.test.ts
+++ b/packages/core/src/harness/v1/session.queue.test.ts
@@ -609,6 +609,8 @@ describe('Session.queue() — admission', () => {
       return runGoalJudge(...args);
     };
 
+    const events: HarnessEvent[] = [];
+    session.subscribe(event => events.push(event));
     const queued = session.queue({ content: 'do work', admissionId: 'queue-finalization-retry' });
     await new Promise(resolve => setImmediate(resolve));
     expect(session.getRecord().pendingQueue).toHaveLength(1);
@@ -617,6 +619,7 @@ describe('Session.queue() — admission', () => {
       status: 'completed',
     });
     expect(pendingReceipt?.postRunFinalizedAt).toBeUndefined();
+    expect(events.filter(event => event.type === 'agent_end')).toHaveLength(0);
 
     const duplicate = session.queue({ content: 'do work', admissionId: 'queue-finalization-retry' });
     await (session as any)._kickQueueDrain();
@@ -626,6 +629,7 @@ describe('Session.queue() — admission', () => {
     expect(duplicateResult.text).toBe('queued reply');
     expect(markerAttempts).toBe(2);
     expect(goalJudgeAttempts).toBe(1);
+    expect(events.filter(event => event.type === 'agent_end')).toHaveLength(1);
     expect(session.getRecord().pendingQueue).toEqual([]);
     const receipt = Object.values(session.getRecord().queueAdmissionReceipts ?? {})[0];
     expect(receipt).toMatchObject({

--- a/packages/core/src/harness/v1/session.queue.test.ts
+++ b/packages/core/src/harness/v1/session.queue.test.ts
@@ -1419,7 +1419,8 @@ describe('Session.queue() — suspension', () => {
 
     expect(result.text).toBe('resumed done');
     expect(events.find(e => e.type === 'suspension_resolved')).toMatchObject({ queuedItemId });
-    expect(events.find(e => e.type === 'agent_end')).toMatchObject({ queuedItemId });
+    const agentEnds = events.filter(e => e.type === 'agent_end');
+    expect(agentEnds).toEqual([expect.objectContaining({ queuedItemId })]);
     expect(events.findIndex(e => e.type === 'agent_end')).toBeGreaterThan(
       events.findIndex(e => e.type === 'suspension_resolved'),
     );

--- a/packages/core/src/harness/v1/session.tool-context.test.ts
+++ b/packages/core/src/harness/v1/session.tool-context.test.ts
@@ -114,7 +114,7 @@ describe('HarnessRequestContext — state reads/writes', () => {
 });
 
 describe('HarnessRequestContext — abort plumbing', () => {
-  it('aborts the slot signal when the caller-supplied signal aborts', async () => {
+  it('does not abort the slot signal from the caller-supplied signal after the turn completes', async () => {
     const { harness, agent } = setupHarness();
     const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
     const controller = new AbortController();
@@ -124,7 +124,7 @@ describe('HarnessRequestContext — abort plumbing', () => {
     expect(slot.abortSignal).toBeInstanceOf(AbortSignal);
     expect(slot.abortSignal).not.toBe(controller.signal);
     controller.abort('caller-cancelled');
-    expect(slot.abortSignal.aborted).toBe(true);
+    expect(slot.abortSignal.aborted).toBe(false);
   });
 
   it('mints a fresh signal when the caller did not supply one', async () => {

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -569,6 +569,7 @@ interface IdleWaiter {
 
 interface ActiveTurnWaiter {
   promise: Promise<never>;
+  controller?: AbortController;
   reject: (err: unknown) => void;
   cleanup: () => void;
 }
@@ -702,6 +703,7 @@ export class Session {
   private _currentMessageId?: string;
   private _currentTraceId?: string;
   private readonly _activeTurnWaiters = new Set<ActiveTurnWaiter>();
+  private readonly _turnAbortSignalCleanups = new WeakMap<AbortController, () => void>();
   private readonly _operationEvidenceSignalIds = new Set<string>();
   private readonly _activeTools = new Map<string, ActiveToolState>();
   private readonly _toolInputBuffers = new Map<string, { toolName: string; text: string }>();
@@ -1084,9 +1086,9 @@ export class Session {
       if (callerSignal.aborted) {
         controller.abort((callerSignal as { reason?: unknown }).reason);
       } else {
-        callerSignal.addEventListener('abort', () => controller.abort((callerSignal as { reason?: unknown }).reason), {
-          once: true,
-        });
+        const forwardAbort = () => controller.abort((callerSignal as { reason?: unknown }).reason);
+        callerSignal.addEventListener('abort', forwardAbort, { once: true });
+        this._turnAbortSignalCleanups.set(controller, () => callerSignal.removeEventListener('abort', forwardAbort));
       }
     }
     return controller;
@@ -1114,6 +1116,8 @@ export class Session {
    * idle state. Cumulative aggregates (`_tokenUsage`) are preserved.
    */
   private _endTurn(controller: AbortController): void {
+    this._turnAbortSignalCleanups.get(controller)?.();
+    this._turnAbortSignalCleanups.delete(controller);
     if (this._currentTurnAbortController === controller) {
       this._currentTurnAbortController = undefined;
       this._currentRunId = undefined;
@@ -1127,10 +1131,12 @@ export class Session {
 
   private _createActiveTurnWaiter(): ActiveTurnWaiter {
     let reject!: (err: unknown) => void;
+    const activeTurn = this._currentTurnAbortController;
     const waiter: ActiveTurnWaiter = {
       promise: new Promise<never>((_, rej) => {
         reject = rej;
       }),
+      controller: activeTurn,
       reject: err => reject(err),
       cleanup: () => {
         this._activeTurnWaiters.delete(waiter);
@@ -1141,25 +1147,40 @@ export class Session {
       this._activeTurnWaiters.delete(waiter);
       waiter.reject(new HarnessSessionDeletedError(this.id));
     }
+    if (activeTurn?.signal.aborted) {
+      this._activeTurnWaiters.delete(waiter);
+      waiter.reject(this._activeTurnAbortError(activeTurn));
+    }
     return waiter;
   }
 
-  private _rejectActiveTurnWaiters(reason: unknown): void {
-    if (this._activeTurnWaiters.size === 0) return;
-    const waiters = Array.from(this._activeTurnWaiters);
-    this._activeTurnWaiters.clear();
-    for (const waiter of waiters) {
+  private _rejectActiveTurnWaiters(reason: unknown, waiters?: ActiveTurnWaiter[]): void {
+    const selectedWaiters = waiters ?? Array.from(this._activeTurnWaiters);
+    if (selectedWaiters.length === 0) return;
+    if (waiters) {
+      for (const waiter of selectedWaiters) {
+        this._activeTurnWaiters.delete(waiter);
+      }
+    } else {
+      this._activeTurnWaiters.clear();
+    }
+    for (const waiter of selectedWaiters) {
       waiter.reject(reason);
     }
   }
 
-  private _scheduleActiveTurnAbort(controller: AbortController): void {
+  private _activeTurnAbortError(controller: AbortController): Error {
     const reason = (controller.signal as { reason?: unknown }).reason;
     const message = typeof reason === 'string' && reason.length > 0 ? reason : 'session_aborted';
-    const err = reason instanceof Error ? reason : new HarnessSessionCancelledError(this.id, message);
+    return reason instanceof Error ? reason : new HarnessSessionCancelledError(this.id, message);
+  }
+
+  private _scheduleActiveTurnAbort(controller: AbortController): void {
+    const err = this._activeTurnAbortError(controller);
+    const waiters = Array.from(this._activeTurnWaiters).filter(waiter => waiter.controller === controller);
     setTimeout(() => {
-      if (this._currentTurnAbortController !== controller || !controller.signal.aborted) return;
-      this._rejectActiveTurnWaiters(err);
+      if (!controller.signal.aborted) return;
+      this._rejectActiveTurnWaiters(err, waiters);
     }, 0);
   }
 
@@ -8209,6 +8230,7 @@ export class Session {
     };
     let agentStarted = false;
     let agentEndEmitted = false;
+    let fallbackRunId = identity.runId;
 
     try {
       const requestContext = await Promise.race([
@@ -8256,6 +8278,7 @@ export class Session {
         signal.runId === identity.runId && signal.signal.id === identity.signalId
           ? identity
           : { runId: signal.runId, signalId: signal.signal.id };
+      fallbackRunId = signalIdentity.runId;
       const completion = this._awaitQueuedRunCompletion(
         item,
         signalIdentity.runId,
@@ -8295,7 +8318,7 @@ export class Session {
         this._emitTurnEvent({
           type: 'agent_end',
           reason: turnAbortController.signal.aborted ? 'aborted' : 'error',
-          runId: identity.runId,
+          runId: fallbackRunId,
           queuedItemId: item.id,
         });
       }
@@ -8419,7 +8442,7 @@ export class Session {
 
     if (full.finishReason !== 'suspended') {
       await this._raceActiveTurnWaiter(this._markQueuedTurnCompleted(item.id, full), activeTurnWaiter);
-      await this._finalizeCompletedQueuedTurn(item, full, modeId, activeTurnWaiter);
+      await this._finalizeCompletedQueuedTurn(item, full, modeId, activeTurnWaiter, opts);
       await this._raceActiveTurnWaiter(
         this._writeQueueSignalResultEvidence({
           status: 'completed',
@@ -8440,6 +8463,7 @@ export class Session {
     full: FullOutput<unknown>,
     modeId: string,
     activeTurnWaiter?: Promise<never>,
+    opts: { onAgentEnd?: () => void } = {},
   ): Promise<void> {
     let alreadyAccounted = false;
     if (this._record.queueAdmissionReceipts?.[item.id]?.postRunFinalizedAt === undefined) {
@@ -8464,6 +8488,7 @@ export class Session {
     }
     await this._finalizeQueuedRunCompletion(item, full, modeId, activeTurnWaiter, {
       skipTokenAccounting: alreadyAccounted,
+      onAgentEnd: opts.onAgentEnd,
     });
   }
 

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -8314,7 +8314,7 @@ export class Session {
       agentEndEmitted = true;
       return full;
     } catch (err) {
-      if (agentStarted && !agentEndEmitted) {
+      if (agentStarted && !agentEndEmitted && !(err instanceof QueuePostRunFinalizationPendingError)) {
         this._emitTurnEvent({
           type: 'agent_end',
           reason: turnAbortController.signal.aborted ? 'aborted' : 'error',

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -1077,6 +1077,9 @@ export class Session {
    */
   private _beginTurn(callerSignal: AbortSignal | undefined): AbortController {
     const controller = new AbortController();
+    this._currentTurnAbortController = controller;
+    this._resetTurnTracking();
+    controller.signal.addEventListener('abort', () => this._scheduleActiveTurnAbort(controller), { once: true });
     if (callerSignal) {
       if (callerSignal.aborted) {
         controller.abort((callerSignal as { reason?: unknown }).reason);
@@ -1086,8 +1089,6 @@ export class Session {
         });
       }
     }
-    this._currentTurnAbortController = controller;
-    this._resetTurnTracking();
     return controller;
   }
 
@@ -1150,6 +1151,23 @@ export class Session {
     for (const waiter of waiters) {
       waiter.reject(reason);
     }
+  }
+
+  private _scheduleActiveTurnAbort(controller: AbortController): void {
+    const reason = (controller.signal as { reason?: unknown }).reason;
+    const message = typeof reason === 'string' && reason.length > 0 ? reason : 'session_aborted';
+    const err = reason instanceof Error ? reason : new HarnessSessionCancelledError(this.id, message);
+    setTimeout(() => {
+      if (this._currentTurnAbortController !== controller || !controller.signal.aborted) return;
+      this._rejectActiveTurnWaiters(err);
+    }, 0);
+  }
+
+  private _agentEndReasonForFullOutput(full: FullOutput<unknown>): 'complete' | 'aborted' | 'error' | 'suspended' {
+    if (full.finishReason === 'suspended') return 'suspended';
+    if (full.finishReason === 'aborted') return 'aborted';
+    if (full.finishReason === 'error') return 'error';
+    return 'complete';
   }
 
   private _raceActiveTurnWaiter<T>(promise: Promise<T>, activeTurnWaiter?: Promise<never>): Promise<T> {
@@ -3741,6 +3759,7 @@ export class Session {
 
     // Structured + sync path: agent.generate with structuredOutput.
     if (opts.output !== undefined && opts.sync === true) {
+      let agentEndEmitted = false;
       try {
         const result = await Promise.race([
           agent.generate(opts.content, {
@@ -3766,11 +3785,20 @@ export class Session {
         }
         this._emitTurnEvent({
           type: 'agent_end',
-          reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
+          reason: this._agentEndReasonForFullOutput(full),
           runId: full.runId,
         });
+        agentEndEmitted = true;
         await Promise.race([this._runGoalJudge(full, false), activeTurnWaiter.promise]);
         return full.object;
+      } catch (err) {
+        if (!agentEndEmitted) {
+          this._emitTurnEvent({
+            type: 'agent_end',
+            reason: turnAbortSignal.aborted ? 'aborted' : 'error',
+          });
+        }
+        throw err;
       } finally {
         finishOwnedMessageTurn();
       }
@@ -4036,6 +4064,7 @@ export class Session {
         throw err;
       }
       let streamCompletedEvidenceWriteFailed = false;
+      let streamAgentEndEmitted = false;
       const streamBookkeeping = Promise.race([completion, activeTurnWaiter.promise])
         .then(async full => {
           try {
@@ -4082,9 +4111,10 @@ export class Session {
         .then(async full => {
           this._emitTurnEvent({
             type: 'agent_end',
-            reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
+            reason: this._agentEndReasonForFullOutput(full),
             runId: full.runId,
           });
+          streamAgentEndEmitted = true;
           await Promise.race([this._runGoalJudge(full, false), activeTurnWaiter.promise]);
         })
         .catch(err => {
@@ -4107,6 +4137,13 @@ export class Session {
               { compatibleAdmissionHashes },
             ).catch(() => {});
           }
+          if (!streamAgentEndEmitted) {
+            this._emitTurnEvent({
+              type: 'agent_end',
+              reason: turnAbortSignal.aborted ? 'aborted' : 'error',
+              runId: signal.runId,
+            });
+          }
           // The caller owns the visible stream; swallow drain-side errors.
         })
         .finally(() => {
@@ -4122,6 +4159,7 @@ export class Session {
     // deliver this run's bundled `FullOutput`, then run post-turn bookkeeping.
     let streamStarted = signal.output === undefined;
     let completedEvidenceWriteFailed = false;
+    let agentEndEmitted = false;
     try {
       // The pre-dispatch reservation is the durable admission barrier here.
       // Keep the post-dispatch pending refresh best-effort so completion
@@ -4174,9 +4212,10 @@ export class Session {
       }
       this._emitTurnEvent({
         type: 'agent_end',
-        reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
+        reason: this._agentEndReasonForFullOutput(full),
         runId: full.runId,
       });
+      agentEndEmitted = true;
       await Promise.race([this._runGoalJudge(full, false), activeTurnWaiter.promise]);
       return full;
     } catch (err) {
@@ -4208,6 +4247,13 @@ export class Session {
           ).catch(() => {}),
           activeTurnWaiter.promise,
         ]);
+      }
+      if (!agentEndEmitted) {
+        this._emitTurnEvent({
+          type: 'agent_end',
+          reason: turnAbortSignal.aborted ? 'aborted' : 'error',
+          runId: signal.runId,
+        });
       }
       throw err;
     } finally {
@@ -4837,6 +4883,7 @@ export class Session {
       // Register the completion waiter before any terminal chunks land.
       const completion = this._awaitRunCompletion(dispatched.runId);
       const completionOrDelete = Promise.race([completion, activeTurnWaiter.promise]);
+      let agentEndEmitted = false;
 
       // Background continuation runs the post-turn bookkeeping so the
       // caller's `result` promise resolves with the final AgentResult.
@@ -4867,11 +4914,22 @@ export class Session {
             }
             this._emitTurnEvent({
               type: 'agent_end',
-              reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
+              reason: this._agentEndReasonForFullOutput(full),
               runId: full.runId,
             });
+            agentEndEmitted = true;
             await Promise.race([this._runGoalJudge(full, false), activeTurnWaiter.promise]);
             return full as AgentResult;
+          })
+          .catch(err => {
+            if (!agentEndEmitted) {
+              this._emitTurnEvent({
+                type: 'agent_end',
+                reason: turnAbortSignal.aborted ? 'aborted' : 'error',
+                runId: dispatched.runId,
+              });
+            }
+            throw err;
           })
           .finally(() => {
             finishOwnedSignalTurn();
@@ -5017,6 +5075,7 @@ export class Session {
 
       const completion = this._awaitRunCompletion(dispatched.runId);
       const completionOrDelete = Promise.race([completion, activeTurnWaiter.promise]);
+      let agentEndEmitted = false;
       const result = this._trackBackgroundTurnCompletion(
         completionOrDelete
           .then(async full => {
@@ -5044,10 +5103,21 @@ export class Session {
             }
             this._emitTurnEvent({
               type: 'agent_end',
-              reason: full.finishReason === 'suspended' ? 'suspended' : 'complete',
+              reason: this._agentEndReasonForFullOutput(full),
               runId: full.runId,
             });
+            agentEndEmitted = true;
             await Promise.race([this._runGoalJudge(full, false), activeTurnWaiter.promise]);
+          })
+          .catch(err => {
+            if (!agentEndEmitted) {
+              this._emitTurnEvent({
+                type: 'agent_end',
+                reason: turnAbortSignal.aborted ? 'aborted' : 'error',
+                runId: dispatched.runId,
+              });
+            }
+            throw err;
           })
           .finally(() => {
             finishOwnedReminderTurn();
@@ -5125,11 +5195,7 @@ export class Session {
     const pending = this._pendingResumeFromSuspendedOutput(full, payload, queuedItemId, modeId, modelId);
     if (pending === undefined) return;
     const existing = this._record.pendingResume;
-    if (
-      existing &&
-      existing.runId === full.runId &&
-      existing.toolCallId === payload.toolCallId
-    ) {
+    if (existing && existing.runId === full.runId && existing.toolCallId === payload.toolCallId) {
       await this._flushUpdate(prev => prev, { tokenUsageDelta: opts.tokenUsageDelta });
       this._clearPendingDurableTurnFlushErrorIfRepaired(full);
       return;
@@ -6763,7 +6829,7 @@ export class Session {
       if (full.finishReason !== 'suspended') {
         this._emitTurnEvent({
           type: 'agent_end',
-          reason: full.finishReason === 'error' ? 'error' : 'complete',
+          reason: this._agentEndReasonForFullOutput(full),
           runId: full.runId,
         });
 
@@ -8141,6 +8207,8 @@ export class Session {
         throw new HarnessSessionDeletedError(this.id);
       }
     };
+    let agentStarted = false;
+    let agentEndEmitted = false;
 
     try {
       const requestContext = await Promise.race([
@@ -8162,6 +8230,7 @@ export class Session {
       };
 
       this._emitTurnEvent({ type: 'agent_start' });
+      agentStarted = true;
 
       await Promise.race([this._ensureThreadSubscription(agent), activeTurnWaiter.promise]);
       assertQueuedTurnNotDeleted();
@@ -8193,6 +8262,7 @@ export class Session {
         signalIdentity.signalId,
         effectiveModeId,
         activeTurnWaiter.promise,
+        { onAgentEnd: () => (agentEndEmitted = true) },
       );
       void completion.catch(() => {});
       if (signalIdentity !== identity) {
@@ -8217,7 +8287,19 @@ export class Session {
         })).catch(() => {}),
         activeTurnWaiter.promise,
       ]);
-      return await Promise.race([completion, activeTurnWaiter.promise]);
+      const full = await Promise.race([completion, activeTurnWaiter.promise]);
+      agentEndEmitted = true;
+      return full;
+    } catch (err) {
+      if (agentStarted && !agentEndEmitted) {
+        this._emitTurnEvent({
+          type: 'agent_end',
+          reason: turnAbortController.signal.aborted ? 'aborted' : 'error',
+          runId: identity.runId,
+          queuedItemId: item.id,
+        });
+      }
+      throw err;
     } finally {
       finishQueuedTurn();
     }
@@ -8312,6 +8394,7 @@ export class Session {
     signalId: string,
     modeId: string,
     activeTurnWaiter?: Promise<never>,
+    opts: { onAgentEnd?: () => void } = {},
   ): Promise<FullOutput<unknown>> {
     let full: FullOutput<unknown>;
     try {
@@ -8347,7 +8430,7 @@ export class Session {
         activeTurnWaiter,
       );
     } else {
-      await this._finalizeQueuedRunCompletion(item, full, modeId, activeTurnWaiter);
+      await this._finalizeQueuedRunCompletion(item, full, modeId, activeTurnWaiter, opts);
     }
     return full;
   }
@@ -8405,10 +8488,7 @@ export class Session {
             item,
             full,
             modeId,
-            new QueuePostRunFinalizationPendingError(
-              Date.now() + QUEUE_POST_RUN_FINALIZATION_RETRY_MS,
-              completionErr,
-            ),
+            new QueuePostRunFinalizationPendingError(Date.now() + QUEUE_POST_RUN_FINALIZATION_RETRY_MS, completionErr),
           );
           return;
         }
@@ -8484,7 +8564,7 @@ export class Session {
     full: FullOutput<unknown>,
     modeId?: string,
     activeTurnWaiter?: Promise<never>,
-    opts: { skipTokenAccounting?: boolean } = {},
+    opts: { skipTokenAccounting?: boolean; onAgentEnd?: () => void } = {},
   ): Promise<FullOutput<unknown>> {
     const tokenUsageDelta = opts.skipTokenAccounting
       ? undefined
@@ -8502,9 +8582,10 @@ export class Session {
     }
     this._emitTurnEvent({
       type: 'agent_end',
-      reason: full.finishReason === 'suspended' ? 'suspended' : full.finishReason === 'error' ? 'error' : 'complete',
+      reason: this._agentEndReasonForFullOutput(full),
       runId: full.runId,
     });
+    opts.onAgentEnd?.();
     await this._raceActiveTurnWaiter(this._runGoalJudge(full, (item.source ?? 'user') === 'goal'), activeTurnWaiter);
     return full;
   }


### PR DESCRIPTION
## Summary

- Settle legacy Harness sendMessage when abort wins before signal acceptance, without allowing the deferred admission task to start an orphan run.
- Emit a single aborted agent_end for legacy subscribed streams that ignore abort, with active-subscription guards for mid-chunk races.
- Make Harness v1 active-turn abort waiters settle non-cooperative turns and map agent_end reasons for aborted/error completions across message, signal, reminder, and queue paths.
- Add v1 regression coverage for an agent that ignores abort.

## Validation

- pnpm prettier:changed
- pnpm --filter @mastra/core check
- pnpm --filter mastracode check
- pnpm --filter ./packages/core test:unit src/harness/v1/session.scheduler.test.ts src/harness/v1/session.cancel.test.ts src/harness/v1/session.tool-context.test.ts src/harness/v1/session.suspend.test.ts src/harness/v1/workspace-restore.test.ts src/harness/v1/contracts.test.ts src/harness/v1/token-usage.test.ts src/harness/v1/session.abort.test.ts src/harness/om-failure-abort.test.ts src/harness/signal-messages.test.ts --reporter=dot
  - 10 files, 195 tests passed. token-usage stderr is expected deliberate failure injection.
- pnpm --filter @mastra/core build:lib
- pnpm --filter ./mastracode test src/headless-integration.test.ts src/harness/runtime.test.ts src/harness/events.test.ts src/tui/handlers/__tests__/prompts.test.ts src/agents/__tests__/model.test.ts src/tools/__tests__/request-sandbox-access.test.ts --reporter=dot
  - 6 files, 116 tests passed.
- pnpm --filter mastracode build:lib
- git diff --check

## Review Evidence

- Claude review returned no BLOCKER findings. One valid legacy duplicate-event REVIEW finding was addressed by adding active-subscription guards after stream chunk processing and in the stream error path.
- Codex review pass 1 found blockers around v1 non-message turn agent_end coverage and legacy follow-up draining; both were fixed.
- Codex review pass 2 found a legacy pre-dispatch orphan-run blocker and v1 queued-turn lifecycle issues; these were fixed with abort-generation admission guards, queued agent_end tracking, and direct non-cooperative abort coverage.
- CodeRabbit CLI was attempted twice, including coderabbit review --agent --base main; it connected and entered summarizing but did not return findings, so this PR should rely on the GitHub CodeRabbit app review.

Linear: PF-580


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5
This PR makes the Harness reliably stop in-progress runs when asked to abort: runs are cleaned up deterministically, duplicate terminal events are avoided, and orphaned or continued work (including from agents that ignore aborts) is prevented.

Changes Overview

Core Harness Abort Lifecycle (packages/core/src/harness/harness.ts)
- Introduces generation-scoped abort tracking (abortGeneration, abortWaiters) to detect and gate concurrent aborts and to race admission against aborts.
- Makes sendSignal/sendMessage admission generation-aware; sendMessage now races admission against abort waiters and ensures deterministic cleanup in finally blocks.
- Adds active-subscription guards and repeated active-checks around chunk processing and error paths to avoid mid-chunk races and duplicate/late processing after unsubscribe/abort.
- Refactors direct-stream and subscribed-stream handling with generation-aware waiters, run-finalization markers, and helpers to avoid multiple agent_end emissions and orphan runs.
- Reworks abort() to increment abortGeneration, resolve abort waiters, best-effort abort active subscriptions/controllers, clear pending tool approvals, and drive a single, well-guarded agent_end with reason 'aborted' for legacy/direct flows.
- Reworks tool approval/resume plumbing to use run-aware AbortControllers, add run-level in-flight protections, prevent resuming when another run is active, and clear pending approval state after handling.

Session Lifecycle & Agent-End Semantics (packages/core/src/harness/v1/session.ts)
- Stores per-turn AbortController and ties waiter rejection to that controller via _scheduleActiveTurnAbort so only active-turn waiters are rejected.
- Normalizes agent_end.reason via _agentEndReasonForFullOutput and centralizes emission; adds flags (agentEndEmitted/streamAgentEndEmitted) to guarantee a single terminal event across message, signal, reminder, and queue paths.
- Updates queued-run completion to propagate onAgentEnd callbacks and avoid duplicate agent_end emission during queued-finalization.

Tests and Coverage
- Adds tests for agents that ignore aborts (AbortIgnoringMockAgent) and asserts session.message() rejects with HarnessSessionCancelledError while emitting exactly one agent_end with reason 'aborted' (v1/session.abort.test.ts).
- Expands harness tool suspension/resumption tests to cover direct-resume abort cleanup, many race conditions, follow-up draining, retargeting, and pending-approval edge cases (harness-tool-suspension.test.ts).
- Tightens and refactors multiple session tests: message abort semantics, queued-run finalization behavior, mode-switch abort wait semantics, and tool-context slot abort signal expectations.
- Test runs reported: unit suites across updated files (195 tests passed; token-usage stderr noted as deliberate), integration suites: 116 tests passed. Prettier, package checks/builds for `@mastra/core` and mastracode, and git diff --check were executed.

Review & Validation
- Addressed automated/code review findings:
  - Claude review: no blockers; added active-subscription guards for duplicate-event case.
  - Codex reviews (pass 1 & 2): addressed blockers for non-message turn agent_end coverage, legacy follow-up draining, pre-dispatch orphan-run, and queued-turn lifecycle issues (applied fixes: abort-generation admission guards, queued agent_end tracking, direct non-cooperative abort coverage).
  - CodeRabbit CLI attempts were made; final review via GitHub CodeRabbit app.
- Linked Linear ticket: PF-580
- Changeset updated to document improved Harness v1 session cancellation reliability (.changeset/pf-747-harness-cancellation.md).

Impact / Notes
- No public API or exported signature changes.
- Significant internal changes and added tests; review effort classified as high due to complex abort/resume/race handling across multiple run types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->