### PR TITLE
[PF-758] Intake upstream files-sdk provider

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -138,6 +138,7 @@
     "@mastra/daytona": "0.4.0",
     "@mastra/docker": "0.2.0",
     "@mastra/e2b": "0.3.1",
+    "@mastra/files-sdk": "0.1.0",
     "@mastra/gcs": "0.2.1",
     "@mastra/google-drive": "0.1.0",
     "@mastra/modal": "0.2.0",

--- a/.changeset/rich-kind-gold.md
+++ b/.changeset/rich-kind-gold.md
@@ -1,0 +1,19 @@
+---
+'@mastra/files-sdk': minor
+---
+
+Added @mastra/files-sdk workspace filesystem provider — a unified storage adapter backed by [FilesSDK](https://files-sdk.dev). Supports any FilesSDK adapter (S3, R2, GCS, Azure Blob, Vercel Blob, local filesystem, and more) through a single `FilesSDKFilesystem` class that implements the `WorkspaceFilesystem` interface.
+
+**Usage**
+
+```ts
+import { Files } from 'files-sdk';
+import { s3 } from 'files-sdk/s3';
+import { FilesSDKFilesystem } from '@mastra/files-sdk';
+
+const files = new Files(s3({ bucket: 'my-bucket', region: 'us-east-1' }));
+
+const filesystem = new FilesSDKFilesystem({ files });
+```
+
+Swap adapters without changing code — just replace `s3()` with `r2()`, `gcs()`, `azure()`, `fs()`, etc.

--- a/.changeset/rich-kind-gold.md
+++ b/.changeset/rich-kind-gold.md
@@ -2,7 +2,7 @@
 '@mastra/files-sdk': minor
 ---
 
-Added @mastra/files-sdk workspace filesystem provider — a unified storage adapter backed by [FilesSDK](https://files-sdk.dev). Supports any FilesSDK adapter (S3, R2, GCS, Azure Blob, Vercel Blob, local filesystem, and more) through a single `FilesSDKFilesystem` class that implements the `WorkspaceFilesystem` interface.
+Added @mastra/files-sdk workspace filesystem provider — a unified storage adapter backed by [FilesSDK](https://files-sdk.dev). Supports any FilesSDK adapter (S3, R2, GCS, Azure Blob, Vercel Blob, local filesystem, and more) through a single `FilesSDKFilesystem` class.
 
 **Usage**
 
@@ -11,7 +11,9 @@ import { Files } from 'files-sdk';
 import { s3 } from 'files-sdk/s3';
 import { FilesSDKFilesystem } from '@mastra/files-sdk';
 
-const files = new Files(s3({ bucket: 'my-bucket', region: 'us-east-1' }));
+const files = new Files({
+  adapter: s3({ bucket: 'my-bucket', region: 'us-east-1' }),
+});
 
 const filesystem = new FilesSDKFilesystem({ files });
 ```

--- a/.changeset/rich-kind-gold.md
+++ b/.changeset/rich-kind-gold.md
@@ -2,7 +2,7 @@
 '@mastra/files-sdk': minor
 ---
 
-Added @mastra/files-sdk workspace filesystem provider — a unified storage adapter backed by [FilesSDK](https://files-sdk.dev). Supports any FilesSDK adapter (S3, R2, GCS, Azure Blob, Vercel Blob, local filesystem, and more) through a single `FilesSDKFilesystem` class.
+Connect your Mastra workspace to any storage backend — S3, R2, GCS, Azure Blob, Vercel Blob, local filesystem, and more — using a single unified interface. Swap storage providers without changing your workspace code through the new `@mastra/files-sdk` package and `FilesSDKFilesystem` class.
 
 **Usage**
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7655,6 +7655,40 @@ importers:
         specifier: 'catalog:'
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
 
+  workspaces/files-sdk:
+    dependencies:
+      files-sdk:
+        specifier: ^1.5.0
+        version: 1.5.0(@aws-sdk/client-s3@3.1045.0)(@azure/core-auth@1.10.1)(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@cfworker/json-schema@4.1.1)(@google-cloud/storage@7.19.0(encoding@0.1.13))(@supabase/storage-js@2.105.4)(ai@6.0.177(zod@4.4.3))(convex@1.38.0(bufferutil@4.1.0)(react@19.2.6))(google-auth-library@9.15.1(encoding@0.1.13))(openai@6.21.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.4.3))(zod@4.4.3)
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@internal/workspace-test-utils':
+        specifier: workspace:*
+        version: link:../_test-utils
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@types/node':
+        specifier: 22.19.15
+        version: 22.19.15
+      eslint:
+        specifier: ^10.2.1
+        version: 10.3.0(jiti@2.6.1)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(patch_hash=78092cc873f6c3c61ff4846b4b326faa7db54bb3c1506c510614d708601e2b7f)(@microsoft/api-extractor@7.58.7(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.21.0)(yaml@2.9.0))
+
   workspaces/gcs:
     dependencies:
       '@google-cloud/storage':
@@ -21647,6 +21681,99 @@ packages:
     resolution: {integrity: sha512-hw9gNZXUfZ02Jo0uafWLaFVPter5/k2rfcrjFJJHX/77xtSDOfJuEFb6oKlFV86FLP1SuyHMW1PSk0U9M5tKkQ==}
     engines: {node: '>=18'}
 
+  files-sdk@1.5.0:
+    resolution: {integrity: sha512-G+zNCMev8zgfbr8qYuxK3jvwkh1DnUJoJpnXbpsdQfw0nnrypH5HG7jOGJSOhqyesw0i/jJ32bW71yI4US9V9g==}
+    hasBin: true
+    peerDependencies:
+      '@anthropic-ai/claude-agent-sdk': ^0.2.0
+      '@aws-sdk/client-s3': ^3.700.0
+      '@aws-sdk/s3-presigned-post': ^3.700.0
+      '@aws-sdk/s3-request-presigner': ^3.700.0
+      '@azure/core-auth': ^1.9.0
+      '@azure/identity': ^4.5.0
+      '@azure/storage-blob': ^12.26.0
+      '@bunny.net/storage-sdk': ^0.3.1
+      '@google-cloud/storage': ^7.19.0
+      '@googleapis/drive': ^14.0.0
+      '@microsoft/microsoft-graph-client': ^3.0.7
+      '@netlify/blobs': ^10.7.4
+      '@openai/agents': ^0.11.0
+      '@supabase/storage-js': ^2.105.4
+      '@vercel/blob': ^2.4.0
+      ai: ^6.0.0
+      basic-ftp: ^6.0.1
+      box-typescript-sdk-gen: ^1.19.1
+      cloudinary: ^2.10.0
+      convex: ^1.16.0
+      dropbox: ^10.34.0
+      firebase-admin: ^13.10.0
+      google-auth-library: ^9.15.1
+      node-appwrite: ^24.1.0
+      openai: ^6.0.0
+      pocketbase: ^0.26.9
+      ssh2-sftp-client: ^12.1.1
+      uploadthing: ^7
+      zod: ^3.23.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@anthropic-ai/claude-agent-sdk':
+        optional: true
+      '@aws-sdk/client-s3':
+        optional: true
+      '@aws-sdk/s3-presigned-post':
+        optional: true
+      '@aws-sdk/s3-request-presigner':
+        optional: true
+      '@azure/core-auth':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@bunny.net/storage-sdk':
+        optional: true
+      '@google-cloud/storage':
+        optional: true
+      '@googleapis/drive':
+        optional: true
+      '@microsoft/microsoft-graph-client':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@openai/agents':
+        optional: true
+      '@supabase/storage-js':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      ai:
+        optional: true
+      basic-ftp:
+        optional: true
+      box-typescript-sdk-gen:
+        optional: true
+      cloudinary:
+        optional: true
+      convex:
+        optional: true
+      dropbox:
+        optional: true
+      firebase-admin:
+        optional: true
+      google-auth-library:
+        optional: true
+      node-appwrite:
+        optional: true
+      openai:
+        optional: true
+      pocketbase:
+        optional: true
+      ssh2-sftp-client:
+        optional: true
+      uploadthing:
+        optional: true
+      zod:
+        optional: true
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -29151,6 +29278,14 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.3.6
 
+  '@ai-sdk/gateway@3.0.112(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+    optional: true
+
   '@ai-sdk/google-vertex@3.0.137(zod@4.3.6)':
     dependencies:
       '@ai-sdk/anthropic': 2.0.79(zod@4.3.6)
@@ -29358,6 +29493,14 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.8
       zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.4.3
+    optional: true
 
   '@ai-sdk/provider@1.0.9':
     dependencies:
@@ -36062,6 +36205,31 @@ snapshots:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
       - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.18)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.5.1(express@5.2.1)
+      hono: 4.12.18
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.0
+      raw-body: 3.0.1
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@module-federation/error-codes@0.22.0': {}
 
@@ -43997,6 +44165,15 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 4.3.6
 
+  ai@6.0.177(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.112(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.4.3
+    optional: true
+
   ajv-draft-04@1.0.0(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -47076,6 +47253,26 @@ snapshots:
       token-types: 6.1.2
       uint8array-extras: 1.5.0
     transitivePeerDependencies:
+      - supports-color
+
+  files-sdk@1.5.0(@aws-sdk/client-s3@3.1045.0)(@azure/core-auth@1.10.1)(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@cfworker/json-schema@4.1.1)(@google-cloud/storage@7.19.0(encoding@0.1.13))(@supabase/storage-js@2.105.4)(ai@6.0.177(zod@4.4.3))(convex@1.38.0(bufferutil@4.1.0)(react@19.2.6))(google-auth-library@9.15.1(encoding@0.1.13))(openai@6.21.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.4.3))(zod@4.4.3):
+    dependencies:
+      commander: 12.1.0
+    optionalDependencies:
+      '@aws-sdk/client-s3': 3.1045.0
+      '@azure/core-auth': 1.10.1
+      '@azure/identity': 4.13.0
+      '@azure/storage-blob': 12.31.0
+      '@google-cloud/storage': 7.19.0(encoding@0.1.13)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      '@supabase/storage-js': 2.105.4
+      ai: 6.0.177(zod@4.4.3)
+      convex: 1.38.0(bufferutil@4.1.0)(react@19.2.6)
+      google-auth-library: 9.15.1(encoding@0.1.13)
+      openai: 6.21.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.4.3)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
       - supports-color
 
   fill-range@7.1.1:
@@ -50905,6 +51102,12 @@ snapshots:
     optionalDependencies:
       ws: 8.20.0(bufferutil@4.1.0)
       zod: 4.3.6
+    optional: true
+
+  openai@6.21.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.20.0(bufferutil@4.1.0)
+      zod: 4.4.3
     optional: true
 
   openapi-fetch@0.14.1:
@@ -56557,6 +56760,11 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+
+  zod-to-json-schema@3.25.1(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+    optional: true
 
   zod-to-ts@2.0.0(typescript@6.0.3)(zod@4.3.6):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7658,8 +7658,8 @@ importers:
   workspaces/files-sdk:
     dependencies:
       files-sdk:
-        specifier: ^1.5.0
-        version: 1.5.0(@aws-sdk/client-s3@3.1045.0)(@azure/core-auth@1.10.1)(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@cfworker/json-schema@4.1.1)(@google-cloud/storage@7.19.0(encoding@0.1.13))(@supabase/storage-js@2.105.4)(ai@6.0.177(zod@4.4.3))(convex@1.38.0(bufferutil@4.1.0)(react@19.2.6))(google-auth-library@9.15.1(encoding@0.1.13))(openai@6.21.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.4.3))(zod@4.4.3)
+        specifier: ^1.6.0
+        version: 1.6.0(@aws-sdk/client-s3@3.1045.0)(@aws-sdk/lib-storage@3.997.0(@aws-sdk/client-s3@3.1045.0))(@azure/core-auth@1.10.1)(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@cfworker/json-schema@4.1.1)(@google-cloud/storage@7.19.0(encoding@0.1.13))(@supabase/storage-js@2.105.4)(ai@6.0.177(zod@4.4.3))(convex@1.38.0(bufferutil@4.1.0)(react@19.2.6))(google-auth-library@10.6.2)(openai@6.21.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.4.3))(zod@4.4.3)
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -21681,12 +21681,13 @@ packages:
     resolution: {integrity: sha512-hw9gNZXUfZ02Jo0uafWLaFVPter5/k2rfcrjFJJHX/77xtSDOfJuEFb6oKlFV86FLP1SuyHMW1PSk0U9M5tKkQ==}
     engines: {node: '>=18'}
 
-  files-sdk@1.5.0:
-    resolution: {integrity: sha512-G+zNCMev8zgfbr8qYuxK3jvwkh1DnUJoJpnXbpsdQfw0nnrypH5HG7jOGJSOhqyesw0i/jJ32bW71yI4US9V9g==}
+  files-sdk@1.6.0:
+    resolution: {integrity: sha512-EctRY0aaDY1YVG/LgT8JMWjM5OvqrvbXjx2EL7aiK9VXNPgOi2sSDOqTmcIVXjUwe3+dJt2XHf9QPSisb+YqkA==}
     hasBin: true
     peerDependencies:
-      '@anthropic-ai/claude-agent-sdk': ^0.2.0
+      '@anthropic-ai/claude-agent-sdk': ^0.3.0
       '@aws-sdk/client-s3': ^3.700.0
+      '@aws-sdk/lib-storage': ^3.700.0
       '@aws-sdk/s3-presigned-post': ^3.700.0
       '@aws-sdk/s3-request-presigner': ^3.700.0
       '@azure/core-auth': ^1.9.0
@@ -21694,7 +21695,7 @@ packages:
       '@azure/storage-blob': ^12.26.0
       '@bunny.net/storage-sdk': ^0.3.1
       '@google-cloud/storage': ^7.19.0
-      '@googleapis/drive': ^14.0.0
+      '@googleapis/drive': ^20.0.0
       '@microsoft/microsoft-graph-client': ^3.0.7
       '@netlify/blobs': ^10.7.4
       '@openai/agents': ^0.11.0
@@ -21707,10 +21708,10 @@ packages:
       convex: ^1.16.0
       dropbox: ^10.34.0
       firebase-admin: ^13.10.0
-      google-auth-library: ^9.15.1
-      node-appwrite: ^24.1.0
+      google-auth-library: ^10.0.0
+      node-appwrite: ^25.0.0
       openai: ^6.0.0
-      pocketbase: ^0.26.9
+      pocketbase: ^0.27.0
       ssh2-sftp-client: ^12.1.1
       uploadthing: ^7
       zod: ^3.23.0 || ^4.0.0
@@ -21718,6 +21719,8 @@ packages:
       '@anthropic-ai/claude-agent-sdk':
         optional: true
       '@aws-sdk/client-s3':
+        optional: true
+      '@aws-sdk/lib-storage':
         optional: true
       '@aws-sdk/s3-presigned-post':
         optional: true
@@ -30682,6 +30685,18 @@ snapshots:
       events: 3.3.0
       stream-browserify: 3.0.0
       tslib: 2.8.1
+
+  '@aws-sdk/lib-storage@3.997.0(@aws-sdk/client-s3@3.1045.0)':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1045.0
+      '@smithy/abort-controller': 4.2.11
+      '@smithy/middleware-endpoint': 4.4.23
+      '@smithy/smithy-client': 4.12.3
+      buffer: 5.6.0
+      events: 3.3.0
+      stream-browserify: 3.0.0
+      tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.10':
     dependencies:
@@ -47255,11 +47270,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  files-sdk@1.5.0(@aws-sdk/client-s3@3.1045.0)(@azure/core-auth@1.10.1)(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@cfworker/json-schema@4.1.1)(@google-cloud/storage@7.19.0(encoding@0.1.13))(@supabase/storage-js@2.105.4)(ai@6.0.177(zod@4.4.3))(convex@1.38.0(bufferutil@4.1.0)(react@19.2.6))(google-auth-library@9.15.1(encoding@0.1.13))(openai@6.21.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.4.3))(zod@4.4.3):
+  files-sdk@1.6.0(@aws-sdk/client-s3@3.1045.0)(@aws-sdk/lib-storage@3.997.0(@aws-sdk/client-s3@3.1045.0))(@azure/core-auth@1.10.1)(@azure/identity@4.13.0)(@azure/storage-blob@12.31.0)(@cfworker/json-schema@4.1.1)(@google-cloud/storage@7.19.0(encoding@0.1.13))(@supabase/storage-js@2.105.4)(ai@6.0.177(zod@4.4.3))(convex@1.38.0(bufferutil@4.1.0)(react@19.2.6))(google-auth-library@10.6.2)(openai@6.21.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.4.3))(zod@4.4.3):
     dependencies:
-      commander: 12.1.0
+      commander: 14.0.3
     optionalDependencies:
       '@aws-sdk/client-s3': 3.1045.0
+      '@aws-sdk/lib-storage': 3.997.0(@aws-sdk/client-s3@3.1045.0)
       '@azure/core-auth': 1.10.1
       '@azure/identity': 4.13.0
       '@azure/storage-blob': 12.31.0
@@ -47268,7 +47284,7 @@ snapshots:
       '@supabase/storage-js': 2.105.4
       ai: 6.0.177(zod@4.4.3)
       convex: 1.38.0(bufferutil@4.1.0)(react@19.2.6)
-      google-auth-library: 9.15.1(encoding@0.1.13)
+      google-auth-library: 10.6.2
       openai: 6.21.0(ws@8.20.0(bufferutil@4.1.0))(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:

--- a/workspaces/files-sdk/CHANGELOG.md
+++ b/workspaces/files-sdk/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @mastra/files-sdk

--- a/workspaces/files-sdk/README.md
+++ b/workspaces/files-sdk/README.md
@@ -1,0 +1,107 @@
+# @mastra/files-sdk
+
+Unified storage filesystem provider for Mastra workspaces, powered by [FilesSDK](https://files-sdk.dev). Works with any FilesSDK adapter — S3, Cloudflare R2, Google Cloud Storage, Azure Blob, Vercel Blob, local filesystem, and more.
+
+## Installation
+
+```bash
+npm install @mastra/files-sdk files-sdk
+```
+
+Then install the FilesSDK adapter for your storage backend:
+
+```bash
+# AWS S3 / R2 / MinIO / DigitalOcean Spaces
+npm install @aws-sdk/client-s3 @aws-sdk/s3-presigned-post @aws-sdk/s3-request-presigner
+
+# Google Cloud Storage
+npm install @google-cloud/storage google-auth-library
+
+# Azure Blob Storage
+npm install @azure/storage-blob @azure/core-auth @azure/identity
+
+# Vercel Blob
+npm install @vercel/blob
+
+# Local filesystem (dev/test)
+# No extra dependencies needed
+```
+
+## Usage
+
+```typescript
+import { Agent } from '@mastra/core/agent';
+import { Workspace } from '@mastra/core/workspace';
+import { FilesSDKFilesystem } from '@mastra/files-sdk';
+import { Files } from 'files-sdk';
+import { s3 } from 'files-sdk/s3';
+
+const files = new Files({
+  adapter: s3({
+    bucket: 'my-bucket',
+    region: 'us-east-1',
+  }),
+});
+
+const workspace = new Workspace({
+  filesystem: new FilesSDKFilesystem({ files }),
+});
+
+const agent = new Agent({
+  name: 'my-agent',
+  model: 'anthropic/claude-opus-4-5',
+  workspace,
+});
+```
+
+### Switching adapters
+
+The power of FilesSDK is that you can swap storage backends by changing only the adapter import:
+
+```typescript
+import { Files } from 'files-sdk';
+import { r2 } from 'files-sdk/r2';
+
+const files = new Files({
+  adapter: r2({
+    accountId: process.env.R2_ACCOUNT_ID!,
+    accessKeyId: process.env.R2_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
+    bucket: 'my-bucket',
+  }),
+});
+
+const workspace = new Workspace({
+  filesystem: new FilesSDKFilesystem({ files }),
+});
+```
+
+### Local filesystem for development
+
+```typescript
+import { Files } from 'files-sdk';
+import { fs } from 'files-sdk/fs';
+
+const files = new Files({
+  adapter: fs({ root: './.uploads' }),
+});
+
+const workspace = new Workspace({
+  filesystem: new FilesSDKFilesystem({ files }),
+});
+```
+
+## Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `files` | `Files` | Yes | Pre-configured FilesSDK instance |
+| `id` | `string` | No | Unique filesystem ID (auto-generated) |
+| `displayName` | `string` | No | Human-friendly name for UI |
+| `icon` | `string` | No | Icon identifier |
+| `description` | `string` | No | Description for UI |
+| `readOnly` | `boolean` | No | Mount as read-only |
+
+## License
+
+Apache-2.0

--- a/workspaces/files-sdk/README.md
+++ b/workspaces/files-sdk/README.md
@@ -49,7 +49,7 @@ const workspace = new Workspace({
 
 const agent = new Agent({
   name: 'my-agent',
-  model: '__GATEWAY_ANTHROPIC_MODEL_OPUS__',
+  model: 'YOUR_MODEL_NAME',
   workspace,
 });
 ```

--- a/workspaces/files-sdk/README.md
+++ b/workspaces/files-sdk/README.md
@@ -49,7 +49,7 @@ const workspace = new Workspace({
 
 const agent = new Agent({
   name: 'my-agent',
-  model: 'anthropic/claude-opus-4-5',
+  model: '__GATEWAY_ANTHROPIC_MODEL_OPUS__',
   workspace,
 });
 ```
@@ -93,14 +93,14 @@ const workspace = new Workspace({
 
 ## Options
 
-| Option | Type | Required | Description |
-|--------|------|----------|-------------|
-| `files` | `Files` | Yes | Pre-configured FilesSDK instance |
-| `id` | `string` | No | Unique filesystem ID (auto-generated) |
-| `displayName` | `string` | No | Human-friendly name for UI |
-| `icon` | `string` | No | Icon identifier |
-| `description` | `string` | No | Description for UI |
-| `readOnly` | `boolean` | No | Mount as read-only |
+| Option        | Type      | Required | Description                           |
+| ------------- | --------- | -------- | ------------------------------------- |
+| `files`       | `Files`   | Yes      | Pre-configured FilesSDK instance      |
+| `id`          | `string`  | No       | Unique filesystem ID (auto-generated) |
+| `displayName` | `string`  | No       | Human-friendly name for UI            |
+| `icon`        | `string`  | No       | Icon identifier                       |
+| `description` | `string`  | No       | Description for UI                    |
+| `readOnly`    | `boolean` | No       | Mount as read-only                    |
 
 ## License
 

--- a/workspaces/files-sdk/eslint.config.js
+++ b/workspaces/files-sdk/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default config;

--- a/workspaces/files-sdk/package.json
+++ b/workspaces/files-sdk/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@mastra/files-sdk",
+  "version": "0.1.0",
+  "description": "FilesSDK filesystem provider for Mastra workspaces — unified storage across S3, R2, GCS, Azure, Vercel Blob, and more",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsup --silent --config tsup.config.ts",
+    "build:lib": "pnpm build",
+    "build:watch": "pnpm build --watch",
+    "test:unit": "vitest run",
+    "test:watch": "vitest watch",
+    "lint": "eslint ."
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "files-sdk": "^1.5.0"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@internal/workspace-test-utils": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "@types/node": "22.19.15",
+    "eslint": "^10.2.1",
+    "tsup": "^8.5.1",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.4.0-0 <2.0.0-0"
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "workspaces/files-sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/workspaces/files-sdk/package.json
+++ b/workspaces/files-sdk/package.json
@@ -28,7 +28,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "files-sdk": "^1.5.0"
+    "files-sdk": "^1.6.0"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",

--- a/workspaces/files-sdk/src/filesystem/index.test.ts
+++ b/workspaces/files-sdk/src/filesystem/index.test.ts
@@ -1,0 +1,680 @@
+/**
+ * FilesSDK Filesystem Provider Tests
+ *
+ * Tests FilesSDK-specific functionality including:
+ * - Constructor options and ID generation
+ * - File operations (read, write, append, delete, copy, move)
+ * - Directory operations (mkdir, readdir, rmdir)
+ * - Path operations (exists, stat)
+ * - Read-only mode
+ * - getInfo() / getInstructions()
+ *
+ * All tests mock the FilesSDK Files instance.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { FilesSDKFilesystem } from './index';
+import type { FilesSDKFilesystemOptions } from './index';
+
+// ---------------------------------------------------------------------------
+// Mock helpers — create a fake Files instance
+// ---------------------------------------------------------------------------
+
+function createMockStoredFile(key: string, data: Uint8Array | string, meta?: Record<string, unknown>) {
+  const buf = typeof data === 'string' ? new TextEncoder().encode(data) : data;
+  return {
+    key,
+    name: key.split('/').pop() ?? key,
+    size: buf.byteLength,
+    type: 'application/octet-stream',
+    lastModified: new Date('2025-06-01T00:00:00Z'),
+    etag: 'mock-etag',
+    metadata: meta ?? {},
+    arrayBuffer: vi.fn().mockResolvedValue(buf.buffer),
+    text: vi.fn().mockResolvedValue(typeof data === 'string' ? data : new TextDecoder().decode(buf)),
+    stream: vi.fn(),
+    blob: vi.fn(),
+  };
+}
+
+function createMockFiles() {
+  return {
+    upload: vi.fn().mockResolvedValue({ key: 'test', size: 0, contentType: 'application/octet-stream' }),
+    download: vi.fn(),
+    head: vi.fn(),
+    exists: vi.fn().mockResolvedValue(false),
+    delete: vi.fn().mockResolvedValue(undefined),
+    copy: vi.fn().mockResolvedValue(undefined),
+    move: vi.fn().mockResolvedValue(undefined),
+    list: vi.fn().mockResolvedValue({ items: [], cursor: undefined }),
+    url: vi.fn(),
+    signedUploadUrl: vi.fn(),
+    file: vi.fn(),
+    adapter: { name: 'mock' },
+  };
+}
+
+function createFs(overrides: Partial<FilesSDKFilesystemOptions> = {}) {
+  const mockFiles = createMockFiles();
+  const fs = new FilesSDKFilesystem({
+    files: mockFiles as any,
+    ...overrides,
+  });
+  // Skip lifecycle init — set status to ready directly
+  (fs as any).status = 'ready';
+  return { fs, mockFiles };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('FilesSDKFilesystem', () => {
+  describe('Constructor & Options', () => {
+    it('generates unique id if not provided', () => {
+      const { fs: fs1 } = createFs();
+      const { fs: fs2 } = createFs();
+
+      expect(fs1.id).toMatch(/^files-sdk-/);
+      expect(fs2.id).toMatch(/^files-sdk-/);
+      expect(fs1.id).not.toBe(fs2.id);
+    });
+
+    it('uses provided id', () => {
+      const { fs } = createFs({ id: 'my-custom-id' });
+
+      expect(fs.id).toBe('my-custom-id');
+    });
+
+    it('sets readOnly from options', () => {
+      const { fs: fsReadOnly } = createFs({ readOnly: true });
+      const { fs: fsWritable } = createFs({ readOnly: false });
+      const { fs: fsDefault } = createFs();
+
+      expect(fsReadOnly.readOnly).toBe(true);
+      expect(fsWritable.readOnly).toBe(false);
+      expect(fsDefault.readOnly).toBeUndefined();
+    });
+
+    it('has correct provider and name', () => {
+      const { fs } = createFs();
+
+      expect(fs.provider).toBe('files-sdk');
+      expect(fs.name).toBe('FilesSDKFilesystem');
+    });
+
+    it('status starts as pending before init', () => {
+      const mockFiles = createMockFiles();
+      const fs = new FilesSDKFilesystem({ files: mockFiles as any });
+
+      expect(fs.status).toBe('pending');
+    });
+
+    it('sets displayName, icon, description from options', () => {
+      const { fs } = createFs({
+        displayName: 'My Storage',
+        icon: 's3',
+        description: 'Test description',
+      });
+
+      expect(fs.displayName).toBe('My Storage');
+      expect(fs.icon).toBe('s3');
+      expect(fs.description).toBe('Test description');
+    });
+
+    it('exposes the underlying Files instance', () => {
+      const mockFiles = createMockFiles();
+      const fs = new FilesSDKFilesystem({ files: mockFiles as any });
+
+      expect(fs.files).toBe(mockFiles);
+    });
+  });
+
+  describe('readFile()', () => {
+    it('returns Buffer by default', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.download.mockResolvedValueOnce(createMockStoredFile('test.txt', 'hello'));
+
+      const result = await fs.readFile('/test.txt');
+
+      expect(Buffer.isBuffer(result)).toBe(true);
+      expect(result.toString()).toBe('hello');
+    });
+
+    it('returns string when encoding specified', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.download.mockResolvedValueOnce(createMockStoredFile('test.txt', 'hi'));
+
+      const result = await fs.readFile('/test.txt', { encoding: 'utf-8' });
+
+      expect(typeof result).toBe('string');
+      expect(result).toBe('hi');
+    });
+
+    it('passes normalized key to download()', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.download.mockResolvedValueOnce(createMockStoredFile('test.txt', 'data'));
+
+      await fs.readFile('/test.txt');
+
+      expect(mockFiles.download).toHaveBeenCalledWith('test.txt');
+    });
+
+    it('throws FileNotFoundError on NotFound', async () => {
+      const { fs, mockFiles } = createFs();
+      const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
+      mockFiles.download.mockRejectedValueOnce(error);
+
+      await expect(fs.readFile('/missing.txt')).rejects.toThrow(/missing\.txt/);
+    });
+
+    it('re-throws non-NotFound errors', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.download.mockRejectedValueOnce(new Error('NetworkError'));
+
+      await expect(fs.readFile('/test.txt')).rejects.toThrow('NetworkError');
+    });
+  });
+
+  describe('writeFile()', () => {
+    it('calls upload with string content', async () => {
+      const { fs, mockFiles } = createFs();
+
+      await fs.writeFile('/test.txt', 'hello world');
+
+      expect(mockFiles.upload).toHaveBeenCalledWith('test.txt', expect.anything(), expect.objectContaining({ contentType: 'text/plain' }));
+    });
+
+    it('calls upload with Buffer content', async () => {
+      const { fs, mockFiles } = createFs();
+
+      await fs.writeFile('/data.bin', Buffer.from([1, 2, 3]));
+
+      expect(mockFiles.upload).toHaveBeenCalledWith('data.bin', expect.any(Uint8Array), expect.objectContaining({ contentType: 'application/octet-stream' }));
+    });
+
+    it('detects MIME type from extension', async () => {
+      const { fs, mockFiles } = createFs();
+
+      await fs.writeFile('/page.html', '<html>');
+      expect(mockFiles.upload).toHaveBeenCalledWith('page.html', expect.anything(), expect.objectContaining({ contentType: 'text/html' }));
+
+      mockFiles.upload.mockClear();
+      await fs.writeFile('/data.json', '{}');
+      expect(mockFiles.upload).toHaveBeenCalledWith('data.json', expect.anything(), expect.objectContaining({ contentType: 'application/json' }));
+    });
+
+    it('respects mimeType option override', async () => {
+      const { fs, mockFiles } = createFs();
+
+      await fs.writeFile('/file.txt', 'data', { mimeType: 'text/csv' });
+
+      expect(mockFiles.upload).toHaveBeenCalledWith('file.txt', expect.anything(), expect.objectContaining({ contentType: 'text/csv' }));
+    });
+
+    it('checks overwrite=false and throws FileExistsError', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.exists.mockResolvedValueOnce(true);
+
+      await expect(fs.writeFile('/existing.txt', 'data', { overwrite: false })).rejects.toThrow(/existing\.txt/);
+    });
+
+    it('allows write when overwrite=false and file does not exist', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.exists.mockResolvedValueOnce(false);
+
+      await fs.writeFile('/new.txt', 'data', { overwrite: false });
+
+      expect(mockFiles.upload).toHaveBeenCalled();
+    });
+  });
+
+  describe('appendFile()', () => {
+    it('reads existing then writes concatenated content', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.download.mockResolvedValueOnce(createMockStoredFile('test.txt', 'hello '));
+
+      await fs.appendFile('/test.txt', 'world');
+
+      expect(mockFiles.download).toHaveBeenCalledWith('test.txt');
+      expect(mockFiles.upload).toHaveBeenCalledTimes(1);
+      // Verify the concatenated content
+      const uploadCall = mockFiles.upload.mock.calls[0]!;
+      const written = Buffer.from(uploadCall[1] as Uint8Array);
+      expect(written.toString()).toBe('hello world');
+    });
+
+    it('creates file if it does not exist', async () => {
+      const { fs, mockFiles } = createFs();
+      const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
+      mockFiles.download.mockRejectedValueOnce(error);
+
+      await fs.appendFile('/new.txt', 'content');
+
+      expect(mockFiles.upload).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('deleteFile()', () => {
+    it('calls delete for files', async () => {
+      const { fs, mockFiles } = createFs();
+      // isDirectory check returns empty (not a directory)
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+
+      await fs.deleteFile('/test.txt');
+
+      expect(mockFiles.delete).toHaveBeenCalledWith('test.txt');
+    });
+
+    it('delegates to rmdir for directories', async () => {
+      const { fs, mockFiles } = createFs();
+      // isDirectory check returns items (is a directory)
+      mockFiles.list
+        .mockResolvedValueOnce({ items: [{ key: 'dir/file.txt' }], cursor: undefined })
+        // rmdir lists all keys
+        .mockResolvedValueOnce({ items: [{ key: 'dir/file.txt' }], cursor: undefined });
+
+      await fs.deleteFile('/dir', { recursive: true });
+
+      // Should have called delete with array of keys (batch)
+      expect(mockFiles.delete).toHaveBeenCalledWith(['dir/file.txt']);
+    });
+
+    it('swallows errors with force=true', async () => {
+      const { fs, mockFiles } = createFs();
+      // isDirectory check
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+      // delete throws
+      mockFiles.delete.mockRejectedValueOnce(new Error('fail'));
+
+      // Should not throw
+      await fs.deleteFile('/gone.txt', { force: true });
+    });
+  });
+
+  describe('copyFile()', () => {
+    it('calls copy with normalized keys', async () => {
+      const { fs, mockFiles } = createFs();
+
+      await fs.copyFile('/src.txt', '/dest.txt');
+
+      expect(mockFiles.copy).toHaveBeenCalledWith('src.txt', 'dest.txt');
+    });
+
+    it('throws FileNotFoundError on NotFound', async () => {
+      const { fs, mockFiles } = createFs();
+      const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
+      mockFiles.copy.mockRejectedValueOnce(error);
+
+      await expect(fs.copyFile('/missing.txt', '/dest.txt')).rejects.toThrow(/missing\.txt/);
+    });
+  });
+
+  describe('moveFile()', () => {
+    it('copies then deletes source', async () => {
+      const { fs, mockFiles } = createFs();
+
+      await fs.moveFile('/src.txt', '/dest.txt');
+
+      expect(mockFiles.copy).toHaveBeenCalledWith('src.txt', 'dest.txt');
+      expect(mockFiles.delete).toHaveBeenCalledWith('src.txt');
+    });
+
+    it('throws FileNotFoundError on NotFound', async () => {
+      const { fs, mockFiles } = createFs();
+      const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
+      mockFiles.copy.mockRejectedValueOnce(error);
+
+      await expect(fs.moveFile('/missing.txt', '/dest.txt')).rejects.toThrow(/missing\.txt/);
+    });
+  });
+
+  describe('mkdir()', () => {
+    it('is a no-op (object storage)', async () => {
+      const { fs, mockFiles } = createFs();
+
+      await fs.mkdir('/newdir');
+
+      // Should not call any file operations
+      expect(mockFiles.upload).not.toHaveBeenCalled();
+      expect(mockFiles.list).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('readdir()', () => {
+    it('returns file entries from list()', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.list.mockResolvedValueOnce({
+        items: [
+          { key: 'dir/file1.txt', size: 100, type: 'text/plain' },
+          { key: 'dir/file2.json', size: 200, type: 'application/json' },
+        ],
+        cursor: undefined,
+      });
+
+      const entries = await fs.readdir('/dir');
+
+      expect(entries).toEqual([
+        { name: 'file1.txt', type: 'file', size: 100 },
+        { name: 'file2.json', type: 'file', size: 200 },
+      ]);
+    });
+
+    it('synthesizes directory entries for nested keys', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.list.mockResolvedValueOnce({
+        items: [
+          { key: 'root/subdir/file.txt', size: 50, type: 'text/plain' },
+          { key: 'root/subdir/other.txt', size: 60, type: 'text/plain' },
+          { key: 'root/top.txt', size: 10, type: 'text/plain' },
+        ],
+        cursor: undefined,
+      });
+
+      const entries = await fs.readdir('/root');
+
+      // Should have one directory entry (subdir) and one file entry (top.txt)
+      expect(entries).toEqual([
+        { name: 'subdir', type: 'directory' },
+        { name: 'top.txt', type: 'file', size: 10 },
+      ]);
+    });
+
+    it('deduplicates directory entries', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.list.mockResolvedValueOnce({
+        items: [
+          { key: 'root/sub/a.txt', size: 1 },
+          { key: 'root/sub/b.txt', size: 2 },
+        ],
+        cursor: undefined,
+      });
+
+      const entries = await fs.readdir('/root');
+      const dirs = entries.filter(e => e.type === 'directory');
+
+      expect(dirs).toHaveLength(1);
+      expect(dirs[0]!.name).toBe('sub');
+    });
+
+    it('filters by extension', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.list.mockResolvedValueOnce({
+        items: [
+          { key: 'dir/a.txt', size: 1 },
+          { key: 'dir/b.json', size: 2 },
+          { key: 'dir/c.txt', size: 3 },
+        ],
+        cursor: undefined,
+      });
+
+      const entries = await fs.readdir('/dir', { extension: '.txt' });
+
+      expect(entries).toEqual([
+        { name: 'a.txt', type: 'file', size: 1 },
+        { name: 'c.txt', type: 'file', size: 3 },
+      ]);
+    });
+
+    it('paginates across multiple pages', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.list
+        .mockResolvedValueOnce({
+          items: [{ key: 'dir/a.txt', size: 1 }],
+          cursor: 'page2',
+        })
+        .mockResolvedValueOnce({
+          items: [{ key: 'dir/b.txt', size: 2 }],
+          cursor: undefined,
+        });
+
+      const entries = await fs.readdir('/dir');
+
+      expect(entries).toHaveLength(2);
+      expect(mockFiles.list).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('rmdir()', () => {
+    it('throws DirectoryNotEmptyError for non-recursive on non-empty dir', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.list.mockResolvedValueOnce({
+        items: [{ key: 'dir/file.txt' }],
+        cursor: undefined,
+      });
+
+      await expect(fs.rmdir('/dir')).rejects.toThrow();
+    });
+
+    it('batch-deletes all keys for recursive rmdir', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.list.mockResolvedValueOnce({
+        items: [
+          { key: 'dir/a.txt' },
+          { key: 'dir/b.txt' },
+          { key: 'dir/sub/c.txt' },
+        ],
+        cursor: undefined,
+      });
+
+      await fs.rmdir('/dir', { recursive: true });
+
+      expect(mockFiles.delete).toHaveBeenCalledWith(['dir/a.txt', 'dir/b.txt', 'dir/sub/c.txt']);
+    });
+
+    it('no-ops if directory is already empty', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+
+      await fs.rmdir('/empty', { recursive: true });
+
+      expect(mockFiles.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('exists()', () => {
+    it('returns true for root', async () => {
+      const { fs } = createFs();
+
+      expect(await fs.exists('/')).toBe(true);
+      expect(await fs.exists('.')).toBe(true);
+    });
+
+    it('returns true when file exists', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.exists.mockResolvedValueOnce(true);
+
+      expect(await fs.exists('/test.txt')).toBe(true);
+    });
+
+    it('checks as directory when file does not exist', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.exists.mockResolvedValueOnce(false);
+      // isDirectory check: has children
+      mockFiles.list.mockResolvedValueOnce({ items: [{ key: 'dir/child.txt' }], cursor: undefined });
+
+      expect(await fs.exists('/dir')).toBe(true);
+    });
+
+    it('returns false when neither file nor directory', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.exists.mockResolvedValueOnce(false);
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+
+      expect(await fs.exists('/nope')).toBe(false);
+    });
+  });
+
+  describe('stat()', () => {
+    it('returns directory stat for root', async () => {
+      const { fs } = createFs();
+
+      const st = await fs.stat('/');
+
+      expect(st.type).toBe('directory');
+      expect(st.name).toBe('/');
+    });
+
+    it('returns file stat from head()', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.head.mockResolvedValueOnce(
+        createMockStoredFile('test.txt', 'hello'),
+      );
+
+      const st = await fs.stat('/test.txt');
+
+      expect(st.type).toBe('file');
+      expect(st.name).toBe('test.txt');
+      expect(st.size).toBe(5);
+    });
+
+    it('returns directory stat when key is a directory', async () => {
+      const { fs, mockFiles } = createFs();
+      const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
+      mockFiles.head.mockRejectedValueOnce(error);
+      // isDirectory check
+      mockFiles.list.mockResolvedValueOnce({ items: [{ key: 'dir/child.txt' }], cursor: undefined });
+
+      const st = await fs.stat('/dir');
+
+      expect(st.type).toBe('directory');
+      expect(st.name).toBe('dir');
+    });
+
+    it('throws FileNotFoundError when nothing matches', async () => {
+      const { fs, mockFiles } = createFs();
+      const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
+      mockFiles.head.mockRejectedValueOnce(error);
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+
+      await expect(fs.stat('/nope')).rejects.toThrow(/nope/);
+    });
+  });
+
+  describe('getInfo()', () => {
+    it('returns correct metadata', () => {
+      const { fs } = createFs({ id: 'my-id', readOnly: true, icon: 'r2' });
+
+      const info = fs.getInfo();
+
+      expect(info.id).toBe('my-id');
+      expect(info.name).toBe('FilesSDKFilesystem');
+      expect(info.provider).toBe('files-sdk');
+      expect(info.readOnly).toBe(true);
+      expect(info.icon).toBe('r2');
+      expect(info.metadata).toEqual({ adapter: 'mock' });
+    });
+  });
+
+  describe('getInstructions()', () => {
+    it('includes adapter name', () => {
+      const { fs } = createFs();
+
+      const instructions = fs.getInstructions();
+
+      expect(instructions).toContain('mock');
+    });
+
+    it('indicates read-only when set', () => {
+      const { fs } = createFs({ readOnly: true });
+
+      expect(fs.getInstructions()).toContain('read-only');
+    });
+
+    it('mentions persistent storage', () => {
+      const { fs } = createFs();
+
+      expect(fs.getInstructions()).toContain('Persistent');
+    });
+  });
+
+  describe('Read-only mode', () => {
+    it('throws on writeFile', async () => {
+      const { fs } = createFs({ readOnly: true });
+
+      await expect(fs.writeFile('/test.txt', 'data')).rejects.toThrow();
+    });
+
+    it('throws on deleteFile', async () => {
+      const { fs } = createFs({ readOnly: true });
+
+      await expect(fs.deleteFile('/test.txt')).rejects.toThrow();
+    });
+
+    it('throws on appendFile', async () => {
+      const { fs } = createFs({ readOnly: true });
+
+      await expect(fs.appendFile('/test.txt', 'data')).rejects.toThrow();
+    });
+
+    it('throws on copyFile', async () => {
+      const { fs } = createFs({ readOnly: true });
+
+      await expect(fs.copyFile('/a.txt', '/b.txt')).rejects.toThrow();
+    });
+
+    it('throws on moveFile', async () => {
+      const { fs } = createFs({ readOnly: true });
+
+      await expect(fs.moveFile('/a.txt', '/b.txt')).rejects.toThrow();
+    });
+
+    it('throws on rmdir', async () => {
+      const { fs } = createFs({ readOnly: true });
+
+      await expect(fs.rmdir('/dir', { recursive: true })).rejects.toThrow();
+    });
+
+    it('allows readFile', async () => {
+      const { fs, mockFiles } = createFs({ readOnly: true });
+      mockFiles.download.mockResolvedValueOnce(createMockStoredFile('test.txt', 'data'));
+
+      const result = await fs.readFile('/test.txt');
+      expect(result.toString()).toBe('data');
+    });
+
+    it('allows readdir', async () => {
+      const { fs, mockFiles } = createFs({ readOnly: true });
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+
+      const entries = await fs.readdir('/');
+      expect(entries).toEqual([]);
+    });
+
+    it('allows exists', async () => {
+      const { fs, mockFiles } = createFs({ readOnly: true });
+      mockFiles.exists.mockResolvedValueOnce(true);
+
+      expect(await fs.exists('/test.txt')).toBe(true);
+    });
+
+    it('allows stat', async () => {
+      const { fs, mockFiles } = createFs({ readOnly: true });
+      mockFiles.head.mockResolvedValueOnce(createMockStoredFile('test.txt', 'data'));
+
+      const st = await fs.stat('/test.txt');
+      expect(st.type).toBe('file');
+    });
+  });
+
+  describe('init()', () => {
+    it('verifies connectivity via list()', async () => {
+      const { fs, mockFiles } = createFs();
+      (fs as any).status = 'pending'; // Reset status
+
+      await (fs as any).init();
+
+      expect(mockFiles.list).toHaveBeenCalledWith({ limit: 1 });
+    });
+
+    it('throws on unauthorized error', async () => {
+      const mockFiles = createMockFiles();
+      const fs = new FilesSDKFilesystem({ files: mockFiles as any });
+      const error = Object.assign(new Error('Unauthorized'), { code: 'Unauthorized' });
+      mockFiles.list.mockRejectedValueOnce(error);
+
+      await expect((fs as any).init()).rejects.toThrow(/Access denied/);
+    });
+  });
+});

--- a/workspaces/files-sdk/src/filesystem/index.test.ts
+++ b/workspaces/files-sdk/src/filesystem/index.test.ts
@@ -12,7 +12,22 @@
  * All tests mock the FilesSDK Files instance.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdir, mkdtemp, stat, writeFile as writeLocalFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+  DirectoryNotEmptyError,
+  DirectoryNotFoundError,
+  FileExistsError,
+  FileNotFoundError,
+  IsDirectoryError,
+  NotDirectoryError,
+  StaleFileError,
+  WorkspaceReadOnlyError,
+} from '@mastra/core/workspace';
+import { describe, it, expect, vi } from 'vitest';
 
 import { FilesSDKFilesystem } from './index';
 import type { FilesSDKFilesystemOptions } from './index';
@@ -51,7 +66,8 @@ function createMockFiles() {
     url: vi.fn(),
     signedUploadUrl: vi.fn(),
     file: vi.fn(),
-    adapter: { name: 'mock' },
+    adapter: { name: 'mock', url: vi.fn() },
+    raw: {},
   };
 }
 
@@ -161,6 +177,15 @@ describe('FilesSDKFilesystem', () => {
       expect(mockFiles.download).toHaveBeenCalledWith('test.txt');
     });
 
+    it('normalizes dot, duplicate separator, and parent segments', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.download.mockResolvedValueOnce(createMockStoredFile('dir/file.txt', 'data'));
+
+      await fs.readFile('./dir//nested/../file.txt');
+
+      expect(mockFiles.download).toHaveBeenCalledWith('dir/file.txt');
+    });
+
     it('throws FileNotFoundError on NotFound', async () => {
       const { fs, mockFiles } = createFs();
       const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
@@ -183,7 +208,11 @@ describe('FilesSDKFilesystem', () => {
 
       await fs.writeFile('/test.txt', 'hello world');
 
-      expect(mockFiles.upload).toHaveBeenCalledWith('test.txt', expect.anything(), expect.objectContaining({ contentType: 'text/plain' }));
+      expect(mockFiles.upload).toHaveBeenCalledWith(
+        'test.txt',
+        expect.anything(),
+        expect.objectContaining({ contentType: 'text/plain' }),
+      );
     });
 
     it('calls upload with Buffer content', async () => {
@@ -191,18 +220,30 @@ describe('FilesSDKFilesystem', () => {
 
       await fs.writeFile('/data.bin', Buffer.from([1, 2, 3]));
 
-      expect(mockFiles.upload).toHaveBeenCalledWith('data.bin', expect.any(Uint8Array), expect.objectContaining({ contentType: 'application/octet-stream' }));
+      expect(mockFiles.upload).toHaveBeenCalledWith(
+        'data.bin',
+        expect.any(Uint8Array),
+        expect.objectContaining({ contentType: 'application/octet-stream' }),
+      );
     });
 
     it('detects MIME type from extension', async () => {
       const { fs, mockFiles } = createFs();
 
       await fs.writeFile('/page.html', '<html>');
-      expect(mockFiles.upload).toHaveBeenCalledWith('page.html', expect.anything(), expect.objectContaining({ contentType: 'text/html' }));
+      expect(mockFiles.upload).toHaveBeenCalledWith(
+        'page.html',
+        expect.anything(),
+        expect.objectContaining({ contentType: 'text/html' }),
+      );
 
       mockFiles.upload.mockClear();
       await fs.writeFile('/data.json', '{}');
-      expect(mockFiles.upload).toHaveBeenCalledWith('data.json', expect.anything(), expect.objectContaining({ contentType: 'application/json' }));
+      expect(mockFiles.upload).toHaveBeenCalledWith(
+        'data.json',
+        expect.anything(),
+        expect.objectContaining({ contentType: 'application/json' }),
+      );
     });
 
     it('respects mimeType option override', async () => {
@@ -210,7 +251,11 @@ describe('FilesSDKFilesystem', () => {
 
       await fs.writeFile('/file.txt', 'data', { mimeType: 'text/csv' });
 
-      expect(mockFiles.upload).toHaveBeenCalledWith('file.txt', expect.anything(), expect.objectContaining({ contentType: 'text/csv' }));
+      expect(mockFiles.upload).toHaveBeenCalledWith(
+        'file.txt',
+        expect.anything(),
+        expect.objectContaining({ contentType: 'text/csv' }),
+      );
     });
 
     it('checks overwrite=false and throws FileExistsError', async () => {
@@ -227,6 +272,84 @@ describe('FilesSDKFilesystem', () => {
       await fs.writeFile('/new.txt', 'data', { overwrite: false });
 
       expect(mockFiles.upload).toHaveBeenCalled();
+    });
+
+    it('throws StaleFileError when expectedMtime does not match', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.head
+        .mockResolvedValueOnce(createMockStoredFile('test.txt', 'old'))
+        .mockResolvedValueOnce(createMockStoredFile('test.txt', 'old'));
+
+      await expect(
+        fs.writeFile('/test.txt', 'new', { expectedMtime: new Date('2025-06-02T00:00:00Z') }),
+      ).rejects.toThrow(StaleFileError);
+      expect(mockFiles.upload).not.toHaveBeenCalled();
+    });
+
+    it('writes when expectedMtime matches', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.head
+        .mockResolvedValueOnce(createMockStoredFile('test.txt', 'old'))
+        .mockResolvedValueOnce(createMockStoredFile('test.txt', 'old'));
+
+      await fs.writeFile('/test.txt', 'new', { expectedMtime: new Date('2025-06-01T00:00:00Z') });
+
+      expect(mockFiles.upload).toHaveBeenCalled();
+    });
+
+    it('throws IsDirectoryError when target is a synthetic directory', async () => {
+      const { fs, mockFiles } = createFs();
+      const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
+      mockFiles.head.mockRejectedValueOnce(error);
+      mockFiles.list.mockResolvedValueOnce({ items: [{ key: 'dir/child.txt' }], cursor: undefined });
+
+      await expect(fs.writeFile('/dir', 'data')).rejects.toThrow(IsDirectoryError);
+      expect(mockFiles.upload).not.toHaveBeenCalled();
+    });
+
+    it('writes exact object keys even when the same key has synthetic children', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.head.mockResolvedValueOnce(createMockStoredFile('dir', 'old'));
+
+      await fs.writeFile('/dir', 'new');
+
+      expect(mockFiles.upload).toHaveBeenCalledWith(
+        'dir',
+        expect.anything(),
+        expect.objectContaining({ contentType: 'application/octet-stream' }),
+      );
+      expect(mockFiles.list).not.toHaveBeenCalled();
+    });
+
+    it('treats nested FilesSDK NotFound errors as missing exact files', async () => {
+      const { fs, mockFiles } = createFs();
+      const notFound = Object.assign(new Error('NotFound'), { code: 'NotFound' });
+      const wrapped = Object.assign(new Error('Provider'), { code: 'Provider', cause: notFound });
+      mockFiles.head.mockRejectedValueOnce(wrapped);
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+
+      await fs.writeFile('/new.txt', 'data');
+
+      expect(mockFiles.upload).toHaveBeenCalledWith(
+        'new.txt',
+        expect.anything(),
+        expect.objectContaining({ contentType: 'text/plain' }),
+      );
+    });
+
+    it('throws IsDirectoryError when target is an empty directory on the FilesSDK fs adapter', async () => {
+      const { fs, mockFiles } = createFs();
+      const tempRoot = await mkdtemp(join(tmpdir(), 'files-sdk-filesystem-'));
+      const emptyPath = join(tempRoot, 'empty');
+      await mkdir(emptyPath);
+
+      mockFiles.adapter.name = 'fs';
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+      mockFiles.exists.mockResolvedValueOnce(true);
+      mockFiles.url.mockResolvedValue(pathToFileURL(emptyPath).href);
+
+      await expect(fs.writeFile('/empty', 'data')).rejects.toThrow(IsDirectoryError);
+      expect(mockFiles.upload).not.toHaveBeenCalled();
     });
   });
 
@@ -281,15 +404,35 @@ describe('FilesSDKFilesystem', () => {
       expect(mockFiles.delete).toHaveBeenCalledWith(['dir/file.txt']);
     });
 
-    it('swallows errors with force=true', async () => {
+    it('swallows NotFound errors with force=true', async () => {
       const { fs, mockFiles } = createFs();
       // isDirectory check
       mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
       // delete throws
-      mockFiles.delete.mockRejectedValueOnce(new Error('fail'));
+      const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
+      mockFiles.delete.mockRejectedValueOnce(error);
 
       // Should not throw
       await fs.deleteFile('/gone.txt', { force: true });
+    });
+
+    it('throws FileNotFoundError for NotFound errors with force=false', async () => {
+      const { fs, mockFiles } = createFs();
+      // isDirectory check
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+      const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
+      mockFiles.delete.mockRejectedValueOnce(error);
+
+      await expect(fs.deleteFile('/gone.txt')).rejects.toThrow(FileNotFoundError);
+    });
+
+    it('re-throws non-NotFound errors with force=true', async () => {
+      const { fs, mockFiles } = createFs();
+      // isDirectory check
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+      mockFiles.delete.mockRejectedValueOnce(new Error('fail'));
+
+      await expect(fs.deleteFile('/test.txt', { force: true })).rejects.toThrow('fail');
     });
   });
 
@@ -309,24 +452,138 @@ describe('FilesSDKFilesystem', () => {
 
       await expect(fs.copyFile('/missing.txt', '/dest.txt')).rejects.toThrow(/missing\.txt/);
     });
+
+    it('throws FileExistsError when overwrite=false and destination exists', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.exists.mockResolvedValueOnce(true);
+
+      await expect(fs.copyFile('/src.txt', '/dest.txt', { overwrite: false })).rejects.toThrow(FileExistsError);
+      expect(mockFiles.copy).not.toHaveBeenCalled();
+    });
+
+    it('copies exact source objects even when the same key has synthetic children', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.head.mockResolvedValueOnce(createMockStoredFile('dir', 'exact'));
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+
+      await fs.copyFile('/dir', '/dest.txt');
+
+      expect(mockFiles.copy).toHaveBeenCalledWith('dir', 'dest.txt');
+      expect(mockFiles.list).not.toHaveBeenCalled();
+    });
+
+    it('throws IsDirectoryError when source is only a synthetic directory', async () => {
+      const { fs, mockFiles } = createFs();
+      const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
+      mockFiles.head.mockRejectedValueOnce(error);
+      mockFiles.list.mockResolvedValueOnce({ items: [{ key: 'src/child.txt' }], cursor: undefined });
+
+      await expect(fs.copyFile('/src', '/dest.txt')).rejects.toThrow(IsDirectoryError);
+      expect(mockFiles.copy).not.toHaveBeenCalled();
+    });
+
+    it('throws IsDirectoryError when destination is a synthetic directory', async () => {
+      const { fs, mockFiles } = createFs();
+      const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
+      mockFiles.head.mockRejectedValueOnce(error).mockRejectedValueOnce(error);
+      mockFiles.list.mockResolvedValueOnce({ items: [{ key: 'dest/child.txt' }], cursor: undefined });
+
+      await expect(fs.copyFile('/src.txt', '/dest')).rejects.toThrow(IsDirectoryError);
+      expect(mockFiles.copy).not.toHaveBeenCalled();
+    });
+
+    it('copies to exact destination objects even when the destination key has synthetic children', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.head
+        .mockResolvedValueOnce(createMockStoredFile('src.txt', 'source'))
+        .mockResolvedValueOnce(createMockStoredFile('dest', 'old'));
+
+      await fs.copyFile('/src.txt', '/dest');
+
+      expect(mockFiles.copy).toHaveBeenCalledWith('src.txt', 'dest');
+      expect(mockFiles.list).not.toHaveBeenCalled();
+    });
   });
 
   describe('moveFile()', () => {
-    it('copies then deletes source', async () => {
+    it('moves with normalized keys', async () => {
       const { fs, mockFiles } = createFs();
 
       await fs.moveFile('/src.txt', '/dest.txt');
 
-      expect(mockFiles.copy).toHaveBeenCalledWith('src.txt', 'dest.txt');
-      expect(mockFiles.delete).toHaveBeenCalledWith('src.txt');
+      expect(mockFiles.move).toHaveBeenCalledWith('src.txt', 'dest.txt');
+      expect(mockFiles.copy).not.toHaveBeenCalled();
+      expect(mockFiles.delete).not.toHaveBeenCalled();
+    });
+
+    it('delegates same-key moves to FilesSDK', async () => {
+      const { fs, mockFiles } = createFs();
+
+      await fs.moveFile('/a/../file.txt', '/file.txt');
+
+      expect(mockFiles.move).toHaveBeenCalledWith('file.txt', 'file.txt');
+      expect(mockFiles.copy).not.toHaveBeenCalled();
+      expect(mockFiles.delete).not.toHaveBeenCalled();
     });
 
     it('throws FileNotFoundError on NotFound', async () => {
       const { fs, mockFiles } = createFs();
       const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
-      mockFiles.copy.mockRejectedValueOnce(error);
+      mockFiles.move.mockRejectedValueOnce(error);
 
       await expect(fs.moveFile('/missing.txt', '/dest.txt')).rejects.toThrow(/missing\.txt/);
+    });
+
+    it('throws FileExistsError when overwrite=false and destination exists', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.exists.mockResolvedValueOnce(true);
+
+      await expect(fs.moveFile('/src.txt', '/dest.txt', { overwrite: false })).rejects.toThrow(FileExistsError);
+      expect(mockFiles.move).not.toHaveBeenCalled();
+      expect(mockFiles.delete).not.toHaveBeenCalled();
+    });
+
+    it('moves exact source objects even when the same key has synthetic children', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.head.mockResolvedValueOnce(createMockStoredFile('dir', 'exact'));
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+
+      await fs.moveFile('/dir', '/dest.txt');
+
+      expect(mockFiles.move).toHaveBeenCalledWith('dir', 'dest.txt');
+      expect(mockFiles.list).not.toHaveBeenCalled();
+    });
+
+    it('throws IsDirectoryError when move source is only a synthetic directory', async () => {
+      const { fs, mockFiles } = createFs();
+      const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
+      mockFiles.head.mockRejectedValueOnce(error);
+      mockFiles.list.mockResolvedValueOnce({ items: [{ key: 'src/child.txt' }], cursor: undefined });
+
+      await expect(fs.moveFile('/src', '/dest.txt')).rejects.toThrow(IsDirectoryError);
+      expect(mockFiles.move).not.toHaveBeenCalled();
+    });
+
+    it('throws IsDirectoryError when destination is a synthetic directory', async () => {
+      const { fs, mockFiles } = createFs();
+      const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
+      mockFiles.head.mockRejectedValueOnce(error).mockRejectedValueOnce(error);
+      mockFiles.list.mockResolvedValueOnce({ items: [{ key: 'dest/child.txt' }], cursor: undefined });
+
+      await expect(fs.moveFile('/src.txt', '/dest')).rejects.toThrow(IsDirectoryError);
+      expect(mockFiles.move).not.toHaveBeenCalled();
+    });
+
+    it('moves to exact destination objects even when the destination key has synthetic children', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.head
+        .mockResolvedValueOnce(createMockStoredFile('src.txt', 'source'))
+        .mockResolvedValueOnce(createMockStoredFile('dest', 'old'));
+
+      await fs.moveFile('/src.txt', '/dest');
+
+      expect(mockFiles.move).toHaveBeenCalledWith('src.txt', 'dest');
+      expect(mockFiles.list).not.toHaveBeenCalled();
     });
   });
 
@@ -339,6 +596,12 @@ describe('FilesSDKFilesystem', () => {
       // Should not call any file operations
       expect(mockFiles.upload).not.toHaveBeenCalled();
       expect(mockFiles.list).not.toHaveBeenCalled();
+    });
+
+    it('throws on read-only filesystems', async () => {
+      const { fs } = createFs({ readOnly: true });
+
+      await expect(fs.mkdir('/newdir')).rejects.toThrow(WorkspaceReadOnlyError);
     });
   });
 
@@ -359,6 +622,33 @@ describe('FilesSDKFilesystem', () => {
         { name: 'file1.txt', type: 'file', size: 100 },
         { name: 'file2.json', type: 'file', size: 200 },
       ]);
+    });
+
+    it('normalizes trailing slashes before listing directories', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.list.mockResolvedValueOnce({
+        items: [{ key: 'dir/file.txt', size: 100, type: 'text/plain' }],
+        cursor: undefined,
+      });
+
+      const entries = await fs.readdir('/dir/');
+
+      expect(mockFiles.list).toHaveBeenCalledWith({ prefix: 'dir/', cursor: undefined, limit: 1000 });
+      expect(entries).toEqual([{ name: 'file.txt', type: 'file', size: 100 }]);
+    });
+
+    it('lists directories even when the adapter reports the directory key exists', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.exists.mockResolvedValueOnce(true);
+      mockFiles.list.mockResolvedValueOnce({
+        items: [{ key: 'dir/file.txt', size: 100, type: 'text/plain' }],
+        cursor: undefined,
+      });
+
+      const entries = await fs.readdir('/dir');
+
+      expect(mockFiles.exists).not.toHaveBeenCalled();
+      expect(entries).toEqual([{ name: 'file.txt', type: 'file', size: 100 }]);
     });
 
     it('synthesizes directory entries for nested keys', async () => {
@@ -417,6 +707,55 @@ describe('FilesSDKFilesystem', () => {
       ]);
     });
 
+    it('returns an empty list when extension filters exclude all files in an existing directory', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.exists.mockResolvedValueOnce(false);
+      mockFiles.list.mockResolvedValueOnce({
+        items: [{ key: 'dir/a.json', size: 1 }],
+        cursor: undefined,
+      });
+
+      await expect(fs.readdir('/dir', { extension: '.txt' })).resolves.toEqual([]);
+    });
+
+    it('returns an empty list for marker-only directories', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.list.mockResolvedValueOnce({
+        items: [{ key: 'dir/', size: 0 }],
+        cursor: undefined,
+      });
+
+      await expect(fs.readdir('/dir')).resolves.toEqual([]);
+      expect(mockFiles.exists).not.toHaveBeenCalled();
+    });
+
+    it('returns an empty list for empty directories on the FilesSDK fs adapter', async () => {
+      const { fs, mockFiles } = createFs();
+      const tempRoot = await mkdtemp(join(tmpdir(), 'files-sdk-filesystem-'));
+      const emptyPath = join(tempRoot, 'empty');
+      await mkdir(emptyPath);
+
+      mockFiles.adapter.name = 'fs';
+      mockFiles.exists.mockResolvedValueOnce(true);
+      mockFiles.url.mockResolvedValueOnce(pathToFileURL(emptyPath).href);
+
+      await expect(fs.readdir('/empty')).resolves.toEqual([]);
+      expect(mockFiles.url).toHaveBeenCalledWith('empty');
+    });
+
+    it('keeps file paths as NotDirectoryError on the FilesSDK fs adapter', async () => {
+      const { fs, mockFiles } = createFs();
+      const tempRoot = await mkdtemp(join(tmpdir(), 'files-sdk-filesystem-'));
+      const filePath = join(tempRoot, 'file.txt');
+      await writeLocalFile(filePath, 'data');
+
+      mockFiles.adapter.name = 'fs';
+      mockFiles.exists.mockResolvedValueOnce(true);
+      mockFiles.url.mockResolvedValueOnce(pathToFileURL(filePath).href);
+
+      await expect(fs.readdir('/file.txt')).rejects.toThrow(NotDirectoryError);
+    });
+
     it('paginates across multiple pages', async () => {
       const { fs, mockFiles } = createFs();
       mockFiles.list
@@ -434,6 +773,22 @@ describe('FilesSDKFilesystem', () => {
       expect(entries).toHaveLength(2);
       expect(mockFiles.list).toHaveBeenCalledTimes(2);
     });
+
+    it('throws DirectoryNotFoundError for missing directories', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.exists.mockResolvedValueOnce(false);
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+
+      await expect(fs.readdir('/missing')).rejects.toThrow(DirectoryNotFoundError);
+    });
+
+    it('throws NotDirectoryError for file paths', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.exists.mockResolvedValueOnce(true);
+
+      await expect(fs.readdir('/file.txt')).rejects.toThrow(NotDirectoryError);
+      expect(mockFiles.list).toHaveBeenCalledWith({ prefix: 'file.txt/', cursor: undefined, limit: 1000 });
+    });
   });
 
   describe('rmdir()', () => {
@@ -444,32 +799,191 @@ describe('FilesSDKFilesystem', () => {
         cursor: undefined,
       });
 
-      await expect(fs.rmdir('/dir')).rejects.toThrow();
+      await expect(fs.rmdir('/dir')).rejects.toThrow(DirectoryNotEmptyError);
     });
 
     it('batch-deletes all keys for recursive rmdir', async () => {
       const { fs, mockFiles } = createFs();
       mockFiles.list.mockResolvedValueOnce({
-        items: [
-          { key: 'dir/a.txt' },
-          { key: 'dir/b.txt' },
-          { key: 'dir/sub/c.txt' },
-        ],
+        items: [{ key: 'dir/a.txt' }, { key: 'dir/b.txt' }, { key: 'dir/sub/c.txt' }],
         cursor: undefined,
       });
+      mockFiles.delete.mockResolvedValueOnce({ deleted: ['dir/a.txt', 'dir/b.txt', 'dir/sub/c.txt'] });
 
       await fs.rmdir('/dir', { recursive: true });
 
       expect(mockFiles.delete).toHaveBeenCalledWith(['dir/a.txt', 'dir/b.txt', 'dir/sub/c.txt']);
     });
 
-    it('no-ops if directory is already empty', async () => {
+    it('removes directories even when the adapter reports the directory key exists', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.exists.mockResolvedValueOnce(true);
+      mockFiles.list.mockResolvedValueOnce({
+        items: [{ key: 'dir/a.txt' }],
+        cursor: undefined,
+      });
+      mockFiles.delete.mockResolvedValueOnce({ deleted: ['dir/a.txt'] });
+
+      await fs.rmdir('/dir', { recursive: true });
+
+      expect(mockFiles.exists).not.toHaveBeenCalled();
+      expect(mockFiles.delete).toHaveBeenCalledWith(['dir/a.txt']);
+    });
+
+    it('removes backing local directories after recursive delete on the FilesSDK fs adapter', async () => {
+      const { fs, mockFiles } = createFs();
+      const tempRoot = await mkdtemp(join(tmpdir(), 'files-sdk-filesystem-'));
+      const dirPath = join(tempRoot, 'dir');
+      const filePath = join(dirPath, 'file.txt');
+      await mkdir(dirPath, { recursive: true });
+      await writeLocalFile(filePath, 'data');
+
+      mockFiles.adapter.name = 'fs';
+      mockFiles.list.mockResolvedValueOnce({
+        items: [{ key: 'dir/file.txt' }],
+        cursor: undefined,
+      });
+      mockFiles.delete.mockResolvedValueOnce({ deleted: ['dir/file.txt'] });
+      mockFiles.url.mockResolvedValueOnce(pathToFileURL(dirPath).href);
+
+      await fs.rmdir('/dir', { recursive: true });
+
+      await expect(stat(dirPath)).rejects.toMatchObject({ code: 'ENOENT' });
+      expect(mockFiles.delete).toHaveBeenCalledWith(['dir/file.txt']);
+    });
+
+    it('throws when recursive bulk delete reports errors', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.list.mockResolvedValueOnce({
+        items: [{ key: 'dir/a.txt' }],
+        cursor: undefined,
+      });
+      mockFiles.delete.mockResolvedValueOnce({
+        deleted: [],
+        errors: [{ key: 'dir/a.txt', error: new Error('delete failed') }],
+      });
+
+      await expect(fs.rmdir('/dir', { recursive: true })).rejects.toThrow(/Failed to delete 1 object/);
+    });
+
+    it('no-ops with force=true if directory is missing', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+      mockFiles.exists.mockResolvedValueOnce(false);
+
+      await fs.rmdir('/empty', { recursive: true, force: true });
+
+      expect(mockFiles.delete).not.toHaveBeenCalled();
+    });
+
+    it('removes marker-only directories without requiring recursive', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.list.mockResolvedValueOnce({
+        items: [{ key: 'dir/' }],
+        cursor: undefined,
+      });
+      mockFiles.delete.mockResolvedValueOnce({ deleted: ['dir/'] });
+
+      await fs.rmdir('/dir');
+
+      expect(mockFiles.delete).toHaveBeenCalledWith(['dir/']);
+    });
+
+    it('throws when marker-only directory delete reports errors', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.list.mockResolvedValueOnce({
+        items: [{ key: 'dir/' }],
+        cursor: undefined,
+      });
+      mockFiles.delete.mockResolvedValueOnce({
+        deleted: [],
+        errors: [{ key: 'dir/', error: new Error('delete failed') }],
+      });
+
+      await expect(fs.rmdir('/dir')).rejects.toThrow(/Failed to delete 1 object/);
+    });
+
+    it('removes empty directories on the FilesSDK fs adapter', async () => {
+      const { fs, mockFiles } = createFs();
+      const tempRoot = await mkdtemp(join(tmpdir(), 'files-sdk-filesystem-'));
+      const emptyPath = join(tempRoot, 'empty');
+      await mkdir(emptyPath);
+
+      mockFiles.adapter.name = 'fs';
+      mockFiles.exists.mockResolvedValueOnce(true);
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+      mockFiles.url.mockResolvedValueOnce(pathToFileURL(emptyPath).href);
+
+      await fs.rmdir('/empty');
+
+      await expect(stat(emptyPath)).rejects.toMatchObject({ code: 'ENOENT' });
+      expect(mockFiles.delete).not.toHaveBeenCalled();
+    });
+
+    it('removes empty directories on the FilesSDK fs adapter when urlBaseUrl is configured', async () => {
+      const { fs, mockFiles } = createFs();
+      const tempRoot = await mkdtemp(join(tmpdir(), 'files-sdk-filesystem-'));
+      const emptyPath = join(tempRoot, 'empty');
+      await mkdir(emptyPath);
+
+      mockFiles.adapter.name = 'fs';
+      mockFiles.raw = { root: tempRoot };
+      mockFiles.exists.mockResolvedValueOnce(true);
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+      mockFiles.url
+        .mockResolvedValueOnce('http://localhost/static/empty')
+        .mockResolvedValueOnce('http://localhost/static/__mastra_files_sdk_prefix_probe__');
+      mockFiles.adapter.url.mockResolvedValueOnce('http://localhost/static/__mastra_files_sdk_prefix_probe__');
+
+      await fs.rmdir('/empty');
+
+      await expect(stat(emptyPath)).rejects.toMatchObject({ code: 'ENOENT' });
+      expect(mockFiles.delete).not.toHaveBeenCalled();
+    });
+
+    it('removes empty directories on prefixed FilesSDK fs adapters with urlBaseUrl', async () => {
+      const { fs, mockFiles } = createFs();
+      const tempRoot = await mkdtemp(join(tmpdir(), 'files-sdk-filesystem-'));
+      const emptyPath = join(tempRoot, 'workspace', 'empty');
+      await mkdir(emptyPath, { recursive: true });
+
+      mockFiles.adapter.name = 'fs';
+      mockFiles.raw = { root: tempRoot };
+      mockFiles.exists.mockResolvedValueOnce(true);
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+      mockFiles.url
+        .mockResolvedValueOnce('http://localhost/static/workspace/empty')
+        .mockResolvedValueOnce('http://localhost/static/workspace/__mastra_files_sdk_prefix_probe__');
+      mockFiles.adapter.url.mockResolvedValueOnce('http://localhost/static/__mastra_files_sdk_prefix_probe__');
+
+      await fs.rmdir('/empty');
+
+      await expect(stat(emptyPath)).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(stat(join(tempRoot, 'empty'))).rejects.toMatchObject({ code: 'ENOENT' });
+      expect(mockFiles.delete).not.toHaveBeenCalled();
+    });
+
+    it('throws DirectoryNotFoundError for missing directories without force', async () => {
       const { fs, mockFiles } = createFs();
       mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
 
-      await fs.rmdir('/empty', { recursive: true });
+      await expect(fs.rmdir('/missing', { recursive: true })).rejects.toThrow(DirectoryNotFoundError);
+    });
 
-      expect(mockFiles.delete).not.toHaveBeenCalled();
+    it('throws NotDirectoryError for file paths', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.exists.mockResolvedValueOnce(true);
+
+      await expect(fs.rmdir('/file.txt', { recursive: true })).rejects.toThrow(NotDirectoryError);
+      expect(mockFiles.list).toHaveBeenCalledWith({ prefix: 'file.txt/', cursor: undefined, limit: 1000 });
+    });
+
+    it('throws NotDirectoryError for file paths even with force=true', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.exists.mockResolvedValueOnce(true);
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
+
+      await expect(fs.rmdir('/file.txt', { recursive: true, force: true })).rejects.toThrow(NotDirectoryError);
     });
   });
 
@@ -518,9 +1032,7 @@ describe('FilesSDKFilesystem', () => {
 
     it('returns file stat from head()', async () => {
       const { fs, mockFiles } = createFs();
-      mockFiles.head.mockResolvedValueOnce(
-        createMockStoredFile('test.txt', 'hello'),
-      );
+      mockFiles.head.mockResolvedValueOnce(createMockStoredFile('test.txt', 'hello'));
 
       const st = await fs.stat('/test.txt');
 
@@ -540,6 +1052,33 @@ describe('FilesSDKFilesystem', () => {
 
       expect(st.type).toBe('directory');
       expect(st.name).toBe('dir');
+    });
+
+    it('preserves exact object keys over synthetic directories for stat', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.head.mockResolvedValueOnce(createMockStoredFile('dir', 'hello'));
+
+      const st = await fs.stat('/dir');
+
+      expect(st.type).toBe('file');
+      expect(st.name).toBe('dir');
+      expect(mockFiles.list).not.toHaveBeenCalled();
+    });
+
+    it('returns directory stat for empty directories on the FilesSDK fs adapter', async () => {
+      const { fs, mockFiles } = createFs();
+      const tempRoot = await mkdtemp(join(tmpdir(), 'files-sdk-filesystem-'));
+      const emptyPath = join(tempRoot, 'empty');
+      await mkdir(emptyPath);
+
+      mockFiles.adapter.name = 'fs';
+      mockFiles.url.mockResolvedValueOnce(pathToFileURL(emptyPath).href);
+
+      const st = await fs.stat('/empty');
+
+      expect(st).toMatchObject({ name: 'empty', path: '/empty', type: 'directory', size: 0 });
+      expect(mockFiles.list).not.toHaveBeenCalled();
+      expect(mockFiles.head).not.toHaveBeenCalled();
     });
 
     it('throws FileNotFoundError when nothing matches', async () => {
@@ -593,37 +1132,37 @@ describe('FilesSDKFilesystem', () => {
     it('throws on writeFile', async () => {
       const { fs } = createFs({ readOnly: true });
 
-      await expect(fs.writeFile('/test.txt', 'data')).rejects.toThrow();
+      await expect(fs.writeFile('/test.txt', 'data')).rejects.toThrow(WorkspaceReadOnlyError);
     });
 
     it('throws on deleteFile', async () => {
       const { fs } = createFs({ readOnly: true });
 
-      await expect(fs.deleteFile('/test.txt')).rejects.toThrow();
+      await expect(fs.deleteFile('/test.txt')).rejects.toThrow(WorkspaceReadOnlyError);
     });
 
     it('throws on appendFile', async () => {
       const { fs } = createFs({ readOnly: true });
 
-      await expect(fs.appendFile('/test.txt', 'data')).rejects.toThrow();
+      await expect(fs.appendFile('/test.txt', 'data')).rejects.toThrow(WorkspaceReadOnlyError);
     });
 
     it('throws on copyFile', async () => {
       const { fs } = createFs({ readOnly: true });
 
-      await expect(fs.copyFile('/a.txt', '/b.txt')).rejects.toThrow();
+      await expect(fs.copyFile('/a.txt', '/b.txt')).rejects.toThrow(WorkspaceReadOnlyError);
     });
 
     it('throws on moveFile', async () => {
       const { fs } = createFs({ readOnly: true });
 
-      await expect(fs.moveFile('/a.txt', '/b.txt')).rejects.toThrow();
+      await expect(fs.moveFile('/a.txt', '/b.txt')).rejects.toThrow(WorkspaceReadOnlyError);
     });
 
     it('throws on rmdir', async () => {
       const { fs } = createFs({ readOnly: true });
 
-      await expect(fs.rmdir('/dir', { recursive: true })).rejects.toThrow();
+      await expect(fs.rmdir('/dir', { recursive: true })).rejects.toThrow(WorkspaceReadOnlyError);
     });
 
     it('allows readFile', async () => {

--- a/workspaces/files-sdk/src/filesystem/index.test.ts
+++ b/workspaces/files-sdk/src/filesystem/index.test.ts
@@ -371,27 +371,54 @@ describe('FilesSDKFilesystem', () => {
     it('creates file if it does not exist', async () => {
       const { fs, mockFiles } = createFs();
       const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
+      mockFiles.head.mockRejectedValueOnce(error);
+      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
       mockFiles.download.mockRejectedValueOnce(error);
 
       await fs.appendFile('/new.txt', 'content');
 
       expect(mockFiles.upload).toHaveBeenCalledTimes(1);
     });
+
+    it('throws IsDirectoryError when target is only a synthetic directory', async () => {
+      const { fs, mockFiles } = createFs();
+      const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
+      mockFiles.head.mockRejectedValueOnce(error);
+      mockFiles.list.mockResolvedValueOnce({ items: [{ key: 'dir/child.txt' }], cursor: undefined });
+
+      await expect(fs.appendFile('/dir', 'content')).rejects.toThrow(IsDirectoryError);
+      expect(mockFiles.download).not.toHaveBeenCalled();
+      expect(mockFiles.upload).not.toHaveBeenCalled();
+    });
+
+    it('appends exact object keys even when the same key has synthetic children', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.head.mockResolvedValueOnce(createMockStoredFile('dir', 'hello '));
+      mockFiles.download.mockResolvedValueOnce(createMockStoredFile('dir', 'hello '));
+
+      await fs.appendFile('/dir', 'world');
+
+      expect(mockFiles.list).not.toHaveBeenCalled();
+      const uploadCall = mockFiles.upload.mock.calls[0]!;
+      const written = Buffer.from(uploadCall[1] as Uint8Array);
+      expect(written.toString()).toBe('hello world');
+    });
   });
 
   describe('deleteFile()', () => {
     it('calls delete for files', async () => {
       const { fs, mockFiles } = createFs();
-      // isDirectory check returns empty (not a directory)
-      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
 
       await fs.deleteFile('/test.txt');
 
       expect(mockFiles.delete).toHaveBeenCalledWith('test.txt');
+      expect(mockFiles.list).not.toHaveBeenCalled();
     });
 
     it('delegates to rmdir for directories', async () => {
       const { fs, mockFiles } = createFs();
+      const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
+      mockFiles.head.mockRejectedValueOnce(error);
       // isDirectory check returns items (is a directory)
       mockFiles.list
         .mockResolvedValueOnce({ items: [{ key: 'dir/file.txt' }], cursor: undefined })
@@ -404,10 +431,18 @@ describe('FilesSDKFilesystem', () => {
       expect(mockFiles.delete).toHaveBeenCalledWith(['dir/file.txt']);
     });
 
+    it('deletes exact object keys even when the same key has synthetic children', async () => {
+      const { fs, mockFiles } = createFs();
+      mockFiles.head.mockResolvedValueOnce(createMockStoredFile('dir', 'exact'));
+
+      await fs.deleteFile('/dir', { recursive: true });
+
+      expect(mockFiles.delete).toHaveBeenCalledWith('dir');
+      expect(mockFiles.list).not.toHaveBeenCalled();
+    });
+
     it('swallows NotFound errors with force=true', async () => {
       const { fs, mockFiles } = createFs();
-      // isDirectory check
-      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
       // delete throws
       const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
       mockFiles.delete.mockRejectedValueOnce(error);
@@ -418,8 +453,6 @@ describe('FilesSDKFilesystem', () => {
 
     it('throws FileNotFoundError for NotFound errors with force=false', async () => {
       const { fs, mockFiles } = createFs();
-      // isDirectory check
-      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
       const error = Object.assign(new Error('NotFound'), { code: 'NotFound' });
       mockFiles.delete.mockRejectedValueOnce(error);
 
@@ -428,8 +461,6 @@ describe('FilesSDKFilesystem', () => {
 
     it('re-throws non-NotFound errors with force=true', async () => {
       const { fs, mockFiles } = createFs();
-      // isDirectory check
-      mockFiles.list.mockResolvedValueOnce({ items: [], cursor: undefined });
       mockFiles.delete.mockRejectedValueOnce(new Error('fail'));
 
       await expect(fs.deleteFile('/test.txt', { force: true })).rejects.toThrow('fail');

--- a/workspaces/files-sdk/src/filesystem/index.ts
+++ b/workspaces/files-sdk/src/filesystem/index.ts
@@ -1,0 +1,540 @@
+import type { Files, StoredFile as SDKStoredFile } from 'files-sdk';
+
+import type {
+  FileContent,
+  FileStat,
+  FileEntry,
+  ReadOptions,
+  WriteOptions,
+  ListOptions,
+  RemoveOptions,
+  CopyOptions,
+  FilesystemIcon,
+  FilesystemInfo,
+  ProviderStatus,
+  MastraFilesystemOptions,
+} from '@mastra/core/workspace';
+import {
+  MastraFilesystem,
+  FileNotFoundError,
+  FileExistsError,
+  DirectoryNotEmptyError,
+  WorkspaceReadOnlyError,
+} from '@mastra/core/workspace';
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface FilesSDKFilesystemOptions extends MastraFilesystemOptions {
+  /** Pre-configured FilesSDK `Files` instance. */
+  files: Files;
+  /** Unique filesystem ID (auto-generated if not provided). */
+  id?: string;
+  /** Human-friendly display name for UI. */
+  displayName?: string;
+  /** Icon identifier for UI. */
+  icon?: FilesystemIcon;
+  /** Description shown in UI / instructions. */
+  description?: string;
+  /** Mount as read-only — all write operations will throw. */
+  readOnly?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a POSIX-style path to an object-storage key.
+ * Strips leading slashes, resolves `.`/`./` to empty string.
+ */
+function toKey(path: string): string {
+  let key = path.replace(/^\/+/, '');
+  if (key === '.' || key === './') return '';
+  // Remove trailing slash (keys don't end with /)
+  key = key.replace(/\/+$/, '');
+  return key;
+}
+
+/**
+ * Extract the basename (last path segment) from a key.
+ */
+function basename(key: string): string {
+  const idx = key.lastIndexOf('/');
+  return idx === -1 ? key : key.slice(idx + 1);
+}
+
+function isNotFoundError(err: unknown): boolean {
+  if (err && typeof err === 'object' && 'code' in err) {
+    return (err as { code: string }).code === 'NotFound';
+  }
+  return false;
+}
+
+function isUnauthorizedError(err: unknown): boolean {
+  if (err && typeof err === 'object' && 'code' in err) {
+    return (err as { code: string }).code === 'Unauthorized';
+  }
+  return false;
+}
+
+function generateId(): string {
+  return `files-sdk-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Convert FileContent (string | Buffer | Uint8Array) to a body acceptable by files-sdk.
+ */
+function toBody(content: FileContent): string | Uint8Array {
+  if (typeof content === 'string') return content;
+  if (Buffer.isBuffer(content)) return new Uint8Array(content);
+  return content;
+}
+
+/**
+ * Infer MIME type from a file path extension.
+ */
+const MIME_TYPES: Record<string, string> = {
+  '.txt': 'text/plain',
+  '.md': 'text/markdown',
+  '.markdown': 'text/markdown',
+  '.html': 'text/html',
+  '.htm': 'text/html',
+  '.css': 'text/css',
+  '.csv': 'text/csv',
+  '.xml': 'text/xml',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.ts': 'text/typescript',
+  '.tsx': 'text/typescript',
+  '.jsx': 'text/javascript',
+  '.json': 'application/json',
+  '.yaml': 'text/yaml',
+  '.yml': 'text/yaml',
+  '.py': 'text/x-python',
+  '.rb': 'text/x-ruby',
+  '.sh': 'text/x-shellscript',
+  '.bash': 'text/x-shellscript',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.pdf': 'application/pdf',
+  '.zip': 'application/zip',
+  '.gz': 'application/gzip',
+  '.tar': 'application/x-tar',
+};
+
+function getMimeType(path: string): string {
+  const dot = path.lastIndexOf('.');
+  if (dot === -1) return 'application/octet-stream';
+  return MIME_TYPES[path.slice(dot).toLowerCase()] ?? 'application/octet-stream';
+}
+
+// ---------------------------------------------------------------------------
+// FilesSDKFilesystem
+// ---------------------------------------------------------------------------
+
+/**
+ * Workspace filesystem adapter backed by [FilesSDK](https://files-sdk.dev).
+ *
+ * Accepts a pre-configured `Files` instance so users choose their own adapter
+ * (S3, R2, GCS, Azure, local fs, etc.) and this class bridges it to the
+ * Mastra `WorkspaceFilesystem` interface.
+ *
+ * Object-storage semantics are bridged to the POSIX-like interface:
+ * - `mkdir` is a no-op (directories don't exist in object storage)
+ * - `readdir` uses `list()` with prefix filtering to synthesize directory entries
+ * - `rmdir` lists all keys under a prefix and batch-deletes them
+ */
+export class FilesSDKFilesystem extends MastraFilesystem {
+  readonly id: string;
+  readonly name = 'FilesSDKFilesystem';
+  readonly provider = 'files-sdk';
+  status: ProviderStatus = 'pending';
+
+  readonly readOnly?: boolean;
+  readonly icon?: FilesystemIcon;
+  readonly displayName?: string;
+  readonly description?: string;
+
+  private readonly _files: Files;
+
+  constructor(options: FilesSDKFilesystemOptions) {
+    super({ name: 'FilesSDKFilesystem', ...options });
+
+    this._files = options.files;
+    this.id = options.id ?? generateId();
+    this.readOnly = options.readOnly;
+    this.icon = options.icon;
+    this.displayName = options.displayName;
+    this.description = options.description;
+  }
+
+  /** The underlying FilesSDK instance, for escape-hatch access. */
+  get files(): Files {
+    return this._files;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  override async init(): Promise<void> {
+    // Verify connectivity by listing at most 1 key
+    try {
+      await this._files.list({ limit: 1 });
+    } catch (err) {
+      if (isUnauthorizedError(err)) {
+        throw new Error('Access denied — check credentials and storage permissions');
+      }
+      throw err;
+    }
+  }
+
+  // destroy() — default no-op is fine; FilesSDK has no explicit teardown.
+
+  getInfo(): FilesystemInfo {
+    return {
+      id: this.id,
+      name: this.name,
+      provider: this.provider,
+      status: this.status,
+      error: this.error,
+      readOnly: this.readOnly,
+      icon: this.icon,
+      metadata: {
+        adapter: this._files.adapter?.name ?? 'unknown',
+      },
+    };
+  }
+
+  getInstructions(): string {
+    const adapterName = this._files.adapter?.name ?? 'unknown';
+    const parts = [`Unified storage via FilesSDK (${adapterName} adapter).`];
+    if (this.readOnly) parts.push('Mounted read-only.');
+    parts.push('Persistent storage — files are retained across sessions.');
+    return parts.join(' ');
+  }
+
+  // ---------------------------------------------------------------------------
+  // File operations
+  // ---------------------------------------------------------------------------
+
+  async readFile(path: string, options?: ReadOptions): Promise<string | Buffer> {
+    await this.ensureReady();
+    const key = toKey(path);
+
+    try {
+      const file = await this._files.download(key);
+      const buf = Buffer.from(await file.arrayBuffer());
+      if (options?.encoding) return buf.toString(options.encoding);
+      return buf;
+    } catch (err) {
+      if (isNotFoundError(err)) throw new FileNotFoundError(path);
+      throw err;
+    }
+  }
+
+  async writeFile(path: string, content: FileContent, options?: WriteOptions): Promise<void> {
+    await this.ensureReady();
+    this.assertWritable('writeFile');
+    const key = toKey(path);
+
+    // Respect overwrite option (default: true)
+    if (options?.overwrite === false) {
+      const fileExists = await this._files.exists(key);
+      if (fileExists) throw new FileExistsError(path);
+    }
+
+    const body = toBody(content);
+    await this._files.upload(key, body, {
+      contentType: options?.mimeType ?? getMimeType(path),
+    });
+  }
+
+  async appendFile(path: string, content: FileContent): Promise<void> {
+    await this.ensureReady();
+    this.assertWritable('appendFile');
+    const key = toKey(path);
+
+    // Read-modify-write (object storage has no native append)
+    let existing = Buffer.alloc(0);
+    try {
+      const file = await this._files.download(key);
+      existing = Buffer.from(await file.arrayBuffer());
+    } catch (err) {
+      if (!isNotFoundError(err)) throw err;
+      // File doesn't exist yet — start fresh
+    }
+
+    const append = typeof content === 'string' ? Buffer.from(content) : toBody(content);
+    const merged = Buffer.concat([existing, Buffer.isBuffer(append) ? append : Buffer.from(append as Uint8Array)]);
+
+    await this._files.upload(key, new Uint8Array(merged), {
+      contentType: getMimeType(path),
+    });
+  }
+
+  async deleteFile(path: string, options?: RemoveOptions): Promise<void> {
+    await this.ensureReady();
+    this.assertWritable('deleteFile');
+    const key = toKey(path);
+
+    // Check if path is a directory (has children)
+    if (await this.isDirectory(key)) {
+      await this.rmdir(path, options);
+      return;
+    }
+
+    try {
+      await this._files.delete(key);
+    } catch (err) {
+      if (options?.force) return;
+      throw err;
+    }
+  }
+
+  async copyFile(src: string, dest: string, _options?: CopyOptions): Promise<void> {
+    await this.ensureReady();
+    this.assertWritable('copyFile');
+    const fromKey = toKey(src);
+    const toKey_ = toKey(dest);
+
+    try {
+      await this._files.copy(fromKey, toKey_);
+    } catch (err) {
+      if (isNotFoundError(err)) throw new FileNotFoundError(src);
+      throw err;
+    }
+  }
+
+  async moveFile(src: string, dest: string, _options?: CopyOptions): Promise<void> {
+    await this.ensureReady();
+    this.assertWritable('moveFile');
+    const fromKey = toKey(src);
+    const toKey_ = toKey(dest);
+
+    try {
+      await this._files.copy(fromKey, toKey_);
+      await this._files.delete(fromKey);
+    } catch (err) {
+      if (isNotFoundError(err)) throw new FileNotFoundError(src);
+      throw err;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Directory operations
+  // ---------------------------------------------------------------------------
+
+  async mkdir(_path: string, _options?: { recursive?: boolean }): Promise<void> {
+    await this.ensureReady();
+    // No-op: object storage creates "directories" implicitly on file write.
+  }
+
+  async rmdir(path: string, options?: RemoveOptions): Promise<void> {
+    await this.ensureReady();
+    this.assertWritable('rmdir');
+    const key = toKey(path);
+    const prefix = key ? `${key}/` : '';
+
+    // List all keys under the prefix
+    const allKeys: string[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const result = await this._files.list({ prefix, cursor, limit: 1000 });
+      for (const item of result.items) {
+        allKeys.push(item.key);
+      }
+      cursor = result.cursor;
+    } while (cursor);
+
+    if (allKeys.length === 0) return;
+
+    // Non-recursive: fail if directory is not empty
+    if (!options?.recursive) {
+      throw new DirectoryNotEmptyError(path);
+    }
+
+    // Batch delete all keys
+    await this._files.delete(allKeys);
+  }
+
+  async readdir(path: string, options?: ListOptions): Promise<FileEntry[]> {
+    await this.ensureReady();
+    const key = toKey(path);
+    const prefix = key ? `${key}/` : '';
+
+    const entries: FileEntry[] = [];
+    const seenDirs = new Set<string>();
+
+    let cursor: string | undefined;
+    const maxDepth = options?.maxDepth;
+    const recursive = options?.recursive ?? false;
+    const extensions = options?.extension
+      ? Array.isArray(options.extension)
+        ? options.extension
+        : [options.extension]
+      : undefined;
+
+    do {
+      const result = await this._files.list({ prefix, cursor, limit: 1000 });
+
+      for (const item of result.items) {
+        // item.key is relative to the Files instance's prefix.
+        // We need to get the portion after our directory prefix.
+        const relativePath = prefix ? item.key.slice(prefix.length) : item.key;
+        if (!relativePath) continue;
+
+        const segments = relativePath.split('/');
+
+        if (segments.length === 1) {
+          // Direct child (file)
+          const name = segments[0]!;
+
+          // Extension filter
+          if (extensions) {
+            const ext = name.lastIndexOf('.') !== -1 ? name.slice(name.lastIndexOf('.')) : '';
+            if (!extensions.includes(ext)) continue;
+          }
+
+          entries.push({
+            name,
+            type: 'file',
+            size: item.size,
+          });
+        } else {
+          // Nested item — synthesize a directory entry for the first segment
+          const dirName = segments[0]!;
+          if (!seenDirs.has(dirName)) {
+            seenDirs.add(dirName);
+            entries.push({
+              name: dirName,
+              type: 'directory',
+            });
+          }
+
+          // If recursive, also include this file
+          if (recursive) {
+            // Check depth
+            if (maxDepth !== undefined && segments.length > maxDepth) continue;
+
+            const name = relativePath;
+
+            if (extensions) {
+              const ext = name.lastIndexOf('.') !== -1 ? name.slice(name.lastIndexOf('.')) : '';
+              if (!extensions.includes(ext)) continue;
+            }
+
+            entries.push({
+              name,
+              type: 'file',
+              size: item.size,
+            });
+          }
+        }
+      }
+
+      cursor = result.cursor;
+    } while (cursor);
+
+    return entries;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Path operations
+  // ---------------------------------------------------------------------------
+
+  async exists(path: string): Promise<boolean> {
+    await this.ensureReady();
+    const key = toKey(path);
+
+    // Root always exists
+    if (!key) return true;
+
+    // Check as file
+    const fileExists = await this._files.exists(key);
+    if (fileExists) return true;
+
+    // Check as directory (any key with this prefix)
+    return this.isDirectory(key);
+  }
+
+  async stat(path: string): Promise<FileStat> {
+    await this.ensureReady();
+    const key = toKey(path);
+
+    // Root is a directory
+    if (!key) {
+      const now = new Date();
+      return {
+        name: '/',
+        path: '/',
+        type: 'directory',
+        size: 0,
+        createdAt: now,
+        modifiedAt: now,
+      };
+    }
+
+    // Try as file first
+    try {
+      const file = await this._files.head(key);
+      return this.storedFileToStat(file, path);
+    } catch (err) {
+      if (!isNotFoundError(err)) throw err;
+    }
+
+    // Try as directory
+    if (await this.isDirectory(key)) {
+      const now = new Date();
+      return {
+        name: basename(key),
+        path,
+        type: 'directory',
+        size: 0,
+        createdAt: now,
+        modifiedAt: now,
+      };
+    }
+
+    throw new FileNotFoundError(path);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private assertWritable(operation: string): void {
+    if (this.readOnly) {
+      throw new WorkspaceReadOnlyError(operation);
+    }
+  }
+
+  /** Check if a key prefix has any children (i.e. acts like a directory). */
+  private async isDirectory(key: string): Promise<boolean> {
+    if (!key) return true; // root
+    const prefix = `${key}/`;
+    const result = await this._files.list({ prefix, limit: 1 });
+    return result.items.length > 0;
+  }
+
+  /** Convert a FilesSDK StoredFile to a Mastra FileStat. */
+  private storedFileToStat(file: SDKStoredFile, path: string): FileStat {
+    return {
+      name: basename(file.key ?? path),
+      path,
+      type: 'file',
+      size: file.size ?? 0,
+      createdAt: file.lastModified ? new Date(file.lastModified) : new Date(),
+      modifiedAt: file.lastModified ? new Date(file.lastModified) : new Date(),
+      mimeType: file.type || undefined,
+    };
+  }
+}

--- a/workspaces/files-sdk/src/filesystem/index.ts
+++ b/workspaces/files-sdk/src/filesystem/index.ts
@@ -1,4 +1,6 @@
-import type { Files, StoredFile as SDKStoredFile } from 'files-sdk';
+import { rm, rmdir as removeDirectory, stat as statPath } from 'node:fs/promises';
+import { join as pathJoin, posix as pathPosix, resolve as pathResolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import type {
   FileContent,
@@ -18,9 +20,14 @@ import {
   MastraFilesystem,
   FileNotFoundError,
   FileExistsError,
+  DirectoryNotFoundError,
+  IsDirectoryError,
+  NotDirectoryError,
   DirectoryNotEmptyError,
+  StaleFileError,
   WorkspaceReadOnlyError,
 } from '@mastra/core/workspace';
+import type { Files, StoredFile as SDKStoredFile } from 'files-sdk';
 
 // ---------------------------------------------------------------------------
 // Options
@@ -50,11 +57,8 @@ export interface FilesSDKFilesystemOptions extends MastraFilesystemOptions {
  * Strips leading slashes, resolves `.`/`./` to empty string.
  */
 function toKey(path: string): string {
-  let key = path.replace(/^\/+/, '');
-  if (key === '.' || key === './') return '';
-  // Remove trailing slash (keys don't end with /)
-  key = key.replace(/\/+$/, '');
-  return key;
+  const normalized = pathPosix.normalize(`/${path}`).slice(1);
+  return normalized === '.' ? '' : normalized.replace(/\/+$/, '');
 }
 
 /**
@@ -65,22 +69,41 @@ function basename(key: string): string {
   return idx === -1 ? key : key.slice(idx + 1);
 }
 
+function getFilesystemErrorCodes(err: unknown, depth = 0): unknown[] {
+  if (!err || typeof err !== 'object' || depth > 4) return [];
+
+  const error = err as { code?: unknown; cause?: unknown; info?: unknown };
+  return [
+    error.code,
+    ...getFilesystemErrorCodes(error.cause, depth + 1),
+    ...getFilesystemErrorCodes(error.info, depth + 1),
+  ].filter(code => code !== undefined);
+}
+
+function hasFilesystemErrorCode(err: unknown, code: string): boolean {
+  return getFilesystemErrorCodes(err).includes(code);
+}
+
 function isNotFoundError(err: unknown): boolean {
-  if (err && typeof err === 'object' && 'code' in err) {
-    return (err as { code: string }).code === 'NotFound';
-  }
-  return false;
+  return hasFilesystemErrorCode(err, 'NotFound');
 }
 
 function isUnauthorizedError(err: unknown): boolean {
-  if (err && typeof err === 'object' && 'code' in err) {
-    return (err as { code: string }).code === 'Unauthorized';
-  }
-  return false;
+  return hasFilesystemErrorCode(err, 'Unauthorized');
+}
+
+function getFilesystemErrorCode(err: unknown): unknown {
+  const codes = getFilesystemErrorCodes(err);
+  return codes.find(code => code !== 'Provider') ?? codes[0];
 }
 
 function generateId(): string {
   return `files-sdk-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function toDate(value: number | Date | undefined): Date | undefined {
+  if (value === undefined) return undefined;
+  return value instanceof Date ? value : new Date(value);
 }
 
 /**
@@ -180,6 +203,102 @@ export class FilesSDKFilesystem extends MastraFilesystem {
     return this._files;
   }
 
+  private async isExistingLocalDirectoryKey(key: string): Promise<boolean> {
+    if (this._files.adapter?.name !== 'fs') return false;
+
+    const localPath = await this.getLocalFsPath(key);
+    if (!localPath) return false;
+
+    try {
+      const stats = await statPath(localPath);
+      return stats.isDirectory();
+    } catch (err) {
+      const code = getFilesystemErrorCode(err);
+      if (code === 'ENOENT' || code === 'ENOTDIR') return false;
+      throw err;
+    }
+  }
+
+  private async isExactFileKey(key: string): Promise<boolean> {
+    if (!key) return false;
+
+    if (await this.isExistingLocalDirectoryKey(key)) return false;
+
+    try {
+      await this._files.head(key);
+      return true;
+    } catch (err) {
+      if (isNotFoundError(err)) return false;
+      throw err;
+    }
+  }
+
+  private async removeExistingLocalDirectoryKey(key: string, path: string, options?: RemoveOptions): Promise<boolean> {
+    if (this._files.adapter?.name !== 'fs') return false;
+
+    const localPath = await this.getLocalFsPath(key);
+    if (!localPath) return false;
+
+    try {
+      const stats = await statPath(localPath);
+      if (!stats.isDirectory()) return false;
+
+      if (options?.recursive) {
+        await rm(localPath, { recursive: true, force: false });
+      } else {
+        await removeDirectory(localPath);
+      }
+      return true;
+    } catch (err) {
+      const code = getFilesystemErrorCode(err);
+      if (code === 'ENOENT') throw new DirectoryNotFoundError(path);
+      if (code === 'ENOTEMPTY' || code === 'EEXIST') throw new DirectoryNotEmptyError(path);
+      if (code === 'ENOTDIR') throw new NotDirectoryError(path);
+      throw err;
+    }
+  }
+
+  private async getLocalFsPath(key: string): Promise<string | undefined> {
+    const url = await this._files.url(key);
+    if (typeof url === 'string' && url.startsWith('file:')) return fileURLToPath(url);
+
+    const raw = this._files.raw as { root?: unknown } | undefined;
+    if (typeof raw?.root !== 'string') return undefined;
+
+    const scopedKey = await this.getScopedLocalFsKey(key);
+    if (!scopedKey) return undefined;
+    return pathJoin(pathResolve(raw.root), ...scopedKey.split('/'));
+  }
+
+  private async getScopedLocalFsKey(key: string): Promise<string | undefined> {
+    const probe = '__mastra_files_sdk_prefix_probe__';
+
+    try {
+      const scopedProbeUrl = await this._files.url(probe);
+      const adapterProbeUrl = await this._files.adapter.url(probe);
+      const scopedProbePath = new URL(scopedProbeUrl).pathname;
+      const adapterProbePath = new URL(adapterProbeUrl).pathname;
+      const probeSuffix = `/${probe}`;
+
+      if (!scopedProbePath.endsWith(probeSuffix) || !adapterProbePath.endsWith(probeSuffix)) return undefined;
+
+      const scopedBasePath = scopedProbePath.slice(0, -probe.length);
+      const adapterBasePath = adapterProbePath.slice(0, -probe.length);
+      if (!scopedBasePath.startsWith(adapterBasePath)) return undefined;
+
+      const prefixPath = scopedBasePath.slice(adapterBasePath.length);
+      const prefix = prefixPath
+        .split('/')
+        .filter(Boolean)
+        .map(segment => decodeURIComponent(segment))
+        .join('/');
+
+      return prefix ? `${prefix}/${key}` : key;
+    } catch {
+      return undefined;
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Lifecycle
   // ---------------------------------------------------------------------------
@@ -245,6 +364,23 @@ export class FilesSDKFilesystem extends MastraFilesystem {
     this.assertWritable('writeFile');
     const key = toKey(path);
 
+    if (!(await this.isExactFileKey(key)) && (await this.isDirectory(key))) {
+      throw new IsDirectoryError(path);
+    }
+
+    if (options?.expectedMtime) {
+      try {
+        const current = await this._files.head(key);
+        const actualMtime = toDate(current.lastModified);
+        if (!actualMtime || actualMtime.getTime() !== options.expectedMtime.getTime()) {
+          throw new StaleFileError(path, options.expectedMtime, actualMtime ?? new Date(0));
+        }
+      } catch (err) {
+        if (err instanceof StaleFileError) throw err;
+        if (!isNotFoundError(err)) throw err;
+      }
+    }
+
     // Respect overwrite option (default: true)
     if (options?.overwrite === false) {
       const fileExists = await this._files.exists(key);
@@ -294,16 +430,31 @@ export class FilesSDKFilesystem extends MastraFilesystem {
     try {
       await this._files.delete(key);
     } catch (err) {
-      if (options?.force) return;
+      if (isNotFoundError(err)) {
+        if (options?.force) return;
+        throw new FileNotFoundError(path);
+      }
       throw err;
     }
   }
 
-  async copyFile(src: string, dest: string, _options?: CopyOptions): Promise<void> {
+  async copyFile(src: string, dest: string, options?: CopyOptions): Promise<void> {
     await this.ensureReady();
     this.assertWritable('copyFile');
     const fromKey = toKey(src);
     const toKey_ = toKey(dest);
+
+    if (!(await this.isExactFileKey(fromKey)) && (await this.isDirectory(fromKey))) {
+      throw new IsDirectoryError(src);
+    }
+
+    if (!(await this.isExactFileKey(toKey_)) && (await this.isDirectory(toKey_))) {
+      throw new IsDirectoryError(dest);
+    }
+
+    if (options?.overwrite === false && (await this._files.exists(toKey_))) {
+      throw new FileExistsError(dest);
+    }
 
     try {
       await this._files.copy(fromKey, toKey_);
@@ -313,15 +464,26 @@ export class FilesSDKFilesystem extends MastraFilesystem {
     }
   }
 
-  async moveFile(src: string, dest: string, _options?: CopyOptions): Promise<void> {
+  async moveFile(src: string, dest: string, options?: CopyOptions): Promise<void> {
     await this.ensureReady();
     this.assertWritable('moveFile');
     const fromKey = toKey(src);
     const toKey_ = toKey(dest);
 
+    if (!(await this.isExactFileKey(fromKey)) && (await this.isDirectory(fromKey))) {
+      throw new IsDirectoryError(src);
+    }
+
+    if (!(await this.isExactFileKey(toKey_)) && (await this.isDirectory(toKey_))) {
+      throw new IsDirectoryError(dest);
+    }
+
+    if (options?.overwrite === false && (await this._files.exists(toKey_))) {
+      throw new FileExistsError(dest);
+    }
+
     try {
-      await this._files.copy(fromKey, toKey_);
-      await this._files.delete(fromKey);
+      await this._files.move(fromKey, toKey_);
     } catch (err) {
       if (isNotFoundError(err)) throw new FileNotFoundError(src);
       throw err;
@@ -334,6 +496,7 @@ export class FilesSDKFilesystem extends MastraFilesystem {
 
   async mkdir(_path: string, _options?: { recursive?: boolean }): Promise<void> {
     await this.ensureReady();
+    this.assertWritable('mkdir');
     // No-op: object storage creates "directories" implicitly on file write.
   }
 
@@ -355,7 +518,19 @@ export class FilesSDKFilesystem extends MastraFilesystem {
       cursor = result.cursor;
     } while (cursor);
 
-    if (allKeys.length === 0) return;
+    if (allKeys.length === 0) {
+      if (key && (await this._files.exists(key))) {
+        if (await this.removeExistingLocalDirectoryKey(key, path, options)) return;
+        throw new NotDirectoryError(path);
+      }
+      if (options?.force) return;
+      throw new DirectoryNotFoundError(path);
+    }
+
+    if (key && allKeys.length === 1 && allKeys[0] === prefix) {
+      await this.deleteKeysOrThrow(allKeys, path);
+      return;
+    }
 
     // Non-recursive: fail if directory is not empty
     if (!options?.recursive) {
@@ -363,7 +538,14 @@ export class FilesSDKFilesystem extends MastraFilesystem {
     }
 
     // Batch delete all keys
-    await this._files.delete(allKeys);
+    await this.deleteKeysOrThrow(allKeys, path);
+    if (key) {
+      try {
+        await this.removeExistingLocalDirectoryKey(key, path, { ...options, recursive: true });
+      } catch (err) {
+        if (!(err instanceof DirectoryNotFoundError)) throw err;
+      }
+    }
   }
 
   async readdir(path: string, options?: ListOptions): Promise<FileEntry[]> {
@@ -377,6 +559,7 @@ export class FilesSDKFilesystem extends MastraFilesystem {
     let cursor: string | undefined;
     const maxDepth = options?.maxDepth;
     const recursive = options?.recursive ?? false;
+    let sawAnyEntry = false;
     const extensions = options?.extension
       ? Array.isArray(options.extension)
         ? options.extension
@@ -390,6 +573,7 @@ export class FilesSDKFilesystem extends MastraFilesystem {
         // item.key is relative to the Files instance's prefix.
         // We need to get the portion after our directory prefix.
         const relativePath = prefix ? item.key.slice(prefix.length) : item.key;
+        sawAnyEntry = true;
         if (!relativePath) continue;
 
         const segments = relativePath.split('/');
@@ -444,6 +628,14 @@ export class FilesSDKFilesystem extends MastraFilesystem {
       cursor = result.cursor;
     } while (cursor);
 
+    if (key && !sawAnyEntry) {
+      if (await this._files.exists(key)) {
+        if (await this.isExistingLocalDirectoryKey(key)) return [];
+        throw new NotDirectoryError(path);
+      }
+      throw new DirectoryNotFoundError(path);
+    }
+
     return entries;
   }
 
@@ -483,7 +675,20 @@ export class FilesSDKFilesystem extends MastraFilesystem {
       };
     }
 
-    // Try as file first
+    // Try local fs directories first, since FilesSDK's fs adapter can `head()` directories.
+    if (this._files.adapter?.name === 'fs' && (await this.isDirectory(key))) {
+      const now = new Date();
+      return {
+        name: basename(key),
+        path,
+        type: 'directory',
+        size: 0,
+        createdAt: now,
+        modifiedAt: now,
+      };
+    }
+
+    // Try as file
     try {
       const file = await this._files.head(key);
       return this.storedFileToStat(file, path);
@@ -491,7 +696,7 @@ export class FilesSDKFilesystem extends MastraFilesystem {
       if (!isNotFoundError(err)) throw err;
     }
 
-    // Try as directory
+    // Try as synthetic object-store directory after preserving exact object keys.
     if (await this.isDirectory(key)) {
       const now = new Date();
       return {
@@ -517,12 +722,24 @@ export class FilesSDKFilesystem extends MastraFilesystem {
     }
   }
 
+  private async deleteKeysOrThrow(keys: string[], path: string): Promise<void> {
+    const deleteResult = await this._files.delete(keys);
+    const errors = deleteResult?.errors ?? [];
+    if (errors.length) {
+      throw new Error(`Failed to delete ${errors.length} object(s) in ${path}`);
+    }
+  }
+
   /** Check if a key prefix has any children (i.e. acts like a directory). */
   private async isDirectory(key: string): Promise<boolean> {
     if (!key) return true; // root
+    if (this._files.adapter?.name === 'fs') {
+      return this.isExistingLocalDirectoryKey(key);
+    }
     const prefix = `${key}/`;
     const result = await this._files.list({ prefix, limit: 1 });
-    return result.items.length > 0;
+    if (result.items.length > 0) return true;
+    return false;
   }
 
   /** Convert a FilesSDK StoredFile to a Mastra FileStat. */

--- a/workspaces/files-sdk/src/filesystem/index.ts
+++ b/workspaces/files-sdk/src/filesystem/index.ts
@@ -398,6 +398,10 @@ export class FilesSDKFilesystem extends MastraFilesystem {
     this.assertWritable('appendFile');
     const key = toKey(path);
 
+    if (!(await this.isExactFileKey(key)) && (await this.isDirectory(key))) {
+      throw new IsDirectoryError(path);
+    }
+
     // Read-modify-write (object storage has no native append)
     let existing = Buffer.alloc(0);
     try {
@@ -421,8 +425,7 @@ export class FilesSDKFilesystem extends MastraFilesystem {
     this.assertWritable('deleteFile');
     const key = toKey(path);
 
-    // Check if path is a directory (has children)
-    if (await this.isDirectory(key)) {
+    if (!(await this.isExactFileKey(key)) && (await this.isDirectory(key))) {
       await this.rmdir(path, options);
       return;
     }

--- a/workspaces/files-sdk/src/index.ts
+++ b/workspaces/files-sdk/src/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @mastra/files-sdk - Unified Storage Filesystem Provider
+ *
+ * A filesystem implementation backed by FilesSDK (https://files-sdk.dev).
+ * Works with any FilesSDK adapter: S3, R2, GCS, Azure Blob, Vercel Blob,
+ * local filesystem, and more.
+ */
+
+export { FilesSDKFilesystem, type FilesSDKFilesystemOptions } from './filesystem';
+export { filesSDKFilesystemProvider } from './provider';

--- a/workspaces/files-sdk/src/provider.ts
+++ b/workspaces/files-sdk/src/provider.ts
@@ -1,0 +1,34 @@
+/**
+ * FilesSDK filesystem provider descriptor for MastraEditor.
+ *
+ * @example
+ * ```typescript
+ * import { filesSDKFilesystemProvider } from '@mastra/files-sdk';
+ *
+ * const editor = new MastraEditor({
+ *   filesystems: [filesSDKFilesystemProvider],
+ * });
+ * ```
+ */
+import type { FilesystemProvider } from '@mastra/core/editor';
+import { FilesSDKFilesystem } from './filesystem';
+import type { FilesSDKFilesystemOptions } from './filesystem';
+
+export const filesSDKFilesystemProvider: FilesystemProvider<FilesSDKFilesystemOptions> = {
+  id: 'files-sdk',
+  name: 'FilesSDK (Unified Storage)',
+  description: 'Unified storage via FilesSDK — supports S3, R2, GCS, Azure, Vercel Blob, local filesystem, and more',
+  configSchema: {
+    type: 'object',
+    required: ['files'],
+    properties: {
+      files: { type: 'object', description: 'Pre-configured FilesSDK Files instance' },
+      id: { type: 'string', description: 'Unique filesystem ID' },
+      displayName: { type: 'string', description: 'Human-friendly display name' },
+      icon: { type: 'string', description: 'Icon identifier for UI' },
+      description: { type: 'string', description: 'Description for UI' },
+      readOnly: { type: 'boolean', description: 'Mount as read-only', default: false },
+    },
+  },
+  createFilesystem: config => new FilesSDKFilesystem(config),
+};

--- a/workspaces/files-sdk/tsconfig.build.json
+++ b/workspaces/files-sdk/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/workspaces/files-sdk/tsconfig.json
+++ b/workspaces/files-sdk/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/workspaces/files-sdk/tsup.config.ts
+++ b/workspaces/files-sdk/tsup.config.ts
@@ -1,0 +1,18 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  external: ['@mastra/core', 'files-sdk'],
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/workspaces/files-sdk/vitest.config.ts
+++ b/workspaces/files-sdk/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 30000,
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Linear: https://linear.app/papersflow/issue/PF-758/intake-upstream-mastra-pr-17027-files-sdk-provider-into-fork
Upstream PR: https://github.com/mastra-ai/mastra/pull/17027
Upstream head: eef3e527a9f3597e1ec166df64f8ab910d7c3c60
Cherry-pick commit: 771f374e84
Local hardening commit: 91230eb38d
FilesSDK release requested by user: https://github.com/haydenbleasel/files-sdk/releases/tag/files-sdk%401.6.0

This PR cherry-picks upstream Mastra PR #17027 into the fork and targets files-sdk@1.6.0. It also hardens the provider before adoption:

- maps nested FilesSDK Provider/NotFound errors correctly
- honors expectedMtime and overwrite=false for write/copy/move
- uses Files.move() for moveFile
- enforces read-only mode for mkdir
- fixes directory semantics for trailing slashes, marker-only directories, local fs directory keys, empty local fs directories, missing/file path errors, exact object precedence, extension filtering, and bulk delete errors
- removes local fs backing directories after recursive rmdir
- fixes release note, README usage, package lock, and pre.json initial version metadata

## Validation

- npm view files-sdk@1.6.0 package metadata and peer dependency shape checked
- pnpm install --lockfile-only --config.minimum-release-age=0
- pnpm install --frozen-lockfile
- node -p require version check confirmed files-sdk 1.6.0 in workspaces/files-sdk
- pnpm prettier:changed
- pnpm --filter @mastra/files-sdk test:unit (102 passed)
- pnpm --filter @mastra/files-sdk lint
- pnpm --filter @mastra/files-sdk exec tsc --noEmit -p tsconfig.json
- pnpm --filter @mastra/files-sdk build:lib
- git diff --check
- real files-sdk fs adapter smoke: readdir, recursive rmdir backing dir removal, empty dir readdir/stat, IsDirectoryError on empty dir write, urlBaseUrl and prefix removal
- local Codex review passes found issues that were fixed in 91230eb38d; final rerun is blocked by account usage limit until 2026-05-26 00:21
- CodeRabbit CLI doctor passed and was authenticated, but local review stalled after setup with no findings emitted; terminated after several minutes. GitHub app review should be used as the primary CodeRabbit surface.

## Known limitations / follow-ups

- pnpm changeset-cli status --since origin/main fails due existing repo pre-release state: @mastra/memory has 1.18.1-papersflow.sha.4177781.0 while .changeset/pre.json records 1.19.0. This is unrelated to this package intake.
- expectedMtime and overwrite=false checks are preflight checks, not atomic object-store conditional writes. A follow-up can improve this if FilesSDK exposes conditional operations.
- the generic provider descriptor still requires a live Files instance and is not yet JSON-hydratable for editor config. That should stay a follow-up rather than blocking this upstream intake.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a new Mastra storage plugin that lets Mastra talk to many cloud and local storage systems via FilesSDK (S3, GCS, Azure, R2, local, etc.), with several fixes and safety checks so file operations behave like a normal filesystem.

## Overview
Cherry-picks upstream Mastra PR `#17027` into the fork (targeting files-sdk@1.6.0) and adds hardening/fixes to safely expose a FilesSDK-backed Mastra filesystem provider as a new workspace package: `@mastra/files-sdk`.

## Key Changes

- New package: workspaces/files-sdk (`@mastra/files-sdk`, initial version 0.1.0)
  - Public exports: FilesSDKFilesystem, FilesSDKFilesystemOptions, filesSDKFilesystemProvider
  - Package manifest, CHANGELOG header, README, build (tsup), test (Vitest), lint, and TypeScript config.

- Core implementation
  - FilesSDKFilesystem: Mastra WorkspaceFilesystem adapter backed by a pre-configured Files (files-sdk) instance.
  - Options: files, id, displayName, icon, description, readOnly.
  - init() does connectivity check (list limit=1) and maps unauthorized errors to access denied.
  - Provider descriptor: filesSDKFilesystemProvider with JSON-schema config requiring a files entry.

- Files & metadata operations
  - readFile, writeFile, appendFile, deleteFile, copyFile, moveFile
  - exists, stat, mkdir (no-op, enforced read-only when applicable), rmdir (recursive prefix deletion), readdir (recursive, maxDepth, extension filtering, deduped directory entries)
  - MIME type inference, conversion of FileContent → upload body
  - Uses Files.move() for moveFile

- Hardening and bug fixes (high-level)
  - Correct mapping of nested FilesSDK Provider/NotFound/Unauthorized errors.
  - Preflight honoring of expectedMtime and overwrite=false for write/copy/move (note: preflight checks, not atomic conditional writes).
  - Trailing-slash normalization, marker-only directory handling, exact-object precedence vs prefix, local FS directory key handling, empty local FS directory semantics.
  - Enforced read-only behavior for mkdir and write-path protections.
  - Bulk delete error reporting and removal of local FS backing directories after recursive rmdir.
  - Fixes to README usage, release notes, package-lock/pre.json metadata.

- Tests
  - Comprehensive Vitest suite for FilesSDKFilesystem (constructor/options, file ops, dir ops, stat/exists helpers, read-only enforcement, connectivity/authorization mapping). Unit test run reported: 102 tests passed for `@mastra/files-sdk`.
  - Includes adapter-specific smoke tests (real local/fs adapter behaviors like recursive rmdir backing dir removal and empty-dir handling).

## Validation Performed
- npm view checked files-sdk@1.6.0 metadata and peer-dep shape.
- pnpm install --lockfile-only and --frozen-lockfile checks; workspace files-sdk version verified.
- Prettier, lint, TypeScript noEmit, build:lib, and git diff --check.
- Local Codex review and CodeRabbit CLI doctor runs; final automated rerun blocked by account limits.
- Real FilesSDK adapter smoke tests (readdir, recursive rmdir backing dir removal, empty dir readdir/stat, IsDirectoryError on empty-dir write, urlBaseUrl/prefix removal).

## Known Limitations / Follow-ups
- expectedMtime and overwrite=false are implemented as preflight checks (not atomic conditional writes) — follow-up if FilesSDK exposes conditional ops.
- Generic provider descriptor requires a live Files instance and is not JSON-hydratable — planned follow-up for JSON serialization/deserialization.
- Minor pnpm changeset-cli status discrepancy unrelated to this package intake.
- Node engine requirement: >=22.13.0.

## Files Added / Modified (high level)
- Added package files under workspaces/files-sdk: src/{index.ts, filesystem/index.ts, provider.ts}, tests, README, CHANGELOG header, package.json, tsup/vitest/tsconfig config files, eslint.config.js, .changeset entries, and accompanying tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mbenhamd/mastra/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->