### PR TITLE
[PF-751] Sync upstream ACP model option

### DIFF
--- a/.changeset/whole-windows-hope.md
+++ b/.changeset/whole-windows-hope.md
@@ -1,0 +1,19 @@
+---
+'@mastra/acp': minor
+---
+
+Added programmatic model selection for ACP agents using the `model` option.
+
+You can now set the model directly when creating `AcpAgent` or `createACPTool`, instead of relying on environment variables.
+
+```ts
+const codeAgent = new AcpAgent({
+  id: 'code-agent',
+  description: 'ACP-compatible coding agent',
+  command: 'claude',
+  args: ['--acp'],
+  model: 'claude-sonnet-4-20250514',
+});
+```
+
+Discover available models with `getAvailableModels()` and change the model at runtime with `setModel()`. Invalid model IDs throw a descriptive error listing valid options.

--- a/.changeset/whole-windows-hope.md
+++ b/.changeset/whole-windows-hope.md
@@ -12,7 +12,7 @@ const codeAgent = new AcpAgent({
   description: 'ACP-compatible coding agent',
   command: 'claude',
   args: ['--acp'],
-  model: 'claude-sonnet-4-20250514',
+  model: '__AI_SDK_ANTHROPIC_MODEL_SONNET__',
 });
 ```
 

--- a/docs/src/content/en/docs/agents/acp.mdx
+++ b/docs/src/content/en/docs/agents/acp.mdx
@@ -130,6 +130,59 @@ If the ACP agent requests permission, the tool can suspend and resume through Ma
 | `persistSession` | `boolean` | Keep the ACP process alive after execution. Defaults to `true`. |
 | `onPermissionRequest` | `(request) => Promise<Response>` | Callback for ACP permission requests. Defaults to selecting the first option. |
 | `workspace` | `Workspace` | Workspace used for ACP file reads and writes. |
+| `model` | `string` | Model ID to select after session creation via the ACP `session/set_model` method. |
+
+## Model selection
+
+ACP agents may expose selectable models. Instead of setting an environment variable like `ANTHROPIC_MODEL`, you can pass a `model` ID directly in the configuration.
+
+### Discover available models
+
+Call `getAvailableModels()` to see which models the ACP agent supports. This starts the agent process and returns the model list from the session:
+
+```typescript title="src/mastra/agents/code-agent.ts"
+import { AcpAgent } from '@mastra/acp'
+
+const codeAgent = new AcpAgent({
+  id: 'code-agent',
+  description: 'An ACP-compatible coding agent',
+  command: 'claude',
+  args: ['--acp'],
+})
+
+const models = await codeAgent.getAvailableModels()
+// [{ modelId: 'claude-sonnet-4-20250514', name: 'Claude Sonnet' }, ...]
+```
+
+### Set the model
+
+Pass the `model` option to select a model at connection time:
+
+```typescript title="src/mastra/agents/code-agent.ts"
+import { AcpAgent } from '@mastra/acp'
+
+export const codeAgent = new AcpAgent({
+  id: 'code-agent',
+  description: 'An ACP-compatible coding agent',
+  command: 'claude',
+  args: ['--acp'],
+  model: '__AI_SDK_ANTHROPIC_MODEL_SONNET__',
+})
+```
+
+You can also change the model at runtime with `setModel()`:
+
+```typescript
+await codeAgent.setModel('__AI_SDK_ANTHROPIC_MODEL_SONNET__')
+```
+
+If the ACP agent advertises available models and your model ID doesn't match any of them, Mastra throws an error listing the valid options:
+
+```text
+Model "bad-model-id" is not available. Available models: claude-sonnet-4-20250514, claude-haiku-4-20250514
+```
+
+If the agent doesn't advertise a model list, the value is passed through without validation.
 
 ## Session lifecycle
 

--- a/docs/src/content/en/docs/agents/acp.mdx
+++ b/docs/src/content/en/docs/agents/acp.mdx
@@ -151,7 +151,7 @@ const codeAgent = new AcpAgent({
 })
 
 const models = await codeAgent.getAvailableModels()
-// [{ modelId: 'claude-sonnet-4-20250514', name: 'Claude Sonnet' }, ...]
+// [{ modelId: '__AI_SDK_ANTHROPIC_MODEL_SONNET__', name: 'Claude Sonnet' }, ...]
 ```
 
 ### Set the model
