### PR TITLE
[PF-802] Characterize aggregate signal output

### DIFF
--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -4132,6 +4132,94 @@ describe('Agent signals', () => {
     subscription.unsubscribe();
   });
 
+  it('characterizes PF-802 active signal output as one aggregate run without segment markers', async () => {
+    let releaseFirst!: () => void;
+    const firstFinished = new Promise<void>(resolve => {
+      releaseFirst = resolve;
+    });
+    let streamCount = 0;
+
+    const model = new MockLanguageModelV2({
+      doStream: async () => {
+        streamCount += 1;
+        const responseText = streamCount === 1 ? 'first response' : 'signal response';
+
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: new ReadableStream({
+            async start(controller) {
+              controller.enqueue({ type: 'stream-start', warnings: [] });
+              controller.enqueue({
+                type: 'response-metadata',
+                id: `id-${streamCount}`,
+                modelId: 'mock-model-id',
+                timestamp: new Date(0),
+              });
+              controller.enqueue({ type: 'text-start', id: `text-${streamCount}` });
+              controller.enqueue({ type: 'text-delta', id: `text-${streamCount}`, delta: responseText });
+              controller.enqueue({ type: 'text-end', id: `text-${streamCount}` });
+              if (streamCount === 1) {
+                await firstFinished;
+              }
+              controller.enqueue({
+                type: 'finish',
+                finishReason: 'stop',
+                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              });
+              controller.close();
+            },
+          }),
+        };
+      },
+    });
+
+    const agent = new Agent({
+      id: 'pf-802-aggregate-signal-agent',
+      name: 'PF-802 Aggregate Signal Agent',
+      instructions: 'Test',
+      model,
+    });
+
+    const subscription = await agent.subscribeToThread({
+      threadId: 'pf-802-aggregate-thread',
+      resourceId: 'pf-802-aggregate-user',
+    });
+    const iterator = subscription.stream[Symbol.asyncIterator]();
+    const runPromise = readNextRunWithParts(iterator);
+
+    const stream = await agent.stream('Hello', {
+      memory: { thread: 'pf-802-aggregate-thread', resource: 'pf-802-aggregate-user' },
+    });
+    await expect(waitForActiveRun(subscription)).resolves.toBe(stream.runId);
+
+    const signalResult = await agent.sendSignal(
+      { type: 'user-message', contents: 'Hello while running' },
+      { resourceId: 'pf-802-aggregate-user', threadId: 'pf-802-aggregate-thread' },
+    );
+    expect(signalResult).toEqual(expect.objectContaining({ accepted: true, runId: stream.runId }));
+
+    releaseFirst();
+    const run = await runPromise;
+    const textDeltas = run.value.parts.filter(part => part.type === 'text-delta');
+
+    expect(run.value.runId).toBe(stream.runId);
+    expect(run.value.text).toBe('first responsesignal response');
+    expect(textDeltas.map(part => part.payload.text)).toEqual(['first response', 'signal response']);
+    expect(new Set(textDeltas.map(part => part.runId))).toEqual(new Set([stream.runId]));
+    const textDeltaMessageIds = textDeltas.map(part => part.messageId ?? part.payload?.messageId);
+    expect(textDeltaMessageIds).toEqual([undefined, undefined]);
+    expect(
+      run.value.parts.map(part => ({
+        segmentId: part.segmentId ?? part.payload?.segmentId,
+        segmentIndex: part.segmentIndex ?? part.payload?.segmentIndex,
+      })),
+    ).toEqual(run.value.parts.map(() => ({ segmentId: undefined, segmentIndex: undefined })));
+
+    await stream.consumeStream();
+    subscription.unsubscribe();
+  });
+
   it('drops a not-yet-visible current-step tool call when draining a follow-up signal', async () => {
     const prompts: any[][] = [];
     let callCount = 0;

--- a/packages/core/src/agent/__tests__/agent-signals.test.ts
+++ b/packages/core/src/agent/__tests__/agent-signals.test.ts
@@ -4141,8 +4141,8 @@ describe('Agent signals', () => {
 
     const model = new MockLanguageModelV2({
       doStream: async () => {
-        streamCount += 1;
-        const responseText = streamCount === 1 ? 'first response' : 'signal response';
+        const streamIndex = ++streamCount;
+        const responseText = streamIndex === 1 ? 'first response' : 'signal response';
 
         return {
           rawCall: { rawPrompt: null, rawSettings: {} },
@@ -4152,14 +4152,14 @@ describe('Agent signals', () => {
               controller.enqueue({ type: 'stream-start', warnings: [] });
               controller.enqueue({
                 type: 'response-metadata',
-                id: `id-${streamCount}`,
+                id: `id-${streamIndex}`,
                 modelId: 'mock-model-id',
                 timestamp: new Date(0),
               });
-              controller.enqueue({ type: 'text-start', id: `text-${streamCount}` });
-              controller.enqueue({ type: 'text-delta', id: `text-${streamCount}`, delta: responseText });
-              controller.enqueue({ type: 'text-end', id: `text-${streamCount}` });
-              if (streamCount === 1) {
+              controller.enqueue({ type: 'text-start', id: `text-${streamIndex}` });
+              controller.enqueue({ type: 'text-delta', id: `text-${streamIndex}`, delta: responseText });
+              controller.enqueue({ type: 'text-end', id: `text-${streamIndex}` });
+              if (streamIndex === 1) {
                 await firstFinished;
               }
               controller.enqueue({
@@ -4185,39 +4185,42 @@ describe('Agent signals', () => {
       threadId: 'pf-802-aggregate-thread',
       resourceId: 'pf-802-aggregate-user',
     });
-    const iterator = subscription.stream[Symbol.asyncIterator]();
-    const runPromise = readNextRunWithParts(iterator);
+    try {
+      const iterator = subscription.stream[Symbol.asyncIterator]();
+      const runPromise = readNextRunWithParts(iterator);
 
-    const stream = await agent.stream('Hello', {
-      memory: { thread: 'pf-802-aggregate-thread', resource: 'pf-802-aggregate-user' },
-    });
-    await expect(waitForActiveRun(subscription)).resolves.toBe(stream.runId);
+      const stream = await agent.stream('Hello', {
+        memory: { thread: 'pf-802-aggregate-thread', resource: 'pf-802-aggregate-user' },
+      });
+      await expect(waitForActiveRun(subscription)).resolves.toBe(stream.runId);
 
-    const signalResult = await agent.sendSignal(
-      { type: 'user-message', contents: 'Hello while running' },
-      { resourceId: 'pf-802-aggregate-user', threadId: 'pf-802-aggregate-thread' },
-    );
-    expect(signalResult).toEqual(expect.objectContaining({ accepted: true, runId: stream.runId }));
+      const signalResult = await agent.sendSignal(
+        { type: 'user-message', contents: 'Hello while running' },
+        { resourceId: 'pf-802-aggregate-user', threadId: 'pf-802-aggregate-thread' },
+      );
+      expect(signalResult).toEqual(expect.objectContaining({ accepted: true, runId: stream.runId }));
 
-    releaseFirst();
-    const run = await runPromise;
-    const textDeltas = run.value.parts.filter(part => part.type === 'text-delta');
+      releaseFirst();
+      const run = await runPromise;
+      const textDeltas = run.value.parts.filter(part => part.type === 'text-delta');
 
-    expect(run.value.runId).toBe(stream.runId);
-    expect(run.value.text).toBe('first responsesignal response');
-    expect(textDeltas.map(part => part.payload.text)).toEqual(['first response', 'signal response']);
-    expect(new Set(textDeltas.map(part => part.runId))).toEqual(new Set([stream.runId]));
-    const textDeltaMessageIds = textDeltas.map(part => part.messageId ?? part.payload?.messageId);
-    expect(textDeltaMessageIds).toEqual([undefined, undefined]);
-    expect(
-      run.value.parts.map(part => ({
-        segmentId: part.segmentId ?? part.payload?.segmentId,
-        segmentIndex: part.segmentIndex ?? part.payload?.segmentIndex,
-      })),
-    ).toEqual(run.value.parts.map(() => ({ segmentId: undefined, segmentIndex: undefined })));
+      expect(run.value.runId).toBe(stream.runId);
+      expect(run.value.text).toBe('first responsesignal response');
+      expect(textDeltas.map(part => part.payload.text)).toEqual(['first response', 'signal response']);
+      expect(new Set(textDeltas.map(part => part.runId))).toEqual(new Set([stream.runId]));
+      const textDeltaMessageIds = textDeltas.map(part => part.messageId ?? part.payload?.messageId);
+      expect(textDeltaMessageIds).toEqual([undefined, undefined]);
+      expect(
+        run.value.parts.map(part => ({
+          segmentId: part.segmentId ?? part.payload?.segmentId,
+          segmentIndex: part.segmentIndex ?? part.payload?.segmentIndex,
+        })),
+      ).toEqual(run.value.parts.map(() => ({ segmentId: undefined, segmentIndex: undefined })));
 
-    await stream.consumeStream();
-    subscription.unsubscribe();
+      await stream.consumeStream();
+    } finally {
+      subscription.unsubscribe();
+    }
   });
 
   it('drops a not-yet-visible current-step tool call when draining a follow-up signal', async () => {


### PR DESCRIPTION
## Summary
- Adds a PF-802 characterization test for active user-message signals drained into an existing thread run.
- Pins the current aggregate behavior: initial output and signal output are emitted as one subscribed run, text deltas have no per-delta message id, and no segment markers are present.
- No runtime behavior changes and no changeset; this is tests-only source verification for papersflow-ai/papersflow#796.

## Validation
- pnpm --filter @mastra/core test -- src/agent/__tests__/agent-signals.test.ts -t PF-802
- pnpm --filter @mastra/core test -- src/agent/__tests__/agent-signals.test.ts -t "drains a user-message signal into the active same-agent thread run|PF-802"
- pnpm build:core
- git diff --check

## Review notes
- CodeRabbit CLI local review was attempted with timeout 120s and timed out while summarizing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 - What this PR does

This PR adds a “behavior snapshot” test. It sends a signal while a chat response is streaming, then checks that the combined result looks exactly like the system does right now—so future changes won’t accidentally alter that behavior.

---

## Summary

This pull request adds a characterization (test-only) test for PF-802 to validate how active user-message signals are drained into an existing thread run. It documents and verifies the current aggregate signal output behavior without changing runtime functionality.

### What’s being tested

In `packages/core/src/agent/__tests__/agent-signals.test.ts`, the new test uses a mock streaming model to emit two `text-delta` segments across an initial and follow-up phase while a thread run is still active, then sends a same-thread signal mid-stream. It asserts that the aggregated output behaves as follows:

- The initial and follow-up `text-delta` parts are represented as a single run (the same `runId`)
- Each `text-delta` part does **not** include per-delta message identifiers (`messageId` remains `undefined`)
- No segment metadata is present in the output (`segmentId` and `segmentIndex` are `undefined` for every emitted part), including cases where those values might exist on the underlying payload
- The stream output is fully consumed and the thread subscription is fully cleaned up

### Test characterization cleanup improvements (still test-only)

Following feedback, the test was updated to improve reliability/robustness of the streaming assertions:
- Captures `streamIndex` per `doStream()` invocation to avoid async callbacks reading a shared `streamCount`
- Moves subscription cleanup into a `finally` block to ensure proper resource cleanup

### Validation steps documented

The PR includes validation steps to:
- Run the specific PF-802 characterization test in `src/agent/__tests__/agent-signals.test.ts`
- Run related tests that drain user-message signals into active same-agent thread runs
- Build the core package with `pnpm build:core`
- Check for trailing whitespace with `git diff --check`

### Changes

- Test-only addition in `packages/core/src/agent/__tests__/agent-signals.test.ts` (+91 lines / -0)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->