### PR TITLE
Fix local multi-subscriber thread broadcast (EventEmitterPubSub starvation)

### DIFF
--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -2083,6 +2083,101 @@ describe('Agent signals', () => {
     }
   });
 
+  it('marks a caller-only approval-suspended run without any thread subscribers', async () => {
+    // Regression: the local multicast drain detects the approval marker. With no
+    // thread subscribers nothing pulls a subscriber stream, so the drain must be
+    // kicked eagerly at registration — otherwise #markApprovalSuspendedFromPart
+    // never runs and the finalizer wrongly treats the suspended run as completed,
+    // clearing its record. Here there is NO subscribeToThread caller at all.
+    const runtime = new AgentThreadStreamRuntime();
+    const agent = { id: 'caller-only-approval-agent' } as Agent<any, any, any, any>;
+    const threadId = 'caller-only-approval-thread';
+    const resourceId = 'caller-only-approval-user';
+    const runId = 'caller-only-approval-run';
+
+    let finishSuspended!: () => void;
+    const suspendedFinished = new Promise<void>(resolve => {
+      finishSuspended = resolve;
+    });
+    const suspendedCompletion = runtime.registerRun(
+      agent,
+      {
+        runId,
+        status: 'suspended',
+        fullStream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: 'start', runId });
+            controller.enqueue({
+              type: 'tool-call-approval',
+              runId,
+              payload: { toolCallId: 'tool-call-1', toolName: 'testTool' },
+            });
+            controller.close();
+          },
+        }),
+        _waitUntilFinished: () => suspendedFinished,
+      } as any,
+      { memory: { thread: threadId, resource: resourceId } } as any,
+    );
+
+    // Drive and await the finalizer with no subscriber ever attached.
+    finishSuspended();
+    await withTimeout(
+      suspendedCompletion ?? Promise.resolve(),
+      'Timed out waiting for caller-only approval-suspended finalizer',
+    );
+    await nextTick();
+
+    // The approval marker must have been set by the eager drain: the thread stays
+    // blocked (active) and the run record is retained rather than finalized-as-
+    // completed and deleted.
+    expect(runtime.getThreadState({ resourceId, threadId })).toBe('active');
+    expect(runtime.getRunOutput(runId)).toBeDefined();
+
+    // A subsequent resume reuses the same runId and must re-register cleanly
+    // (the retained record is dropped via #clearApprovalSuspendedRunForResume).
+    let finishResumed!: () => void;
+    const resumedFinished = new Promise<void>(resolve => {
+      finishResumed = resolve;
+    });
+    const resumedCompletion = runtime.registerRun(
+      agent,
+      {
+        runId,
+        status: 'running',
+        fullStream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: 'start', runId });
+            controller.enqueue({ type: 'text-start', runId, payload: { id: 'text-1' } });
+            controller.enqueue({
+              type: 'text-delta',
+              runId,
+              payload: { id: 'text-1', text: 'approved response' },
+            });
+            controller.enqueue({ type: 'text-end', runId, payload: { id: 'text-1' } });
+            controller.enqueue({
+              type: 'finish',
+              runId,
+              payload: { usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 }, finishReason: 'stop' },
+            });
+            controller.close();
+            finishResumed();
+          },
+        }),
+        _waitUntilFinished: () => resumedFinished,
+      } as any,
+      { memory: { thread: threadId, resource: resourceId } } as any,
+    );
+
+    await withTimeout(resumedCompletion ?? Promise.resolve(), 'Timed out waiting for resumed run completion');
+    await nextTick();
+
+    // The resumed run completed normally: the thread is idle again and the record
+    // is cleared.
+    expect(runtime.getThreadState({ resourceId, threadId })).toBe('idle');
+    expect(runtime.getRunOutput(runId)).toBeUndefined();
+  });
+
   it('queues queueMessage until the active run completes', async () => {
     let releaseFirst!: () => void;
     const firstFinished = new Promise<void>(resolve => {

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -295,15 +295,27 @@ export class AgentThreadStreamRuntime {
       for (const waiter of pending) waiter();
     };
 
+    // A real `MastraModelOutput` exposes `fullStream` as an evented getter that
+    // yields a fresh independent stream on every access, so the drain loop can
+    // read it lazily without competing with the caller. The synthetic
+    // persisted-signal output (#broadcastPersistedSignal) instead defines
+    // `fullStream` as a one-shot OWN-PROPERTY ReadableStream that only one
+    // consumer can drain. Capture that single stream up front so the drain owns
+    // it, then (below) redefine the own property to a multicast replay so the
+    // caller reads through the same buffer instead of racing the drain.
+    const ownFullStream = Object.prototype.hasOwnProperty.call(output, 'fullStream');
+    const capturedSource = ownFullStream ? (output.fullStream as any) : undefined;
+
     const start = () => {
       if (started) return;
       started = true;
       void (async () => {
         try {
-          // Read `output.fullStream` lazily so a real MastraModelOutput's evented
-          // getter yields a fresh stream for the drain loop, independent of the
-          // caller's own `output.fullStream` access.
-          const source = output.fullStream as any;
+          // For getter-based outputs read `output.fullStream` lazily so the
+          // evented getter yields a fresh stream for the drain loop, independent
+          // of the caller's own access; for own-property one-shot outputs drain
+          // the single captured stream.
+          const source = ownFullStream ? capturedSource : (output.fullStream as any);
           if (!source) return;
           for await (const part of source) {
             runtime.#markApprovalSuspendedFromPart(pubsub, runId, part);
@@ -359,6 +371,26 @@ export class AgentThreadStreamRuntime {
         },
       });
     };
+
+    // For the own-property one-shot path, redefine `fullStream` to a multicast
+    // replay stream so the caller reads through the shared buffer (single drain,
+    // no starvation) instead of racing the eager drain for the single stream.
+    if (ownFullStream) {
+      Object.defineProperty(output, 'fullStream', {
+        configurable: true,
+        enumerable: true,
+        get: () => createSubscriberStream(),
+      });
+    }
+
+    // Kick the drain eagerly (matching upstream's `#withBroadcastStream`, whose
+    // buffer fills regardless of subscribers). A LOCAL run consumed only by the
+    // original caller — with no thread subscribers — must still run the drain so
+    // `#markApprovalSuspendedFromPart` observes a `tool-call-approval` part and
+    // marks the run approval-suspended; otherwise the finalizer treats a
+    // suspended run as completed and clears its record. The buffer-fills-
+    // regardless memory profile was explicitly accepted by review.
+    start();
 
     return createSubscriberStream;
   }

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -64,6 +64,13 @@ type AgentThreadRunRecord<OUTPUT = unknown> = {
   threadId: string;
   resourceId?: string;
   streamOptions: AgentExecutionOptions<OUTPUT>;
+  // For local (same-runtime / EventEmitterPubSub) runs, a multicast factory that
+  // returns an independent ReadableStream per thread subscriber. The fork does not
+  // republish local runs through pubsub, so without this every subscriber (and the
+  // caller) would compete over the single `output.fullStream`, starving all but the
+  // first reader. Absent for remote runs, whose subscribers already get a dedicated
+  // per-subscription stream fed by `stream-part` pubsub events.
+  createSubscriberStream?: () => ReadableStream<unknown>;
 };
 
 type PreparedThreadRun = {
@@ -260,44 +267,116 @@ export class AgentThreadStreamRuntime {
     }
   }
 
-  // For local (EventEmitterPubSub) runs the fork does not republish the stream,
-  // so the broadcast part-loop that detects approval suspension never runs and
-  // the subscriber stream reads `output.fullStream` directly. Wrap that stream
-  // with an inline detection passthrough so the approval marker is recorded
-  // *before* each part is yielded to the local subscriber — matching upstream's
-  // always-running broadcast loop where `emitPart` sets the marker before the
-  // part is buffered for subscribers. An inline wrapper (not `tee`) keeps the
-  // marker write ordered ahead of the subscriber observing the part, avoiding a
-  // race where `getThreadState` is queried before a detached detector caught up.
-  #attachLocalApprovalDetection<OUTPUT>(output: MastraModelOutput<OUTPUT>, pubsub: PubSub | undefined) {
-    const source = output.fullStream as any;
-    if (!source) return;
-    if (!Object.prototype.hasOwnProperty.call(output, 'fullStream')) return;
-
+  // For local (EventEmitterPubSub) runs the fork does not republish the stream
+  // through pubsub, so thread subscribers cannot be fed by `stream-part` events
+  // like remote runs are. Historically the subscriber loop then read the run's
+  // single `output.fullStream` directly, which only one consumer can drain — every
+  // other subscriber (and the caller) starved or hung. This builds a multicast
+  // buffer that drains the source exactly once into a shared `parts[]` array and
+  // hands each subscriber an independent ReadableStream replaying that buffer,
+  // matching upstream's `#withBroadcastStream` fan-out. The single drain loop also
+  // records the approval-suspension marker before any subscriber observes the
+  // `tool-call-approval` part — folding in the former `#attachLocalApprovalDetection`
+  // so the marker is set strictly ahead of the part (keeping the thread blocked
+  // when `getThreadState` is queried) while the subscriber's reader stays unlocked.
+  #withLocalBroadcastStream<OUTPUT>(output: MastraModelOutput<OUTPUT>, pubsub: PubSub | undefined) {
     const runtime = this;
     const runId = output.runId;
 
-    const fullStream = (async function* () {
-      for await (const part of source) {
-        runtime.#markApprovalSuspendedFromPart(pubsub, runId, part);
-        yield part;
-      }
-    })();
-    Object.defineProperty(output, 'fullStream', {
-      configurable: true,
-      enumerable: true,
-      value: fullStream,
-    });
+    const parts: unknown[] = [];
+    const waiters = new Set<() => void>();
+    let started = false;
+    let done = false;
+    let error: unknown;
+
+    const wake = () => {
+      const pending = [...waiters];
+      waiters.clear();
+      for (const waiter of pending) waiter();
+    };
+
+    const start = () => {
+      if (started) return;
+      started = true;
+      void (async () => {
+        try {
+          // Read `output.fullStream` lazily so a real MastraModelOutput's evented
+          // getter yields a fresh stream for the drain loop, independent of the
+          // caller's own `output.fullStream` access.
+          const source = output.fullStream as any;
+          if (!source) return;
+          for await (const part of source) {
+            runtime.#markApprovalSuspendedFromPart(pubsub, runId, part);
+            parts.push(part);
+            wake();
+          }
+        } catch (caught) {
+          error = caught;
+        } finally {
+          done = true;
+          wake();
+        }
+      })();
+    };
+
+    const createSubscriberStream = (): ReadableStream<unknown> => {
+      let index = 0;
+      let closed = false;
+      let waiter: (() => void) | undefined;
+      return new ReadableStream({
+        async pull(controller) {
+          start();
+          while (!closed) {
+            if (index < parts.length) {
+              controller.enqueue(parts[index++]);
+              return;
+            }
+            if (error) {
+              controller.error(error);
+              return;
+            }
+            if (done) {
+              controller.close();
+              return;
+            }
+            await new Promise<void>(resolve => {
+              waiter = resolve;
+              waiters.add(resolve);
+            });
+            if (waiter) {
+              waiters.delete(waiter);
+              waiter = undefined;
+            }
+          }
+        },
+        cancel() {
+          closed = true;
+          if (waiter) {
+            waiters.delete(waiter);
+            waiter();
+            waiter = undefined;
+          }
+        },
+      });
+    };
+
+    return createSubscriberStream;
   }
 
-  #prepareBroadcastSource<OUTPUT>(output: MastraModelOutput<OUTPUT>, pubsub: PubSub | undefined, key: string) {
+  #prepareBroadcastSource<OUTPUT>(
+    output: MastraModelOutput<OUTPUT>,
+    pubsub: PubSub | undefined,
+    key: string,
+  ): {
+    source?: AsyncIterable<unknown> | ReadableStream<unknown>;
+    createSubscriberStream?: () => ReadableStream<unknown>;
+  } {
     if (this.#getPubSub(pubsub) instanceof EventEmitterPubSub) {
-      this.#attachLocalApprovalDetection(output, pubsub);
-      return;
+      return { createSubscriberStream: this.#withLocalBroadcastStream(output, pubsub) };
     }
 
     let source = output.fullStream as any;
-    if (!source) return;
+    if (!source) return {};
 
     if (Object.prototype.hasOwnProperty.call(output, 'fullStream')) {
       if (typeof source.tee === 'function') {
@@ -326,11 +405,11 @@ export class AgentThreadStreamRuntime {
           enumerable: true,
           value: fullStream,
         });
-        return;
+        return {};
       }
     }
 
-    return source;
+    return { source };
   }
 
   async #broadcastStream<OUTPUT>(
@@ -894,12 +973,13 @@ export class AgentThreadStreamRuntime {
       }),
       _waitUntilFinished: () => finished,
     } as MastraModelOutput<any>;
-    // Fork broadcast pattern: #prepareBroadcastSource tees `output.fullStream`
-    // in place (subscribers read the teed caller side via the record's `output`)
-    // and #broadcastStream publishes the broadcast side once registration lands —
-    // the same shape as registerThreadRun below. Replaces upstream's
-    // #withBroadcastStream helper, which does not exist in the fork runtime.
-    const broadcastSource = this.#prepareBroadcastSource(output, pubsub, key);
+    // Fork broadcast pattern: #prepareBroadcastSource either tees `output.fullStream`
+    // in place for remote pubsub (subscribers read the teed caller side via the
+    // record's `output`, #broadcastStream publishes the broadcast side once
+    // registration lands) or, for the local EventEmitterPubSub, returns a
+    // multicast `createSubscriberStream` factory so every same-runtime subscriber
+    // gets an independent fan-out view instead of competing over `output.fullStream`.
+    const { source: broadcastSource, createSubscriberStream } = this.#prepareBroadcastSource(output, pubsub, key);
     const startBroadcast = () => {
       void this.#broadcastStream(output, broadcastSource, pubsub, key).catch(() => {});
     };
@@ -910,6 +990,7 @@ export class AgentThreadStreamRuntime {
       threadId,
       resourceId,
       streamOptions: {},
+      createSubscriberStream,
     };
 
     state.threadRunsById.set(runId, record);
@@ -998,7 +1079,7 @@ export class AgentThreadStreamRuntime {
       state.inflightIdleThreadKeysByRunId.delete(output.runId);
       state.inflightIdleAgentIdsByRunId.delete(output.runId);
     }
-    const broadcastSource = this.#prepareBroadcastSource(output, pubsub, key);
+    const { source: broadcastSource, createSubscriberStream } = this.#prepareBroadcastSource(output, pubsub, key);
     const record: AgentThreadRunRecord<OUTPUT> = {
       agent,
       output,
@@ -1006,6 +1087,7 @@ export class AgentThreadStreamRuntime {
       threadId,
       resourceId,
       streamOptions: streamOptions as AgentThreadRunRecord<OUTPUT>['streamOptions'],
+      createSubscriberStream,
     };
 
     state.threadRunsById.set(output.runId, record);
@@ -1600,7 +1682,13 @@ export class AgentThreadStreamRuntime {
               continue;
             }
             const run = pendingRuns.shift()!;
-            for await (const part of run.output.fullStream) {
+            // Local registered runs expose a multicast `createSubscriberStream`
+            // giving this subscriber an independent fan-out view; remote runs are
+            // already per-subscription streams fed by pubsub `stream-part` events.
+            // Reading `output.fullStream` directly would let one subscriber lock
+            // and drain the shared stream, starving every other subscriber.
+            const subscriberStream = run.createSubscriberStream?.() ?? run.output.fullStream;
+            for await (const part of subscriberStream) {
               yield part as any;
               if (done) break;
             }
@@ -1893,7 +1981,19 @@ export class AgentThreadStreamRuntime {
     runId ??= randomUUID();
     if (idleBehavior !== 'wake') {
       if (idleBehavior === 'persist') {
-        const persisted = this.#persistSignal(
+        // Persist the signal AND broadcast it to thread subscribers (upstream
+        // parity). The fork previously only persisted, so idle-persist signals —
+        // e.g. low-priority notification summaries dispatched via
+        // `ifIdle: { behavior: 'persist' }` — never reached same-runtime
+        // subscribers. #persistAndBroadcastIdleSignal persists first, then emits
+        // a synthetic start/data/finish run through the (multicast) broadcast
+        // machinery without waking the agent.
+        key ??= this.#threadKey(resourceId, threadId);
+        const persisted = this.#persistAndBroadcastIdleSignal(
+          state,
+          pubsub,
+          key,
+          runId,
           agent,
           signal,
           resourceId,


### PR DESCRIPTION
## Summary

Fixes the long-standing **local multi-subscriber broadcast regression** in `thread-stream-runtime.ts` — the root cause behind ~7 failing/hanging `agent-signals` tests (documented as a known pre-existing issue in PR #200) and the broader sibling of the approval-marker bug fixed there.

### Root cause
`#prepareBroadcastSource` early-returned for the default `EventEmitterPubSub`, so all local same-runtime thread subscribers read the run record's **single shared `output.fullStream`**. A `ReadableStream` has one reader: the first consumer drained it and every other subscriber starved (tests hung). A coupled regression: the idle `behavior:'persist'` branch never broadcast — `#persistAndBroadcastIdleSignal` was dead code, so persisted signals (e.g. notification summaries) never reached subscribers.

### Fix (mirrors upstream's multicast model)
- `#withLocalBroadcastStream`: drains the source **exactly once** into a shared buffer; each subscriber gets an independent fan-out stream replayed from it (`createSubscriberStream` on the run record, consumed by `subscribeToThread`)
- The drain starts **eagerly at registration** — approval-suspension marker detection lives in the drain loop, so caller-only runs (no subscribers) still mark correctly and are never finalized-as-completed (review-found blocker, fixed + regression-tested)
- One-shot own-property `fullStream` outputs are captured up front and redefined as a multicast replay accessor — the caller reads through the shared buffer instead of racing the drain
- Idle-persist branch rewired to `#persistAndBroadcastIdleSignal` (persists once, broadcasts once)

### Validation
- The previously hanging multi-subscriber tests now pass and terminate (~tens of ms): multi-subscriber delivery, multicast-alive, notification summaries ×2, persisted idle signal, future-thread-run fan-out, no-replay-to-late-subscribers
- New regression test: caller-only approval-suspended run retains its record and resumes cleanly
- Gates: approval suites, tool-call-step, stream-until-idle, harness request-context + events (71), agent-channels (44), core `tsc` 0
- Two Codex review passes; all findings addressed (replay semantics, backpressure isolation, buffer lifecycle vs upstream model, ordering, own-property semantics)

### Known pre-existing failures NOT addressed (verified identical on the pre-fix tip)
`fans out sequential idle signal runs` (signal data-shape in idle-wake injection), `queues a signal from another agent`, `converts signals between DB/LLM/data part formats`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes a "starvation" bug where multiple subscribers trying to read messages from the same local thread broadcast would hang. The problem was they were all reading from a single shared stream that could only be drained once—the first reader would consume everything, and the others would wait forever. The fix creates a shared buffer that drains the stream once, then gives each subscriber their own independent tap to read from that buffer, so everyone can read without blocking each other.

---

## Problem

A regression in the local (same-process) multi-subscriber broadcast mechanism caused approximately 7 `agent-signals` tests to hang. The root cause: when multiple subscribers tried to read from the same thread run's output stream via `EventEmitterPubSub`, they all received a reference to a single shared `ReadableStream`. Since a `ReadableStream` can only be drained once, the first consumer would exhaust it, causing all other subscribers to starve indefinitely.

Additionally, the idle signal persistence logic was broken—the "persist" behavior never actually broadcasted idle signals to subscribers.

## Solution

### Main Fix: Multicast Subscriber Stream Factory

Modified `thread-stream-runtime.ts` to introduce a multicast pattern that:

1. **Drains once into a shared buffer**: `#withLocalBroadcastStream` consumes the source output exactly once into a shared buffer, preventing multiple readers from competing for the same stream.

2. **Creates independent fan-out streams per subscriber**: Each subscriber gets an independent replay stream (`createSubscriberStream`) that reads from the shared buffer, so they can consume at their own pace without blocking each other.

3. **Eager drain at registration**: The drain starts immediately when a run is registered, not when the first subscriber connects. This ensures approval-suspension markers are detected and recorded even if there are currently zero subscribers (preventing caller-only runs from being incorrectly finalized without retaining output).

4. **Captures and replays fullStream outputs**: One-shot `fullStream` outputs are captured up front and redefined as multicast replay accessors, allowing callers to read through the shared buffer without racing the drain.

### Secondary Fix: Idle Signal Broadcasting

Rewired the idle "persist" signal routing to call `#persistAndBroadcastIdleSignal`, ensuring that persisted idle signals are properly broadcast to all subscribers (not just persisted silently).

## Changes

**`packages/core/src/agent/thread-stream-runtime.ts`** (+172/-40)
- `#prepareBroadcastSource` now returns a multicast `createSubscriberStream` factory for local runs (replacing inline approval detection logic)
- `AgentThreadRunRecord` optionally carries `createSubscriberStream` for per-run subscriber stream creation
- Thread subscriptions now read from `run.createSubscriberStream?.()` with fallback to `run.output.fullStream`
- Idle "persist" behavior now calls `#persistAndBroadcastIdleSignal` to broadcast persisted signals

**`packages/core/src/agent/__tests__/agent-signals.test.ts`** (+95/-0)
- Added regression test: verifies that approval-suspended runs without active subscribers still retain their output and record suspension state, allowing them to be resumed later
- Test ensures the fix handles the edge case of caller-only runs (no `subscribeToThread` consumers) correctly

## Validation

- Previously hanging multi-subscriber tests now pass and terminate correctly
- New regression test ensures the caller-only approval-suspension scenario works as expected
- Multiple test suites and type checks reported passing
- Known pre-existing failures remain unchanged

<!-- end of auto-generated comment: release notes by coderabbit.ai -->