### PR TITLE
Persisted-signal completion ordering + presence-tracked replay errors (PR #202 follow-ups)

### DIFF
--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -288,6 +288,7 @@ export class AgentThreadStreamRuntime {
     let started = false;
     let done = false;
     let error: unknown;
+    let hasError = false;
 
     const wake = () => {
       const pending = [...waiters];
@@ -324,6 +325,7 @@ export class AgentThreadStreamRuntime {
           }
         } catch (caught) {
           error = caught;
+          hasError = true;
         } finally {
           done = true;
           wake();
@@ -343,7 +345,10 @@ export class AgentThreadStreamRuntime {
               controller.enqueue(parts[index++]);
               return;
             }
-            if (error) {
+            if (hasError) {
+              // Presence-tracked separately: a source that throws a FALSY value
+              // (undefined/null/0/'') must still fail the subscriber stream
+              // rather than close it cleanly (PR #202 review).
               controller.error(error);
               return;
             }
@@ -1012,9 +1017,7 @@ export class AgentThreadStreamRuntime {
     // multicast `createSubscriberStream` factory so every same-runtime subscriber
     // gets an independent fan-out view instead of competing over `output.fullStream`.
     const { source: broadcastSource, createSubscriberStream } = this.#prepareBroadcastSource(output, pubsub, key);
-    const startBroadcast = () => {
-      void this.#broadcastStream(output, broadcastSource, pubsub, key).catch(() => {});
-    };
+    const startBroadcast = () => this.#broadcastStream(output, broadcastSource, pubsub, key);
     const record: AgentThreadRunRecord<any> = {
       agent: { id: `persisted-signal:${signal.id}` } as Agent<any, any, any, any>,
       output,
@@ -1028,8 +1031,15 @@ export class AgentThreadStreamRuntime {
     state.threadRunsById.set(runId, record);
     state.threadKeysByRunId.set(runId, key);
     const registered = this.#publishAndWait(pubsub, key, { type: 'run-registered', runId });
-    void registered.then(startBroadcast, startBroadcast);
-    void output._waitUntilFinished().finally(() => {
+    const broadcast = registered.then(startBroadcast, startBroadcast).catch(() => {});
+    // PR #202 review (P2): the synthetic output's `finish()` fires at stream
+    // CONSTRUCTION, long before an async pubsub has published the stream-parts.
+    // Publishing `run-completed` off `_waitUntilFinished()` alone let remote
+    // subscribers observe completion FIRST, delete the remote run, and ignore
+    // the late persisted-signal parts. Gate completion on registration + the
+    // stream-part broadcast settling (local multicast resolves immediately —
+    // `#broadcastStream` is a fast no-op without a remote source).
+    void Promise.allSettled([output._waitUntilFinished(), broadcast]).then(() => {
       setTimeout(() => {
         state.threadRunsById.delete(runId);
         state.threadKeysByRunId.delete(runId);


### PR DESCRIPTION
Implements the two post-merge review findings on #202: (1) `run-completed` for persisted signals now waits for registration + the stream-part broadcast to settle, so async-pubsub subscribers can no longer observe completion before the parts arrive and drop them; (2) the local replay stream tracks error *presence* separately, so a source throwing a falsy value fails subscriber streams instead of closing them cleanly. Validation: persist 3 ✓, subscriber 7 ✓ (the 1 failure is the known pre-existing fans-out data-shape issue, unchanged), notification 11 ✓, core tsc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 Explanation

This PR fixes two messaging problems: (1) When broadcasting data to multiple subscribers, the "we're done" message now waits for all data pieces to actually arrive before being sent, preventing late arrivals from being lost; (2) If something throws an "empty" error value (like `undefined` or `0`), it's now correctly treated as an actual error instead of just cleanly closing.

## Changes

### `packages/core/src/agent/thread-stream-runtime.ts`

**Error tracking for falsy thrown values:**
- Added explicit `hasError` flag tracking in `#withLocalBroadcastStream` to distinguish between streams that ended normally vs. ended due to an exception
- The drain loop's `catch` block now sets `hasError`, and subscriber `pull` checks this flag before deciding whether to close or fail
- This ensures subscriber streams properly fail even when the thrown value is falsy (e.g., `undefined`, `null`, `0`, empty string)

**Persisted-signal completion ordering:**
- Refactored `#broadcastPersistedSignal` so broadcast starts immediately after registration via `registered.then(startBroadcast, startBroadcast).catch(() => {})`
- Changed completion gating for persisted-signal runs to wait for both `output._waitUntilFinished()` and broadcast settling using `Promise.allSettled([output._waitUntilFinished(), broadcast])`
- This prevents the `run-completed` event/cleanup from being published before the stream-part broadcast has settled, ensuring remote async-pubsub subscribers receive parts before observing completion

**Code metrics:**
- Lines changed: +16/-6
- No changes to exported or public entity declarations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->