### PR TITLE
Fix fastify server-adapter query redaction export

### DIFF
--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -302,6 +302,34 @@ export function normalizeQueryParams(rawQuery: Record<string, unknown>): Record<
 }
 
 /**
+ * Returns true when a query parameter key appears to carry credentials or
+ * authorization material, including bracket-notation keys like auth[token].
+ */
+function isSensitiveQueryParamKey(key: string): boolean {
+  const normalized = key
+    .toLowerCase()
+    .replace(/[\[\]]/g, '')
+    .replace(/[^a-z0-9]/g, '');
+
+  return (
+    normalized.includes('apikey') ||
+    normalized.includes('token') ||
+    normalized.includes('secret') ||
+    normalized.includes('password') ||
+    normalized.includes('authorization')
+  );
+}
+
+/**
+ * Returns a copy of query parameters with credential-like values redacted.
+ */
+export function redactSensitiveQueryParams(rawQuery: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(rawQuery).map(([key, value]) => [key, isSensitiveQueryParamKey(key) ? '[REDACTED]' : value]),
+  );
+}
+
+/**
  * Abstract base class for server adapters that handle HTTP requests.
  *
  * This class extends `MastraServerBase` to inherit app storage functionality


### PR DESCRIPTION
Fixes the fork package build after PR #205 by exporting the query-parameter redaction helper that @mastra/fastify imports from @mastra/server/server-adapter.\n\nEvidence:\n- @mastra/server build:lib passed in temp packaging worktree\n- @mastra/fastify build passed in temp packaging worktree\n- focused @mastra/server vitest could not start in temp tree because @internal/test-utils/setup was unresolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes the server hide secret bits in web request URLs (like API keys or passwords) by replacing their values with "[REDACTED]" so those secrets don't show up in logs or error messages.

## Summary

Exports a query-parameter redaction helper from the server adapter so other packages (e.g., `@mastra/fastify`) can build correctly. The new exported function, redactSensitiveQueryParams(), normalizes query keys (lowercases, strips bracket notation and non-alphanumeric characters) and treats keys whose normalized form contains common secret/auth terms—apikey, token, secret, password, authorization—as sensitive. Values for sensitive keys are replaced with "[REDACTED]" while other parameters are preserved.

Evidence: `@mastra/server` and `@mastra/fastify` builds succeeded in a temporary packaging worktree; a focused vitest run failed in the temp tree due to an unrelated unresolved internal test-utils import.

## Changes

packages/server/src/server/server-adapter/index.ts
- Added internal helper isSensitiveQueryParamKey(key: string): boolean
- Added exported function export function redactSensitiveQueryParams(rawQuery: Record<string, unknown>): Record<string, unknown> which returns a new query object with sensitive values replaced by "[REDACTED]"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->