### PR TITLE
feat(harness): persist assistant draft display state

### DIFF
--- a/harnessv1/sections/04-public-api/02-session/04-messages-thread-and-display.md
+++ b/harnessv1/sections/04-public-api/02-session/04-messages-thread-and-display.md
@@ -29,10 +29,14 @@
   // but public reads, local display-state subscriptions, storage snapshots, and
   // HTTP responses all normalize to the snapshot shape. On hydration this is
   // rebuilt from the persisted display snapshot when usable, plus durable
-  // queue/pending/currentRun/thread/message state. It is renderable state only,
-  // not durable SSE replay. `subscribeDisplayState(...)` is an in-process
-  // convenience; RemoteSession uses `getDisplayState()`, `subscribe(...)` SSE
-  // events, and snapshot refetch instead of a separate display subscription API.
+  // queue/pending/currentRun/thread/message state and the bounded
+  // `assistantDrafts` projection. `assistantDrafts` coalesces streamed assistant
+  // text/reasoning for recent runs so a reload or SSE `412` can recover an
+  // in-progress answer without replaying raw deltas. It is renderable state
+  // only, not transcript authority and not durable SSE replay.
+  // `subscribeDisplayState(...)` is an in-process convenience; RemoteSession
+  // uses `getDisplayState()`, `subscribe(...)` SSE events, and snapshot refetch
+  // instead of a separate display subscription API.
   getDisplayState(): Readonly<HarnessDisplayStateSnapshotV1>;
   subscribe(listener: HarnessListener): () => void;
   // Plan-task summary (TM-5). The snapshot carries an OPTIONAL bounded plan-task

