### PR TITLE
Fix network-route requestContext passthrough + deterministic heartbeat test

### DIFF
--- a/packages/server/src/server/handlers/agents.test.ts
+++ b/packages/server/src/server/handlers/agents.test.ts
@@ -1885,6 +1885,14 @@ describe('Agent Routes Authorization', () => {
           })(),
         }));
 
+        // Baseline timer count owned by the shared Mastra/storage machinery
+        // (e.g. background flush timers wired up via the mastra instance in
+        // beforeEach). The handler must clear the single heartbeat timer it
+        // schedules on abort, returning the count to this baseline — asserting
+        // an absolute 0 conflates the handler's timer with unrelated framework
+        // timers and is non-deterministic.
+        const baselineTimerCount = vi.getTimerCount();
+
         const stream = (await SUBSCRIBE_AGENT_THREAD_ROUTE.handler({
           mastra,
           agentId: 'test-agent',
@@ -1895,12 +1903,14 @@ describe('Agent Routes Authorization', () => {
         } as any)) as ReadableStream;
 
         const reader = stream.getReader();
+        // Sanity check: the handler scheduled exactly one heartbeat timer.
+        expect(vi.getTimerCount()).toBe(baselineTimerCount + 1);
         abortController.abort();
         await Promise.resolve();
 
         expect(abort).not.toHaveBeenCalled();
         expect(unsubscribe).toHaveBeenCalledTimes(1);
-        expect(vi.getTimerCount()).toBe(0);
+        expect(vi.getTimerCount()).toBe(baselineTimerCount);
         await vi.advanceTimersByTimeAsync(25_000);
         await expect(reader.read()).resolves.toEqual({ value: undefined, done: true });
       } finally {

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -2777,6 +2777,7 @@ export const STREAM_NETWORK_ROUTE = createRoute({
 
       const streamResult = await agent.network(messages, {
         ...params,
+        requestContext,
       });
 
       return streamResult;
@@ -2816,6 +2817,7 @@ export const APPROVE_NETWORK_TOOL_CALL_ROUTE = createRoute({
 
       const streamResult = await agent.approveNetworkToolCall({
         ...params,
+        requestContext,
       });
 
       return streamResult;
@@ -2855,6 +2857,7 @@ export const DECLINE_NETWORK_TOOL_CALL_ROUTE = createRoute({
 
       const streamResult = await agent.declineNetworkToolCall({
         ...params,
+        requestContext,
       });
 
       return streamResult;


### PR DESCRIPTION
## Summary

Fixes the 3 pre-existing `agents.test.ts` failures documented in PR #200.

### Network routes dropped `requestContext` (source bug)
The stream-network, approve-network-tool-call, and decline-network-tool-call handlers destructured `requestContext` out of the handler params but never forwarded it into the options passed to `agent.network()` / `approveNetworkToolCall()` / `declineNetworkToolCall()` — so caller request context silently never reached network runs or approval helpers. Upstream has the identical bug with no tests covering it; this fork's tests asserted the correct contract (matching how `STREAM_GENERATE_ROUTE` threads it). Fixed by forwarding `requestContext` in all three routes.

### Heartbeat-abort test made deterministic and stronger (test bug)
The test asserted an absolute `vi.getTimerCount() === 0` after abort, conflating the handler's heartbeat timer with an unrelated background framework timer from the shared test `Mastra` instance. Instrumentation proved the handler is correct (schedules exactly one heartbeat, clears it synchronously on abort). Reworked to baseline-relative assertions: handler adds exactly **+1** timer, abort returns to baseline — strictly stronger than before.

## Validation
agents.test.ts 80 ✓ + harness.test.ts 85 ✓ (= the prior 162 + the 3 fixed) · server `tsc` 0 · Codex-reviewed (SHIP; reviewer re-ran the focused tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes two things that were broken: (1) When network handlers processed requests, they were forgetting to pass along important context information (like who made the request) to the underlying agent methods, which is like passing a letter through people but losing the sender's name. (2) A test that checked if timers were being cleaned up properly was unreliable because it was counting all timers in the system instead of just the ones the handler created, so we fixed it to measure only what the handler does.

---

## Changes

### agents.ts
Three network route handlers (`stream-network`, `approve-network-tool-call`, `decline-network-tool-call`) now forward `requestContext` to the underlying agent methods. Previously, these handlers extracted `requestContext` from the request but did not pass it through to `agent.network()`, `agent.approveNetworkToolCall()`, or `agent.declineNetworkToolCall()`, causing caller context (including reserved fields like `mastra__resourceId`) to be lost. The handlers now include `requestContext` in the options argument, matching the pattern used in the `STREAM_GENERATE_ROUTE` handler.

### agents.test.ts
The `should clear heartbeat timers when an idle subscription stream is aborted` test was rewritten to eliminate flakiness. Instead of asserting an absolute timer count of zero after abort (which conflated the handler's heartbeat timer with background framework timers from the shared test instance), the test now:
- Captures a baseline timer count before invoking the route
- Asserts the handler adds exactly +1 timer during operation
- Asserts abort returns the timer count to the baseline

This approach strengthens test determinism without assumptions about other timers in the system.

---

## Impact

- Test pass rate: agents.test.ts now passes 80 tests; harness.test.ts 85 tests; server TypeScript compilation shows 0 errors
- No public API changes; modifications are internal to handler wiring and test instrumentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->