@@ -179,7 +179,7 @@ await codeAgent.setModel('__AI_SDK_ANTHROPIC_MODEL_SONNET__')
 If the ACP agent advertises available models and your model ID doesn't match any of them, Mastra throws an error listing the valid options:
 
 ```text
-Model "bad-model-id" is not available. Available models: claude-sonnet-4-20250514, claude-haiku-4-20250514
+Model "bad-model-id" is not available. Available models: __AI_SDK_ANTHROPIC_MODEL_SONNET__, __AI_SDK_ANTHROPIC_MODEL_HAIKU__
 ```
 
 If the agent doesn't advertise a model list, the value is passed through without validation.

--- a/docs/src/plugins/remark-model-tokens/models.ts
+++ b/docs/src/plugins/remark-model-tokens/models.ts
@@ -21,4 +21,5 @@ export const MODEL_TOKENS: Record<string, string> = {
   __GATEWAY_ANTHROPIC_MODEL_SONNET__: 'anthropic/claude-sonnet-4-6',
   __GATEWAY_ANTHROPIC_MODEL_OPUS__: 'anthropic/claude-opus-4-6',
   __GATEWAY_ANTHROPIC_MODEL_HAIKU__: 'anthropic/claude-haiku-4-5',
+  __AI_SDK_ANTHROPIC_MODEL_SONNET__: 'claude-sonnet-4-6',
 }

--- a/docs/src/plugins/remark-model-tokens/models.ts
+++ b/docs/src/plugins/remark-model-tokens/models.ts
@@ -22,4 +22,5 @@ export const MODEL_TOKENS: Record<string, string> = {
   __GATEWAY_ANTHROPIC_MODEL_OPUS__: 'anthropic/claude-opus-4-6',
   __GATEWAY_ANTHROPIC_MODEL_HAIKU__: 'anthropic/claude-haiku-4-5',
   __AI_SDK_ANTHROPIC_MODEL_SONNET__: 'claude-sonnet-4-6',
+  __AI_SDK_ANTHROPIC_MODEL_HAIKU__: 'claude-haiku-4-5',
 }

--- a/packages/acp/README.md
+++ b/packages/acp/README.md
@@ -148,5 +148,58 @@ By default, the ACP workspace uses `cwd` as its filesystem root. Pass a Mastra `
 | `persistSession`      | `boolean`                        | Keep the ACP process alive after execution. Defaults to `true`.                        |
 | `onPermissionRequest` | `(request) => Promise<Response>` | Callback for ACP permission requests.                                                  |
 | `workspace`           | `Workspace`                      | Workspace used for ACP file reads and writes.                                          |
+| `model`               | `string`                         | Model ID to select after session creation via the ACP `session/set_model` method.      |
 
 `AcpAgent` also accepts `name` to set the display name used by Mastra agent delegation.
+
+## Configure the model
+
+ACP agents may expose selectable models. Instead of setting an environment variable like `ANTHROPIC_MODEL`, you can pass a `model` ID directly in the configuration.
+
+### Discover available models
+
+Call `getAvailableModels()` to see which models the ACP agent supports. This starts the agent process and returns the model list from the session:
+
+```typescript
+import { AcpAgent } from '@mastra/acp';
+
+const codeAgent = new AcpAgent({
+  id: 'code-agent',
+  description: 'An ACP-compatible coding agent',
+  command: 'claude',
+  args: ['--acp'],
+});
+
+const models = await codeAgent.getAvailableModels();
+// [{ modelId: 'claude-sonnet-4-20250514', name: 'Claude Sonnet' }, ...]
+```
+
+### Set the model
+
+Pass the `model` option to select a model at connection time:
+
+```typescript
+import { AcpAgent } from '@mastra/acp';
+
+const codeAgent = new AcpAgent({
+  id: 'code-agent',
+  description: 'An ACP-compatible coding agent',
+  command: 'claude',
+  args: ['--acp'],
+  model: 'claude-sonnet-4-20250514',
+});
+```
+
+You can also change the model at runtime with `setModel()`:
+
+```typescript
+await codeAgent.setModel('claude-sonnet-4-20250514');
+```
+
+If the ACP agent advertises available models and your model ID doesn't match any of them, Mastra throws an error listing the valid options:
+
+```text
+Model "bad-model-id" is not available. Available models: claude-sonnet-4-20250514, claude-haiku-4-20250514
+```
+
+If the agent doesn't advertise a model list, the value is passed through without validation.

--- a/packages/acp/README.md
+++ b/packages/acp/README.md
@@ -171,7 +171,7 @@ const codeAgent = new AcpAgent({
 });
 
 const models = await codeAgent.getAvailableModels();
-// [{ modelId: 'claude-sonnet-4-20250514', name: 'Claude Sonnet' }, ...]
+// [{ modelId: 'agent-reported-model-id', name: 'Agent Reported Model' }, ...]
 ```
 
 ### Set the model
