### PR TITLE
[PF-574] Add Harness lease heartbeat

### DIFF
--- a/.changeset/pf-574-lease-heartbeat.md
+++ b/.changeset/pf-574-lease-heartbeat.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': minor
+---
+
+Added Harness v1 lease heartbeat recovery and explicit lease extension support.
+
+Live Harness sessions now renew their storage leases in the background, fail closed when ownership is lost, and expose `Session.extendLease()` / `Session.withExtendedLease()` for long-running work.

--- a/packages/core/src/harness/v1/contracts.ts
+++ b/packages/core/src/harness/v1/contracts.ts
@@ -147,6 +147,22 @@ export type PendingInteraction = Omit<
 >;
 
 /**
+ * Documentation-only recovery policy for interrupted live sessions.
+ *
+ * Harness owners renew live session leases periodically before the storage
+ * TTL expires. Tools that know they may outlive the default TTL should call
+ * `ctx.extendLease({ ttlMs })` before the long operation starts. If the
+ * process crashes or the event loop is starved long enough for the lease to
+ * expire, a new process may re-open the session after TTL expiry. If another
+ * process already owns the lease, callers receive `HarnessSessionLockedError`
+ * with the current owner id and expiry timestamp instead of silently writing
+ * into a contested session. If a live process loses its lease during renewal,
+ * that local session is evicted with `session_evicted` reason `lease_lost`;
+ * clients should re-resolve the session and replay from durable events.
+ */
+export type HarnessLeaseRecoveryPolicy = never;
+
+/**
  * Documentation-only type. Maps pre-existing identifiers in the
  * harness to the canonical primitive they belong to.
  *

--- a/packages/core/src/harness/v1/events.ts
+++ b/packages/core/src/harness/v1/events.ts
@@ -83,7 +83,7 @@ export interface SessionClosedEvent extends HarnessEventBase {
 
 export interface SessionEvictedEvent extends HarnessEventBase {
   type: 'session_evicted';
-  reason: 'idle' | 'pressure' | 'pinned_timeout' | 'shutdown';
+  reason: 'idle' | 'pressure' | 'pinned_timeout' | 'shutdown' | 'lease_lost';
 }
 
 export interface ModeChangedEvent extends HarnessEventBase {

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -678,6 +678,8 @@ export class Harness {
   private readonly _defaultModeId?: string;
   private readonly _liveSessions = new Map<string, Session>();
   private readonly _leaseTtlMs: number;
+  private _leaseRenewalTimer?: ReturnType<typeof setInterval>;
+  private readonly _leaseRenewingSessionIds = new Set<string>();
   private readonly _maxQueueDepth: number;
   private readonly _queueBackpressure: HarnessQueueBackpressurePolicy;
   private readonly _closeTimeoutMs: number;
@@ -2189,6 +2191,7 @@ export class Harness {
     // events keep their original id/timestamp/sessionId.
     const bridge = session._subscribeInternal(event => this._emitter.forward(event));
     this._sessionEventBridges.set(record.id, bridge);
+    this._ensureLeaseRenewalLoop();
 
     if (opts.emitCreated) {
       // Surface session creation to harness-level subscribers AFTER the bridge
@@ -2222,6 +2225,94 @@ export class Harness {
     }
 
     return session;
+  }
+
+  private _ensureLeaseRenewalLoop(): void {
+    if (this._shutdown) return;
+    if (this._leaseRenewalTimer !== undefined) return;
+    const intervalMs = Math.max(1_000, Math.floor(this._leaseTtlMs / 3));
+    this._leaseRenewalTimer = setInterval(() => {
+      void this._renewLiveSessionLeases();
+    }, intervalMs);
+    this._leaseRenewalTimer.unref?.();
+  }
+
+  private _stopLeaseRenewalLoop(): void {
+    if (this._leaseRenewalTimer === undefined) return;
+    clearInterval(this._leaseRenewalTimer);
+    this._leaseRenewalTimer = undefined;
+  }
+
+  private _stopLeaseRenewalLoopIfIdle(): void {
+    if (this._liveSessions.size > 0) return;
+    this._stopLeaseRenewalLoop();
+  }
+
+  private async _renewLiveSessionLeases(): Promise<void> {
+    if (this._shutdown || this._liveSessions.size === 0) {
+      this._stopLeaseRenewalLoopIfIdle();
+      return;
+    }
+    const storage = this._requireStorage('session lease renewal');
+    const sessions = Array.from(this._liveSessions.values());
+    await Promise.all(sessions.map(session => this._renewLiveSessionLease(storage, session)));
+    this._stopLeaseRenewalLoopIfIdle();
+  }
+
+  private async _renewLiveSessionLease(storage: HarnessStorage, session: Session): Promise<void> {
+    if (session.lifecycleState !== 'live' && session.lifecycleState !== 'closing') return;
+    if (this._leaseRenewingSessionIds.has(session.id)) return;
+    this._leaseRenewingSessionIds.add(session.id);
+    try {
+      await session._enqueueLeaseRenewal(async () => {
+        const record = session.getRecord();
+        const effectiveTtl = session._getEffectiveLeaseTtlMs(this._leaseTtlMs);
+        const lease = await storage.renewSessionLease({
+          harnessName: record.harnessName,
+          sessionId: session.id,
+          ownerId: this.ownerId,
+          ttlMs: effectiveTtl,
+        });
+        session._markLeaseRenewed(lease.expiresAt);
+      });
+    } catch (err) {
+      if (err instanceof HarnessStorageLeaseConflictError || err instanceof HarnessStorageSessionNotFoundError) {
+        await this._evictLiveSession(session, 'lease_lost');
+        return;
+      }
+      console.error('[harness/v1] session lease renewal failed:', err);
+    } finally {
+      this._leaseRenewingSessionIds.delete(session.id);
+    }
+  }
+
+  private async _evictLiveSession(session: Session, reason: 'lease_lost'): Promise<void> {
+    if (this._liveSessions.get(session.id) !== session) return;
+    const record = session.getRecord() as SessionRecord;
+    session._markEvicted(record);
+    session._emit({ type: 'session_evicted', reason });
+    try {
+      await session._flushEventPersistence();
+    } catch {
+      // Best-effort: lease loss may also mean event persistence is unavailable.
+    }
+    const bridge = this._sessionEventBridges.get(session.id);
+    if (bridge) {
+      bridge();
+      this._sessionEventBridges.delete(session.id);
+    }
+    this._liveSessions.delete(session.id);
+    this._stopLeaseRenewalLoopIfIdle();
+
+    try {
+      if (this._workspaceKind === 'per-session') {
+        await this._workspaceRegistry.releasePerSession({ sessionId: session.id });
+      } else if (this._workspaceKind === 'per-resource') {
+        await this._workspaceRegistry.releasePerResource({ resourceId: session.resourceId });
+      }
+    } catch {
+      // Best-effort; workspace registry errors are surfaced through events elsewhere.
+    }
   }
 
   private async _eventReplaySeedFor(
@@ -2614,6 +2705,7 @@ export class Harness {
         this._liveSessions.delete(node.record.id);
       }
     }
+    this._stopLeaseRenewalLoopIfIdle();
   }
 
   private _emitSessionClosing(session: Session | undefined, record: SessionRecord): void {
@@ -2683,6 +2775,7 @@ export class Harness {
       this._sessionEventBridges.delete(record.id);
     }
     this._liveSessions.delete(record.id);
+    this._stopLeaseRenewalLoopIfIdle();
 
     if (eventPersistenceError !== undefined) {
       throw new HarnessStorageError(record.id, 'flush', eventPersistenceError);
@@ -2848,6 +2941,7 @@ export class Harness {
       this._sessionEventBridges.delete(node.record.id);
     }
     this._liveSessions.delete(node.record.id);
+    this._stopLeaseRenewalLoopIfIdle();
     return live;
   }
 
@@ -2918,6 +3012,7 @@ export class Harness {
   async shutdown(opts?: ShutdownOptions): Promise<void> {
     if (this._shutdown) return;
     this._shutdown = true;
+    this._stopLeaseRenewalLoop();
 
     let storage: HarnessStorage;
     try {
@@ -2974,6 +3069,9 @@ export class Harness {
         session._restoreLiveAfterFailedClose();
       }
       this._shutdown = false;
+      if (this._liveSessions.size > 0) {
+        this._ensureLeaseRenewalLoop();
+      }
       throw new HarnessStorageError(eventPersistenceError.sessionId, 'flush', eventPersistenceError.error);
     }
 
@@ -2996,6 +3094,9 @@ export class Harness {
         session._restoreLiveAfterFailedClose();
       }
       this._shutdown = false;
+      if (this._liveSessions.size > 0) {
+        this._ensureLeaseRenewalLoop();
+      }
       throw new HarnessStorageError(eventPersistenceError.sessionId, 'flush', eventPersistenceError.error);
     }
 
@@ -3912,6 +4013,10 @@ export class Harness {
     return this._liveSessions.get(sessionId);
   }
 
+  async _internalEvictLiveSessionLeaseLost(session: Session): Promise<void> {
+    await this._evictLiveSession(session, 'lease_lost');
+  }
+
   /** @internal — exposed for inspection in tests. */
   _internalLiveSessionCount(): number {
     return this._liveSessions.size;
@@ -3925,6 +4030,11 @@ export class Harness {
   /** @internal — accessor for `Session.queue()` full-queue behavior. */
   get _internalQueueBackpressure(): HarnessQueueBackpressurePolicy {
     return this._queueBackpressure;
+  }
+
+  /** @internal — default lease TTL consumed by `Session.extendLease(...)`. */
+  get _internalLeaseTtlMs(): number {
+    return this._leaseTtlMs;
   }
 
   /** @internal — goal-loop defaults, consumed by `Session.setGoal()` (§4.7). */

--- a/packages/core/src/harness/v1/session.lease.test.ts
+++ b/packages/core/src/harness/v1/session.lease.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Lease renewal and extension coverage for Harness v1 sessions.
+ *
+ * The Harness owns a periodic heartbeat for normal live sessions. `extendLease`
+ * is the explicit tool/runtime escape hatch for work that may exceed the
+ * default lease TTL or block the event loop long enough to miss a heartbeat.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
+import { InMemoryDB } from '../../storage/domains/inmemory-db';
+
+import { setupHarness } from './__test-utils__/setup';
+import { HarnessSessionClosedError, HarnessSessionLockedError, HarnessValidationError } from './errors';
+import type { Session } from './session';
+
+interface SessionLeaseInternals {
+  _leaseExtensionDeadline?: number;
+  _beginClosing(): void;
+  _getEffectiveLeaseTtlMs(defaultTtlMs: number): number;
+  _enqueueLeaseRenewal(run: () => Promise<void>): Promise<void>;
+}
+
+function asInternals(session: Session): SessionLeaseInternals {
+  return session as unknown as SessionLeaseInternals;
+}
+
+describe('Session.extendLease', () => {
+  it('rejects invalid ttl values', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await expect(session.extendLease({ ttlMs: Number.NaN })).rejects.toBeInstanceOf(HarnessValidationError);
+    await expect(session.extendLease({ ttlMs: Number.POSITIVE_INFINITY })).rejects.toBeInstanceOf(
+      HarnessValidationError,
+    );
+    await expect(session.extendLease({ ttlMs: 0 })).rejects.toBeInstanceOf(HarnessValidationError);
+    await expect(session.extendLease({ ttlMs: -10 })).rejects.toBeInstanceOf(HarnessValidationError);
+    await expect(session.extendLease({ ttlMs: 1.5 })).rejects.toBeInstanceOf(HarnessValidationError);
+    await expect(session.extendLease({ ttlMs: 25 * 60 * 60 * 1_000 })).rejects.toBeInstanceOf(HarnessValidationError);
+  });
+
+  it('renews storage and records a deadline that heartbeat renewal respects', async () => {
+    const { harness, storage } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    const before = (await storage.loadSession({ sessionId: session.id }))!.leaseExpiresAt!;
+    await session.extendLease({ ttlMs: 5 * 60_000 });
+    const afterExtend = (await storage.loadSession({ sessionId: session.id }))!.leaseExpiresAt!;
+
+    expect(afterExtend).toBeGreaterThan(before);
+    expect(asInternals(session)._leaseExtensionDeadline).toBe(afterExtend);
+    expect(asInternals(session)._getEffectiveLeaseTtlMs(30_000)).toBeGreaterThan(30_000);
+  });
+
+  it('does not shrink an active longer extension with a shorter follow-up', async () => {
+    const { harness, storage } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await session.extendLease({ ttlMs: 10 * 60_000 });
+    const afterLong = (await storage.loadSession({ sessionId: session.id }))!.leaseExpiresAt!;
+    await session.extendLease({ ttlMs: 60_000 });
+    const afterShort = (await storage.loadSession({ sessionId: session.id }))!.leaseExpiresAt!;
+
+    expect(afterShort).toBeGreaterThanOrEqual(afterLong - 2_000);
+  });
+
+  it('withExtendedLease invokes the wrapped function and returns its result', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await expect(session.withExtendedLease(async () => 42, { ttlMs: 60_000 })).resolves.toBe(42);
+  });
+
+  it('throws if an explicit extension is queued after close', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+
+    await session.close();
+
+    await expect(session.extendLease({ ttlMs: 60_000 })).rejects.toBeInstanceOf(HarnessSessionClosedError);
+  });
+
+  it('allows explicit extension while a closing session drains admitted work', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    asInternals(session)._beginClosing();
+
+    await expect(session.extendLease({ ttlMs: 60_000 })).resolves.toBeUndefined();
+  });
+
+  it('evicts the local session if explicit extension observes lease loss', async () => {
+    const { harness, storage } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await storage.releaseSessionLease({ sessionId: session.id, harnessName: 'default', ownerId: harness.ownerId });
+    await storage.acquireSessionLease({
+      sessionId: session.id,
+      harnessName: 'default',
+      ownerId: 'other-process',
+      ttlMs: 30_000,
+    });
+    const events: string[] = [];
+    const unsubscribe = session.subscribe(event => events.push(event.type));
+
+    await expect(session.extendLease({ ttlMs: 60_000 })).rejects.toBeInstanceOf(HarnessSessionLockedError);
+
+    unsubscribe();
+    expect(events).toContain('session_evicted');
+    expect(harness._internalLiveSessionCount()).toBe(0);
+    expect(session.lifecycleState).toBe('evicted');
+  });
+
+  it('blocks stale writes after the local lease has expired', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2_000_000);
+    try {
+      const { harness } = setupHarness();
+      const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+      vi.setSystemTime(2_031_000);
+
+      await expect(session.setState({ stale: true })).rejects.toBeInstanceOf(HarnessSessionLockedError);
+      expect(session.lifecycleState).toBe('evicted');
+      expect(harness._internalLiveSessionCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('Lease heartbeat coordination', () => {
+  it('renews live session leases before the TTL expires and stops after shutdown', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+    try {
+      const { harness, storage } = setupHarness();
+      const renew = vi.spyOn(storage, 'renewSessionLease');
+      const session = await harness.session({ threadId: 't1', resourceId: 'r1' });
+
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(renew).toHaveBeenCalledWith({
+        harnessName: 'default',
+        sessionId: session.id,
+        ownerId: harness.ownerId,
+        ttlMs: 30_000,
+      });
+      expect(session.getRecord().leaseExpiresAt).toBe(1_040_000);
+
+      const renewCount = renew.mock.calls.length;
+      await harness.shutdown();
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(renew).toHaveBeenCalledTimes(renewCount);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('uses the extended TTL when the heartbeat renews during an active extension', async () => {
+    const { harness, storage } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.extendLease({ ttlMs: 5 * 60_000 });
+    const extendedAt = (await storage.loadSession({ sessionId: session.id }))!.leaseExpiresAt!;
+
+    await asInternals(session)._enqueueLeaseRenewal(async () => {
+      const effectiveTtl = asInternals(session)._getEffectiveLeaseTtlMs(30_000);
+      const lease = await storage.renewSessionLease({
+        harnessName: session.getRecord().harnessName,
+        sessionId: session.id,
+        ownerId: session.getRecord().ownerId!,
+        ttlMs: effectiveTtl,
+      });
+      session._markLeaseRenewed(lease.expiresAt);
+    });
+
+    const afterHeartbeat = (await storage.loadSession({ sessionId: session.id }))!.leaseExpiresAt!;
+    expect(afterHeartbeat).toBeGreaterThanOrEqual(extendedAt - 2_000);
+  });
+
+  it('keeps cancelled live sessions renewed until they close', async () => {
+    const { harness, session, storage } = await (async () => {
+      const setup = setupHarness();
+      const session = await setup.harness.session({ resourceId: 'u', threadId: { fresh: true } });
+      return { ...setup, session };
+    })();
+    await session.cancel({ reason: 'no-renew' });
+    const renew = vi.spyOn(storage, 'renewSessionLease');
+
+    await (harness as unknown as { _renewLiveSessionLeases(): Promise<void> })._renewLiveSessionLeases();
+
+    expect(renew).toHaveBeenCalledWith({
+      harnessName: 'default',
+      sessionId: session.id,
+      ownerId: harness.ownerId,
+      ttlMs: 30_000,
+    });
+  });
+
+  it('restarts the heartbeat when shutdown fails and restores live sessions', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(3_000_000);
+    try {
+      const { harness, storage } = setupHarness();
+      const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+      const append = vi.spyOn(storage, 'appendSessionEvent').mockRejectedValueOnce(new Error('append failed'));
+
+      await expect(harness.shutdown()).rejects.toThrow('append failed');
+      append.mockRestore();
+      expect(session.lifecycleState).toBe('live');
+
+      const renew = vi.spyOn(storage, 'renewSessionLease');
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(renew).toHaveBeenCalledWith({
+        harnessName: 'default',
+        sessionId: session.id,
+        ownerId: harness.ownerId,
+        ttlMs: 30_000,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('evicts a live session fail-closed when renewal observes lease loss', async () => {
+    const { harness, session, storage } = await (async () => {
+      const setup = setupHarness();
+      const session = await setup.harness.session({ resourceId: 'u', threadId: { fresh: true } });
+      return { ...setup, session };
+    })();
+    const stored = (await storage.loadSession({ sessionId: session.id, harnessName: 'default' }))!;
+    await storage.releaseSessionLease({ sessionId: session.id, harnessName: 'default', ownerId: harness.ownerId });
+    await storage.acquireSessionLease({
+      sessionId: session.id,
+      harnessName: 'default',
+      ownerId: 'other-process',
+      ttlMs: 30_000,
+    });
+    const events: string[] = [];
+    const unsubscribe = session.subscribe(event => events.push(event.type));
+
+    await (harness as unknown as { _renewLiveSessionLeases(): Promise<void> })._renewLiveSessionLeases();
+
+    unsubscribe();
+    expect(events).toContain('session_evicted');
+    expect(harness._internalLiveSessionCount()).toBe(0);
+    expect(session.lifecycleState).toBe('evicted');
+    await expect(storage.loadSession({ sessionId: stored.id, harnessName: 'default' })).resolves.toMatchObject({
+      ownerId: 'other-process',
+    });
+  });
+});
+
+describe('Lease takeover contention', () => {
+  it('blocks a second Harness while an extended lease is active', async () => {
+    const sharedStorage = new InMemoryHarness({ db: new InMemoryDB() });
+    const { harness } = setupHarness({ sessions: { storage: sharedStorage } });
+    const session = await harness.session({ threadId: 't-lease', resourceId: 'u' });
+
+    await session.extendLease({ ttlMs: 5 * 60_000 });
+
+    const { harness: otherHarness } = setupHarness({ sessions: { storage: sharedStorage } });
+    await expect(otherHarness.session({ sessionId: session.id })).rejects.toBeInstanceOf(HarnessSessionLockedError);
+  });
+
+  it('lets a fresh Harness take over once the prior owner lease has expired', async () => {
+    const db = new InMemoryDB();
+    const storage = new InMemoryHarness({ db });
+    const { harness } = setupHarness({ sessions: { storage } });
+    const session = await harness.session({ threadId: 't-expired', resourceId: 'u' });
+    const stored = db.harnessSessions.get(`default\u0000${session.id}`);
+    if (!stored) throw new Error('expected stored session');
+    db.harnessSessions.set(`default\u0000${session.id}`, { ...stored, leaseExpiresAt: Date.now() - 60_000 });
+
+    const { harness: otherHarness } = setupHarness({ sessions: { storage } });
+    const taken = await otherHarness.session({ sessionId: session.id });
+
+    expect(taken.id).toBe(session.id);
+    expect(taken._internalOwnerId).toBe(otherHarness.ownerId);
+  });
+});

--- a/packages/core/src/harness/v1/session.test.ts
+++ b/packages/core/src/harness/v1/session.test.ts
@@ -211,6 +211,8 @@ describe('Session — surface area (M1)', () => {
         'isBusy',
         'getQueueDepth',
         'getTokenUsage',
+        'extendLease',
+        'withExtendedLease',
         'waitForIdle',
         'listMessages',
         'message',

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -21,8 +21,8 @@
  *   - 'closed'  — `close()` has run; record has `closedAt` set in storage.
  *   - 'deleted' — the session row has been hard-deleted from storage.
  *   - 'evicted' — flushed to storage and dropped from live map; the record
- *                 remains active and the session can be re-hydrated. Currently
- *                 unused; lands with §5.4 idle eviction.
+ *                 remains active and the session can be re-hydrated after
+ *                 fail-closed lease loss.
  *
  * Once a Session leaves 'live', every method except identity reads throws.
  * Callers must re-resolve via `harness.session(...)` to get a fresh instance.
@@ -39,7 +39,9 @@ import { PrefillErrorHandler, ProviderHistoryCompat, StreamErrorRetryProcessor }
 import { RequestContext } from '../../request-context';
 import {
   HarnessStorageAdmissionConflictError,
+  HarnessStorageLeaseConflictError,
   HarnessStorageSessionEventReplayUnsupportedError,
+  HarnessStorageSessionNotFoundError,
 } from '../../storage/domains/harness';
 import type {
   GoalJudgeDecision,
@@ -83,6 +85,8 @@ import {
   HarnessSessionClosedError,
   HarnessSessionClosingError,
   HarnessSessionDeletedError,
+  HarnessSessionLockedError,
+  HarnessSessionNotFoundError,
   HarnessStateConflictError,
   HarnessSkillArgsValidationError,
   HarnessSkillNotFoundError,
@@ -205,6 +209,8 @@ const QUEUE_POST_RUN_FINALIZATION_RETRY_MS = 1_000;
 const ACTION_CATALOG_DEFAULT_LIMIT = 100;
 const ACTION_CATALOG_MAX_LIMIT = 500;
 const ACTION_CATALOG_MCP_LIST_TIMEOUT_MS = 2_000;
+// Cap explicit extensions to one day so a lost worker cannot pin a session indefinitely.
+const MAX_LEASE_EXTENSION_MS = 24 * 60 * 60 * 1_000;
 const ACTION_CATALOG_MCP_SUCCESS_CACHE_MS = 5_000;
 const ACTION_CATALOG_MCP_FAILURE_CACHE_MS = 30_000;
 const ACTION_CATALOG_MCP_MAX_TIMEOUT_RETRIES = 1;
@@ -718,6 +724,8 @@ export class Session {
    * latest value.
    */
   private _tokenUsage: TokenUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+  private _leaseExtensionDeadline?: number;
+  private _leaseRenewalChain: Promise<void> = Promise.resolve();
   /**
    * Outstanding `waitForIdle()` callers. On close/evict each waiter is
    * rejected so callers don't hang on a dead session.
@@ -1653,6 +1661,83 @@ export class Session {
    */
   getTokenUsage(): TokenUsage {
     return { ...this._tokenUsage };
+  }
+
+  async extendLease(opts: { ttlMs: number }): Promise<void> {
+    if (this._state === 'deleted') {
+      throw new HarnessSessionDeletedError(this.id);
+    }
+    if (this._state !== 'live' && this._state !== 'closing') {
+      throw new HarnessSessionClosedError(this.id);
+    }
+    if (!Number.isFinite(opts.ttlMs) || !Number.isInteger(opts.ttlMs) || opts.ttlMs <= 0) {
+      throw new HarnessValidationError('extendLease().ttlMs', 'ttlMs must be a positive integer in milliseconds');
+    }
+    if (opts.ttlMs > MAX_LEASE_EXTENSION_MS) {
+      throw new HarnessValidationError(
+        'extendLease().ttlMs',
+        `ttlMs must be at most ${MAX_LEASE_EXTENSION_MS}ms (24h)`,
+      );
+    }
+
+    const defaultTtl = this._harness._internalLeaseTtlMs;
+    const run = async (): Promise<void> => {
+      if (this._state !== 'live' && this._state !== 'closing') {
+        throw this._state === 'deleted'
+          ? new HarnessSessionDeletedError(this.id)
+          : new HarnessSessionClosedError(this.id);
+      }
+      const remainingExtension =
+        this._leaseExtensionDeadline !== undefined && Number.isFinite(this._leaseExtensionDeadline)
+          ? this._leaseExtensionDeadline - Date.now()
+          : 0;
+      const effectiveTtl = Math.max(opts.ttlMs, defaultTtl, remainingExtension);
+      try {
+        const lease = await this._storage.renewSessionLease({
+          harnessName: this._record.harnessName,
+          sessionId: this.id,
+          ownerId: this._ownerId,
+          ttlMs: effectiveTtl,
+        });
+        this._markLeaseRenewed(lease.expiresAt);
+        this._leaseExtensionDeadline = lease.expiresAt;
+      } catch (err) {
+        if (err instanceof HarnessStorageLeaseConflictError) {
+          await this._harness._internalEvictLiveSessionLeaseLost(this);
+          throw new HarnessSessionLockedError(this.id, err.heldBy, err.expiresAt);
+        }
+        if (err instanceof HarnessStorageSessionNotFoundError) {
+          await this._harness._internalEvictLiveSessionLeaseLost(this);
+          throw new HarnessSessionNotFoundError(this.id);
+        }
+        throw err;
+      }
+    };
+    const next = this._leaseRenewalChain.then(run, run);
+    this._leaseRenewalChain = next.catch(() => {});
+    return next;
+  }
+
+  async withExtendedLease<T>(fn: () => Promise<T>, opts: { ttlMs: number }): Promise<T> {
+    await this.extendLease(opts);
+    return fn();
+  }
+
+  _getEffectiveLeaseTtlMs(defaultTtlMs: number): number {
+    const deadline = this._leaseExtensionDeadline;
+    if (deadline === undefined || !Number.isFinite(deadline)) return defaultTtlMs;
+    const remaining = deadline - Date.now();
+    return remaining > defaultTtlMs ? remaining : defaultTtlMs;
+  }
+
+  _enqueueLeaseRenewal(run: () => Promise<void>): Promise<void> {
+    const guardedRun = async () => {
+      if (this._state !== 'live' && this._state !== 'closing') return;
+      await run();
+    };
+    const next = this._leaseRenewalChain.then(guardedRun, guardedRun);
+    this._leaseRenewalChain = next.catch(() => {});
+    return next;
   }
 
   /**
@@ -9272,6 +9357,15 @@ export class Session {
       return Promise.reject(new HarnessSessionClosedError(this.id));
     }
     const run = async (): Promise<void> => {
+      const leaseExpiresAt = this._record.leaseExpiresAt;
+      if (
+        (this._state === 'live' || this._state === 'closing') &&
+        leaseExpiresAt !== undefined &&
+        leaseExpiresAt <= Date.now()
+      ) {
+        await this._harness._internalEvictLiveSessionLeaseLost(this);
+        throw new HarnessSessionLockedError(this.id, 'unknown', leaseExpiresAt);
+      }
       if (opts?.ifVersion !== undefined && this._record.version !== opts.ifVersion) {
         throw new HarnessStateConflictError(this.id, opts.ifVersion, this._record.version);
       }
@@ -9401,6 +9495,7 @@ export class Session {
         session._registerPlanApproval({ ...params, modeId: turn.modeId, modelId: turn.modelId }),
       registerSandboxAccess: params =>
         session._registerSandboxAccess({ ...params, modeId: turn.modeId, modelId: turn.modelId }),
+      extendLease: opts => session.extendLease(opts),
       // Subagent linkage — set from the record so spawned sessions report
       // their depth + parent linkage on the harness slot.
       subagentDepth: this._record.subagentDepth ?? 0,
@@ -9530,6 +9625,7 @@ export class Session {
    */
   _markClosed(updatedRecord: SessionRecord): void {
     this._clearQueueWakeTimer();
+    this._leaseExtensionDeadline = undefined;
     this._record = updatedRecord;
     this._state = 'closed';
     this._tearDownThreadSubscription(new HarnessValidationError('session.close()', 'Session closed'));
@@ -9539,6 +9635,7 @@ export class Session {
   /** @internal — used by Harness hard-delete after storage has removed the row. */
   _markDeleted(): void {
     const err = new HarnessSessionDeletedError(this.id);
+    this._leaseExtensionDeadline = undefined;
     this._state = 'deleted';
     this._rejectIdleWaiters(err);
     this._rejectActiveTurnWaiters(err);
@@ -9578,6 +9675,7 @@ export class Session {
    */
   _markEvicted(updatedRecord: SessionRecord): void {
     const err = new HarnessValidationError('session.evict()', 'Session evicted');
+    this._leaseExtensionDeadline = undefined;
     this._record = updatedRecord;
     this._state = 'evicted';
     this._tearDownThreadSubscription(err);

--- a/packages/core/src/harness/v1/types.ts
+++ b/packages/core/src/harness/v1/types.ts
@@ -1813,6 +1813,11 @@ export interface HarnessRequestContext<TState = unknown> {
   registerPlanApproval: (params: RegisterPlanApprovalParams) => Promise<void>;
   /** Register a pending sandbox-access approval. */
   registerSandboxAccess?: (params: RegisterSandboxAccessParams) => Promise<void>;
+  /**
+   * Extend the current session lease before work that may exceed the default
+   * lease TTL or block the event loop long enough for the heartbeat to miss.
+   */
+  extendLease?: (opts: { ttlMs: number }) => Promise<void>;
 
   /** Depth of the session in the subagent tree. `0` for the parent. */
   subagentDepth: number;


### PR DESCRIPTION
## Summary

- Adds Harness v1 live-session lease heartbeat renewal with per-session renewal guards.
- Adds `Session.extendLease()` / `Session.withExtendedLease()` and exposes `ctx.extendLease({ ttlMs })` through the Harness request context for long-running tools.
- Fails closed on lease loss by evicting local live sessions, mapping explicit extension conflicts to `HarnessSessionLockedError`, and blocking stale writes after the local lease deadline.
- Documents the lease recovery policy and adds focused lease extension, heartbeat, takeover, shutdown-recovery, and stale-write coverage.

## Evidence

- Base refreshed against `mbenhamd/mastra@c470aa902209088b106d2318f5bfe0062ba06198` immediately before commit.
- Compared official upstream PR #16912 lease primitives and adopted the relevant native Harness/session lease heartbeat shape instead of adding PapersFlow compatibility layers.
- Open PR overlap checked: only #194 (`feature/pf-746-sandbox-access`) is open and it touches adjacent Harness request-context/sandbox files but not the lease heartbeat implementation path. This PR can proceed independently; merge ordering should still re-run checks after either PR lands.

## Review

- Claude read-only review found a shutdown recovery blocker and lifecycle review items; addressed by restarting the heartbeat after failed shutdown restore, mapping explicit lease conflicts, allowing extension while closing, and making lease-loss eviction fail closed before emission.
- Codex correctness review found explicit `extendLease()` lease-loss eviction, canceled-session renewal, and global heartbeat guard risks; addressed in this diff.
- Codex tests/maintainability review found the same failed-shutdown heartbeat blocker, stale lifecycle docs, and stale-write window; addressed in this diff.
- Local CodeRabbit CLI `coderabbit review --agent --type uncommitted` connected and entered analysis but timed out after the 10-minute cap without findings. Please rely on the GitHub CodeRabbit app review for final PR evidence.

## Validation

- `pnpm exec prettier --check .changeset/pf-574-lease-heartbeat.md packages/core/src/harness/v1/contracts.ts packages/core/src/harness/v1/events.ts packages/core/src/harness/v1/harness.ts packages/core/src/harness/v1/session.ts packages/core/src/harness/v1/types.ts packages/core/src/harness/v1/session.test.ts packages/core/src/harness/v1/session.lease.test.ts` passed.
- `git diff --check` passed.
- `pnpm --filter ./packages/core exec vitest run src/harness/v1/session.lease.test.ts src/harness/v1/session.test.ts` did not execute tests: isolated worktree cannot resolve `packages/core/@internal/test-utils/setup`.
- `pnpm --filter @mastra/core check` is blocked by existing non-Harness package/type issues in `src/agent/**`, `src/test-utils/llm-mock.ts`, `src/tools/**`, and missing `@internal/external-types`; no `packages/core/src/harness/v1/**` diagnostics were emitted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds automatic "heartbeat" renewal for long-running Harness sessions so they don't time out. It lets tools request extra time when they need it (via `extendLease()`), and automatically evicts sessions if they lose ownership or become stale.

## Overview

Introduces Harness v1 live-session lease heartbeat renewal with per-session renewal guards and explicit lease extension APIs. The implementation includes:

- **Background lease renewal**: Maintains an in-process periodic renewal loop that automatically renews leases for sessions in `live`/`closing` state
- **Lease extension APIs**: Adds `Session.extendLease()` and `Session.withExtendedLease()` for explicit lease extension, plus `ctx.extendLease({ ttlMs })` on the Harness request context for tool-facing long-running work
- **Fail-closed behavior**: 
  - Evicts local live sessions when lease renewal fails
  - Maps explicit extension conflicts to `HarnessSessionLockedError`
  - Blocks stale writes after the local lease deadline expires
- **Lease recovery policy**: Documents the lease recovery behavior for interrupted live sessions via new `HarnessLeaseRecoveryPolicy` type
- **Session eviction tracking**: Expands `SessionEvictedEvent.reason` to include `'lease_lost'` as a new eviction cause

## Key Changes

**packages/core/src/harness/v1/contracts.ts**
- Added `HarnessLeaseRecoveryPolicy` type alias with comprehensive documentation on lease-recovery behavior

**packages/core/src/harness/v1/harness.ts** (+110 lines)
- Implemented lease renewal timer that starts when sessions are adopted into `_liveSessions`
- Added `_internalEvictLiveSessionLeaseLost()` method to handle lease loss eviction
- Exposed `_internalLeaseTtlMs` getter for session lease logic
- Integrated renewal loop cleanup during session teardown and shutdown recovery

**packages/core/src/harness/v1/session.ts** (+100 lines, -2 lines)
- Added `extendLease(opts: { ttlMs: number })` public method for explicit lease extension
- Added `withExtendedLease<T>(fn: () => Promise<T>, opts: { ttlMs: number })` helper method
- Introduced `MAX_LEASE_EXTENSION_MS` cap (24 hours) to prevent indefinite session pinning
- Added internal lease extension state tracking via `_leaseExtensionDeadline` and `_leaseRenewalChain`
- Updated `_flushUpdate` to detect and evict sessions with expired leases
- Clears lease extension deadline when sessions transition to terminal states
- Added new private methods `_getEffectiveLeaseTtlMs()` and `_enqueueLeaseRenewal()`

**packages/core/src/harness/v1/types.ts** (+5 lines)
- Added optional `extendLease?: (opts: { ttlMs: number }) => Promise<void>` to `HarnessRequestContext`

**packages/core/src/harness/v1/events.ts** (+1 line, -1 line)
- Updated `SessionEvictedEvent.reason` to include `'lease_lost'` eviction cause

**packages/core/src/harness/v1/session.lease.test.ts** (+281 lines)
- New comprehensive test suite covering:
  - Lease extension validation and deadline recording
  - Heartbeat renewal coordination with extended leases
  - Lifecycle edge cases (extensions after close, during drain)
  - Stale write detection and session eviction
  - Lease takeover contention across harness instances
  - Shutdown recovery and heartbeat restart

**packages/core/src/harness/v1/session.test.ts** (+2 lines)
- Updated surface-area test to include `extendLease` and `withExtendedLease` methods

**.changeset/pf-574-lease-heartbeat.md** (+7 lines)
- Changeset documenting the minor release with lease heartbeat recovery and extension APIs

## Testing & Validation

- Addressed issues from automated and code reviews: shutdown recovery, lifecycle items, explicit lease-loss eviction, canceled-session renewal, and global heartbeat guard risks
- Prettier and git diff checks passed
- Comprehensive test coverage added for lease extension, heartbeat renewal, takeover scenarios, shutdown-recovery, and stale-write detection
- Base refreshed against upstream; compared with related PR patterns but adopted Harness-specific lease heartbeat shape

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->