### PR TITLE
[PF-814] Cover canonical Harness state diffs

### DIFF
--- a/packages/core/src/harness/v1/session.events.test.ts
+++ b/packages/core/src/harness/v1/session.events.test.ts
@@ -156,6 +156,28 @@ describe('Session.subscribe()', () => {
     expect(second.changedKeys).toEqual(['c']);
   });
 
+  it('does not emit state_changed when object keys are only reordered (§10.2)', async () => {
+    const { harness } = setup();
+    const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });
+
+    const events: HarnessEvent[] = [];
+    session.subscribe(e => {
+      if (e.type === 'state_changed') events.push(e);
+    });
+
+    await session.setState({ filters: { status: 'open', owner: 'u1' }, page: 1 });
+    await session.setState({ filters: { owner: 'u1', status: 'open' } });
+    await session.setState({ filters: { owner: 'u1', status: 'closed' } });
+
+    expect(events).toHaveLength(2);
+    const first = events[0] as { state: Record<string, unknown>; changedKeys: string[] };
+    expect(first.state).toEqual({ filters: { status: 'open', owner: 'u1' }, page: 1 });
+    expect(first.changedKeys.sort()).toEqual(['filters', 'page']);
+    const second = events[1] as { state: Record<string, unknown>; changedKeys: string[] };
+    expect(second.state).toEqual({ filters: { owner: 'u1', status: 'closed' }, page: 1 });
+    expect(second.changedKeys).toEqual(['filters']);
+  });
+
   it('emits state_changed with the "$" root sentinel for scalar/array root changes (§10.2)', async () => {
     const { harness } = setup();
     const session = await harness.session({ resourceId: 'u1', threadId: { fresh: true } });


### PR DESCRIPTION
## Summary
- Adds a Harness v1 regression test proving `state_changed` is not emitted when object values only differ by key order.
- Keeps the existing true-change case covered so `changedKeys` still reports `filters` when the nested value actually changes.

## Context
- PapersFlow Linear: PF-814
- PapersFlow GitHub issue: papersflow-ai/papersflow#809
- Source lane: mbenhamd/mastra fork, `packages/core`.
- This is test-only; no PapersFlow submodule pointer or package artifact is changed.

## Validation
- `pnpm build:core` passed.
- `pnpm --filter @mastra/core test -- src/harness/v1/session.events.test.ts` passed: 1 file, 47 tests.
- `git diff --check` passed before commit.
- Local Codex review attempted twice but unavailable: OpenAI API returned 401.
- CodeRabbit CLI attempted on the uncommitted diff but produced no result after several minutes and was stopped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds a test that checks whether the system correctly ignores changes where objects have the same data but keys in a different order—it should **not** report this as a change. The test also makes sure the system still catches **real** changes when actual values are different.

## Test Coverage Addition

Added a regression test case titled "does not emit state_changed when object keys are only reordered (§10.2)" to the `Session.subscribe()` test suite:

**Test scenario:**
- First state update: `{ filters: { status: 'open', owner: 'u1' }, page: 1 }` → emits `state_changed` event (expected)
- Second state update: `{ filters: { owner: 'u1', status: 'open' } }` → **no** `state_changed` event (key order differs, but values are identical; correctly suppressed)
- Third state update: `{ filters: { owner: 'u1', status: 'closed' } }` → emits `state_changed` event (value changed; expected)

**Assertions:**
- Only 2 `state_changed` events are emitted (not 3), confirming canonical equality is respected
- First event contains changed keys `['filters', 'page']`
- Second event contains changed key `['filters']` with the updated value
- Session state properly reflects all updates

## References
- Addresses PapersFlow issue PF-814 (papersflow-ai/papersflow#809)
- Test-only change with no public API modifications

Lines changed: +22/-0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->