@@ -186,20 +186,20 @@ const codeAgent = new AcpAgent({
   description: 'An ACP-compatible coding agent',
   command: 'claude',
   args: ['--acp'],
-  model: 'claude-sonnet-4-20250514',
+  model: 'agent-reported-model-id',
 });
 ```
 
 You can also change the model at runtime with `setModel()`:
 
 ```typescript
-await codeAgent.setModel('claude-sonnet-4-20250514');
+await codeAgent.setModel('agent-reported-model-id');
 ```
 
 If the ACP agent advertises available models and your model ID doesn't match any of them, Mastra throws an error listing the valid options:
 
 ```text
-Model "bad-model-id" is not available. Available models: claude-sonnet-4-20250514, claude-haiku-4-20250514
+Model "bad-model-id" is not available. Available models: agent-reported-model-id, another-model-id
 ```
 
 If the agent doesn't advertise a model list, the value is passed through without validation.

--- a/packages/acp/src/__tests__/tool.test.ts
+++ b/packages/acp/src/__tests__/tool.test.ts
@@ -9,13 +9,15 @@ const mocks = vi.hoisted(() => {
   const ndJsonStream = vi.fn(() => ({ readable: {}, writable: {} }));
   const connectionInstances: MockClientSideConnection[] = [];
   let onPrompt: ((connection: MockClientSideConnection) => Promise<void> | void) | undefined;
+  let sessionResponse: Record<string, unknown> = { sessionId: 'session-1' };
 
   class MockClientSideConnection {
     client: any;
     initialize = vi.fn().mockResolvedValue({});
     authenticate = vi.fn().mockResolvedValue({});
-    newSession = vi.fn().mockResolvedValue({ sessionId: 'session-1' });
+    newSession = vi.fn().mockImplementation(() => Promise.resolve(sessionResponse));
     cancel = vi.fn().mockResolvedValue({});
+    unstable_setSessionModel = vi.fn().mockResolvedValue({});
     prompt = vi.fn(async () => {
       await onPrompt?.(this);
       return { stopReason: 'end_turn' };
@@ -37,6 +39,12 @@ const mocks = vi.hoisted(() => {
     },
     set onPrompt(value: ((connection: MockClientSideConnection) => Promise<void> | void) | undefined) {
       onPrompt = value;
+    },
+    get sessionResponse() {
+      return sessionResponse;
+    },
+    set sessionResponse(value: Record<string, unknown>) {
+      sessionResponse = value;
     },
   };
 });
@@ -77,6 +85,7 @@ describe('createACPTool', () => {
     vi.clearAllMocks();
     mocks.connectionInstances.length = 0;
     mocks.onPrompt = undefined;
+    mocks.sessionResponse = { sessionId: 'session-1' };
     mocks.spawn.mockImplementation(() => createProcess());
   });
 
@@ -130,6 +139,7 @@ describe('ACPConnection', () => {
     vi.clearAllMocks();
     mocks.connectionInstances.length = 0;
     mocks.onPrompt = undefined;
+    mocks.sessionResponse = { sessionId: 'session-1' };
     mocks.spawn.mockImplementation(() => createProcess());
   });
 
@@ -288,6 +298,190 @@ describe('ACPConnection', () => {
     await expect(client.requestPermission(request)).resolves.toEqual({ outcome: { outcome: 'cancelled' } });
     expect(handler).toHaveBeenCalledWith(request);
   });
+
+  it('calls unstable_setSessionModel when model option is provided', async () => {
+    const { ACPConnection } = await import('../connection');
+
+    const connection = new ACPConnection({
+      id: 'claude-code',
+      description: 'Build anything with Claude Code',
+      command: 'claude',
+      args: ['--acp'],
+      model: 'claude-sonnet-4-20250514',
+      persistSession: true,
+    });
+
+    await connection.prompt('implement feature');
+    const acpConnection = mocks.connectionInstances[0];
+
+    expect(acpConnection?.unstable_setSessionModel).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      modelId: 'claude-sonnet-4-20250514',
+    });
+  });
+
+  it('does not call unstable_setSessionModel when model option is omitted', async () => {
+    const { ACPConnection } = await import('../connection');
+
+    const connection = new ACPConnection({
+      id: 'claude-code',
+      description: 'Build anything with Claude Code',
+      command: 'claude',
+      persistSession: true,
+    });
+
+    await connection.prompt('implement feature');
+    const acpConnection = mocks.connectionInstances[0];
+
+    expect(acpConnection?.unstable_setSessionModel).not.toHaveBeenCalled();
+  });
+
+  it('returns available models from the session response', async () => {
+    const { ACPConnection } = await import('../connection');
+    const availableModels = [
+      { modelId: 'claude-sonnet-4-20250514', name: 'Claude Sonnet' },
+      { modelId: 'claude-haiku-4-20250514', name: 'Claude Haiku' },
+    ];
+
+    mocks.sessionResponse = {
+      sessionId: 'session-1',
+      models: { availableModels, currentModelId: 'claude-sonnet-4-20250514' },
+    };
+
+    const connection = new ACPConnection({
+      id: 'claude-code',
+      description: 'Build anything with Claude Code',
+      command: 'claude',
+      persistSession: true,
+    });
+
+    const models = await connection.getAvailableModels();
+    expect(models).toEqual(availableModels);
+  });
+
+  it('returns empty array when session has no models', async () => {
+    const { ACPConnection } = await import('../connection');
+
+    const connection = new ACPConnection({
+      id: 'claude-code',
+      description: 'Build anything with Claude Code',
+      command: 'claude',
+      persistSession: true,
+    });
+
+    const models = await connection.getAvailableModels();
+    expect(models).toEqual([]);
+  });
+
+  it('throws when model option does not match available models', async () => {
+    const { ACPConnection } = await import('../connection');
+
+    mocks.sessionResponse = {
+      sessionId: 'session-1',
+      models: {
+        availableModels: [
+          { modelId: 'claude-sonnet-4-20250514', name: 'Claude Sonnet' },
+          { modelId: 'claude-haiku-4-20250514', name: 'Claude Haiku' },
+        ],
+        currentModelId: 'claude-sonnet-4-20250514',
+      },
+    };
+
+    const connection = new ACPConnection({
+      id: 'claude-code',
+      description: 'Build anything with Claude Code',
+      command: 'claude',
+      model: 'nonexistent-model',
+      persistSession: true,
+    });
+
+    await expect(connection.prompt('implement feature')).rejects.toThrow(
+      'Model "nonexistent-model" is not available. Available models: claude-sonnet-4-20250514, claude-haiku-4-20250514',
+    );
+  });
+
+  it('skips validation when session does not expose available models', async () => {
+    const { ACPConnection } = await import('../connection');
+
+    const connection = new ACPConnection({
+      id: 'claude-code',
+      description: 'Build anything with Claude Code',
+      command: 'claude',
+      model: 'any-model-id',
+      persistSession: true,
+    });
+
+    await connection.prompt('implement feature');
+    const acpConnection = mocks.connectionInstances[0];
+
+    expect(acpConnection?.unstable_setSessionModel).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      modelId: 'any-model-id',
+    });
+  });
+
+  it('setModel calls unstable_setSessionModel with the given model ID', async () => {
+    const { ACPConnection } = await import('../connection');
+
+    const connection = new ACPConnection({
+      id: 'claude-code',
+      description: 'Build anything with Claude Code',
+      command: 'claude',
+      persistSession: true,
+    });
+
+    await connection.setModel('claude-sonnet-4-20250514');
+    const acpConnection = mocks.connectionInstances[0];
+
+    expect(acpConnection?.unstable_setSessionModel).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      modelId: 'claude-sonnet-4-20250514',
+    });
+  });
+
+  it('setModel throws when model does not match available models', async () => {
+    const { ACPConnection } = await import('../connection');
+
+    mocks.sessionResponse = {
+      sessionId: 'session-1',
+      models: {
+        availableModels: [{ modelId: 'claude-sonnet-4-20250514', name: 'Claude Sonnet' }],
+        currentModelId: 'claude-sonnet-4-20250514',
+      },
+    };
+
+    const connection = new ACPConnection({
+      id: 'claude-code',
+      description: 'Build anything with Claude Code',
+      command: 'claude',
+      persistSession: true,
+    });
+
+    await expect(connection.setModel('nonexistent')).rejects.toThrow(
+      'Model "nonexistent" is not available. Available models: claude-sonnet-4-20250514',
+    );
+  });
+
+  it('throws when available models is an empty array', async () => {
+    const { ACPConnection } = await import('../connection');
+
+    mocks.sessionResponse = {
+      sessionId: 'session-1',
+      models: { availableModels: [], currentModelId: undefined },
+    };
+
+    const connection = new ACPConnection({
+      id: 'claude-code',
+      description: 'Build anything with Claude Code',
+      command: 'claude',
+      model: 'any-model',
+      persistSession: true,
+    });
+
+    await expect(connection.prompt('implement feature')).rejects.toThrow(
+      'Model "any-model" is not available. Available models: (none)',
+    );
+  });
 });
 
 describe('AcpAgent', () => {
@@ -295,6 +489,7 @@ describe('AcpAgent', () => {
     vi.clearAllMocks();
     mocks.connectionInstances.length = 0;
     mocks.onPrompt = undefined;
+    mocks.sessionResponse = { sessionId: 'session-1' };
     mocks.spawn.mockImplementation(() => createProcess());
   });
 

--- a/packages/acp/src/__tests__/tool.test.ts
+++ b/packages/acp/src/__tests__/tool.test.ts
@@ -49,6 +49,9 @@ const mocks = vi.hoisted(() => {
   };
 });
 
+const TEST_MODEL_ID = 'test-model-alpha';
+const TEST_SECONDARY_MODEL_ID = 'test-model-beta';
+
 vi.mock('node:child_process', async importOriginal => {
   const actual = await importOriginal<object>();
   return {
@@ -307,7 +310,7 @@ describe('ACPConnection', () => {
       description: 'Build anything with Claude Code',
       command: 'claude',
       args: ['--acp'],
-      model: 'claude-sonnet-4-20250514',
+      model: TEST_MODEL_ID,
       persistSession: true,
     });
 
@@ -316,7 +319,7 @@ describe('ACPConnection', () => {
 
     expect(acpConnection?.unstable_setSessionModel).toHaveBeenCalledWith({
       sessionId: 'session-1',
-      modelId: 'claude-sonnet-4-20250514',
+      modelId: TEST_MODEL_ID,
     });
   });
 
@@ -339,13 +342,13 @@ describe('ACPConnection', () => {
   it('returns available models from the session response', async () => {
     const { ACPConnection } = await import('../connection');
     const availableModels = [
-      { modelId: 'claude-sonnet-4-20250514', name: 'Claude Sonnet' },
-      { modelId: 'claude-haiku-4-20250514', name: 'Claude Haiku' },
+      { modelId: TEST_MODEL_ID, name: 'Test Model Alpha' },
+      { modelId: TEST_SECONDARY_MODEL_ID, name: 'Test Model Beta' },
     ];
 
     mocks.sessionResponse = {
       sessionId: 'session-1',
-      models: { availableModels, currentModelId: 'claude-sonnet-4-20250514' },
+      models: { availableModels, currentModelId: TEST_MODEL_ID },
     };
 
     const connection = new ACPConnection({
@@ -380,10 +383,10 @@ describe('ACPConnection', () => {
       sessionId: 'session-1',
       models: {
         availableModels: [
-          { modelId: 'claude-sonnet-4-20250514', name: 'Claude Sonnet' },
-          { modelId: 'claude-haiku-4-20250514', name: 'Claude Haiku' },
+          { modelId: TEST_MODEL_ID, name: 'Test Model Alpha' },
+          { modelId: TEST_SECONDARY_MODEL_ID, name: 'Test Model Beta' },
         ],
-        currentModelId: 'claude-sonnet-4-20250514',
+        currentModelId: TEST_MODEL_ID,
       },
     };
 
@@ -396,7 +399,7 @@ describe('ACPConnection', () => {
     });
 
     await expect(connection.prompt('implement feature')).rejects.toThrow(
-      'Model "nonexistent-model" is not available. Available models: claude-sonnet-4-20250514, claude-haiku-4-20250514',
+      `Model "nonexistent-model" is not available. Available models: ${TEST_MODEL_ID}, ${TEST_SECONDARY_MODEL_ID}`,
     );
   });
 
@@ -430,12 +433,12 @@ describe('ACPConnection', () => {
       persistSession: true,
     });
 
-    await connection.setModel('claude-sonnet-4-20250514');
+    await connection.setModel(TEST_MODEL_ID);
     const acpConnection = mocks.connectionInstances[0];
 
     expect(acpConnection?.unstable_setSessionModel).toHaveBeenCalledWith({
       sessionId: 'session-1',
-      modelId: 'claude-sonnet-4-20250514',
+      modelId: TEST_MODEL_ID,
     });
   });
 
@@ -445,8 +448,8 @@ describe('ACPConnection', () => {
     mocks.sessionResponse = {
       sessionId: 'session-1',
       models: {
-        availableModels: [{ modelId: 'claude-sonnet-4-20250514', name: 'Claude Sonnet' }],
-        currentModelId: 'claude-sonnet-4-20250514',
+        availableModels: [{ modelId: TEST_MODEL_ID, name: 'Test Model Alpha' }],
+        currentModelId: TEST_MODEL_ID,
       },
     };
 
@@ -458,7 +461,7 @@ describe('ACPConnection', () => {
     });
 
     await expect(connection.setModel('nonexistent')).rejects.toThrow(
-      'Model "nonexistent" is not available. Available models: claude-sonnet-4-20250514',
+      `Model "nonexistent" is not available. Available models: ${TEST_MODEL_ID}`,
     );
   });
 

--- a/packages/acp/src/agent.ts
+++ b/packages/acp/src/agent.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { ReadableStream } from 'node:stream/web';
 
-import type { SessionUpdate } from '@agentclientprotocol/sdk';
+import type { ModelInfo, SessionUpdate } from '@agentclientprotocol/sdk';
 import type {
   AgentGenerateOptions,
   AgentInstructions,
@@ -86,6 +86,14 @@ export class AcpAgent<
 
   getInstructions(): string {
     return '';
+  }
+
+  async getAvailableModels(): Promise<ModelInfo[]> {
+    return this.connection.getAvailableModels();
+  }
+
+  async setModel(modelId: string): Promise<void> {
+    return this.connection.setModel(modelId);
   }
 
   async generate(messages: MessageListInput, options?: AgentGenerateOptions): Promise<SubAgentGenerateResult> {

--- a/packages/acp/src/connection.ts
+++ b/packages/acp/src/connection.ts
@@ -6,6 +6,7 @@ import { ClientSideConnection, ndJsonStream, PROTOCOL_VERSION } from '@agentclie
 import type {
   Client,
   InitializeRequest,
+  ModelInfo,
   NewSessionRequest,
   NewSessionResponse,
   PermissionOption,
@@ -110,6 +111,27 @@ export class ACPConnection {
 
   get sessionId(): string | undefined {
     return this.session?.sessionId;
+  }
+
+  async getAvailableModels(): Promise<ModelInfo[]> {
+    await this.ensureConnected();
+    return this.session?.models?.availableModels ?? [];
+  }
+
+  async setModel(modelId: string): Promise<void> {
+    await this.ensureConnected();
+
+    const available = this.session?.models?.availableModels;
+
+    if (available && !available.some(m => m.modelId === modelId)) {
+      const ids = available.map(m => m.modelId).join(', ') || '(none)';
+      throw new Error(`Model "${modelId}" is not available. Available models: ${ids}`);
+    }
+
+    await this.connection!.unstable_setSessionModel({
+      sessionId: this.session!.sessionId,
+      modelId,
+    });
   }
 
   async prompt(task: string, signal?: AbortSignal): Promise<string> {
@@ -256,6 +278,20 @@ export class ACPConnection {
       }
 
       this.session = await this.connection.newSession(this.getNewSessionRequest());
+
+      if (this.options.model) {
+        const available = this.session.models?.availableModels;
+
+        if (available && !available.some(m => m.modelId === this.options.model)) {
+          const ids = available.map(m => m.modelId).join(', ') || '(none)';
+          throw new Error(`Model "${this.options.model}" is not available. Available models: ${ids}`);
+        }
+
+        await this.connection.unstable_setSessionModel({
+          sessionId: this.session.sessionId,
+          modelId: this.options.model,
+        });
+      }
     } catch (error) {
       this.disconnect();
       throw this.withStderr(error);

--- a/packages/acp/src/index.ts
+++ b/packages/acp/src/index.ts
@@ -1,3 +1,4 @@
+export type { ModelInfo } from '@agentclientprotocol/sdk';
 export { AcpAgent } from './agent';
 export { createACPTool } from './tool';
 export type { AcpAgentOptions } from './agent';

--- a/packages/acp/src/types.ts
+++ b/packages/acp/src/types.ts
@@ -1,5 +1,6 @@
 import type {
   InitializeRequest,
+  ModelId,
   NewSessionRequest,
   RequestPermissionRequest,
   RequestPermissionResponse,
@@ -34,6 +35,8 @@ export type CreateACPToolOptions = {
   onPermissionRequest?: (request: RequestPermissionRequest) => Promise<RequestPermissionResponse>;
   /** Workspace for the ACP agent process and ACP session. */
   workspace?: Workspace;
+  /** Model ID to select after session creation via the ACP `session/set_model` method. */
+  model?: ModelId;
 };
 
 export type ACPToolInput = {


### PR DESCRIPTION
## Summary

- Merge official upstream `mastra-ai/mastra@9c1dccade6` (`feat(acp): add model option for programmatic model selection (#17010)`) into the fork.
- Keep the upstream ACP patch intact except for one fork-local docs-token adaptation.
- Add the missing `__AI_SDK_ANTHROPIC_MODEL_SONNET__` token so the new ACP docs examples render concrete model IDs instead of leaking a placeholder.

## Scope Evidence

- Upstream-only commit before sync: `9c1dccade6 feat(acp): add model option for programmatic model selection (#17010)`.
- Changed paths are limited to ACP package/docs, the ACP changeset, and the docs model-token registry.
- No Harness v1, `packages/core/src/harness/**`, or MastraCode runtime paths are touched.

## Validation

- `pnpm install --prefer-offline`
- Built required local internal package prerequisites for this fresh worktree:
  - `pnpm --filter @internal/ai-sdk-v4 build`
  - `pnpm --filter @internal/ai-sdk-v5 build`
  - `pnpm --filter @internal/ai-v6 build`
  - `pnpm --filter @internal/core build:lib`
  - `pnpm --filter @mastra/schema-compat build`
  - `pnpm --filter @internal/external-types build:lib`
- `pnpm --filter ./packages/acp test`
  - 2 files, 29 tests passed.
- `pnpm --filter ./packages/acp build:lib`
- `pnpm --filter ./packages/acp lint`
- `pnpm prettier:changed`
- `git diff --check`

## Review Evidence

- Codex review pass 1: no BLOCKER/REVIEW findings; noted a model-token NITPICK while confirming the upstream patch matched by patch-id/range-diff and did not touch Harness/MastraCode.
- Codex review pass 2: found a REVIEW issue where `docs/src/content/en/docs/agents/acp.mdx` used `__AI_SDK_ANTHROPIC_MODEL_SONNET__` but this fork did not define it in `docs/src/plugins/remark-model-tokens/models.ts`. Fixed in `45b43c1b53`.
- CodeRabbit CLI was attempted with `timeout 5m coderabbit review --agent --base main`; it connected and entered summarizing but timed out without findings. Relying on the GitHub CodeRabbit app review for final PR evidence.

Linear: PF-751


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5

This PR lets you pick which AI model an ACP agent uses when you create it (or change it later) instead of relying on env vars; docs were also updated so examples show a real Anthropic model name.

Overview

Syncs upstream commit that adds programmatic model selection to `@mastra/acp` and includes a fork-local docs token addition so Anthropic examples render concrete model IDs. The upstream ACP implementation was preserved unchanged except for that docs token adaptation.

Changes by category

New API / behavior
- Add programmatic model selection for ACP connections:
  - CreateACPToolOptions: optional model?: ModelId (select model at connection creation)
  - ACPConnection.getAvailableModels(): Promise<ModelInfo[]>
  - ACPConnection.setModel(modelId: string): Promise<void> (validates against available models and calls unstable_setSessionModel)
  - During initialize(), connection applies options.model (validated if the session advertises available models)
  - AcpAgent.getAvailableModels(): Promise<ModelInfo[]>
  - AcpAgent.setModel(modelId: string): Promise<void>

Types & exports
- Export type ModelInfo from `@agentclientprotocol/sdk` via packages/acp/src/index.ts
- CreateACPToolOptions now uses ModelId for model?: ModelId

Documentation
- packages/acp/README.md and docs/src/content/en/docs/agents/acp.mdx: add “Model selection” / “Configure the model” docs with examples for getAvailableModels(), model option at creation, and setModel() runtime switching; document validation behavior and error message that lists available model IDs when applicable.
- .changeset/whole-windows-hope.md: changeset note describing the minor release and example usage.
- docs/src/plugins/remark-model-tokens/models.ts: added __AI_SDK_ANTHROPIC_MODEL_SONNET__ → 'claude-sonnet-4-6' so docs render concrete Anthropic model IDs.

Tests & validation
- Test updates in packages/acp/src/__tests__/tool.test.ts: extended mocks to support configurable session responses and added tests covering model-selection behavior (getAvailableModels, setModel, initialization-time model application, validation/error cases, and path where session does not advertise models).
- Local validation performed: pnpm install and built required internal packages; ACP tests passed (2 files, 29 tests); acp build:lib and lint completed; prettier and git diff --check run; Codex review had no blockers; docs token missing was fixed in a follow-up commit.

Scope & notes
- Changes are limited to ACP package, ACP docs/changeset, and the docs model-token registry. No changes touch Harness v1, packages/core/src/harness/**, or MastraCode runtime paths.
- Validation evidence includes unit tests and build/lint steps described above.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->