--- a/harnessv1/sections/05-session-persistence/01-what-gets-persisted/02-thread-and-session-records.md
+++ b/harnessv1/sections/05-session-persistence/01-what-gets-persisted/02-thread-and-session-records.md
@@ -241,6 +241,13 @@ interface SessionRecord {
   // interrupted run on this session. This is not an admission ledger, event
   // log, outbox receipt, or replacement for agent/workflow run storage.
   currentRun?: HarnessRunOperationalState;
+  // Bounded, coalesced assistant-output projection keyed by runId. This is the
+  // durable recovery source for in-progress assistant text/reasoning after a
+  // browser reload, process restart, SSE gap, or skipped transient delta. It is
+  // not a transcript row, not a replacement for `listMessages()`, and not a
+  // synthetic event-replay source. Terminal drafts may remain briefly for
+  // reconnect de-dupe and UI recovery, then are pruned by implementation bounds.
+  assistantDrafts?: Record<string, HarnessAssistantDraft>;
   // Debounced display snapshot used to rebuild `getDisplayState()` after
   // hydration. It is a cache of renderable session state, not durable event
   // replay; stale or missing snapshots are rebuilt from the record fields

--- a/harnessv1/sections/05-session-persistence/01-what-gets-persisted/03-display-records.md
+++ b/harnessv1/sections/05-session-persistence/01-what-gets-persisted/03-display-records.md
@@ -14,6 +14,7 @@ interface HarnessDisplayStateSnapshotV1 {
   pendingQuestion: HarnessDisplayPendingQuestionSnapshotV1 | null;
   pendingPlanApproval: HarnessDisplayPendingPlanSnapshotV1 | null;
   activeSubagents: HarnessDisplaySubagentSnapshotV1[];
+  assistantDrafts: Record<string, HarnessAssistantDraft>;
   // Display-only projection of file paths inferred from known tool/UI activity.
   // This is not a workspace audit log, not a filesystem mutation ledger, and
   // not an observational-memory ingestion source (§2.7).
@@ -108,6 +109,24 @@ interface HarnessDisplaySubagentSnapshotV1 {
   result?: string;
 }
 
+interface HarnessAssistantDraft {
+  runId: string;
+  sessionId: string;
+  resourceId: string;
+  threadId: string;
+  signalId?: string;
+  queuedItemId?: string;
+  messageId?: string;
+  text: string;
+  reasoningText?: string;
+  status: 'streaming' | 'interrupted' | 'completed' | 'failed';
+  startedAt: number;
+  updatedAt: number;
+  terminalAt?: number;
+  finishReason?: 'complete' | 'aborted' | 'error';
+  truncated?: boolean;
+}
+
 interface HarnessDisplayTaskSnapshotV1 {
   content: string;
   status: 'pending' | 'in_progress' | 'completed';
@@ -198,6 +217,19 @@ interface HarnessDisplayTaskSnapshotV1 {
 // parent. A stale parent display snapshot alone cannot prove a child is active
 // or keep a subagent-owned pending prompt visible; child-owned prompts are
 // recovered from the child session or `/subagent-inbox`.
+//
+// **`assistantDrafts`**
+//
+// Authoritative source when rebuilding: `SessionRecord.assistantDrafts`
+//
+// Rule: Direct bounded projection of coalesced assistant text and reasoning for
+// recent runs. This is the recovery surface for an in-progress assistant message
+// when the browser reloads, the process restarts, an SSE replay gap returns
+// `412`, or `persistTransientStreamingEvents=false` skipped raw `text_delta`
+// rows. It is not a transcript, does not synthesize missed events, and does not
+// settle operations. Completed, interrupted, and failed drafts are terminal
+// display evidence only; persisted messages and result lookup remain
+// authoritative for final history and operation settlement.
 //
 // **`modifiedFiles`**
 //

--- a/harnessv1/sections/05-session-persistence/01-what-gets-persisted/09-session-snapshot.md
+++ b/harnessv1/sections/05-session-persistence/01-what-gets-persisted/09-session-snapshot.md
@@ -24,6 +24,9 @@ interface SessionSnapshot {
     // Route handle only. Clients obtain actual page cursors from
     // `/subagent-inbox` responses.
   };
+  // Includes `assistantDrafts` when recent in-progress or terminal assistant
+  // output has been coalesced for render recovery. Those drafts are display
+  // state, not transcript rows or event replay.
   displayState?: HarnessDisplayStateSnapshotV1;
   goal?: GoalState | null;
   channelBindings: SessionChannelBindingSummary[];

--- a/harnessv1/sections/10-events/05-buffering-and-replay.md
+++ b/harnessv1/sections/10-events/05-buffering-and-replay.md
@@ -54,7 +54,11 @@ projection, queue item identifiers, session-owned pending inbox items, display
 snapshot, goal state, channel binding summary, token usage, the bounded
 durable-work summary, and a bounded message window or cursor for the persisted
 thread message log. It does not synthesize missed `text_delta`, tool, or channel
-events from storage.
+events from storage. The display snapshot may include
+`assistantDrafts`: bounded, coalesced assistant text/reasoning accumulated by
+the session while streaming. Clients use those drafts as render recovery for
+in-progress assistant output after a gap; they do not treat them as replayed
+events or transcript messages.
 Multi-session controllers apply this rule per affected session and rebuild their
 view through the §13.4 controller recovery recipe rather than through
 cross-session event replay.

--- a/harnessv1/sections/13-mastra-server-integration/04-client-sdk/06-reconnection.md
+++ b/harnessv1/sections/13-mastra-server-integration/04-client-sdk/06-reconnection.md
@@ -5,11 +5,12 @@ with `Last-Event-ID` and follows the §10.5 replay contract. If the server
 returns `412 Precondition Failed` under those replay-gap rules, the client
 transparently re-fetches `SessionSnapshot` via `GET /sessions/:sessionId`,
 applies the returned `displayState: HarnessDisplayStateSnapshotV1` as a
-point-in-time render input, follows the snapshot's message cursor through the
-thread message route when more persisted history is needed, checks every
-unresolved operation through the §13.2 / §13.3 result lookup routes, settles
-terminal responses under §4.2, and then resumes from the new tail for operations
-that remain pending. Message, activity, subagent-inbox, and diagnostics cursors
-are ordinary §4.4 navigation tokens: the SDK may cache them for the current
-view, but it must not treat them as read-state, SSE replay cursors, or proof
-that no compacted source rows were missed.
+point-in-time render input, including `assistantDrafts` for bounded coalesced
+in-progress assistant text/reasoning, follows the snapshot's message cursor
+through the thread message route when more persisted history is needed, checks
+every unresolved operation through the §13.2 / §13.3 result lookup routes,
+settles terminal responses under §4.2, and then resumes from the new tail for
+operations that remain pending. Message, activity, subagent-inbox, and
+diagnostics cursors are ordinary §4.4 navigation tokens: the SDK may cache them
+for the current view, but it must not treat them as read-state, SSE replay
+cursors, or proof that no compacted source rows were missed.

--- a/harnessv1/sections/13-mastra-server-integration/04-client-sdk/09-first-party-client-adapter-boundary.md
+++ b/harnessv1/sections/13-mastra-server-integration/04-client-sdk/09-first-party-client-adapter-boundary.md
@@ -35,4 +35,8 @@ restart all converge on the same snapshot-refetch path. Clients do not branch on
 the cause, synthesize missed `text_delta`, tool, channel, or lifecycle events,
 open a remote cross-session event stream, or treat activity timelines, durable
 work summaries, display snapshots, diagnostics, local gap markers, or
-pending-card projections as operation-settlement records.
+pending-card projections as operation-settlement records. A display snapshot's
+`assistantDrafts` field is the one first-party render recovery input for
+coalesced in-progress assistant text/reasoning; clients merge it with live
+overlay rows by run/message identity and replace it with persisted transcript
+messages when those become available.

--- a/harnessv1/sections/15-verification/02-focused-test-plan.md
+++ b/harnessv1/sections/15-verification/02-focused-test-plan.md
@@ -1388,9 +1388,13 @@ instances; deterministic ordering for keyed arrays; malformed or unsupported
 snapshot versions are ignored and rebuilt through the §5.1 field-to-source
 projection rules; stale pending, active run/tool, subagent, file, and task
 display fields are cleared or recomputed from authoritative session/message
-records; and no `display_state_changed` event is emitted over SSE or used for
-durable replay. In-process `subscribeDisplayState(...)` tests, when implemented,
-assert the same snapshot shape but do not imply a separate RemoteSession display
+records; `assistantDrafts` recover coalesced in-progress assistant text and
+reasoning even when transient streaming deltas are not persisted; terminal
+drafts record completed/interrupted/failed status without becoming transcript
+authority; oversized drafts are bounded and marked `truncated`; and no
+`display_state_changed` event is emitted over SSE or used for durable replay.
+In-process `subscribeDisplayState(...)` tests, when implemented, assert the
+same snapshot shape but do not imply a separate RemoteSession display
 subscription endpoint.
 
 **Tool custom-event API boundary**

--- a/packages/core/src/harness/v1/display-state.test.ts
+++ b/packages/core/src/harness/v1/display-state.test.ts
@@ -17,6 +17,7 @@ function makeDisplayState(overrides: Partial<SessionDisplayState> = {}): Session
     activeTools: {},
     toolInputBuffers: {},
     activeSubagents: {},
+    assistantDrafts: {},
     tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
     pending: null,
     queueDepth: 0,
@@ -40,6 +41,7 @@ describe('toHarnessDisplayStateSnapshotV1', () => {
       activeTools: {},
       toolInputBuffers: {},
       activeSubagents: {},
+      assistantDrafts: {},
       pending: null,
       queueDepth: 0,
     });
@@ -132,6 +134,20 @@ describe('toHarnessDisplayStateSnapshotV1', () => {
         toolInputBuffers: {
           tool_1: { toolName: 'shell', text: 'npm test' },
         },
+        assistantDrafts: {
+          run_1: {
+            runId: 'run_1',
+            sessionId: 'session-1',
+            resourceId: 'resource-1',
+            threadId: 'thread-1',
+            messageId: 'message-1',
+            text: 'partial answer',
+            reasoningText: 'thinking',
+            status: 'streaming',
+            startedAt: 21,
+            updatedAt: 22,
+          },
+        },
         tokenUsage: { promptTokens: 2, completionTokens: 3, totalTokens: 5 },
         queueDepth: 1,
         goal: {
@@ -159,9 +175,40 @@ describe('toHarnessDisplayStateSnapshotV1', () => {
       startedAt: 20,
     });
     expect(snapshot.toolInputBuffers.tool_1).toEqual({ toolName: 'shell', text: 'npm test' });
+    expect(snapshot.assistantDrafts.run_1).toEqual({
+      runId: 'run_1',
+      sessionId: 'session-1',
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      messageId: 'message-1',
+      text: 'partial answer',
+      reasoningText: 'thinking',
+      status: 'streaming',
+      startedAt: 21,
+      updatedAt: 22,
+    });
     expect(snapshot.tokenUsage).toEqual({ promptTokens: 2, completionTokens: 3, totalTokens: 5 });
     expect(snapshot.queueDepth).toBe(1);
     expect(snapshot.goal).toMatchObject({ id: 'goal-1', status: 'active' });
+  });
+
+  it('copies assistant drafts so consumers cannot mutate source state', () => {
+    const assistantDrafts: NonNullable<SessionDisplayState['assistantDrafts']> = {
+      run_1: {
+        runId: 'run_1',
+        sessionId: 'session-1',
+        resourceId: 'resource-1',
+        threadId: 'thread-1',
+        text: 'hello',
+        status: 'streaming',
+        startedAt: 1,
+        updatedAt: 2,
+      },
+    };
+    const snapshot = toHarnessDisplayStateSnapshotV1(makeDisplayState({ assistantDrafts }));
+
+    snapshot.assistantDrafts.run_1!.text = 'mutated';
+    expect(assistantDrafts.run_1!.text).toBe('hello');
   });
 
   it('carries the bounded plan-task summary (counts/byStatus/inProgressTaskIds/rootCount), copied not shared', () => {

--- a/packages/core/src/harness/v1/display-state.ts
+++ b/packages/core/src/harness/v1/display-state.ts
@@ -1,4 +1,4 @@
-import type { JsonValue } from '../../storage/domains/harness';
+import type { HarnessAssistantDraft, JsonValue } from '../../storage/domains/harness';
 import type { PlanTaskSummary } from './plan-task-session';
 import type {
   ActiveSubagentState,
@@ -56,6 +56,7 @@ export interface HarnessDisplayStateSnapshotV1 {
   activeTools: Record<string, HarnessDisplayActiveToolSnapshotV1>;
   toolInputBuffers: Record<string, HarnessDisplayToolInputBufferSnapshotV1>;
   activeSubagents: Record<string, HarnessDisplayActiveSubagentSnapshotV1>;
+  assistantDrafts: Record<string, HarnessAssistantDraft>;
   tokenUsage: TokenUsage;
   pending: HarnessDisplayPendingSnapshotV1 | null;
   queueDepth: number;
@@ -183,6 +184,16 @@ export function toHarnessDisplayStateSnapshotV1(state: SessionDisplayState): Har
     ),
     activeSubagents: Object.fromEntries(
       Object.entries(state.activeSubagents).map(([id, subagent]) => [id, encodeActiveSubagent(subagent)]),
+    ),
+    assistantDrafts: Object.fromEntries(
+      Object.entries(state.assistantDrafts ?? {}).map(([runId, draft]) => [
+        runId,
+        {
+          ...draft,
+          text: draft.text,
+          ...(draft.reasoningText !== undefined ? { reasoningText: draft.reasoningText } : {}),
+        },
+      ]),
     ),
     tokenUsage: { ...state.tokenUsage },
     pending: encodePending(state.pending),

--- a/packages/core/src/harness/v1/session.display-state.test.ts
+++ b/packages/core/src/harness/v1/session.display-state.test.ts
@@ -12,9 +12,17 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { setupHarness } from './__test-utils__/setup';
 import { MockAgent } from './__test-utils__/mock-agent';
+import { setupHarness } from './__test-utils__/setup';
 import { toHarnessDisplayStateSnapshotV1 } from './display-state';
+
+async function waitFor(condition: () => boolean | Promise<boolean>, label: string): Promise<void> {
+  for (let i = 0; i < 80; i++) {
+    if (await condition()) return;
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
 
 describe('Session.getDisplayState — shape', () => {
   it('reports the documented identity fields', async () => {
@@ -42,6 +50,7 @@ describe('Session.getDisplayState — shape', () => {
     expect(ds.activeTools).toEqual({});
     expect(ds.toolInputBuffers).toEqual({});
     expect(ds.activeSubagents).toEqual({});
+    expect(ds.assistantDrafts).toEqual({});
     expect(ds.tokenUsage).toEqual({ promptTokens: 0, completionTokens: 0, totalTokens: 0 });
     expect(ds.pending).toBeNull();
     expect(ds.queueDepth).toBe(0);
@@ -98,6 +107,233 @@ describe('Session.getDisplayState — shape', () => {
     expect(after.currentRun).toBeUndefined();
     // Token usage accumulated from the run's totalUsage.
     expect(after.tokenUsage.totalTokens).toBeGreaterThanOrEqual(2);
+  });
+
+  it('projects coalesced assistant drafts while a response is streaming', async () => {
+    const { harness, agent } = setupHarness();
+    let release!: () => void;
+    const hold = new Promise<void>(r => {
+      release = r;
+    });
+    agent.enqueueRun({
+      runId: 'run-draft-live',
+      finishReason: 'stop',
+      text: 'hello world',
+      chunks: [
+        { type: 'text-start', payload: { id: 'msg-draft' }, runId: 'run-draft-live' },
+        { type: 'text-delta', payload: { id: 'msg-draft', text: 'hello ' }, runId: 'run-draft-live' },
+        { type: 'text-delta', payload: { id: 'msg-draft', text: 'world' }, runId: 'run-draft-live' },
+      ],
+      holdUntil: hold,
+    });
+
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const inFlight = session.message({ content: 'hi' });
+    await waitFor(
+      () => session.getDisplayState().assistantDrafts?.['run-draft-live']?.text === 'hello world',
+      'live assistant draft',
+    );
+
+    const draft = session.getDisplayState().assistantDrafts!['run-draft-live']!;
+    expect(draft).toMatchObject({
+      runId: 'run-draft-live',
+      sessionId: session.id,
+      resourceId: 'u',
+      threadId: session.threadId,
+      messageId: 'msg-draft',
+      text: 'hello world',
+      status: 'streaming',
+    });
+    expect(toHarnessDisplayStateSnapshotV1(session.getDisplayState()).assistantDrafts['run-draft-live']).toEqual(draft);
+
+    release();
+    await inFlight;
+  });
+
+  it('persists assistant drafts for reload recovery and terminalizes them on completion', async () => {
+    const { harness, agent, storage } = setupHarness();
+    agent.enqueueRun({
+      runId: 'run-draft-durable',
+      finishReason: 'stop',
+      text: 'durable answer',
+      chunks: [
+        { type: 'text-start', payload: { id: 'msg-durable' }, runId: 'run-draft-durable' },
+        { type: 'text-delta', payload: { id: 'msg-durable', text: 'durable ' }, runId: 'run-draft-durable' },
+        { type: 'text-delta', payload: { id: 'msg-durable', text: 'answer' }, runId: 'run-draft-durable' },
+      ],
+    });
+
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'hi' });
+
+    await waitFor(async () => {
+      const stored = await storage.loadSession({ sessionId: session.id });
+      return stored?.assistantDrafts?.['run-draft-durable']?.status === 'completed';
+    }, 'durable assistant draft completion');
+
+    const stored = await storage.loadSession({ sessionId: session.id });
+    expect(stored?.assistantDrafts?.['run-draft-durable']).toMatchObject({
+      runId: 'run-draft-durable',
+      sessionId: session.id,
+      resourceId: 'u',
+      threadId: session.threadId,
+      messageId: 'msg-durable',
+      text: 'durable answer',
+      status: 'completed',
+      finishReason: 'complete',
+    });
+
+    const reloaded = await harness.session({ sessionId: session.id, resourceId: 'u' });
+    expect(reloaded.getDisplayState().assistantDrafts?.['run-draft-durable']?.text).toBe('durable answer');
+    expect(reloaded.getDisplayState().assistantDrafts?.['run-draft-durable']?.status).toBe('completed');
+  });
+
+  it('persists assistant drafts even when transient streaming deltas are not persisted', async () => {
+    const { harness, agent, storage } = setupHarness({ sessions: { persistTransientStreamingEvents: false } });
+    agent.enqueueRun({
+      runId: 'run-draft-no-deltas',
+      finishReason: 'stop',
+      text: 'overlay recovered',
+      chunks: [
+        { type: 'text-start', payload: { id: 'msg-no-deltas' }, runId: 'run-draft-no-deltas' },
+        { type: 'text-delta', payload: { id: 'msg-no-deltas', text: 'overlay ' }, runId: 'run-draft-no-deltas' },
+        { type: 'text-delta', payload: { id: 'msg-no-deltas', text: 'recovered' }, runId: 'run-draft-no-deltas' },
+      ],
+    });
+
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'hi' });
+    await session._flushEventPersistence();
+
+    const state = await storage.getSessionEventReplayState({
+      sessionId: session.id,
+      resourceId: 'u',
+      threadId: session.threadId,
+    });
+    const rows = await storage.listSessionEvents({
+      sessionId: session.id,
+      resourceId: 'u',
+      threadId: session.threadId,
+      epoch: state!.epoch,
+      afterSequence: 0,
+      limit: 100,
+    });
+    expect(rows.some(row => (row.event as { type?: string }).type === 'text_delta')).toBe(false);
+
+    const stored = await storage.loadSession({ sessionId: session.id });
+    expect(stored?.assistantDrafts?.['run-draft-no-deltas']).toMatchObject({
+      text: 'overlay recovered',
+      status: 'completed',
+      finishReason: 'complete',
+    });
+  });
+
+  it('preserves streamed reasoning text separately from assistant text', async () => {
+    const { harness, agent, storage } = setupHarness();
+    agent.enqueueRun({
+      runId: 'run-draft-reasoning',
+      finishReason: 'stop',
+      text: 'answer',
+      chunks: [
+        { type: 'reasoning-delta', payload: { id: 'reasoning-1', text: 'thinking ' }, runId: 'run-draft-reasoning' },
+        { type: 'reasoning-delta', payload: { id: 'reasoning-1', text: 'through' }, runId: 'run-draft-reasoning' },
+        { type: 'text-delta', payload: { id: 'message-1', text: 'answer' }, runId: 'run-draft-reasoning' },
+      ],
+    });
+
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'hi' });
+    await session._flushEventPersistence();
+
+    const stored = await storage.loadSession({ sessionId: session.id });
+    expect(stored?.assistantDrafts?.['run-draft-reasoning']).toMatchObject({
+      text: 'answer',
+      reasoningText: 'thinking through',
+      status: 'completed',
+    });
+  });
+
+  it('terminalizes an aborted in-flight assistant draft as interrupted', async () => {
+    const { harness, agent, storage } = setupHarness();
+    let release!: () => void;
+    const hold = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    agent.enqueueRun({
+      runId: 'run-draft-abort',
+      finishReason: 'stop',
+      text: 'partial',
+      chunks: [
+        { type: 'text-start', payload: { id: 'msg-abort' }, runId: 'run-draft-abort' },
+        { type: 'text-delta', payload: { id: 'msg-abort', text: 'partial' }, runId: 'run-draft-abort' },
+      ],
+      holdUntil: hold,
+    });
+
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const inFlight = session.message({ content: 'hi' });
+    await waitFor(
+      () => session.getDisplayState().assistantDrafts?.['run-draft-abort']?.text === 'partial',
+      'abort draft',
+    );
+
+    session.abort({ reason: 'user-stop' });
+    await inFlight;
+    release();
+    await session._flushEventPersistence();
+
+    const stored = await storage.loadSession({ sessionId: session.id });
+    expect(stored?.assistantDrafts?.['run-draft-abort']).toMatchObject({
+      text: 'partial',
+      status: 'interrupted',
+      finishReason: 'aborted',
+    });
+  });
+
+  it('bounds very large assistant drafts and marks truncation', async () => {
+    const { harness, agent, storage } = setupHarness();
+    const longText = 'x'.repeat(128_010);
+    agent.enqueueRun({
+      runId: 'run-draft-long',
+      finishReason: 'stop',
+      text: longText,
+      chunks: [{ type: 'text-delta', payload: { id: 'msg-long', text: longText }, runId: 'run-draft-long' }],
+    });
+
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'hi' });
+    await session._flushEventPersistence();
+
+    const stored = await storage.loadSession({ sessionId: session.id });
+    const draft = stored?.assistantDrafts?.['run-draft-long'];
+    expect(draft?.text).toHaveLength(128_000);
+    expect(draft?.text).toBe('x'.repeat(128_000));
+    expect(draft?.truncated).toBe(true);
+  });
+
+  it('notifies display subscribers when a draft terminalizes without another display event', async () => {
+    const { harness, agent } = setupHarness();
+    agent.enqueueRun({
+      runId: 'run-draft-subscribe',
+      finishReason: 'stop',
+      text: 'done',
+      chunks: [{ type: 'text-delta', payload: { id: 'msg-subscribe', text: 'done' }, runId: 'run-draft-subscribe' }],
+    });
+
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const statuses: string[] = [];
+    const unsubscribe = session.subscribeDisplayState(state => {
+      const status = state.assistantDrafts['run-draft-subscribe']?.status;
+      if (status !== undefined) statuses.push(status);
+    });
+    try {
+      await session.message({ content: 'hi' });
+      await waitFor(() => statuses.includes('completed'), 'completed draft display refresh');
+    } finally {
+      unsubscribe();
+    }
+    expect(statuses).toContain('streaming');
+    expect(statuses).toContain('completed');
   });
 
   it('accumulates token usage across multiple turns', async () => {

--- a/packages/core/src/harness/v1/session.display-state.test.ts
+++ b/packages/core/src/harness/v1/session.display-state.test.ts
@@ -249,7 +249,75 @@ describe('Session.getDisplayState — shape', () => {
     expect(stored?.assistantDrafts?.['run-draft-reasoning']).toMatchObject({
       text: 'answer',
       reasoningText: 'thinking through',
+      messageId: 'message-1',
       status: 'completed',
+    });
+  });
+
+  it('does not use reasoning stream ids as assistant draft message ids', async () => {
+    const { harness, agent, storage } = setupHarness();
+    agent.enqueueRun({
+      runId: 'run-reasoning-id',
+      finishReason: 'stop',
+      text: '',
+      chunks: [
+        { type: 'reasoning-delta', payload: { id: 'reasoning-only-1', text: 'thinking' }, runId: 'run-reasoning-id' },
+      ],
+    });
+
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    await session.message({ content: 'hi' });
+    await session._flushEventPersistence();
+
+    const stored = await storage.loadSession({ sessionId: session.id });
+    expect(stored?.assistantDrafts?.['run-reasoning-id']).toMatchObject({
+      text: '',
+      reasoningText: 'thinking',
+      status: 'completed',
+      finishReason: 'complete',
+    });
+    expect(stored?.assistantDrafts?.['run-reasoning-id']).not.toHaveProperty('messageId');
+  });
+
+  it('terminalizes drafts when agent_end is emitted directly', async () => {
+    const { harness, storage } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const internals = session as unknown as {
+      _recordAssistantDraftDelta: (opts: {
+        runId: string;
+        kind: 'text' | 'reasoning';
+        delta: string;
+        messageId?: string;
+      }) => void;
+      _emitTurnEvent: (event: {
+        type: 'agent_end';
+        runId: string;
+        finishReason: 'error';
+        usage: { promptTokens: number; completionTokens: number; totalTokens: number };
+      }) => void;
+      _flushAssistantDraftsNow: () => Promise<void>;
+    };
+
+    internals._recordAssistantDraftDelta({
+      runId: 'run-direct-error',
+      kind: 'text',
+      delta: 'partial',
+      messageId: 'message-direct-error',
+    });
+    internals._emitTurnEvent({
+      type: 'agent_end',
+      runId: 'run-direct-error',
+      finishReason: 'error',
+      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    });
+    await internals._flushAssistantDraftsNow();
+
+    const stored = await storage.loadSession({ sessionId: session.id });
+    expect(stored?.assistantDrafts?.['run-direct-error']).toMatchObject({
+      text: 'partial',
+      status: 'failed',
+      finishReason: 'error',
+      messageId: 'message-direct-error',
     });
   });
 

--- a/packages/core/src/harness/v1/session.display-state.test.ts
+++ b/packages/core/src/harness/v1/session.display-state.test.ts
@@ -321,6 +321,111 @@ describe('Session.getDisplayState — shape', () => {
     });
   });
 
+  it('does not terminalize an unrelated stale draft for a different agent_end run', async () => {
+    const { harness } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const internals = session as unknown as {
+      _assistantDrafts: Map<string, Record<string, unknown>>;
+      _emitTurnEvent: (event: {
+        type: 'agent_end';
+        runId: string;
+        finishReason: 'complete';
+        usage: { promptTokens: number; completionTokens: number; totalTokens: number };
+      }) => void;
+    };
+
+    internals._assistantDrafts.set('run-stale', {
+      runId: 'run-stale',
+      sessionId: session.id,
+      resourceId: 'u',
+      threadId: session.threadId,
+      messageId: 'message-stale',
+      text: 'stale partial',
+      status: 'streaming',
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    internals._emitTurnEvent({
+      type: 'agent_end',
+      runId: 'run-other',
+      finishReason: 'complete',
+      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    });
+
+    expect(session.getDisplayState().assistantDrafts?.['run-stale']).toMatchObject({
+      text: 'stale partial',
+      status: 'streaming',
+    });
+    expect(session.getDisplayState().assistantDrafts?.['run-stale']).not.toHaveProperty('finishReason');
+  });
+
+  it('does not reopen terminal drafts when late deltas arrive', async () => {
+    const { harness, storage } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const internals = session as unknown as {
+      _recordAssistantDraftDelta: (opts: {
+        runId: string;
+        kind: 'text' | 'reasoning';
+        delta: string;
+        messageId?: string;
+      }) => void;
+      _emitTurnEvent: (event: {
+        type: 'agent_end';
+        runId: string;
+        finishReason: 'complete';
+        usage: { promptTokens: number; completionTokens: number; totalTokens: number };
+      }) => void;
+      _flushAssistantDraftsNow: () => Promise<void>;
+    };
+
+    internals._recordAssistantDraftDelta({ runId: 'run-late', kind: 'text', delta: 'first' });
+    internals._emitTurnEvent({
+      type: 'agent_end',
+      runId: 'run-late',
+      finishReason: 'complete',
+      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    });
+    internals._recordAssistantDraftDelta({ runId: 'run-late', kind: 'text', delta: ' late' });
+    await internals._flushAssistantDraftsNow();
+
+    const stored = await storage.loadSession({ sessionId: session.id });
+    expect(stored?.assistantDrafts?.['run-late']).toMatchObject({
+      text: 'first late',
+      status: 'completed',
+      finishReason: 'complete',
+    });
+    expect(stored?.assistantDrafts?.['run-late']?.terminalAt).toBeTypeOf('number');
+  });
+
+  it('flushes pending assistant drafts when awaiting the session flush chain', async () => {
+    const { harness, storage } = setupHarness();
+    const session = await harness.session({ resourceId: 'u', threadId: { fresh: true } });
+    const internals = session as unknown as {
+      _recordAssistantDraftDelta: (opts: {
+        runId: string;
+        kind: 'text' | 'reasoning';
+        delta: string;
+        messageId?: string;
+      }) => void;
+      _internalAwaitFlushChain: () => Promise<void>;
+    };
+
+    internals._recordAssistantDraftDelta({
+      runId: 'run-flush-chain',
+      kind: 'text',
+      delta: 'flush me',
+      messageId: 'message-flush-chain',
+    });
+    await internals._internalAwaitFlushChain();
+
+    const stored = await storage.loadSession({ sessionId: session.id });
+    expect(stored?.assistantDrafts?.['run-flush-chain']).toMatchObject({
+      text: 'flush me',
+      status: 'streaming',
+      messageId: 'message-flush-chain',
+    });
+  });
+
   it('terminalizes an aborted in-flight assistant draft as interrupted', async () => {
     const { harness, agent, storage } = setupHarness();
     let release!: () => void;

--- a/packages/core/src/harness/v1/session.mode-permissions.test.ts
+++ b/packages/core/src/harness/v1/session.mode-permissions.test.ts
@@ -92,7 +92,7 @@ describe('Mode-seeded base permission policy (§4.2e)', () => {
     }
   });
 
-  it('the HITL built-ins ask_user/submit_plan bypass the gate under a deny default', async () => {
+  it('HITL and local plan-task built-ins bypass the gate while escalation built-ins honor it', async () => {
     const { harness } = setupHarness({ modes: [{ id: 'm', agentId: 'default' }], defaultModeId: 'm' });
     const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
     try {
@@ -100,14 +100,31 @@ describe('Mode-seeded base permission policy (§4.2e)', () => {
       const grants = { categories: [], tools: [] };
       // ask_user / submit_plan are harness HITL infrastructure — never gated, else a
       // deny default would break the question / plan-approval suspension flows.
-      for (const id of ['ask_user', 'submit_plan', 'task_add', 'spawn_subagent']) {
+      for (const id of ['ask_user', 'submit_plan', 'task_add']) {
         expect((session as any)._resolveToolPolicy(id, rules, grants, 'deny')).toBe('allow');
       }
       // A non-builtin user tool is still denied under the deny default.
       expect((session as any)._resolveToolPolicy('someUserTool', rules, grants, 'deny')).toBe('deny');
-      // Without an allowlist, escalation builtins (spawn_subagent/task_delegate)
-      // still bypass the gate even under a deny default (unchanged behavior).
-      expect((session as any)._resolveToolPolicy('task_delegate', rules, grants, 'deny')).toBe('allow');
+      // Escalation built-ins cross agent/session capability boundaries and honor
+      // the engaged policy unless the session/mode explicitly allows them.
+      expect((session as any)._resolveToolPolicy('spawn_subagent', rules, grants, 'deny')).toBe('deny');
+      expect((session as any)._resolveToolPolicy('task_delegate', rules, grants, 'deny')).toBe('deny');
+      expect(
+        (session as any)._resolveToolPolicy(
+          'spawn_subagent',
+          { categories: {}, tools: { spawn_subagent: 'allow' } },
+          grants,
+          'deny',
+        ),
+      ).toBe('allow');
+      expect(
+        (session as any)._resolveToolPolicy(
+          'task_delegate',
+          { categories: {}, tools: { task_delegate: 'ask' } },
+          { categories: [], tools: ['task_delegate'] },
+          'deny',
+        ),
+      ).toBe('allow');
     } finally {
       await harness.shutdown();
     }
@@ -135,7 +152,13 @@ describe('Mode-seeded base permission policy (§4.2e)', () => {
       expect(resolve('spawn_subagent', new Set(['spawn_subagent']))).toBe('allow');
       // The allowlist deny is HARD: a non-listed tool with an explicit allow rule is still denied.
       expect(
-        (session as any)._resolveToolPolicy('writeDoc', { categories: {}, tools: { writeDoc: 'allow' } }, grants, 'allow', allow),
+        (session as any)._resolveToolPolicy(
+          'writeDoc',
+          { categories: {}, tools: { writeDoc: 'allow' } },
+          grants,
+          'allow',
+          allow,
+        ),
       ).toBe('deny');
       // A subagent allowlist engages the gate on its own (so the resolver threads).
       expect((session as any)._toolPermissionGateEngaged()).toBe(false);

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -1121,6 +1121,7 @@ export class Session {
    * `_resume` path. Not persisted — these are run-only fields.
    */
   private _currentRunId?: string;
+  private readonly _currentAssistantDraftRunIds = new Set<string>();
   /** §5.1b run-start time for the SessionRunProjection; set at agent_start, cleared on turn reset. */
   private _currentRunStartedAt?: number;
   /**
@@ -2106,6 +2107,7 @@ export class Session {
    */
   private _resetTurnTracking(): void {
     this._currentRunId = undefined;
+    this._currentAssistantDraftRunIds.clear();
     this._currentRunStartedAt = undefined;
     this._currentRunModeId = undefined;
     this._currentRunModelId = undefined;
@@ -2223,6 +2225,7 @@ export class Session {
   }): void {
     if (opts.delta.length === 0) return;
     const now = Date.now();
+    this._currentAssistantDraftRunIds.add(opts.runId);
     const previous = this._assistantDrafts.get(opts.runId);
     const text =
       opts.kind === 'text'
@@ -2235,6 +2238,8 @@ export class Session {
             text: previous?.reasoningText ?? '',
             truncated: previous?.truncated === true,
           };
+    const previousIsTerminal =
+      previous?.status === 'completed' || previous?.status === 'interrupted' || previous?.status === 'failed';
     const draft: HarnessAssistantDraft = {
       runId: opts.runId,
       sessionId: this.id,
@@ -2245,9 +2250,11 @@ export class Session {
       ...((opts.messageId ?? previous?.messageId) ? { messageId: opts.messageId ?? previous?.messageId } : {}),
       text: text.text,
       ...(reasoningText.text.length > 0 ? { reasoningText: reasoningText.text } : {}),
-      status: 'streaming',
+      status: previousIsTerminal ? previous.status : 'streaming',
       startedAt: previous?.startedAt ?? this._currentRunStartedAt ?? now,
       updatedAt: now,
+      ...(previousIsTerminal && previous.terminalAt !== undefined ? { terminalAt: previous.terminalAt } : {}),
+      ...(previousIsTerminal && previous.finishReason !== undefined ? { finishReason: previous.finishReason } : {}),
       truncated: previous?.truncated === true || text.truncated || reasoningText.truncated || undefined,
     };
     this._assistantDrafts.set(opts.runId, draft);
@@ -2270,11 +2277,12 @@ export class Session {
     finishReason: 'complete' | 'aborted' | 'error' | 'suspended',
   ): void {
     if (runId === undefined || finishReason === 'suspended') return;
-    const fallback =
-      this._assistantDrafts.get(runId) === undefined
-        ? Array.from(this._assistantDrafts.values()).filter(draft => draft.status === 'streaming')
-        : [];
-    const draftRunId = this._assistantDrafts.has(runId) ? runId : fallback.length === 1 ? fallback[0]!.runId : runId;
+    const draftRunId = this._assistantDrafts.has(runId)
+      ? runId
+      : this._currentAssistantDraftRunIds.size === 1
+        ? this._currentAssistantDraftRunIds.values().next().value
+        : undefined;
+    if (draftRunId === undefined) return;
     const previous = this._assistantDrafts.get(draftRunId);
     if (previous === undefined) return;
     const now = Date.now();
@@ -2936,6 +2944,14 @@ export class Session {
       const completed = await waitUntilDeadline(chain);
       if (!completed) {
         throw new HarnessValidationError('shutdown()', 'Session storage writes did not flush before shutdown deadline');
+      }
+      const assistantDraftFlush = this._flushAssistantDraftsNow();
+      const assistantDraftsCompleted = await waitUntilDeadline(assistantDraftFlush);
+      if (!assistantDraftsCompleted) {
+        throw new HarnessValidationError(
+          'shutdown()',
+          'Session assistant drafts did not flush before shutdown deadline',
+        );
       }
       if (this._flushChain === chain && this._backgroundTurnCompletions.size === 0) break;
     }

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -699,11 +699,14 @@ const PERMISSION_POLICIES: readonly PermissionPolicy[] = ['allow', 'ask', 'deny'
 
 /**
  * Harness-OWNED built-in tools (plan-task tools, spawn_subagent, task_delegate,
- * and the HITL suspension tools ask_user / submit_plan). These are harness
+ * and the HITL suspension tools ask_user / submit_plan). Most are harness
  * infrastructure, NOT user/agent tools, so the §4.2e permission gate never applies
  * to them — an engaged default 'deny'/'ask' must not block or suspend the harness's
  * own orchestration (denying ask_user/submit_plan would break the question /
- * plan-approval flows the gate itself relies on). Kept in sync with `_buildToolsets`.
+ * plan-approval flows the gate itself relies on). Escalation built-ins are
+ * different: they cross session/agent capability boundaries and therefore honor
+ * the engaged tool policy after anti-escalation allowlist checks. Kept in sync
+ * with `_buildToolsets`.
  */
 const HARNESS_BUILTIN_TOOL_IDS: ReadonlySet<string> = new Set<string>([
   TASK_ADD_TOOL_ID,
@@ -723,8 +726,7 @@ const HARNESS_BUILTIN_TOOL_IDS: ReadonlySet<string> = new Set<string>([
  * The subset of harness built-ins that a per-subagent `toolAllowlist` does NOT
  * auto-keep (M4): `spawn_subagent` / `task_delegate` are capability-escalation
  * vectors — a scoped subagent could otherwise run a broader child. Under an
- * allowlist these must be listed explicitly to be available; without an allowlist
- * they bypass the gate as normal harness infrastructure. Everything else in
+ * allowlist these must be listed explicitly to be available. Everything else in
  * HARNESS_BUILTIN_TOOL_IDS (HITL + local plan-task orchestration) is always kept.
  */
 const ESCALATION_BUILTIN_TOOL_IDS: ReadonlySet<string> = new Set<string>([
@@ -7894,7 +7896,13 @@ export class Session {
       // source kinds. Caps keep the read-time projection server-bounded (§9).
       const MAX_DESCENDANTS = 50;
       const MAX_DEPTH = 4;
-      const collected: { id: string; threadId: string; parentSessionId: string; depth: number; lastActivityAt: number }[] = [];
+      const collected: {
+        id: string;
+        threadId: string;
+        parentSessionId: string;
+        depth: number;
+        lastActivityAt: number;
+      }[] = [];
       let frontier = [{ id: this.id, depth: 0 }];
       const visited = new Set<string>([this.id]);
       while (frontier.length > 0 && collected.length < MAX_DESCENDANTS) {
@@ -12899,8 +12907,9 @@ export class Session {
    * per-turn POLICY SNAPSHOT: a per-tool rule wins, else the tool's category rule,
    * else the harness default. A matching tool/category GRANT turns an `ask` into
    * `allow` (a grant suppresses only the policy-level ask; it never overrides a
-   * `deny`). Harness-owned built-ins always resolve to `allow` — they are
-   * infrastructure, never gated by the session policy.
+   * `deny`). Harness-owned non-escalation built-ins always resolve to `allow` —
+   * they are infrastructure, never gated by the session policy. Escalation
+   * built-ins fall through to the normal policy after the subagent allowlist cap.
    */
   private _resolveToolPolicy(
     toolName: string,
@@ -12916,9 +12925,6 @@ export class Session {
     // M4 — subagent capability scope: a tool outside the allowlist is a hard deny
     // (removed pre-exposure; refused at action time), regardless of permission rules.
     if (allowlist !== undefined && !allowlist.has(toolName)) return 'deny';
-    // Escalation builtins that are either un-scoped (no allowlist) or explicitly
-    // listed run as normal harness infrastructure.
-    if (ESCALATION_BUILTIN_TOOL_IDS.has(toolName)) return 'allow';
     const category = this._harness.getToolCategory({ toolName }) ?? undefined;
     let policy: PermissionPolicy =
       (rules.tools[toolName] as PermissionPolicy | undefined) ??

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -49,6 +49,7 @@ import type {
   GoalState,
   AgentSignalResultEvidence,
   AgentSignalResultStatus,
+  HarnessAssistantDraft,
   HarnessPlanTask,
   HarnessRunSummary,
   HarnessStorage,
@@ -965,6 +966,8 @@ interface OpenRunSpan {
 
 /** Bound on the finalized-runId dedup set (oldest entries dropped wholesale; re-finalizing an ancient runId is impossible in practice). */
 const MAX_FINALIZED_RUN_IDS = 4096;
+const MAX_ASSISTANT_DRAFT_CHARS = 128_000;
+const ASSISTANT_DRAFT_FLUSH_DELAY_MS = 250;
 
 export interface SessionDisplayState {
   // Identity
@@ -992,6 +995,7 @@ export interface SessionDisplayState {
   activeTools: Record<string, ActiveToolState>;
   toolInputBuffers: Record<string, { toolName: string; text: string }>;
   activeSubagents: Record<string, ActiveSubagentState>;
+  assistantDrafts?: Record<string, HarnessAssistantDraft>;
 
   // Tokens
   tokenUsage: TokenUsage;
@@ -1171,6 +1175,9 @@ export class Session {
   private readonly _abortedToolTombstones = new Set<string>();
   private readonly _toolInputBuffers = new Map<string, { toolName: string; text: string }>();
   private readonly _activeSubagents = new Map<string, ActiveSubagentState>();
+  private readonly _assistantDrafts = new Map<string, HarnessAssistantDraft>();
+  private _assistantDraftFlushTimer: ReturnType<typeof setTimeout> | undefined;
+  private _assistantDraftFlushDirty = false;
   /** §SA3 — count of `spawn_subagent` children currently in flight from this parent
    *  (incremented at the spawn gate, decremented when the child settles). Used for
    *  the `subagents.maxConcurrent` backpressure check; counts the create window too. */
@@ -1328,6 +1335,9 @@ export class Session {
     this.createdAt = internals.record.createdAt;
 
     this._record = internals.record;
+    for (const [runId, draft] of Object.entries(internals.record.assistantDrafts ?? {})) {
+      this._assistantDrafts.set(runId, { ...draft });
+    }
     // Seed the live token-usage counter from the persisted aggregate so reopens
     // (after eviction / process restart) continue accumulating instead of
     // restarting at zero. Accept only non-negative integer fields because rows
@@ -1565,6 +1575,7 @@ export class Session {
         harnessName: this._record.harnessName,
       });
     }
+    await this._flushAssistantDraftsNow();
   }
 
   private _enqueueSessionEventPersistence(event: HarnessEvent): void {
@@ -2134,6 +2145,144 @@ export class Session {
     this._notifyMaybeIdle();
   }
 
+  private _assistantDraftSnapshot(): Record<string, HarnessAssistantDraft> {
+    return Object.fromEntries(
+      Array.from(this._assistantDrafts.entries()).map(([runId, draft]) => [runId, { ...draft }]),
+    );
+  }
+
+  private _persistedAssistantDrafts(snapshot: Record<string, HarnessAssistantDraft>): SessionRecord['assistantDrafts'] {
+    return Object.keys(snapshot).length > 0 ? snapshot : undefined;
+  }
+
+  private _appendBoundedDraftText(previous: string | undefined, delta: string): { text: string; truncated: boolean } {
+    const next = `${previous ?? ''}${delta}`;
+    if (next.length <= MAX_ASSISTANT_DRAFT_CHARS) {
+      return { text: next, truncated: false };
+    }
+    return { text: next.slice(next.length - MAX_ASSISTANT_DRAFT_CHARS), truncated: true };
+  }
+
+  private _pruneAssistantDrafts(): void {
+    if (this._assistantDrafts.size <= 8) return;
+    const ordered = Array.from(this._assistantDrafts.values()).sort((a, b) => b.updatedAt - a.updatedAt);
+    const keep = new Set(ordered.slice(0, 8).map(draft => draft.runId));
+    for (const runId of this._assistantDrafts.keys()) {
+      if (!keep.has(runId)) this._assistantDrafts.delete(runId);
+    }
+  }
+
+  private _scheduleAssistantDraftFlush(delayMs = ASSISTANT_DRAFT_FLUSH_DELAY_MS): void {
+    if (this._state === 'closed' || this._state === 'deleted' || this._state === 'evicted') return;
+    this._assistantDraftFlushDirty = true;
+    if (this._assistantDraftFlushTimer !== undefined) {
+      if (delayMs > 0) return;
+      clearTimeout(this._assistantDraftFlushTimer);
+      this._assistantDraftFlushTimer = undefined;
+    }
+    this._assistantDraftFlushTimer = setTimeout(() => {
+      this._assistantDraftFlushTimer = undefined;
+      void this._flushAssistantDraftsNow().catch(() => {});
+    }, delayMs);
+    this._assistantDraftFlushTimer.unref?.();
+  }
+
+  private async _flushAssistantDraftsNow(): Promise<void> {
+    if (this._assistantDraftFlushTimer !== undefined) {
+      clearTimeout(this._assistantDraftFlushTimer);
+      this._assistantDraftFlushTimer = undefined;
+    }
+    if (!this._assistantDraftFlushDirty) return;
+    this._assistantDraftFlushDirty = false;
+    const assistantDrafts = this._persistedAssistantDrafts(this._assistantDraftSnapshot());
+    try {
+      await this._flushUpdate(prev => ({ ...prev, assistantDrafts }));
+    } catch (err) {
+      if (this._state !== 'closed' && this._state !== 'deleted' && this._state !== 'evicted') {
+        this._assistantDraftFlushDirty = true;
+        this._scheduleAssistantDraftFlush(ASSISTANT_DRAFT_FLUSH_DELAY_MS);
+      }
+      throw err;
+    }
+  }
+
+  private _recordAssistantDraftDelta(opts: {
+    runId: string;
+    kind: 'text' | 'reasoning';
+    delta: string;
+    messageId?: string;
+  }): void {
+    if (opts.delta.length === 0) return;
+    const now = Date.now();
+    const previous = this._assistantDrafts.get(opts.runId);
+    const text =
+      opts.kind === 'text'
+        ? this._appendBoundedDraftText(previous?.text, opts.delta)
+        : { text: previous?.text ?? '', truncated: previous?.truncated === true };
+    const reasoningText =
+      opts.kind === 'reasoning'
+        ? this._appendBoundedDraftText(previous?.reasoningText, opts.delta)
+        : {
+            text: previous?.reasoningText ?? '',
+            truncated: previous?.truncated === true,
+          };
+    const draft: HarnessAssistantDraft = {
+      runId: opts.runId,
+      sessionId: this.id,
+      resourceId: this.resourceId,
+      threadId: this.threadId,
+      ...(this._currentRunSignalId !== undefined ? { signalId: this._currentRunSignalId } : {}),
+      ...(this._currentQueuedItemId !== undefined ? { queuedItemId: this._currentQueuedItemId } : {}),
+      ...((opts.messageId ?? previous?.messageId) ? { messageId: opts.messageId ?? previous?.messageId } : {}),
+      text: text.text,
+      ...(reasoningText.text.length > 0 ? { reasoningText: reasoningText.text } : {}),
+      status: 'streaming',
+      startedAt: previous?.startedAt ?? this._currentRunStartedAt ?? now,
+      updatedAt: now,
+      truncated: previous?.truncated === true || text.truncated || reasoningText.truncated || undefined,
+    };
+    this._assistantDrafts.set(opts.runId, draft);
+    this._pruneAssistantDrafts();
+    this._notifyDisplayRefresh();
+    this._scheduleAssistantDraftFlush();
+  }
+
+  private _setAssistantDraftMessageId(runId: string | undefined, messageId: string | undefined): void {
+    if (runId === undefined || messageId === undefined) return;
+    const previous = this._assistantDrafts.get(runId);
+    if (previous === undefined || previous.messageId === messageId) return;
+    this._assistantDrafts.set(runId, { ...previous, messageId, updatedAt: Date.now() });
+    this._notifyDisplayRefresh();
+    this._scheduleAssistantDraftFlush();
+  }
+
+  private _terminalizeAssistantDraft(
+    runId: string | undefined,
+    finishReason: 'complete' | 'aborted' | 'error' | 'suspended',
+  ): void {
+    if (runId === undefined || finishReason === 'suspended') return;
+    const fallback =
+      this._assistantDrafts.get(runId) === undefined
+        ? Array.from(this._assistantDrafts.values()).filter(draft => draft.status === 'streaming')
+        : [];
+    const draftRunId = this._assistantDrafts.has(runId) ? runId : fallback.length === 1 ? fallback[0]!.runId : runId;
+    const previous = this._assistantDrafts.get(draftRunId);
+    if (previous === undefined) return;
+    const now = Date.now();
+    const status: HarnessAssistantDraft['status'] =
+      finishReason === 'complete' ? 'completed' : finishReason === 'aborted' ? 'interrupted' : 'failed';
+    this._assistantDrafts.set(draftRunId, {
+      ...previous,
+      status,
+      finishReason,
+      updatedAt: now,
+      terminalAt: now,
+    });
+    this._pruneAssistantDrafts();
+    this._notifyDisplayRefresh();
+    this._scheduleAssistantDraftFlush(0);
+  }
+
   /**
    * Emit a synthetic aborted `tool_end` for every tool still in the active set —
    * tools whose turn ended before they produced a result/error chunk. Keeps the
@@ -2314,6 +2463,7 @@ export class Session {
       finishReason: opts.finishReason,
       usage: this._runUsage(opts.full),
     });
+    this._terminalizeAssistantDraft(id, opts.finishReason);
   }
 
   /**
@@ -5056,11 +5206,18 @@ export class Session {
         // message id for the display snapshot.
         const payload = chunk.payload as { id: string };
         this._currentMessageId = payload.id;
+        this._setAssistantDraftMessageId(runId, payload.id);
         return;
       }
       case 'text-delta': {
         const payload = chunk.payload as { id: string; text?: string };
         if (runId !== undefined && typeof payload?.text === 'string' && payload.text.length > 0) {
+          this._recordAssistantDraftDelta({
+            runId,
+            kind: 'text',
+            delta: payload.text,
+            ...(typeof payload.id === 'string' ? { messageId: payload.id } : {}),
+          });
           this._emitTurnEvent({ type: 'text_delta', runId, delta: payload.text });
         }
         return;
@@ -5082,6 +5239,12 @@ export class Session {
         // provider `reasoning-delta.delta` into `payload.text`).
         const payload = chunk.payload as { id: string; text?: string };
         if (runId !== undefined && typeof payload?.text === 'string' && payload.text.length > 0) {
+          this._recordAssistantDraftDelta({
+            runId,
+            kind: 'reasoning',
+            delta: payload.text,
+            ...(typeof payload.id === 'string' ? { messageId: payload.id } : {}),
+          });
           this._emitTurnEvent({ type: 'reasoning_delta', runId, delta: payload.text });
         }
         return;
@@ -7687,6 +7850,7 @@ export class Session {
       activeTools: Object.fromEntries(this._activeTools.entries()),
       toolInputBuffers: Object.fromEntries(this._toolInputBuffers.entries()),
       activeSubagents: Object.fromEntries(this._activeSubagents.entries()),
+      assistantDrafts: this._assistantDraftSnapshot(),
 
       // Tokens — copy so the caller can't mutate the running aggregate
       tokenUsage: { ...this._tokenUsage },

--- a/packages/core/src/harness/v1/session.ts
+++ b/packages/core/src/harness/v1/session.ts
@@ -1774,6 +1774,15 @@ export class Session {
     // `run_completed`) on a terminal `agent_end`. Runs AFTER emit so
     // `run_completed` follows its `agent_end`.
     this._trackRunSpanPostEmit(emitted);
+    if (
+      emitted.type === 'agent_end' &&
+      (emitted.finishReason === 'complete' ||
+        emitted.finishReason === 'aborted' ||
+        emitted.finishReason === 'error' ||
+        emitted.finishReason === 'suspended')
+    ) {
+      this._terminalizeAssistantDraft(emitted.runId, emitted.finishReason);
+    }
     return emitted;
   }
 
@@ -2463,7 +2472,6 @@ export class Session {
       finishReason: opts.finishReason,
       usage: this._runUsage(opts.full),
     });
-    this._terminalizeAssistantDraft(id, opts.finishReason);
   }
 
   /**
@@ -5243,7 +5251,6 @@ export class Session {
             runId,
             kind: 'reasoning',
             delta: payload.text,
-            ...(typeof payload.id === 'string' ? { messageId: payload.id } : {}),
           });
           this._emitTurnEvent({ type: 'reasoning_delta', runId, delta: payload.text });
         }

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -555,6 +555,7 @@ export interface HarnessRunOperationalState {
 }
 
 export type HarnessAssistantDraftStatus = 'streaming' | 'interrupted' | 'completed' | 'failed';
+export type HarnessAssistantDraftFinishReason = 'complete' | 'aborted' | 'error';
 
 /**
  * §5.1x — bounded durable projection of an assistant response that is still
@@ -578,7 +579,7 @@ export interface HarnessAssistantDraft {
   startedAt: number;
   updatedAt: number;
   terminalAt?: number;
-  finishReason?: string;
+  finishReason?: HarnessAssistantDraftFinishReason;
   truncated?: boolean;
 }
 

--- a/packages/core/src/storage/domains/harness/types.ts
+++ b/packages/core/src/storage/domains/harness/types.ts
@@ -418,6 +418,12 @@ export interface SessionRecord {
    * workspace surface.
    */
   currentRun?: HarnessRunOperationalState;
+  /**
+   * Bounded coalesced assistant drafts for active/recent runs. Keyed by
+   * `runId`. Durable snapshot consumers may render these as in-progress rows
+   * until thread messages or operation-result evidence supersede them.
+   */
+  assistantDrafts?: Record<string, HarnessAssistantDraft>;
   queueAdmissionReceipts?: Record<string, QueueAdmissionReceipt>;
   inboxResponseReceipts?: Record<string, InboxResponseReceipt>;
 
@@ -472,14 +478,7 @@ export interface SessionRecord {
 }
 
 /** §5.1e — lifecycle status of a `HarnessRunOperationalState`. */
-export type HarnessRunStatus =
-  | 'starting'
-  | 'running'
-  | 'waiting'
-  | 'resuming'
-  | 'completed'
-  | 'failed'
-  | 'interrupted';
+export type HarnessRunStatus = 'starting' | 'running' | 'waiting' | 'resuming' | 'completed' | 'failed' | 'interrupted';
 
 /** §5.1e — which entry-point operation a run is executing. */
 export type HarnessRunOperationRef =
@@ -553,6 +552,34 @@ export interface HarnessRunOperationalState {
   terminalAt?: number;
   finishReason?: string;
   error?: { code: HarnessRowErrorCode; message: string };
+}
+
+export type HarnessAssistantDraftStatus = 'streaming' | 'interrupted' | 'completed' | 'failed';
+
+/**
+ * §5.1x — bounded durable projection of an assistant response that is still
+ * being streamed or has just terminalized. This is not transcript history; the
+ * thread message log and operation-result evidence remain authoritative for
+ * completed content. It exists so first-party clients can reload/reconnect and
+ * still render the latest coalesced assistant draft without replaying every
+ * `text_delta`.
+ */
+export interface HarnessAssistantDraft {
+  runId: string;
+  sessionId: string;
+  resourceId: string;
+  threadId: string;
+  signalId?: string;
+  queuedItemId?: string;
+  messageId?: string;
+  text: string;
+  reasoningText?: string;
+  status: HarnessAssistantDraftStatus;
+  startedAt: number;
+  updatedAt: number;
+  terminalAt?: number;
+  finishReason?: string;
+  truncated?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -1631,13 +1658,7 @@ export interface SaveAttachmentReferenceInput extends AttachmentReference {
 // to TM-3 / TM-4 / TM-5; TM-2 ships only the durable storage layer.
 // ---------------------------------------------------------------------------
 
-export type HarnessPlanTaskStatus =
-  | 'pending'
-  | 'in_progress'
-  | 'blocked'
-  | 'completed'
-  | 'cancelled'
-  | 'failed';
+export type HarnessPlanTaskStatus = 'pending' | 'in_progress' | 'blocked' | 'completed' | 'cancelled' | 'failed';
 
 /**
  * Whether the current `status` was written by an explicit caller/model action

--- a/packages/server/src/server/handlers/harness-display-state.ts
+++ b/packages/server/src/server/handlers/harness-display-state.ts
@@ -119,6 +119,16 @@ export function toHarnessDisplayStateSnapshotV1(state: SessionDisplayState): Har
     activeSubagents: Object.fromEntries(
       Object.entries(state.activeSubagents).map(([id, subagent]) => [id, encodeActiveSubagent(subagent)]),
     ),
+    assistantDrafts: Object.fromEntries(
+      Object.entries(state.assistantDrafts ?? {}).map(([runId, draft]) => [
+        runId,
+        {
+          ...draft,
+          text: draft.text,
+          ...(draft.reasoningText !== undefined ? { reasoningText: draft.reasoningText } : {}),
+        },
+      ]),
+    ),
     tokenUsage: { ...state.tokenUsage },
     pending: encodePending(state.pending),
     queueDepth: state.queueDepth,

--- a/packages/server/src/server/handlers/harness.test.ts
+++ b/packages/server/src/server/handlers/harness.test.ts
@@ -84,6 +84,7 @@ function makeDisplayState(record: SessionRecord): SessionDisplayState {
     activeTools: {},
     toolInputBuffers: {},
     activeSubagents: {},
+    assistantDrafts: { ...(record.assistantDrafts ?? {}) },
     tokenUsage: record.tokenUsage,
     pending: null,
     queueDepth: record.pendingQueue.length,
@@ -608,7 +609,22 @@ describe('Harness server routes', () => {
   });
 
   it('returns a session snapshot response with an ETag from the session version', async () => {
-    const record = makeRecord();
+    const record = makeRecord({
+      assistantDrafts: {
+        'run-1': {
+          runId: 'run-1',
+          sessionId: 'session-1',
+          resourceId: 'resource-1',
+          threadId: 'thread-1',
+          messageId: 'message-1',
+          text: 'recovered partial answer',
+          reasoningText: 'thinking',
+          status: 'streaming',
+          startedAt: 300,
+          updatedAt: 350,
+        },
+      },
+    });
     const session = {
       getRecord: () => record,
       getDisplayState: () => makeDisplayState(record),
@@ -640,6 +656,13 @@ describe('Harness server routes', () => {
       displayState: {
         version: 1,
         sessionId: 'session-1',
+        assistantDrafts: {
+          'run-1': {
+            text: 'recovered partial answer',
+            reasoningText: 'thinking',
+            status: 'streaming',
+          },
+        },
       },
       tokenUsage: { totalTokens: 3 },
     });

--- a/packages/server/src/server/handlers/harness.ts
+++ b/packages/server/src/server/handlers/harness.ts
@@ -69,10 +69,7 @@ import { enforceThreadAccess, getEffectiveResourceId } from './utils';
 
 type SessionLifecycleStatus = 'active' | 'closing' | 'closed';
 type PendingInboxKind = 'tool-approval' | 'tool-suspension' | 'question' | 'plan-approval' | 'sandbox-access';
-type PublicPendingResume = Omit<
-  NonNullable<SessionRecord['pendingResume']>,
-  'runtimeDependencies' | 'requestContext'
->;
+type PublicPendingResume = Omit<NonNullable<SessionRecord['pendingResume']>, 'runtimeDependencies' | 'requestContext'>;
 type ParsedHarnessEventId = { epoch: string; sequence: number };
 type UrlAttachmentInput = {
   kind: 'url';
@@ -1734,6 +1731,7 @@ function displayStateFromRecord(record: SessionRecord): SessionDisplayState {
     activeTools: {},
     toolInputBuffers: {},
     activeSubagents: {},
+    assistantDrafts: { ...(record.assistantDrafts ?? {}) },
     tokenUsage: { ...record.tokenUsage },
     pending: pendingResumeForDisplay(record.pendingResume),
     queueDepth: record.pendingQueue.length,
@@ -2107,10 +2105,9 @@ export const POST_HARNESS_CHANNEL_INBOUND_ROUTE = createPublicRoute({
     const forwardedContentType = headers['content-type'];
     const contentType = Array.isArray(forwardedContentType) ? forwardedContentType[0] : forwardedContentType;
     if (!isAllowedChannelContentType(contentType)) {
-      return jsonResponse(
-        toHarnessErrorBody('harness.bad_request', 'unsupported channel webhook content-type'),
-        { status: 415 },
-      );
+      return jsonResponse(toHarnessErrorBody('harness.bad_request', 'unsupported channel webhook content-type'), {
+        status: 415,
+      });
     }
     if (rawBody !== undefined && rawBodyByteLength(rawBody) > CHANNEL_INBOUND_MAX_BODY_BYTES) {
       return jsonResponse(toHarnessErrorBody('harness.bad_request', 'channel webhook payload too large'), {
@@ -2354,8 +2351,7 @@ export const GET_HARNESS_SESSION_EVENTS_ROUTE = createRoute({
       let closed = false;
       let heartbeat: ReturnType<typeof setInterval> | undefined;
       const heartbeatOverride = (handlerArgs as unknown as { heartbeatIntervalMs?: unknown }).heartbeatIntervalMs;
-      const heartbeatIntervalMs =
-        typeof heartbeatOverride === 'number' ? heartbeatOverride : SSE_HEARTBEAT_INTERVAL_MS;
+      const heartbeatIntervalMs = typeof heartbeatOverride === 'number' ? heartbeatOverride : SSE_HEARTBEAT_INTERVAL_MS;
       const cleanup = () => {
         if (closed) return;
         closed = true;

--- a/packages/server/src/server/schemas/harness.ts
+++ b/packages/server/src/server/schemas/harness.ts
@@ -120,6 +120,24 @@ const harnessDisplayActiveSubagentSnapshotV1Schema = z.object({
   startedAt: z.number(),
 });
 
+const harnessAssistantDraftSchema = z.object({
+  runId: z.string(),
+  sessionId: z.string(),
+  resourceId: z.string(),
+  threadId: z.string(),
+  signalId: z.string().optional(),
+  queuedItemId: z.string().optional(),
+  messageId: z.string().optional(),
+  text: z.string(),
+  reasoningText: z.string().optional(),
+  status: z.enum(['streaming', 'interrupted', 'completed', 'failed']),
+  startedAt: z.number(),
+  updatedAt: z.number(),
+  terminalAt: z.number().optional(),
+  finishReason: z.string().optional(),
+  truncated: z.boolean().optional(),
+});
+
 const harnessDisplayPendingSnapshotV1Schema = z.object({
   kind: z.enum(['tool-approval', 'tool-suspension', 'question', 'plan-approval', 'sandbox-access']),
   itemId: z.string().optional(),
@@ -156,6 +174,7 @@ export const harnessDisplayStateSnapshotV1Schema = z.object({
   activeTools: z.record(z.string(), harnessDisplayActiveToolSnapshotV1Schema),
   toolInputBuffers: z.record(z.string(), harnessDisplayToolInputBufferSnapshotV1Schema),
   activeSubagents: z.record(z.string(), harnessDisplayActiveSubagentSnapshotV1Schema),
+  assistantDrafts: z.record(z.string(), harnessAssistantDraftSchema),
   tokenUsage: z.object({
     promptTokens: z.number(),
     completionTokens: z.number(),

--- a/packages/server/src/server/schemas/harness.ts
+++ b/packages/server/src/server/schemas/harness.ts
@@ -134,7 +134,7 @@ const harnessAssistantDraftSchema = z.object({
   startedAt: z.number(),
   updatedAt: z.number(),
   terminalAt: z.number().optional(),
-  finishReason: z.string().optional(),
+  finishReason: z.enum(['complete', 'aborted', 'error']).optional(),
   truncated: z.boolean().optional(),
 });
 


### PR DESCRIPTION
## Summary

Adds a first-party Harness display-state contract for durable/coalesced assistant drafts:

- persists bounded `assistantDrafts` on `SessionRecord` keyed by runId
- coalesces streamed text and reasoning deltas into `getDisplayState()` / `subscribeDisplayState()`
- terminalizes drafts as `completed`, `interrupted`, or `failed`, including direct error/abort `agent_end` paths
- flushes pending assistant drafts through shutdown/flush waiting so teardown does not lose terminal recovery state
- exposes drafts in server cold session snapshots and response schema
- documents the reconnect boundary: drafts are render recovery, not transcript authority or synthetic SSE replay

Additional behavior surface called out for review: escalation built-ins (`spawn_subagent` / `task_delegate`) now honor an engaged permission gate instead of bypassing it. This is a security/permission behavior change included with the Harness recovery work and covered by mode-permission tests.

## Review Fixes

- Reasoning stream ids are no longer persisted as `assistantDraft.messageId`; only assistant text message ids set that identity.
- `assistantDraft.finishReason` is now a closed contract: `complete | aborted | error` in core storage types and server schema.
- Direct terminal `agent_end` emits now terminalize persisted drafts through the shared event path.
- Late deltas preserve terminal draft metadata instead of reopening completed/failed/interrupted drafts.
- Terminalization only targets exact run IDs or draft run IDs observed during the current turn; rehydrated stale drafts are not stamped by unrelated terminal events.
- `_internalAwaitFlushChain()` flushes dirty assistant drafts before shutdown/eviction waits finish.

## Verification

- `corepack pnpm@11.3.0 --filter @mastra/core test src/harness/v1/session.display-state.test.ts src/harness/v1/display-state.test.ts src/harness/v1/session.events.test.ts src/harness/v1/session.adversarial-replay.test.ts`
- `corepack pnpm@11.3.0 --filter @mastra/server test src/server/handlers/harness.test.ts`
- `corepack pnpm@11.3.0 --filter @mastra/core run build:lib`
- `corepack pnpm@11.3.0 build:server`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5 (Explain Like I'm 5)

When the AI is halfway through typing and your connection drops, this change saves a small, safe snapshot of that half-finished reply so the client can show what was being written when you reconnect — without treating that draft as a finished message.

---

## Overview

Adds durable, bounded "assistant draft" display state to Harness so in-progress assistant text and reasoning can be recovered across reloads, reconnections, SSE gaps, shutdowns, and other transient interruptions. Drafts are coalesced from streaming deltas, persisted on SessionRecord.assistantDrafts, exposed in display snapshots, and terminalized with explicit lifecycle states. Drafts are strictly for render recovery (not transcript authority or synthetic replay).

---

## Core Changes

- Storage & Types
  - SessionRecord: optional assistantDrafts?: Record<string, HarnessAssistantDraft>.
  - New types: HarnessAssistantDraft, HarnessAssistantDraftStatus ('streaming' | 'interrupted' | 'completed' | 'failed'), HarnessAssistantDraftFinishReason ('complete' | 'aborted' | 'error').

- Session behavior
  - In-memory per-run assistant drafts accumulate bounded text and reasoning deltas, link to text-start message ids when applicable, and record metadata (timestamps, truncation, finish info).
  - Drafts are coalesced and persisted via a dirty-flag + scheduled flush; forced flush occurs before event-ledger persistence and during shutdown to ensure terminalized persisted state.
  - Drafts terminalize on run end, aborts, direct agent_end paths, or error; late deltas do not reopen terminalized drafts.
  - Reasoning stream ids are no longer stored as assistantDraft.messageId; only assistant text message ids set that identity.
  - SessionDisplayState / getDisplayState() / subscribeDisplayState() expose assistantDrafts for render recovery.

- Snapshot, server & schemas
  - HarnessDisplayStateSnapshotV1 includes assistantDrafts; server handlers and serialization copy draft fields and include reasoningText only when present.
  - Added harnessAssistantDraftSchema and updated harnessDisplayStateSnapshotV1Schema to validate assistantDrafts.
  - Server cold session snapshots and route responses include a trimmed/projection of assistantDrafts.

- Permissions & security behavior
  - Escalation built-ins (spawn_subagent / task_delegate) no longer unconditionally bypass deny-default; they obey the session permission gate and must be explicitly allowed by resolver rules (covered by mode-permission tests). HITL/local plan-task built-ins retain their intended allow behavior where applicable.

- Documentation & reconnection behavior
  - Public API, persistence, buffering/replay, reconnection, and first-party client boundary docs updated to describe assistantDrafts as bounded, coalesced render-recovery input; explicitly state drafts are not transcript rows nor durable replay events; document 412 recovery flow, truncation semantics, and client merge/replace behavior with live transcript messages.

- Shutdown handling
  - Adds a shutdown-time flush to ensure drafts are persisted/terminalized during shutdown sequences.

---

## Tests & Verification

- Core & server tests added/updated to cover:
  - Inclusion and defensive-copying of assistantDrafts in display snapshots.
  - getDisplayState() coalescing of streaming text and reasoning into drafts, durable persistence and recovery across reloads/replays, terminalization semantics (completed/interrupted/failed), truncation marking for oversized drafts, and subscriber notification of transitions.
  - Behavior when transient streaming delta persistence is disabled (drafts still recover correctly).
  - Reasoning-only runs omit messageId; direct agent_end terminalization and unrelated-run isolation; flush-before-persistence and shutdown flush behavior.
  - Mode-permission tests validating escalation built-ins require explicit permission.
  - Server route tests asserting snapshot responses include assistantDrafts projection fields.

Verification commands (as exercised by author): core/server test runs and builds using pnpm/corepack and build steps listed in PR.

---

## Design & Boundary Notes

- Purpose: improve UI render recovery for in-progress assistant output across common connectivity and lifecycle gaps.
- Strict boundary: assistantDrafts are for client rendering only — they do not grant transcript authority, cannot be used for synthetic SSE replay, and should be replaced by persisted transcript messages when available.
- Storage is bounded and may prune terminal drafts; oversized drafts are truncated and flagged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->