### PR TITLE
[PF-579][PF-582] Restore MastraCode OM thread metadata

### DIFF
--- a/.changeset/pf-579-mastracode-thread-settings.md
+++ b/.changeset/pf-579-mastracode-thread-settings.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed MastraCode restoring per-thread observational memory settings when switching Harness v1 threads.

--- a/mastracode/src/harness/runtime.test.ts
+++ b/mastracode/src/harness/runtime.test.ts
@@ -2,7 +2,12 @@ import { Agent } from '@mastra/core/agent';
 import { InMemoryStore } from '@mastra/core/storage';
 import { describe, expect, it, vi } from 'vitest';
 
-import { MASTRACODE_HARNESS_NAME, toHarnessV1Agents, toHarnessV1Modes } from './config.js';
+import {
+  MASTRACODE_HARNESS_NAME,
+  MASTRACODE_RUNTIME_COMPATIBILITY_GENERATION,
+  toHarnessV1Agents,
+  toHarnessV1Modes,
+} from './config.js';
 import { MastraCodeHarnessRuntime } from './runtime.js';
 
 function createRuntime(
@@ -80,10 +85,33 @@ describe('MastraCodeHarnessRuntime', () => {
     await runtime.switchObserverModel({ modelId: 'google/gemini-2.5-flash' });
     await runtime.switchReflectorModel({ modelId: 'anthropic/claude-haiku-4-5' });
     await runtime.setSubagentModelId({ modelId: 'openai/gpt-5.4-mini' });
+    await runtime.setState({
+      observationThreshold: 12_345,
+      reflectionThreshold: 54_321,
+      cavemanObservations: true,
+      observeAttachments: false,
+    });
+    // Mirror the `/om` flow: update live state and persist the same per-thread settings.
+    await runtime.setThreadSetting({ key: 'observationThreshold', value: 12_345 });
+    await runtime.setThreadSetting({ key: 'reflectionThreshold', value: 54_321 });
+    await runtime.setThreadSetting({ key: 'cavemanObservations', value: true });
+    await runtime.setThreadSetting({ key: 'observeAttachments', value: false });
 
-    await runtime.createThread({ title: 'second' });
+    const second = await runtime.createThread({ title: 'second' });
+    expect(second.metadata).toMatchObject({
+      observationThreshold: 12_345,
+      reflectionThreshold: 54_321,
+      cavemanObservations: true,
+      observeAttachments: false,
+    });
     await runtime.switchMode({ modeId: 'build' });
     await runtime.switchModel({ modelId: 'anthropic/claude-opus-4-6' });
+    await runtime.setState({
+      observationThreshold: 30_000,
+      reflectionThreshold: 40_000,
+      cavemanObservations: false,
+      observeAttachments: 'auto',
+    });
 
     await runtime.switchThread({ threadId: first.id });
 
@@ -92,8 +120,142 @@ describe('MastraCodeHarnessRuntime', () => {
     expect(runtime.getObserverModelId()).toBe('google/gemini-2.5-flash');
     expect(runtime.getReflectorModelId()).toBe('anthropic/claude-haiku-4-5');
     expect(runtime.getSubagentModelId()).toBe('openai/gpt-5.4-mini');
+    expect(runtime.getObservationThreshold()).toBe(12_345);
+    expect(runtime.getReflectionThreshold()).toBe(54_321);
+    expect(runtime.getState()).toMatchObject({
+      cavemanObservations: true,
+      observeAttachments: false,
+    });
 
     await runtime.destroy();
+  });
+
+  it('ignores invalid Harness v1 thread metadata for MastraCode-owned OM settings', async () => {
+    const runtime = createRuntime();
+    await runtime.init();
+    const firstThreadId = runtime.getCurrentThreadId();
+    if (!firstThreadId) throw new Error('expected initial thread');
+    await runtime.core.threads.setSettings({
+      resourceId: runtime.getResourceId(),
+      threadId: firstThreadId,
+      patch: {
+        observerModelId: 42,
+        reflectorModelId: false,
+        subagentModelId: null,
+        subagentModelId_reviewer: {},
+        observationThreshold: 0,
+        reflectionThreshold: -1,
+        cavemanObservations: 'false',
+        observeAttachments: null,
+      },
+    });
+
+    await runtime.createThread({ title: 'second' });
+    await runtime.setState({
+      observerModelId: 'google/gemini-2.5-flash',
+      reflectorModelId: 'anthropic/claude-haiku-4-5',
+      subagentModelId: 'openai/gpt-5.4-mini',
+      subagentModelId_reviewer: 'openai/gpt-5.4',
+      observationThreshold: 12_345,
+      reflectionThreshold: 54_321,
+      cavemanObservations: true,
+      observeAttachments: false,
+    });
+
+    await runtime.switchThread({ threadId: firstThreadId });
+
+    expect(runtime.getState()).toMatchObject({
+      observerModelId: 'google/gemini-2.5-flash',
+      reflectorModelId: 'anthropic/claude-haiku-4-5',
+      subagentModelId: 'openai/gpt-5.4-mini',
+      subagentModelId_reviewer: 'openai/gpt-5.4',
+      observationThreshold: 12_345,
+      reflectionThreshold: 54_321,
+      cavemanObservations: true,
+      observeAttachments: false,
+    });
+
+    await runtime.destroy();
+  });
+
+  it('does not seed invalid MastraCode-owned OM settings into new Harness v1 thread metadata', async () => {
+    const runtime = createRuntime({
+      initialState: {
+        observerModelId: 42,
+        reflectorModelId: false,
+        subagentModelId: null,
+        subagentModelId_reviewer: {},
+        observationThreshold: 0,
+        reflectionThreshold: -1,
+        cavemanObservations: 'true',
+        observeAttachments: 42,
+      },
+    });
+
+    const thread = await runtime.createThread({ title: 'invalid metadata seed' });
+
+    expect(thread.metadata).not.toHaveProperty('cavemanObservations');
+    expect(thread.metadata).not.toHaveProperty('observeAttachments');
+    expect(thread.metadata).not.toHaveProperty('observerModelId');
+    expect(thread.metadata).not.toHaveProperty('reflectorModelId');
+    expect(thread.metadata).not.toHaveProperty('subagentModelId');
+    expect(thread.metadata).not.toHaveProperty('subagentModelId_reviewer');
+    expect(thread.metadata).not.toHaveProperty('observationThreshold');
+    expect(thread.metadata).not.toHaveProperty('reflectionThreshold');
+    expect(runtime.getState()).not.toHaveProperty('cavemanObservations');
+    expect(runtime.getState()).not.toHaveProperty('observeAttachments');
+    expect(runtime.getState()).not.toHaveProperty('observerModelId');
+    expect(runtime.getState()).not.toHaveProperty('reflectorModelId');
+    expect(runtime.getState()).not.toHaveProperty('subagentModelId');
+    expect(runtime.getState()).not.toHaveProperty('subagentModelId_reviewer');
+    expect(runtime.getState()).not.toHaveProperty('observationThreshold');
+    expect(runtime.getState()).not.toHaveProperty('reflectionThreshold');
+
+    await runtime.setState({
+      observerModelId: 'google/gemini-2.5-flash',
+      reflectorModelId: 'anthropic/claude-haiku-4-5',
+      subagentModelId: 'openai/gpt-5.4-mini',
+      subagentModelId_reviewer: 'openai/gpt-5.4',
+      observationThreshold: 12_345,
+      reflectionThreshold: 54_321,
+      cavemanObservations: true,
+      observeAttachments: false,
+    });
+    await runtime.setState({
+      observerModelId: 42,
+      reflectorModelId: false,
+      subagentModelId: null,
+      subagentModelId_reviewer: {},
+      observationThreshold: 0,
+      reflectionThreshold: -1,
+      cavemanObservations: 'true',
+      observeAttachments: 42,
+    } as any);
+
+    expect(runtime.getState()).toMatchObject({
+      observerModelId: 'google/gemini-2.5-flash',
+      reflectorModelId: 'anthropic/claude-haiku-4-5',
+      subagentModelId: 'openai/gpt-5.4-mini',
+      subagentModelId_reviewer: 'openai/gpt-5.4',
+      observationThreshold: 12_345,
+      reflectionThreshold: 54_321,
+      cavemanObservations: true,
+      observeAttachments: false,
+    });
+
+    await runtime.destroy();
+  });
+
+  it('pins MastraCode recoverable runtime work to the compatibility generation', () => {
+    const runtime = createRuntime();
+    const modelId = runtime.getCurrentModelId();
+
+    expect((runtime.core as any)._runtimeDependenciesForMode('build', modelId)).toMatchObject({
+      modeId: 'build',
+      agentId: 'code-agent',
+      modelId,
+      runtimeCompatibilityGeneration: MASTRACODE_RUNTIME_COMPATIBILITY_GENERATION,
+    });
   });
 
   it('does not write target thread metadata into the previously active session while switching threads', async () => {
@@ -440,6 +602,50 @@ describe('MastraCodeHarnessRuntime', () => {
     expect(prepareStep({ tools: { allowed_tool: {}, blocked_tool: {} } })).toEqual({ activeTools: ['allowed_tool'] });
 
     await runtime.destroy();
+  });
+
+  it('delegates the action catalog through the active Harness v1 session', async () => {
+    const runtime = createRuntime();
+    const actions = {
+      list: vi.fn(async () => [{ id: 'action-1' }]),
+      search: vi.fn(async () => [{ id: 'action-2' }]),
+      refresh: vi.fn(async () => undefined),
+    };
+    (runtime as any).session = { actions };
+
+    await expect(runtime.actions.list({ source: 'skill' })).resolves.toEqual([{ id: 'action-1' }]);
+    await expect(runtime.actions.search('inspect', { source: 'mcp-tool' })).resolves.toEqual([{ id: 'action-2' }]);
+    await expect(runtime.actions.refresh()).resolves.toBeUndefined();
+
+    expect(actions.list).toHaveBeenCalledWith({ source: 'skill' });
+    expect(actions.search).toHaveBeenCalledWith('inspect', { source: 'mcp-tool' });
+    expect(actions.refresh).toHaveBeenCalled();
+  });
+
+  it('queues active follow-ups through Harness v1 with runtime controls', async () => {
+    const runtime = createRuntime({ initialState: { yolo: true }, disabledTools: ['blocked_tool'] });
+    const queue = vi.fn(async () => ({ status: 'completed' }));
+    (runtime as any).session = {
+      isRunning: () => true,
+      queue,
+    };
+    const listener = vi.fn();
+    runtime.subscribe(listener);
+
+    await runtime.followUp({ content: 'next turn' });
+
+    expect(listener).toHaveBeenCalledWith({ type: 'follow_up_queued', count: 1 });
+    expect(queue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'next turn',
+        yolo: true,
+        prepareStep: expect.any(Function),
+      }),
+    );
+    const [{ prepareStep }] = queue.mock.calls[0] as any;
+    expect(prepareStep({ tools: { allowed_tool: {}, blocked_tool: {} } })).toEqual({ activeTools: ['allowed_tool'] });
+
+    await vi.waitFor(() => expect(runtime.getFollowUpCount()).toBe(0));
   });
 
   it('persists system reminder messages and first user previews through memory storage', async () => {

--- a/mastracode/src/harness/runtime.test.ts
+++ b/mastracode/src/harness/runtime.test.ts
@@ -1062,6 +1062,18 @@ describe('MastraCodeHarnessRuntime', () => {
       result: 'ok',
       isError: false,
     });
+    await (runtime as any).handleCoreEvent({
+      type: 'subagent_tool_start',
+      innerToolCallId: 'sub-tool-1',
+      toolName: 'write_file',
+    });
+    await (runtime as any).handleCoreEvent({
+      type: 'subagent_tool_end',
+      innerToolCallId: 'sub-tool-1',
+      toolName: 'write_file',
+      output: 'ok',
+      isError: false,
+    });
 
     expect(runtime.getDisplayState().modifiedFiles.size).toBe(0);
     await runtime.destroy();

--- a/mastracode/src/harness/runtime.ts
+++ b/mastracode/src/harness/runtime.ts
@@ -169,6 +169,69 @@ function isHarnessSessionLifecycleError(error: unknown): boolean {
   return error instanceof Error && HARNESS_SESSION_LIFECYCLE_ERROR_NAMES.has(error.name);
 }
 
+function isValidCavemanObservations(value: unknown): value is boolean {
+  return typeof value === 'boolean';
+}
+
+function isValidObserveAttachments(value: unknown): value is 'auto' | boolean {
+  return value === 'auto' || typeof value === 'boolean';
+}
+
+function isValidOMThreshold(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+function isValidModelId(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function sanitizeMastraCodeOMStatePatch<T extends Record<string, unknown>>(patch: T): T {
+  const sanitized = { ...patch };
+  for (const key of ['observerModelId', 'reflectorModelId', 'subagentModelId']) {
+    if (
+      Object.prototype.hasOwnProperty.call(sanitized, key) &&
+      sanitized[key] !== undefined &&
+      !isValidModelId(sanitized[key])
+    ) {
+      delete sanitized[key];
+    }
+  }
+  for (const key of Object.keys(sanitized)) {
+    if (key.startsWith('subagentModelId_') && sanitized[key] !== undefined && !isValidModelId(sanitized[key])) {
+      delete sanitized[key];
+    }
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(sanitized, 'observationThreshold') &&
+    sanitized.observationThreshold !== undefined &&
+    !isValidOMThreshold(sanitized.observationThreshold)
+  ) {
+    delete sanitized.observationThreshold;
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(sanitized, 'reflectionThreshold') &&
+    sanitized.reflectionThreshold !== undefined &&
+    !isValidOMThreshold(sanitized.reflectionThreshold)
+  ) {
+    delete sanitized.reflectionThreshold;
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(sanitized, 'cavemanObservations') &&
+    sanitized.cavemanObservations !== undefined &&
+    !isValidCavemanObservations(sanitized.cavemanObservations)
+  ) {
+    delete sanitized.cavemanObservations;
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(sanitized, 'observeAttachments') &&
+    sanitized.observeAttachments !== undefined &&
+    !isValidObserveAttachments(sanitized.observeAttachments)
+  ) {
+    delete sanitized.observeAttachments;
+  }
+  return sanitized as T;
+}
+
 function toLegacyThread(thread: ThreadRecord): HarnessThread {
   return {
     id: thread.id,
@@ -287,7 +350,7 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
     this.modes = config.modes;
     this.defaultModeId = resolveDefaultModeId(config.modes);
     this.currentModeId = this.defaultModeId;
-    this.state = { ...config.initialState };
+    this.state = sanitizeMastraCodeOMStatePatch({ ...config.initialState });
     this.currentDisplayTasks = cloneTasks(this.state.tasks);
     const harnessV1Agents = toHarnessV1Agents(config.agents, config.modes, this.state);
     const exposedSubagents = this.shouldExposeSubagentTool() ? config.subagents : [];
@@ -781,16 +844,17 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
   }
 
   private applyLocalState(updates: Partial<TState>, options: { emitLegacy?: boolean } = {}): void {
-    this.state = { ...this.state, ...updates };
-    if (Object.prototype.hasOwnProperty.call(updates, 'tasks')) {
+    const sanitizedUpdates = sanitizeMastraCodeOMStatePatch(updates as Record<string, unknown>) as Partial<TState>;
+    this.state = { ...this.state, ...sanitizedUpdates };
+    if (Object.prototype.hasOwnProperty.call(sanitizedUpdates, 'tasks')) {
       this.previousDisplayTasks = [...this.currentDisplayTasks];
-      this.currentDisplayTasks = cloneTasks((updates as Record<string, unknown>).tasks);
+      this.currentDisplayTasks = cloneTasks((sanitizedUpdates as Record<string, unknown>).tasks);
     }
     if (options.emitLegacy ?? true) {
       this.emit({
         type: 'state_changed',
         state: this.state,
-        changedKeys: Object.keys(updates),
+        changedKeys: Object.keys(sanitizedUpdates),
       } as unknown as HarnessEvent);
     }
   }
@@ -1681,18 +1745,23 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
     if (typeof projectPath === 'string' && projectPath.length > 0) {
       metadata.projectPath = projectPath;
     }
-    for (const key of [
-      'observerModelId',
-      'reflectorModelId',
-      'observationThreshold',
-      'reflectionThreshold',
-      'subagentModelId',
-      'cavemanObservations',
-    ]) {
-      if (this.state[key] !== undefined) metadata[key] = this.state[key];
+    for (const key of ['observerModelId', 'reflectorModelId', 'subagentModelId']) {
+      if (isValidModelId(this.state[key])) metadata[key] = this.state[key];
+    }
+    if (isValidOMThreshold(this.state.observationThreshold)) {
+      metadata.observationThreshold = this.state.observationThreshold;
+    }
+    if (isValidOMThreshold(this.state.reflectionThreshold)) {
+      metadata.reflectionThreshold = this.state.reflectionThreshold;
+    }
+    if (isValidCavemanObservations(this.state.cavemanObservations)) {
+      metadata.cavemanObservations = this.state.cavemanObservations;
+    }
+    if (isValidObserveAttachments(this.state.observeAttachments)) {
+      metadata.observeAttachments = this.state.observeAttachments;
     }
     for (const [key, value] of Object.entries(this.state)) {
-      if (key.startsWith('subagentModelId_') && value !== undefined) {
+      if (key.startsWith('subagentModelId_') && isValidModelId(value)) {
         metadata[key] = value;
       }
     }
@@ -1743,14 +1812,20 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
       if (fallback) updates.currentModelId = fallback;
     }
 
-    for (const key of [
-      'observerModelId',
-      'reflectorModelId',
-      'observationThreshold',
-      'reflectionThreshold',
-      'subagentModelId',
-    ]) {
-      if (metadata[key] !== undefined) updates[key] = metadata[key];
+    for (const key of ['observerModelId', 'reflectorModelId', 'subagentModelId']) {
+      if (isValidModelId(metadata[key])) updates[key] = metadata[key];
+    }
+    if (isValidOMThreshold(metadata.observationThreshold)) {
+      updates.observationThreshold = metadata.observationThreshold;
+    }
+    if (isValidOMThreshold(metadata.reflectionThreshold)) {
+      updates.reflectionThreshold = metadata.reflectionThreshold;
+    }
+    if (isValidCavemanObservations(metadata.cavemanObservations)) {
+      updates.cavemanObservations = metadata.cavemanObservations;
+    }
+    if (isValidObserveAttachments(metadata.observeAttachments)) {
+      updates.observeAttachments = metadata.observeAttachments;
     }
     for (const [key, value] of Object.entries(metadata)) {
       if (key.startsWith('subagentModelId_') && typeof value === 'string') {

--- a/mastracode/src/harness/runtime.ts
+++ b/mastracode/src/harness/runtime.ts
@@ -185,6 +185,10 @@ function isValidModelId(value: unknown): value is string {
   return typeof value === 'string';
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function sanitizeMastraCodeOMStatePatch<T extends Record<string, unknown>>(patch: T): T {
   const sanitized = { ...patch };
   for (const key of ['observerModelId', 'reflectorModelId', 'subagentModelId']) {
@@ -482,7 +486,7 @@ export class MastraCodeHarnessRuntime<TState extends Record<string, unknown>> {
     this.activeToolCalls.delete(endedToolCallId);
     if (!tool || isError || !isHarnessWorkspaceFileMutationTool(tool.name)) return;
 
-    const filePath = getHarnessWorkspaceActionPathInput(tool.name, tool.args as Record<string, unknown>);
+    const filePath = getHarnessWorkspaceActionPathInput(tool.name, isRecord(tool.args) ? tool.args : {});
     if (!filePath) return;
 
     const existing = this.modifiedFiles.get(filePath);


### PR DESCRIPTION
## Summary
- Restore MastraCode-owned observational memory settings from Harness v1 thread metadata when switching threads.
- Sanitize invalid thread/runtime values for observer, reflector, subagent model ids, OM thresholds, caveman observations, and attachment observation before they enter runtime state or future thread metadata.
- Add targeted coverage for runtime compatibility generation, action catalog delegation, and active follow-up queue controls.

## Validation
- PASS: pnpm --filter mastracode test src/harness/runtime.test.ts --run (37 tests)
- PASS: pnpm prettier:changed
- PASS: git diff --check
- LIMITATION: pnpm --filter mastracode check was attempted earlier in the isolated worktree and failed on pre-existing copied workspace dependency/build artifact issues, including missing @mastra/fastembed, @mastra/mcp, @mastra/observability, @mastra/stagehand, @mastra/agent-browser, and @mastra/tavily artifacts.
- LIMITATION: CodeRabbit CLI hung while summarizing changes and was killed after about 5 minutes; GitHub app review should be used for PR review evidence.

## Local Review
- Claude review: no blocker after source verification; follow-up queue robustness and invalid metadata coverage findings were addressed.
- Codex review pass 1: found invalid model-id metadata/state hardening gap; fixed in this PR.
- Codex review pass 2: no findings.

## Notes
- This is independent of PR #191 and PR #192. Those remain ready for merge in order (#191 then #192) once explicitly authorized after the recorded gate summary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes MastraCode remember and restore its per-thread observation/reflection settings when you switch conversations, and prevents broken or malicious thread metadata from corrupting those settings. It also adds tests to confirm the behavior.

## Overview

Restores MastraCode-owned observational memory (OM) settings from Harness v1 thread metadata when switching threads, and enforces validation/sanitization of OM-related runtime and metadata values to avoid invalid state or metadata seeding.

## Changes

### Configuration & Setup
- Added a changeset documenting the MastraCode thread settings restoration fix.

### Core Runtime Logic (mastracode/src/harness/runtime.ts)
- Added explicit validation helpers and type guards:
  - isValidCavemanObservations, isValidObserveAttachments, isValidOMThreshold, isValidModelId, isRecord.
- Introduced sanitizeMastraCodeOMStatePatch to strip invalid OM keys from state patches (observer/reflector/subagent model IDs, subagentModelId_* overrides, observation/reflection thresholds, cavemanObservations, observeAttachments).
- Applied sanitization in constructor and applyLocalState so initialState and incoming updates cannot seed invalid OM settings.
- Thread metadata persistence (buildThreadMetadata) now includes OM keys only when values pass validation; metadata restoration (applyThreadMetadata) only applies validated OM keys back into runtime state.
- Modified modified-file tracking to safely build workspace path input using tool.args only when args is a record (guard against missing/non-object tool args).

### Tests (mastracode/src/harness/runtime.test.ts)
- Extended thread switch test to set and persist OM-related runtime state (observation/reflection thresholds, cavemanObservations, observeAttachments, model IDs) and assert restoration on thread switch.
- Added tests to ensure invalid Harness v1 thread metadata is ignored and cannot override MastraCode-owned OM settings when switching threads.
- Added test ensuring invalid MastraCode-owned OM settings in initialState are not seeded into new thread metadata and are ignored on subsequent invalid writes.
- Added test anchoring that build-mode pins runtimeCompatibilityGeneration to MASTRACODE_RUNTIME_COMPATIBILITY_GENERATION.
- Added tests verifying runtime.actions delegates list/search/refresh to the active Harness v1 session and runtime.followUp queues follow-ups through the session while applying runtime controls (yolo, prepareStep filtering) and emitting follow_up_queued.
- Adjusted tool-mutation tracking test to include explicit subagent_tool_end event to ensure expected modified-file snapshot behavior.

## Testing & Validation
- Unit tests: pnpm --filter mastracode test src/harness/runtime.test.ts --run — PASS (37 tests).
- Formatting/lint: pnpm prettier:changed — PASS; git diff --check — PASS.
- Note: pnpm --filter mastracode check failed earlier in an isolated worktree due to missing workspace dependency artifacts; CodeRabbit CLI hung summarizing changes — use GitHub app review for PR review artifacts.

## Commits / Notes
- Commit adds a guard for missing/non-record tool.args when tracking modified files (handles subagent tool arg robustness).
- PR is independent of PR `#191` and PR `#192`; those remain ready to merge separately in order.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->