### PR TITLE
[PF-755] Include sandbox access in Harness server schemas

### DIFF
--- a/.changeset/flat-sandboxes-respond.md
+++ b/.changeset/flat-sandboxes-respond.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Include sandbox-access inbox items in Harness server schemas and route responses.

--- a/packages/server/src/server/handlers/harness.test.ts
+++ b/packages/server/src/server/handlers/harness.test.ts
@@ -2348,12 +2348,54 @@ describe('Harness server routes', () => {
     });
   });
 
+  it('responds to sandbox access requests with approval metadata', async () => {
+    const response = {
+      itemId: 'item-1',
+      kind: 'sandbox-access' as const,
+      status: 'accepted' as const,
+      responseId: 'response-1',
+      duplicate: false,
+    };
+    const session = {
+      respondToSandboxAccess: vi.fn(async () => response),
+    };
+    const harness = { session: vi.fn(async () => session) };
+    const mastra = { getHarness: vi.fn(() => harness) };
+
+    await expect(
+      RESPOND_HARNESS_INBOX_ROUTE.handler(
+        makeParams({
+          mastra,
+          name: 'query-code',
+          sessionId: 'query-session',
+          itemId: 'query-item',
+          requestPathParams: { name: 'code', sessionId: 'session-1', itemId: 'item-1' },
+          requestBody: {
+            kind: 'sandbox-access',
+            approved: false,
+            reason: 'Needs a narrower write path',
+            responseId: 'response-1',
+          },
+        }),
+      ),
+    ).resolves.toEqual(response);
+    expect(mastra.getHarness).toHaveBeenCalledWith('code');
+    expect(harness.session).toHaveBeenCalledWith({ sessionId: 'session-1', resourceId: 'resource-1' });
+    expect(session.respondToSandboxAccess).toHaveBeenCalledWith({
+      itemId: 'item-1',
+      responseId: 'response-1',
+      approved: false,
+      reason: 'Needs a narrower write path',
+    });
+  });
+
   it('rejects unsupported inbox response kinds from direct handler calls', async () => {
     const session = {
       respondToToolApproval: vi.fn(),
       respondToToolSuspension: vi.fn(),
       respondToQuestion: vi.fn(),
       respondToPlanApproval: vi.fn(),
+      respondToSandboxAccess: vi.fn(),
     };
     const harness = { session: vi.fn(async () => session) };
     const mastra = { getHarness: vi.fn(() => harness) };
@@ -2379,6 +2421,7 @@ describe('Harness server routes', () => {
     expect(session.respondToToolSuspension).not.toHaveBeenCalled();
     expect(session.respondToQuestion).not.toHaveBeenCalled();
     expect(session.respondToPlanApproval).not.toHaveBeenCalled();
+    expect(session.respondToSandboxAccess).not.toHaveBeenCalled();
   });
 
   it('maps inbox response conflicts to the wire error code', async () => {

--- a/packages/server/src/server/handlers/harness.ts
+++ b/packages/server/src/server/handlers/harness.ts
@@ -65,7 +65,7 @@ import { toHarnessDisplayStateSnapshotV1 } from './harness-display-state';
 import { enforceThreadAccess, getEffectiveResourceId } from './utils';
 
 type SessionLifecycleStatus = 'active' | 'closing' | 'closed';
-type PendingInboxKind = 'tool-approval' | 'tool-suspension' | 'question' | 'plan-approval';
+type PendingInboxKind = 'tool-approval' | 'tool-suspension' | 'question' | 'plan-approval' | 'sandbox-access';
 type PublicPendingResume = Omit<NonNullable<SessionRecord['pendingResume']>, 'runtimeDependencies'>;
 type ParsedHarnessEventId = { epoch: string; sequence: number };
 type UrlAttachmentInput = {
@@ -228,6 +228,12 @@ type HarnessLike = {
       approved: boolean;
       revision?: string;
       transitionToMode?: string;
+    }): Promise<InboxResponseResult>;
+    respondToSandboxAccess(opts: {
+      itemId: string;
+      responseId: string;
+      approved: boolean;
+      reason?: string;
     }): Promise<InboxResponseResult>;
     setGoal(opts: GoalOptions): Promise<GoalState>;
     getGoal(): GoalState | undefined;
@@ -2511,14 +2517,15 @@ export const RESPOND_HARNESS_INBOX_ROUTE = createRoute({
   harnessAuth: { clientRoute: true },
   onValidationError: harnessValidationErrorHook,
   summary: 'Respond to a Harness inbox item',
-  description: 'Applies a typed, idempotent response to a pending Harness approval, suspension, question, or plan.',
+  description:
+    'Applies a typed, idempotent response to a pending Harness approval, suspension, question, plan, or sandbox access request.',
   tags: ['Harness'],
   handler: async ({ mastra, requestContext, name, sessionId, itemId, requestBody, requestPathParams }) => {
     try {
       const { pathName, pathSessionId } = harnessSessionPathIdentity(requestPathParams, name, sessionId);
       const pathItemId = stringPathParam(requestPathParams, itemId, 'itemId');
       const body = objectRequestBody(requestBody, 'Inbox response') as {
-        kind: 'tool-approval' | 'tool-suspension' | 'question' | 'plan-approval';
+        kind: 'tool-approval' | 'tool-suspension' | 'question' | 'plan-approval' | 'sandbox-access';
         responseId: string;
         approved?: boolean;
         reason?: string;
@@ -2557,6 +2564,13 @@ export const RESPOND_HARNESS_INBOX_ROUTE = createRoute({
             approved: body.approved!,
             ...(body.revision !== undefined ? { revision: body.revision } : {}),
             ...(body.transitionToMode !== undefined ? { transitionToMode: body.transitionToMode } : {}),
+          });
+        case 'sandbox-access':
+          return await session.respondToSandboxAccess({
+            itemId: pathItemId,
+            responseId: body.responseId,
+            approved: body.approved!,
+            ...(body.reason !== undefined ? { reason: body.reason } : {}),
           });
         default: {
           const unsupportedKind: never = body.kind;

--- a/packages/server/src/server/schemas/harness.ts
+++ b/packages/server/src/server/schemas/harness.ts
@@ -73,7 +73,7 @@ const lifecycleSchema = z.enum(['active', 'closing', 'closed']);
 
 const pendingInboxSummarySchema = z.object({
   count: z.number(),
-  kinds: z.array(z.enum(['tool-approval', 'tool-suspension', 'question', 'plan-approval'])),
+  kinds: z.array(z.enum(['tool-approval', 'tool-suspension', 'question', 'plan-approval', 'sandbox-access'])),
   sessionOwnedOnly: z.literal(true),
 });
 
@@ -117,7 +117,7 @@ const harnessDisplayActiveSubagentSnapshotV1Schema = z.object({
 });
 
 const harnessDisplayPendingSnapshotV1Schema = z.object({
-  kind: z.enum(['tool-approval', 'tool-suspension', 'question', 'plan-approval']),
+  kind: z.enum(['tool-approval', 'tool-suspension', 'question', 'plan-approval', 'sandbox-access']),
   itemId: z.string().optional(),
   runId: z.string(),
   toolCallId: z.string(),
@@ -314,7 +314,7 @@ const channelActionTokenDiagnosticSchema = z
     resourceId: z.string(),
     owningSessionId: z.string(),
     itemId: z.string(),
-    kind: z.enum(['tool-approval', 'tool-suspension', 'question', 'plan-approval']),
+    kind: z.enum(['tool-approval', 'tool-suspension', 'question', 'plan-approval', 'sandbox-access']),
     runId: z.string(),
     pendingRequestedAt: z.number(),
     expiresAt: z.number().optional(),
@@ -338,7 +338,7 @@ const channelActionReceiptDiagnosticSchema = z
     resourceId: z.string(),
     owningSessionId: z.string(),
     itemId: z.string(),
-    kind: z.enum(['tool-approval', 'tool-suspension', 'question', 'plan-approval']),
+    kind: z.enum(['tool-approval', 'tool-suspension', 'question', 'plan-approval', 'sandbox-access']),
     runId: z.string(),
     pendingRequestedAt: z.number(),
     conflictReason: z.string().optional(),
@@ -626,11 +626,19 @@ export const harnessInboxResponseBodySchema = z.discriminatedUnion('kind', [
       transitionToMode: z.string().min(1).optional(),
     })
     .strict(),
+  z
+    .object({
+      kind: z.literal('sandbox-access'),
+      approved: z.boolean(),
+      reason: z.string().optional(),
+      responseId: z.string().min(1),
+    })
+    .strict(),
 ]);
 
 export const harnessInboxResponseResultSchema = z.object({
   itemId: z.string(),
-  kind: z.enum(['tool-approval', 'tool-suspension', 'question', 'plan-approval']),
+  kind: z.enum(['tool-approval', 'tool-suspension', 'question', 'plan-approval', 'sandbox-access']),
   status: z.enum(['accepted', 'applied']),
   responseId: z.string(),
   duplicate: z.boolean(),


### PR DESCRIPTION
## Summary
- Adds sandbox-access to Harness server pending inbox/schema unions.
- Routes sandbox-access inbox responses through Session.respondToSandboxAccess.
- Adds route coverage for sandbox-access inbox responses.

## Why
PapersFlow PF-755 artifact adoption for e097 is blocked because @mastra/server fails to build at e097 after core added sandbox-access pending resume support. The server schemas/handler types still only allowed tool-approval, tool-suspension, question, and plan-approval.

## Verification
- pnpm -C /tmp/mastra-e097-package-build --filter @mastra/server run build:lib
- pnpm -C /tmp/mastra-e097-package-build --filter @mastra/server test src/server/handlers/harness.test.ts

## PapersFlow
Unblocks papersflow-ai/papersflow PF-755 package artifact adoption after this fork commit is merged and artifacts are built from the new fork head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

This PR teaches a server framework to understand and handle "sandbox access" requests. Before this change, the server could only deal with certain types of approval requests (like "can I use this tool?" or "should I do this action?"). Now it also understands "can I access a sandbox?" requests and knows how to respond to them correctly. This was needed to fix a broken package that other projects depend on.

## Overview

This PR extends the Harness server framework to support sandbox-access inbox items, unblocking PapersFlow PF-755 artifact adoption. The server previously only handled tool-approval, tool-suspension, question, and plan-approval inbox response types, causing build failures when core added sandbox-access pending support.

## Changes

### Schema Updates (packages/server/src/server/schemas/harness.ts)

Extended Zod schemas to include `sandbox-access` as a valid inbox item kind:
- Updated `pendingInboxSummarySchema` and `harnessDisplayPendingSnapshotV1Schema` to allow `sandbox-access` in kind enums
- Extended `channelActionTokenDiagnosticSchema` and `channelActionReceiptDiagnosticSchema` to include `sandbox-access` in kind enums
- Added new discriminated-union variant to `harnessInboxResponseBodySchema` with `kind: 'sandbox-access'`, including `approved`, optional `reason`, and `responseId` fields
- Updated `harnessInboxResponseResultSchema` to include `sandbox-access` in the kind enum

### Handler Implementation (packages/server/src/server/handlers/harness.ts)

Added sandbox-access support to the request/response workflow:
- Extended `PendingInboxKind` type to include `sandbox-access`
- Added `respondToSandboxAccess` method to the `HarnessLike` session interface
- Enhanced `RESPOND_HARNESS_INBOX_ROUTE` handler to accept `sandbox-access` requests and route them through `session.respondToSandboxAccess` with `itemId`, `responseId`, `approved`, and optional `reason`
- Updated route description to list sandbox access as a supported approval type

### Test Coverage (packages/server/src/server/handlers/harness.test.ts)

Added comprehensive test coverage:
- New test verifying `RESPOND_HARNESS_INBOX_ROUTE` correctly processes `sandbox-access` responses by calling `session.respondToSandboxAccess` with expected parameters
- Updated existing unsupported inbox response test to include `respondToSandboxAccess` in session mocks and verify it's not called for unknown kinds

### Release Notes

Added changeset documenting the patch-level bump to `@mastra/server` with sandbox-access inbox item support.

## Impact

Unblocks papersflow-ai/papersflow PF-755 package artifact adoption by enabling `@mastra/server` to build successfully with core's sandbox-access pending resume support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->