### PR TITLE
Fix pre-existing agent-signals failures (acceptedAt regression + stale test contracts)

### DIFF
--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -240,6 +240,7 @@ describe('Agent signals', () => {
         attributes: { priority: 'high' },
         metadata: { source: 'test', signal: { userProvided: true } },
       },
+      transient: true,
     });
 
     const dbMessage = signal.toDBMessage({ threadId: 'thread-1', resourceId: 'resource-1' });
@@ -250,7 +251,6 @@ describe('Agent signals', () => {
         type: 'user',
         tagName: 'user',
         createdAt: '2026-01-01T00:00:00.000Z',
-        contents: 'Signal contents',
         attributes: { priority: 'high' },
         metadata: { source: 'test', signal: { userProvided: true } },
       },
@@ -269,13 +269,11 @@ describe('Agent signals', () => {
       attributes: { type: 'dynamic-agents-md', path: '/tmp/AGENTS.md', enabled: true, ignored: null },
     });
 
-    expect(reminderSignal.toLLMMessage()).toEqual([
-      {
-        role: 'user',
-        content:
-          '<system-reminder type="dynamic-agents-md" path="/tmp/AGENTS.md" enabled="true">Use &lt;safe&gt; content &amp; continue</system-reminder>',
-      },
-    ]);
+    expect(reminderSignal.toLLMMessage()).toEqual({
+      role: 'user',
+      content:
+        '<system-reminder type="dynamic-agents-md" path="/tmp/AGENTS.md" enabled="true">Use &lt;safe&gt; content &amp; continue</system-reminder>',
+    });
     expect(reminderSignal.toDataPart().data.attributes).toEqual({
       type: 'dynamic-agents-md',
       path: '/tmp/AGENTS.md',
@@ -289,18 +287,15 @@ describe('Agent signals', () => {
       ignored: null,
     });
 
-    const fileContents = {
-      role: 'user' as const,
-      content: [
-        { type: 'text' as const, text: 'Review this file' },
-        {
-          type: 'file' as const,
-          data: 'data:text/plain;base64,aGVsbG8=',
-          mediaType: 'text/plain',
-          filename: 'note.txt',
-        },
-      ],
-    };
+    const fileContents = [
+      { type: 'text' as const, text: 'Review this file' },
+      {
+        type: 'file' as const,
+        data: 'data:text/plain;base64,aGVsbG8=',
+        mediaType: 'text/plain',
+        filename: 'note.txt',
+      },
+    ];
     const fileSignal = createSignal({
       id: 'signal-3',
       type: 'user-message',
@@ -308,7 +303,19 @@ describe('Agent signals', () => {
       createdAt: new Date('2026-01-01T00:00:00.000Z'),
     });
 
-    expect(fileSignal.toLLMMessage()).toEqual(fileContents);
+    // toLLMMessage emits the v5 UserModelMessage shape (uses mediaType for FilePart).
+    expect(fileSignal.toLLMMessage()).toEqual({
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Review this file' },
+        {
+          type: 'file',
+          data: 'data:text/plain;base64,aGVsbG8=',
+          mediaType: 'text/plain',
+          filename: 'note.txt',
+        },
+      ],
+    });
     expect(fileSignal.toDataPart().data.contents).toEqual(fileContents);
     expect(mastraDBMessageToSignal(fileSignal.toDBMessage()).contents).toEqual(fileContents);
   });

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -4581,7 +4581,7 @@ describe('Agent signals', () => {
       memory: { thread: 'cross-agent-thread', resource: 'cross-agent-user' },
     });
     const firstText = firstStream.text;
-    await nextTick();
+    await waitForCondition(() => firstStarted);
     expect(firstStarted).toBe(true);
 
     const signalResult = await secondAgent.sendSignal(

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -1866,7 +1866,7 @@ export class AgentThreadStreamRuntime {
     pubsub?: PubSub,
   ): SendAgentSignalResult {
     const state = this.#getState(pubsub);
-    const signal = createSignal(signalInput);
+    const signal = createSignal({ ...signalInput, acceptedAt: new Date() });
     const callerSignalId = signalInput.id;
     let key: string | undefined;
     let runId = target.runId;


### PR DESCRIPTION
Fixes the 3 pre-existing `agent-signals` failures documented in PR #200, each diagnosed against upstream/main's passing equivalents:

1. **Source bug (merge regression)**: `sendSignal` dropped upstream's `acceptedAt` stamp during the signals-normalization merge — `createSignal({ ...signalInput, acceptedAt: new Date() })` restored (1 line; `signalToDataPart` omits falsy `acceptedAt`, which broke the idle-wake fan-out test whose assertions are byte-identical to upstream's).
2. **Test timing**: the cross-agent queue test budgeted exactly one `nextTick` for run start; the fork's reservation machinery is one async hop deeper than upstream's direct registration. Replaced with the file's existing bounded `waitForCondition` — same flag, same assertions, deterministic ×3.
3. **Test asserted pre-merge shapes**: four divergences from the merged signals contract (missing `transient: true`, phantom `metadata.signal.contents`, array-wrapped `toLLMMessage`, `{role, content}` file contents that throw under `AgentSignalContents`) — aligned to upstream's own test; source untouched and byte-identical to upstream.

**Validation**: all 3 targets pass; subscriber batch now 8/8 (first time fully green); broadcast/multicast + caller-only approval batch 10 ✓; core tsc 0. Known artifact unchanged: the whole-file runner for this 131-test file remains CPU-bound (pre-existing isolation issue, independent of these fixes — `-t` runs are reliable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes some broken tests that check how agents send and receive messages. It makes sure messages get timestamped correctly, makes a timing test more reliable by waiting for the actual thing to happen instead of just waiting a fixed amount of time, and updates the test expectations to match how the message format actually works after recent changes.

## Overview

Fixes three pre-existing test failures in agent-signals that resulted from alignment with upstream/main behaviors:

1. **acceptedAt regression**: Restores upstream signal timestamping in `sendSignal` by explicitly creating signals with `acceptedAt: new Date()`. The signals data-part serializer omits falsy timestamps, which broke an idle-wake fan-out test.

2. **Test timing**: Replaces a brittle single-tick delay in the cross-agent queue test with a bounded `waitForCondition` (500ms) poll for `firstStarted`. The fork's run reservation/registration path introduces an additional async hop, making the original timing assertion unreliable.

3. **Test shape alignment**: Updates test assertions to match merged signal normalization contracts:
   - Includes `transient: true` in `toDataPart()` representations
   - Removes phantom `metadata.signal.contents` from assertions
   - Expects `toLLMMessage()` to return a single `UserModelMessage` (not wrapped in an array)
   - Provides `fileContents` as a parts array per `AgentSignalContents`

## Changes

**packages/core/src/agent/thread-stream-runtime.ts**
- Modifies `sendSignal` to construct signals via `createSignal({ ...signalInput, acceptedAt: new Date() })` instead of passing `signalInput` directly, ensuring consistent `acceptedAt` timestamps.

**packages/core/src/agent/__tests__/agent-signals.test.ts**
- Updates "converts signals between DB, LLM, and data part formats" test expectations:
  - `user-message` signal `toDataPart()` now includes `transient: true`
  - DB metadata assertions no longer include `contents` field
  - `system-reminder` signal `toLLMMessage()` expectation changed from array-wrapped to single object
  - `user-message` signal `toLLMMessage()` rewritten to build multimodal `contents` as array of parts
- Replaces generic `nextTick()` delay with `waitForCondition(() => firstStarted)` in cross-agent queuing test for deterministic start detection

**Validation**: All three target test suites pass (subscriber batch 8/8, broadcast/multicast + caller-only approval batch 10/10, core tsc 0)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->