### PR TITLE
Sync selected upstream runtime fixes

### DIFF
--- a/.changeset/dark-ways-post.md
+++ b/.changeset/dark-ways-post.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Multimodal content returned from `toModelOutput` (e.g. images via `type: 'image-url'`) is now correctly preserved as native provider content instead of being stringified into a JSON string. Previously, tools returning `{ type: 'content', value: [...] }` with image parts would cause providers like OpenRouter and Mistral to receive a plain text string instead of multimodal content.

--- a/.changeset/dull-comics-tease.md
+++ b/.changeset/dull-comics-tease.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed supervisor sub-agent tool preparation so memory tools are available when agents derive their thread and resource from default options. This prevents misleading "Skipping memory tools (no thread or resource context)" debug logs for correctly configured sub-agents.

--- a/.changeset/fix-tools-merge-mcp.md
+++ b/.changeset/fix-tools-merge-mcp.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed the tools API endpoint to include dynamically created tools (e.g., MCP tools) alongside bundler-discovered tools. Previously, when the CLI bundler discovered tools, dynamically created tools registered via `new Mastra({ tools })` were silently dropped from the `/api/tools` response. Now both sources are merged, with bundler-discovered tools taking precedence on conflicts.

--- a/.changeset/four-ghosts-make.md
+++ b/.changeset/four-ghosts-make.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed extractV6NativeApproval to pick the most recent approval-responded tool part within a trailing assistant message. Earlier, when one message accumulated multiple approval-responded parts across sequential resume cycles, the resume flow used the oldest stale decision instead of the one the user just acted on. Closes #17899.

--- a/.changeset/khaki-words-lie.md
+++ b/.changeset/khaki-words-lie.md
@@ -1,0 +1,21 @@
+---
+'@mastra/core': patch
+---
+
+Improved BM25 tokenization to support CJK (Japanese, Chinese, Korean) and other non-Latin languages. Added `TokenizeOptions.tokenizer` for plugging in custom tokenizers (e.g. n-gram, kuromoji). Workspace `bm25` config now accepts `tokenize` options for full control over how text is split into search tokens.
+
+**Before:** BM25 search returned no results for non-English content — CJK characters were silently stripped during tokenization.
+
+**After:** Non-Latin characters are preserved by default. Users can also plug in a custom tokenizer:
+
+```ts
+new Workspace({
+  bm25: {
+    tokenize: {
+      tokenizer: myCustomCjkTokenizer,
+    },
+  },
+});
+```
+
+Fixes #17636

--- a/.changeset/memory-embedding-cache-bounds.md
+++ b/.changeset/memory-embedding-cache-bounds.md
@@ -1,0 +1,9 @@
+---
+"@mastra/memory": patch
+---
+
+Fixed the semantic recall embedding cache so it no longer grows without bound and can no longer return another message's embeddings.
+
+The in-process cache that stores embeddings for recall now uses an LRU with a fixed capacity, so a long-running `Memory` instance stops accumulating every message and query it has ever embedded (each entry holds chunk text plus vectors) for the lifetime of the process. Cache keys also moved from a 32-bit hash to a 64-bit hash, removing a collision that could make one message silently receive a different message's cached embeddings — corrupting what gets indexed and recalled.
+
+No API changes; semantic recall results for correctly cached content are unchanged.

--- a/.changeset/old-news-press.md
+++ b/.changeset/old-news-press.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed message part timestamps affecting transcript ordering by ensuring only message-level timestamps advance the ordering watermark.

--- a/.changeset/quiet-storage-processor-workflow.md
+++ b/.changeset/quiet-storage-processor-workflow.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fix `Cannot get workflow run. Mastra storage is not initialized` debug log spam on agents that use memory or any input/output processors.
+
+#17344 fixed this for the internal `execution-workflow`, but agents with memory/processors also build an internal *processor* workflow (`Agent.combineProcessorsIntoWorkflow`, run by `ProcessorRunner.executeWorkflowAsProcessor`) that never received the parent `Mastra` instance — so its `createRun()` → `getWorkflowRunById()` saw no storage and logged the noise on every run. The processor workflow now receives the parent `Mastra` instance and opts out of snapshot persistence (`shouldPersistSnapshot: () => false`), mirroring the execution-workflow fix. Follow-up to #17137 / #17344.

--- a/.changeset/thick-camels-decide.md
+++ b/.changeset/thick-camels-decide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed base64-encoded images failing when sent to Gemini through withMastra. Images now reach the provider in the correct format, matching the behavior of calling generateText without withMastra.

--- a/client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts
@@ -255,6 +255,37 @@ describe('extractV6NativeApproval', () => {
     expect(extractV6NativeApproval(messages as any)).toBeNull();
   });
 
+  it('picks the most recent approval-responded part when one assistant message has several (issue #17899)', () => {
+    const messages = [
+      {
+        role: 'assistant' as const,
+        id: 'msg-1',
+        parts: [
+          {
+            type: 'tool-myTool',
+            toolCallId: 'old-call',
+            state: 'approval-responded' as const,
+            input: {},
+            approval: { id: `old-run${APPROVAL_ID_SEPARATOR}old-call`, approved: true },
+          },
+          {
+            type: 'tool-myTool',
+            toolCallId: 'new-call',
+            state: 'approval-responded' as const,
+            input: {},
+            approval: { id: `new-run${APPROVAL_ID_SEPARATOR}new-call`, approved: false, reason: 'changed mind' },
+          },
+        ],
+      },
+    ];
+
+    const result = extractV6NativeApproval(messages as any);
+
+    expect(result?.runId).toBe('new-run');
+    expect(result?.resumeData.approved).toBe(false);
+    expect(result?.resumeData.reason).toBe('changed mind');
+  });
+
   it('scans from the end and picks the most recent approval-responded part', () => {
     const messages = [
       {

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -24,13 +24,16 @@ import type {
 } from './public-types';
 
 /**
- * Scans a v6 UIMessage array for an 'approval-responded' tool part in the
- * last trailing assistant message only. When found, splits the composite
- * approvalId ("${runId}::${toolCallId}") to recover the runId needed for
- * resumeStream.
+ * Scans a v6 UIMessage array for the most recent 'approval-responded' tool
+ * part in the last trailing assistant message only. When found, splits the
+ * composite approvalId ("${runId}::${toolCallId}") to recover the runId
+ * needed for resumeStream.
  *
  * Only the last trailing assistant message is inspected so that approval
- * responses from earlier turns are never re-processed.
+ * responses from earlier turns are never re-processed. Within that message,
+ * parts are scanned in reverse so the decision the user just acted on wins
+ * over any earlier 'approval-responded' parts that have not yet transitioned
+ * to 'output-available'.
  *
  * Returns null when no approval response is present (normal chat turn).
  */
@@ -43,7 +46,9 @@ export function extractV6NativeApproval(
   const lastAssistantMsg = messages.at(-1);
   if (!lastAssistantMsg || lastAssistantMsg.role !== 'assistant') return null;
 
-  for (const part of lastAssistantMsg.parts ?? []) {
+  const parts = lastAssistantMsg.parts ?? [];
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const part = parts[i]!;
     if (!isToolUIPart(part) || part.state !== 'approval-responded') continue;
 
     const lastSep = part.approval.id.lastIndexOf(APPROVAL_ID_SEPARATOR);

--- a/client-sdks/ai-sdk/src/workflow-route.ts
+++ b/client-sdks/ai-sdk/src/workflow-route.ts
@@ -239,14 +239,6 @@ export function workflowRoute({
         throw new Error('Workflow ID is required');
       }
 
-      if (contextRequestContext && params.requestContext) {
-        mastra
-          .getLogger()
-          ?.warn(
-            `"requestContext" from the request body will be ignored because "requestContext" is already set in the route options.`,
-          );
-      }
-
       const handlerOptions = {
         mastra,
         workflowId: workflowToUse,

--- a/e2e-tests/monorepo/monorepo.test.ts
+++ b/e2e-tests/monorepo/monorepo.test.ts
@@ -93,7 +93,9 @@ describe.for([['pnpm'] as const])(`%s monorepo`, ([pkgManager]) => {
       const res = await fetch(`http://localhost:${port}/api/tools`);
       const body = await res.json();
       expect(res.status).toBe(200);
-      expect(Object.keys(body)).toEqual(['calculatorTool', 'lodashTool']);
+      expect(Object.keys(body).sort()).toEqual(
+        ['calculatorTool', 'lodashTool', 'hello-world', 'generate-password', 'compare-password'].sort(),
+      );
     });
   }
 

--- a/packages/core/src/agent/__tests__/processor-workflow-storage-noise.test.ts
+++ b/packages/core/src/agent/__tests__/processor-workflow-storage-noise.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression test for the processor-workflow variant of
+ * https://github.com/mastra-ai/mastra/issues/17137 (follow-up to #17344).
+ *
+ * #17344 fixed the internal `execution-workflow`, but agents that use memory or any
+ * input/output processors also build an internal *processor* workflow
+ * (Agent.combineProcessorsIntoWorkflow, executed by ProcessorRunner.executeWorkflowAsProcessor).
+ * That workflow never received the parent Mastra reference, so its createRun() ->
+ * getWorkflowRunById() saw no storage and emitted, on every run:
+ *   "Cannot get workflow run. Mastra storage is not initialized"
+ * before falling back to in-memory state.
+ *
+ * When an agent with a processor is registered to a Mastra instance that has storage
+ * configured, calling agent.generate()/stream() must:
+ *   1. NOT take the no-storage branch for the internal `<agentId>-input-processor` workflow
+ *      (it now receives the parent Mastra reference).
+ *   2. NOT persist a workflow snapshot for that throwaway internal processor workflow.
+ */
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it, vi } from 'vitest';
+import { Mastra } from '../../mastra';
+import type { Processor } from '../../processors';
+import { InMemoryStore } from '../../storage';
+import { Workflow } from '../../workflows/workflow';
+import { Agent } from '../agent';
+
+const AGENT_ID = 'processor-noise-agent';
+const PROCESSOR_WORKFLOW_ID = `${AGENT_ID}-input-processor`;
+
+function createDummyModel() {
+  return new MockLanguageModelV2({
+    doGenerate: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop',
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      content: [{ type: 'text', text: 'Dummy response' }],
+      warnings: [],
+    }),
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Dummy response' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 } },
+      ]),
+    }),
+  });
+}
+
+// A minimal no-op input processor. A single non-workflow processor forces the agent to build
+// the internal `createWorkflow(...)` processor workflow (the branch that triggers the bug),
+// without pulling in @mastra/memory.
+const noopInputProcessor: Processor = {
+  id: 'noop-input-processor',
+  processInput: async ({ messages }) => messages,
+};
+
+function buildAgentWithProcessor() {
+  const storage = new InMemoryStore();
+  const agent = new Agent({
+    id: AGENT_ID,
+    name: AGENT_ID,
+    instructions: 'test',
+    model: createDummyModel(),
+    inputProcessors: [noopInputProcessor],
+  });
+  const mastra = new Mastra({
+    agents: { [AGENT_ID]: agent },
+    storage,
+    logger: false,
+  });
+  return { mastra, storage };
+}
+
+describe('agent processor-workflow storage noise (issue #17137 follow-up to #17344)', () => {
+  it('gives the internal processor workflow access to storage (no "storage is not initialized" branch)', async () => {
+    // The buggy processor workflow used its own un-registered logger, so spying on the Mastra
+    // logger does not see the noise. Instead, assert the root cause directly: when
+    // getWorkflowRunById runs for the processor workflow it now has storage, so the
+    // no-storage debug branch is unreachable.
+    const seen: Array<{ id: string; hasStorage: boolean }> = [];
+    const original = (Workflow.prototype as unknown as { getWorkflowRunById: (...a: unknown[]) => unknown })
+      .getWorkflowRunById;
+    const spy = vi
+      .spyOn(Workflow.prototype as unknown as Record<string, any>, 'getWorkflowRunById')
+      .mockImplementation(async function (this: any, ...args: unknown[]) {
+        seen.push({ id: this.id, hasStorage: Boolean(this.mastra?.getStorage?.()) });
+        return original.apply(this, args);
+      });
+
+    try {
+      const { mastra } = buildAgentWithProcessor();
+      await mastra.getAgent(AGENT_ID).generate('Hello!');
+    } finally {
+      spy.mockRestore();
+    }
+
+    const processorLookups = seen.filter(s => s.id === PROCESSOR_WORKFLOW_ID);
+    expect(processorLookups.length).toBeGreaterThan(0);
+    expect(processorLookups.every(s => s.hasStorage)).toBe(true);
+  });
+
+  it('does not persist a snapshot for the internal processor workflow on generate', async () => {
+    const { mastra, storage } = buildAgentWithProcessor();
+
+    await mastra.getAgent(AGENT_ID).generate('Hello!');
+
+    const workflowsStore = await storage.getStore('workflows');
+    const { runs, total } = await workflowsStore!.listWorkflowRuns({ workflowName: PROCESSOR_WORKFLOW_ID });
+    expect(total).toBe(0);
+    expect(runs).toEqual([]);
+  });
+});

--- a/packages/core/src/agent/__tests__/working-memory-context.test.ts
+++ b/packages/core/src/agent/__tests__/working-memory-context.test.ts
@@ -2,6 +2,7 @@ import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 import { MockMemory } from '../../memory/mock';
+import { RequestContext } from '../../request-context';
 import type { ChunkType } from '../../stream/types';
 import { createTool, Tool } from '../../tools';
 import { createWorkflow, createStep } from '../../workflows';
@@ -325,6 +326,35 @@ describe('Working memory tool context propagation', () => {
     }
 
     expect(toolNames).not.toContain('updateWorkingMemory');
+  });
+
+  it('should use defaultOptions memory context when assembling tools for execution', async () => {
+    const requestContext = new RequestContext();
+    requestContext.set('testThreadId', 'default-thread');
+    requestContext.set('testResourceId', 'default-resource');
+
+    const mockMemory = new MockMemory({
+      enableWorkingMemory: true,
+      workingMemoryTemplate: `# Notes\n- **Key**:\n- **Value**:\n`,
+    });
+
+    const agent = new Agent({
+      id: 'default-tools-memory-test',
+      name: 'Default Tools Memory Test',
+      instructions: 'You are a helpful agent.',
+      model: createSimpleMockModel(),
+      memory: mockMemory,
+      defaultOptions: ({ requestContext }) => ({
+        memory: {
+          thread: requestContext.get('testThreadId') as string,
+          resource: requestContext.get('testResourceId') as string,
+        },
+      }),
+    });
+
+    const tools = await agent.getToolsForExecution({ requestContext });
+
+    expect(Object.keys(tools)).toContain('updateWorkingMemory');
   });
 
   it('should provide memory context when updateWorkingMemory is called inside a workflow step', async () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -5269,9 +5269,34 @@ export class Agent<
     autoResumeSuspendedTools?: boolean;
   }): Promise<Record<string, CoreTool>> {
     const requestContext = options.requestContext ?? new RequestContext();
+    const defaultOptions = await this.getDefaultOptions({ requestContext });
+    const mergedOptions = deepMerge(
+      defaultOptions as Record<string, unknown>,
+      { ...options, requestContext } as Record<string, unknown>,
+    ) as AgentExecutionOptions & typeof options;
+    const optionMemory = (options as { memory?: AgentExecutionOptionsBase<any>['memory'] }).memory;
+    const mergedMemory = mergedOptions.memory;
+    const threadIdFromContext = requestContext.get(MASTRA_THREAD_ID_KEY) as string | undefined;
+    const explicitThreadFromArgs = resolveThreadIdFromArgs({
+      memory: optionMemory,
+      threadId: options.threadId,
+      overrideId: threadIdFromContext,
+    });
+    const defaultThreadFromArgs = resolveThreadIdFromArgs({
+      memory: mergedMemory,
+      overrideId: threadIdFromContext,
+    });
+    const resourceIdFromContext = requestContext.get(MASTRA_RESOURCE_ID_KEY) as string | undefined;
+
     return this.convertTools({
-      ...options,
+      toolsets: mergedOptions.toolsets,
+      clientTools: mergedOptions.clientTools,
+      threadId: explicitThreadFromArgs?.id ?? defaultThreadFromArgs?.id,
+      resourceId: resourceIdFromContext || options.resourceId || optionMemory?.resource || mergedMemory?.resource,
+      runId: mergedOptions.runId,
       requestContext,
+      memoryConfig: options.memoryConfig ?? mergedMemory?.options,
+      autoResumeSuspendedTools: mergedOptions.autoResumeSuspendedTools,
       methodType: 'stream',
       pubsub: this.getPubSub() ?? defaultAgentThreadPubSub,
     });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1207,6 +1207,9 @@ export class Agent<
       type: 'processor',
       options: {
         validateInputs: false,
+        // Internal processor workflows are transient and non-resumable, so they must never
+        // write snapshot rows to the user's storage (mirrors the execution-workflow fix in #17344).
+        shouldPersistSnapshot: () => false,
         tracingPolicy: {
           // mark all workflow spans related to processor execution as internal
           internal: InternalSpans.WORKFLOW,
@@ -1242,6 +1245,14 @@ export class Agent<
     }
 
     const committedWorkflow = workflow.commit() as T;
+    // Register the parent Mastra instance on this internal processor workflow so that its
+    // createRun() -> getWorkflowRunById() can read configured storage instead of logging
+    // "Cannot get workflow run. Mastra storage is not initialized" on every run (then falling
+    // back to in-memory). Combined with shouldPersistSnapshot:()=>false above, this does not
+    // write any processor-workflow rows to storage. Mirrors the execution-workflow fix in #17344.
+    if (this.#mastra && isProcessorWorkflow(committedWorkflow)) {
+      committedWorkflow.__registerMastra(this.#mastra);
+    }
     if (stateSignalProcessors.length > 0 && isProcessorWorkflow(committedWorkflow)) {
       committedWorkflow.__stateSignalProcessors = stateSignalProcessors;
     }

--- a/packages/core/src/agent/message-list/conversion/output-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/output-converter.ts
@@ -224,10 +224,19 @@ export function sanitizeV5UIMessages(
           if (AIV5.isToolUIPart(part) && part.state === 'output-available') {
             return {
               ...part,
-              output:
-                typeof part.output === 'object' && part.output && 'value' in part.output
-                  ? part.output.value
-                  : part.output,
+              output: (() => {
+                const o = part.output;
+                if (o == null || typeof o !== 'object') return o;
+                const obj = o as Record<string, unknown>;
+                // Preserve { type: 'content', value: [...] } — this is the AI SDK's
+                // native multimodal tool result shape. Unwrapping it here causes
+                // convertToModelMessages to receive a raw array which gets stringified.
+                // See: https://github.com/mastra-ai/mastra/issues/17876
+                if (obj.type === 'content' && Array.isArray(obj.value)) return o;
+                // For other wrapped shapes (legacy), unwrap as before
+                if ('value' in obj) return obj.value;
+                return o;
+              })(),
             };
           }
           return part;

--- a/packages/core/src/agent/message-list/conversion/to-prompt-tool-name-sanitization.test.ts
+++ b/packages/core/src/agent/message-list/conversion/to-prompt-tool-name-sanitization.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, it } from 'vitest';
 
-import { aiV5ModelMessageToV2PromptMessage } from './to-prompt';
+import { aiV4CoreMessageToV1PromptMessage, aiV5ModelMessageToV2PromptMessage } from './to-prompt';
+
+describe('aiV4CoreMessageToV1PromptMessage image conversion', () => {
+  it('converts raw base64 image strings to Uint8Array for provider prompts', () => {
+    const base64Image = Buffer.from([1, 2, 3, 4]).toString('base64');
+
+    const result = aiV4CoreMessageToV1PromptMessage({
+      role: 'user',
+      content: [{ type: 'image', image: base64Image, mimeType: 'image/png' }],
+    });
+
+    expect(result.role).toBe('user');
+    expect(result.content[0]).toMatchObject({
+      type: 'image',
+      mimeType: 'image/png',
+    });
+    expect(result.content[0].image).toBeInstanceOf(Uint8Array);
+    expect(Array.from(result.content[0].image as Uint8Array)).toEqual([1, 2, 3, 4]);
+  });
+});
 
 describe('aiV5ModelMessageToV2PromptMessage tool-name sanitization', () => {
   it('sanitizes invalid tool names in tool-call parts', () => {

--- a/packages/core/src/agent/message-list/conversion/to-prompt.ts
+++ b/packages/core/src/agent/message-list/conversion/to-prompt.ts
@@ -2,7 +2,7 @@ import type { LanguageModelV2Prompt } from '@ai-sdk/provider-v5';
 import type { LanguageModelV1Prompt, CoreMessage as CoreMessageV4 } from '@internal/ai-sdk-v4';
 
 import { convertDataContentToBase64String } from '../prompt/data-content';
-import { categorizeFileData, createDataUri } from '../prompt/image-utils';
+import { categorizeFileData } from '../prompt/image-utils';
 import type { AIV5Type } from '../types';
 import { sanitizeToolName } from '../utils/tool-name';
 
@@ -102,11 +102,10 @@ export function aiV4CoreMessageToV1PromptMessage(coreMessage: CoreMessageV4): La
           const categorized = categorizeFileData(part.image, part.mimeType);
 
           if (categorized.type === 'raw') {
-            // Raw base64 - convert to data URI before creating URL
-            const dataUri = createDataUri(part.image, part.mimeType || 'image/png');
-            processedImage = new URL(dataUri);
+            // Raw base64 — keep as Uint8Array so providers receive raw bytes
+            // and don't double-wrap in a data URI (e.g. Gemini inline_data.data)
+            processedImage = new Uint8Array(Buffer.from(part.image, 'base64'));
           } else {
-            // It's already a URL or data URI
             processedImage = new URL(part.image);
           }
         }

--- a/packages/core/src/agent/message-list/merge/MessageMerger.ts
+++ b/packages/core/src/agent/message-list/merge/MessageMerger.ts
@@ -85,18 +85,19 @@ export class MessageMerger {
   }
 
   /**
-   * Merge an incoming assistant message into the latest assistant message
+   * Merge an incoming assistant message into the latest assistant message.
+   *
+   * This preserves the existing message-level createdAt. OM uses that timestamp
+   * as its observation boundary, so moving it forward can make an already
+   * observed message look unobserved and eligible for reprocessing.
    *
    * This handles:
    * - Updating tool invocations with their results
    * - Adding new parts in the correct order using anchor maps
    * - Inserting step-start markers where needed
-   * - Updating timestamps and content strings
+   * - Updating content strings
    */
   static merge(latestMessage: MastraDBMessage, incomingMessage: MastraDBMessage): void {
-    // Update timestamp
-    latestMessage.createdAt = incomingMessage.createdAt || latestMessage.createdAt;
-
     if (incomingMessage.content.metadata) {
       latestMessage.content.metadata = {
         ...(latestMessage.content.metadata ?? {}),
@@ -208,9 +209,6 @@ export class MessageMerger {
       partsToAdd,
     });
 
-    if (latestMessage.createdAt.getTime() < incomingMessage.createdAt.getTime()) {
-      latestMessage.createdAt = incomingMessage.createdAt;
-    }
     if (!latestMessage.content.content && incomingMessage.content.content) {
       latestMessage.content.content = incomingMessage.content.content;
     }

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -1618,17 +1618,10 @@ export class MessageList {
   private lastCreatedAt?: number;
 
   private updateLastCreatedAt(message: MastraDBMessage): void {
-    const latestMessageTime = message.createdAt.getTime();
-    const latestPartTime = Array.isArray(message.content.parts)
-      ? message.content.parts.reduce((latest, part) => {
-          if (typeof part.createdAt === 'number' && part.createdAt > latest) {
-            return part.createdAt;
-          }
-          return latest;
-        }, latestMessageTime)
-      : latestMessageTime;
-
-    this.lastCreatedAt = Math.max(this.lastCreatedAt || 0, latestPartTime);
+    // Message-level createdAt controls transcript ordering and OM observation boundaries.
+    // Part timestamps are event metadata within a message and must not advance the
+    // ordering watermark used to timestamp later messages/signals.
+    this.lastCreatedAt = Math.max(this.lastCreatedAt || 0, message.createdAt.getTime());
   }
 
   // this makes sure messages added in order will always have a date atleast 1ms apart.
@@ -1654,10 +1647,9 @@ export class MessageList {
 
     const now = new Date();
     const nowTime = startDate?.getTime() || now.getTime();
-    // find the latest createdAt in stored messages and parts
     const lastTime = this.lastCreatedAt || 0;
 
-    // make sure our new message is created later than the latest known message time
+    // make sure our new message is created later than the latest known ordering timestamp
     // it's expected that messages are added to the list in order if they don't have a createdAt date on them
     if (nowTime <= lastTime) {
       const newDate = new Date(lastTime + 1);

--- a/packages/core/src/agent/message-list/tests/message-list-om-multistep.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-om-multistep.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { MastraDBMessage } from '../../../memory';
+import { createSignal } from '../../signals';
 import { MessageList } from '../index';
 
 const threadId = 'om-thread';
@@ -13,11 +14,12 @@ const resourceId = 'om-user';
 describe('MessageList — OM multi-step source handoff', () => {
   it('removes memory source when merged assistant content is promoted to response', () => {
     const assistantId = 'asst-om-1';
+    const originalCreatedAt = new Date(1);
     const step1: MastraDBMessage = {
       id: assistantId,
       role: 'assistant',
       type: 'text',
-      createdAt: new Date(1),
+      createdAt: originalCreatedAt,
       threadId,
       resourceId,
       content: {
@@ -72,6 +74,7 @@ describe('MessageList — OM multi-step source handoff', () => {
     const responseDb = list.get.response.db();
     expect(responseDb).toHaveLength(1);
     expect(responseDb[0]!.id).toBe(assistantId);
+    expect(responseDb[0]!.createdAt).toEqual(originalCreatedAt);
     expect(responseDb[0]!.content.parts?.some(p => p.type === 'text' && p.text === 'Done.')).toBe(true);
 
     // Must not still be tracked as a memory-only row for the same object identity
@@ -80,5 +83,75 @@ describe('MessageList — OM multi-step source handoff', () => {
     const secondClear = list.clear.response.db();
     expect(secondClear).toHaveLength(1);
     expect(secondClear[0]!.content.parts?.some(p => p.type === 'text' && p.text === 'Done.')).toBe(true);
+  });
+
+  it('does not let promoted memory part timestamps advance signal timestamps', () => {
+    const now = Date.now();
+    const assistantId = 'asst-om-late-part';
+    const messageCreatedAt = new Date(now);
+    const latePartCreatedAt = now + 30_000;
+
+    const list = new MessageList({ threadId, resourceId });
+    list.add(
+      {
+        id: assistantId,
+        role: 'assistant',
+        type: 'text',
+        createdAt: messageCreatedAt,
+        threadId,
+        resourceId,
+        content: {
+          format: 2,
+          parts: [
+            { type: 'text', text: 'Observed response start' },
+            {
+              type: 'tool-invocation',
+              createdAt: latePartCreatedAt,
+              toolInvocation: { state: 'call', toolCallId: 'tc-late', toolName: 'noop', args: {} },
+            },
+          ],
+        },
+      },
+      'memory',
+    );
+
+    list.add(
+      {
+        id: assistantId,
+        role: 'assistant',
+        type: 'text',
+        createdAt: new Date(now + 2_000),
+        threadId,
+        resourceId,
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId: 'tc-late',
+                toolName: 'noop',
+                args: {},
+                result: { ok: true },
+              },
+            },
+            { type: 'text', text: 'Observed response complete' },
+          ],
+        },
+      },
+      'response',
+    );
+
+    const signalForTranscript = list.addSignal(
+      createSignal({
+        id: 'next-signal',
+        type: 'user-message',
+        contents: 'Next signal',
+        createdAt: new Date(now + 3_000),
+      }),
+    );
+
+    expect(signalForTranscript.createdAt.getTime()).toBeLessThan(latePartCreatedAt);
   });
 });

--- a/packages/core/src/agent/message-list/tests/message-list-ordering.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-ordering.test.ts
@@ -533,7 +533,8 @@ describe('Message ordering with identical timestamps (Issue #10683)', () => {
       const storedSignal = list.get.all.db().at(-1)!;
       const recalledSignal = mastraDBMessageToSignal(storedSignal);
       expect(storedSignal.id).toBe(signal.id);
-      expect(storedSignal.createdAt.getTime()).toBe(toolPartTime + 1);
+      expect(storedSignal.createdAt.getTime()).toBe(responseTime.getTime() + 1);
+      expect(storedSignal.createdAt.getTime()).toBeLessThan(toolPartTime);
       expect(recalledSignal.createdAt).toEqual(storedSignal.createdAt);
       expect(recalledSignal.acceptedAt).toEqual(signalTime);
       expect(storedSignal.content.metadata?.signal).toMatchObject({

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts
@@ -1023,7 +1023,7 @@ describe('createLLMMappingStep toModelOutput', () => {
     );
   });
 
-  it('should normalize media parts in toModelOutput to image-data/file-data', async () => {
+  it('should preserve media parts in toModelOutput', async () => {
     const toModelOutputMock = vi.fn(() => ({
       type: 'content',
       value: [
@@ -1069,8 +1069,8 @@ describe('createLLMMappingStep toModelOutput', () => {
             modelOutput: {
               type: 'content',
               value: [
-                { type: 'image-data', data: 'base64png', mediaType: 'image/png' },
-                { type: 'file-data', data: 'base64pdf', mediaType: 'application/pdf' },
+                { type: 'media', data: 'base64png', mediaType: 'image/png' },
+                { type: 'media', data: 'base64pdf', mediaType: 'application/pdf' },
                 { type: 'text', text: 'caption' },
               ],
             },
@@ -1121,7 +1121,7 @@ describe('createLLMMappingStep toModelOutput', () => {
           mastra: expect.objectContaining({
             modelOutput: {
               type: 'content',
-              value: [null, undefined, 'not-an-object', { type: 'image-data', data: 'abc', mediaType: 'image/png' }],
+              value: [null, undefined, 'not-an-object', { type: 'media', data: 'abc', mediaType: 'image/png' }],
             },
           }),
         }),

--- a/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.ts
@@ -143,11 +143,16 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
        * traces can distinguish "never invoked" from "ran no-op" from "ran transforming."
        */
       /**
-       * Normalize modelOutput from toModelOutput() so that `type: 'media'` parts
-       * are converted to `type: 'image-data'` or `type: 'file-data'` as AI SDK
-       * providers expect. AI SDK does this internally in `mapToolResultOutput`,
-       * but Mastra calls toModelOutput directly and stores the result, bypassing
-       * that normalization.
+       * Normalize modelOutput from toModelOutput() into the AI SDK's
+       * LanguageModelV2ToolResultOutput shape.
+       *
+       * The AI SDK's content array only accepts type 'text' or 'media'.
+       * Mastra's createTool docs show type 'image-url' as a convenience shorthand,
+       * so we normalize that here into type 'media' with the correct structure.
+       *
+       * Previously this converted 'media' -> 'image-data'/'file-data' which was wrong
+       * (those types are not valid in LanguageModelV2ToolResultOutput).
+       * See: https://github.com/mastra-ai/mastra/issues/17876
        */
       function normalizeModelOutput(output: unknown): unknown {
         if (output == null || typeof output !== 'object') return output;
@@ -160,11 +165,25 @@ export function createLLMMappingStep<Tools extends ToolSet = ToolSet, OUTPUT = u
           value: (obj.value as unknown[]).map(item => {
             if (item == null || typeof item !== 'object') return item;
             const part = item as Record<string, unknown>;
-            if (part.type !== 'media') return part;
-            if (typeof part.mediaType === 'string' && part.mediaType.startsWith('image/')) {
-              return { type: 'image-data', data: part.data, mediaType: part.mediaType };
+            // Normalize 'image-url' convenience type -> 'media' as AI SDK expects
+            if (part.type === 'image-url' && typeof part.url === 'string') {
+              // Prefer caller-supplied mediaType; fall back to parsing data: URI or defaulting to image/jpeg
+              const mediaType =
+                typeof part.mediaType === 'string' && part.mediaType
+                  ? part.mediaType
+                  : part.url.startsWith('data:')
+                    ? part.url.slice(5, part.url.indexOf(';')) || 'image/jpeg'
+                    : 'image/jpeg';
+              return { type: 'media', data: part.url, mediaType };
             }
-            return { type: 'file-data', data: part.data, mediaType: part.mediaType };
+            // 'image-data'/'file-data' from old normalizeModelOutput — convert back to 'media'
+            if (part.type === 'image-data' && typeof part.data === 'string') {
+              return { type: 'media', data: part.data, mediaType: part.mediaType ?? 'image/jpeg' };
+            }
+            if (part.type === 'file-data' && typeof part.data === 'string') {
+              return { type: 'media', data: part.data, mediaType: part.mediaType ?? 'application/octet-stream' };
+            }
+            return part;
           }),
         };
       }

--- a/packages/core/src/workspace/index.ts
+++ b/packages/core/src/workspace/index.ts
@@ -102,6 +102,9 @@ export { detectIsolation, isIsolationAvailable, getRecommendedIsolation } from '
 // Constants
 export { WORKSPACE_TOOLS_PREFIX, WORKSPACE_TOOLS, type WorkspaceToolName } from './constants';
 
+// Search types
+export type { TokenizeOptions } from './search';
+
 // Shared types
 export type { InstructionsOption } from './types';
 

--- a/packages/core/src/workspace/search/bm25.test.ts
+++ b/packages/core/src/workspace/search/bm25.test.ts
@@ -75,6 +75,79 @@ describe('tokenize', () => {
     });
     expect(tokens).toEqual(['github_create_issue']);
   });
+
+  it('should preserve CJK characters with default removePunctuation', () => {
+    const tokens = tokenize('カフェでコーヒーを飲む', {
+      stopwords: new Set(),
+      minLength: 1,
+    });
+    // CJK text is contiguous (no whitespace), so it stays as one token
+    expect(tokens.length).toBe(1);
+    expect(tokens[0]).toBe('カフェでコーヒーを飲む');
+  });
+
+  it('should preserve Chinese characters with default removePunctuation', () => {
+    const tokens = tokenize('机器学习是人工智能的一个子集', {
+      stopwords: new Set(),
+      minLength: 1,
+    });
+    expect(tokens.length).toBe(1);
+    expect(tokens[0]).toBe('机器学习是人工智能的一个子集');
+  });
+
+  it('should preserve Korean characters with default removePunctuation', () => {
+    const tokens = tokenize('인공지능 머신러닝', {
+      stopwords: new Set(),
+      minLength: 1,
+    });
+    expect(tokens).toEqual(['인공지능', '머신러닝']);
+  });
+
+  it('should handle mixed CJK and ASCII text', () => {
+    const tokens = tokenize('LINEで友達を追加する', {
+      stopwords: new Set(),
+      minLength: 1,
+    });
+    // "lineで友達を追加する" as a single token (no whitespace separator)
+    expect(tokens.length).toBe(1);
+    expect(tokens[0]).toContain('line');
+  });
+
+  it('should strip CJK punctuation but keep CJK letters', () => {
+    const tokens = tokenize('東京、大阪、名古屋', {
+      stopwords: new Set(),
+      minLength: 1,
+    });
+    // 、 is CJK punctuation — stripped and replaced with spaces
+    expect(tokens).toEqual(['東京', '大阪', '名古屋']);
+  });
+
+  it('should use custom tokenizer function when provided', () => {
+    // Character bigram tokenizer for CJK
+    const bigramTokenizer = (text: string) => {
+      const tokens: string[] = [];
+      const normalized = text.toLowerCase();
+      for (let i = 0; i < normalized.length - 1; i++) {
+        const bigram = normalized.slice(i, i + 2).trim();
+        if (bigram.length === 2) tokens.push(bigram);
+      }
+      return tokens;
+    };
+
+    const tokens = tokenize('カフェ', { tokenizer: bigramTokenizer });
+    expect(tokens).toEqual(['カフ', 'フェ']);
+  });
+
+  it('should ignore other options when custom tokenizer is provided', () => {
+    const customTokenizer = (text: string) => text.split('');
+    const tokens = tokenize('ABC', {
+      tokenizer: customTokenizer,
+      lowercase: true,
+      removePunctuation: true,
+    });
+    // Custom tokenizer returns uppercase because it bypasses the built-in pipeline
+    expect(tokens).toEqual(['A', 'B', 'C']);
+  });
 });
 
 describe('BM25Index', () => {
@@ -215,6 +288,49 @@ describe('BM25Index', () => {
     it('should handle multi-word queries', () => {
       const results = index.search('artificial intelligence machine learning');
       expect(results.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('CJK content', () => {
+    it('should index and search Japanese content', () => {
+      const cjkIndex = new BM25Index({}, { minLength: 1, stopwords: new Set() });
+      cjkIndex.add('doc1', '東京 大阪 名古屋');
+      cjkIndex.add('doc2', '京都 奈良 神戸');
+
+      const results = cjkIndex.search('東京');
+      expect(results.length).toBe(1);
+      expect(results[0]?.id).toBe('doc1');
+    });
+
+    it('should index and search Korean content', () => {
+      const cjkIndex = new BM25Index({}, { minLength: 1, stopwords: new Set() });
+      cjkIndex.add('doc1', '인공지능 머신러닝');
+      cjkIndex.add('doc2', '딥러닝 자연어처리');
+
+      const results = cjkIndex.search('머신러닝');
+      expect(results.length).toBe(1);
+      expect(results[0]?.id).toBe('doc1');
+    });
+
+    it('should find CJK content with custom tokenizer', () => {
+      // Character bigram tokenizer
+      const bigramTokenizer = (text: string) => {
+        const tokens: string[] = [];
+        const normalized = text.toLowerCase();
+        for (let i = 0; i < normalized.length - 1; i++) {
+          const bigram = normalized.slice(i, i + 2).trim();
+          if (bigram.length === 2) tokens.push(bigram);
+        }
+        return tokens;
+      };
+
+      const cjkIndex = new BM25Index({}, { tokenizer: bigramTokenizer });
+      cjkIndex.add('doc1', 'カフェでコーヒーを飲む');
+      cjkIndex.add('doc2', 'レストランで食事する');
+
+      const results = cjkIndex.search('カフェ');
+      expect(results.length).toBe(1);
+      expect(results[0]?.id).toBe('doc1');
     });
   });
 

--- a/packages/core/src/workspace/search/bm25.ts
+++ b/packages/core/src/workspace/search/bm25.ts
@@ -76,6 +76,26 @@ export interface TokenizeOptions {
   stopwords?: Set<string>;
   /** Custom split pattern (default: /\s+/) */
   splitPattern?: RegExp;
+  /**
+   * Custom tokenizer function that bypasses the built-in pipeline entirely.
+   * When provided, all other options (lowercase, removePunctuation, etc.) are ignored.
+   * Useful for CJK languages that need morphological analysis or n-gram tokenization.
+   *
+   * @example
+   * ```ts
+   * // Character bigram tokenizer for CJK
+   * tokenizer: (text) => {
+   *   const tokens: string[] = [];
+   *   const normalized = text.toLowerCase();
+   *   for (let i = 0; i < normalized.length - 1; i++) {
+   *     const bigram = normalized.slice(i, i + 2).trim();
+   *     if (bigram.length === 2) tokens.push(bigram);
+   *   }
+   *   return tokens;
+   * }
+   * ```
+   */
+  tokenizer?: (text: string) => string[];
 }
 
 /**
@@ -113,7 +133,7 @@ export const DEFAULT_STOPWORDS = new Set([
 /**
  * Default tokenization options
  */
-const DEFAULT_TOKENIZE_OPTIONS: Required<TokenizeOptions> = {
+const DEFAULT_TOKENIZE_OPTIONS: Omit<Required<TokenizeOptions>, 'tokenizer'> = {
   lowercase: true,
   removePunctuation: true,
   minLength: 2,
@@ -125,6 +145,11 @@ const DEFAULT_TOKENIZE_OPTIONS: Required<TokenizeOptions> = {
  * Tokenize text into an array of terms
  */
 export function tokenize(text: string, options: TokenizeOptions = {}): string[] {
+  // If a custom tokenizer is provided, bypass the built-in pipeline entirely
+  if (options.tokenizer) {
+    return options.tokenizer(text);
+  }
+
   const opts = { ...DEFAULT_TOKENIZE_OPTIONS, ...options };
 
   let processed = text;
@@ -134,9 +159,13 @@ export function tokenize(text: string, options: TokenizeOptions = {}): string[] 
     processed = processed.toLowerCase();
   }
 
-  // Remove punctuation if enabled
+  // Remove punctuation if enabled — use Unicode-aware pattern to preserve
+  // non-Latin characters (CJK, Arabic, Thai, etc.).  \p{L} matches any
+  // Unicode letter, \p{N} any Unicode digit, so the negated class strips
+  // only characters that are neither letters, digits, underscores, nor
+  // whitespace.
   if (opts.removePunctuation) {
-    processed = processed.replace(/[^\w\s]/g, ' ');
+    processed = processed.replace(/[^\p{L}\p{N}_\s]/gu, ' ');
   }
 
   // Split into tokens

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -49,7 +49,15 @@ import type { LSPConfig } from './lsp/types';
 import type { WorkspaceSandbox, OnMountHook } from './sandbox';
 import { LocalSandbox } from './sandbox/local-sandbox';
 import { MastraSandbox } from './sandbox/mastra-sandbox';
-import type { BM25Config, Embedder, SearchOptions, SearchResult, IndexDocument } from './search';
+import type {
+  BM25Config,
+  BM25SearchConfig,
+  TokenizeOptions,
+  Embedder,
+  SearchOptions,
+  SearchResult,
+  IndexDocument,
+} from './search';
 import { SearchEngine, splitIntoChunks } from './search';
 import type { WorkspaceSkills, SkillsResolver, SkillSource } from './skills';
 import { WorkspaceSkillsImpl, LocalSkillSource } from './skills';
@@ -279,9 +287,24 @@ export interface WorkspaceConfig<
 
   /**
    * Enable BM25 keyword search.
-   * Pass true for defaults, or a BM25Config object for custom parameters.
+   * Pass `true` for defaults, a {@link BM25Config} for custom k1/b parameters,
+   * or a `{ bm25?, tokenize? }` object to also customise tokenization.
+   *
+   * The `tokenize` field accepts a {@link TokenizeOptions} object that lets you
+   * tune how text is split into tokens (e.g. for CJK or other non-Latin scripts).
+   *
+   * @example
+   * ```ts
+   * new Workspace({
+   *   bm25: {
+   *     k1: 1.5,
+   *     b: 0.75,
+   *     tokenize: { removePunctuation: false, minLength: 1 },
+   *   },
+   * });
+   * ```
    */
-  bm25?: boolean | BM25Config;
+  bm25?: boolean | BM25Config | { bm25?: BM25Config; tokenize?: TokenizeOptions };
 
   /**
    * Custom index name for the vector store.
@@ -507,6 +530,23 @@ export interface WorkspaceInfo {
  */
 const FS_READ_CONCURRENCY = 8;
 
+/**
+ * Parse the user-facing `bm25` config union into the `BM25SearchConfig` shape
+ * that `SearchEngine` expects.
+ */
+function parseBM25Config(
+  bm25: boolean | BM25Config | { bm25?: BM25Config; tokenize?: TokenizeOptions },
+): BM25SearchConfig {
+  if (typeof bm25 === 'boolean') return {};
+  if ('bm25' in bm25 || 'tokenize' in bm25) {
+    return {
+      bm25: (bm25 as { bm25?: BM25Config }).bm25,
+      tokenize: (bm25 as { tokenize?: TokenizeOptions }).tokenize,
+    };
+  }
+  return { bm25: bm25 as BM25Config };
+}
+
 // =============================================================================
 // Workspace Class
 // =============================================================================
@@ -657,11 +697,7 @@ export class Workspace<
       };
 
       this._searchEngine = new SearchEngine({
-        bm25: config.bm25
-          ? {
-              bm25: typeof config.bm25 === 'object' ? config.bm25 : undefined,
-            }
-          : undefined,
+        bm25: config.bm25 ? parseBM25Config(config.bm25) : undefined,
         vector:
           config.vectorStore && config.embedder
             ? {

--- a/packages/memory/src/embedding-cache.test.ts
+++ b/packages/memory/src/embedding-cache.test.ts
@@ -1,0 +1,80 @@
+import { InMemoryStore } from '@mastra/core/storage';
+import { describe, it, expect, vi } from 'vitest';
+import { Memory } from './index';
+
+// Mock embedMany across AI SDK versions so embedMessageContent does no network I/O.
+vi.mock('@internal/ai-v6', () => ({
+  embedMany: vi.fn().mockResolvedValue({ embeddings: [[0.1, 0.2]], usage: { tokens: 1 } }),
+}));
+vi.mock('@internal/ai-sdk-v5', () => ({
+  embedMany: vi.fn().mockResolvedValue({ embeddings: [[0.1, 0.2]], usage: { tokens: 1 } }),
+}));
+vi.mock('@internal/ai-sdk-v4', () => ({
+  embedMany: vi.fn().mockResolvedValue({ embeddings: [[0.1, 0.2]], usage: { tokens: 1 } }),
+}));
+
+function createMemory() {
+  return new Memory({
+    storage: new InMemoryStore(),
+    vector: {
+      upsert: vi.fn().mockResolvedValue('id'),
+      createIndex: vi.fn().mockResolvedValue({ indexName: 'test-index' }),
+      query: vi.fn().mockResolvedValue([]),
+      describeIndex: vi.fn(),
+    } as any,
+    embedder: {
+      specificationVersion: 'v3',
+      provider: 'test',
+      modelId: 'test-model',
+      doEmbed: vi.fn().mockResolvedValue({ embeddings: [[0.1, 0.2]], usage: { tokens: 1 }, warnings: [] }),
+    } as any,
+    options: { semanticRecall: true },
+  });
+}
+
+describe('embedMessageContent caching', () => {
+  it('reuses cached embeddings for repeated content (cache hit)', async () => {
+    const memory = createMemory() as any;
+
+    const a = await memory.embedMessageContent('hello world');
+    const b = await memory.embedMessageContent('hello world');
+
+    // Same content returns the same cached object reference.
+    expect(b).toBe(a);
+  });
+
+  it('bounds the cache via LRU eviction instead of growing unboundedly', async () => {
+    const memory = createMemory() as any;
+    const N = 1500;
+
+    for (let i = 0; i < N; i++) {
+      await memory.embedMessageContent(`unique-content-${i}`);
+    }
+
+    // Without eviction the cache would hold all N entries. The LRU caps it well
+    // below N, so a long-running instance can't accumulate every embedded content.
+    expect(memory.embeddingCache.size).toBeLessThan(N);
+    expect(memory.embeddingCache.size).toBeLessThanOrEqual(1000);
+  });
+
+  it('does not return the wrong cached embeddings for h32-colliding content', async () => {
+    const memory = createMemory() as any;
+
+    // These two strings collide under the 32-bit xxhash (both -> 2346541822) but
+    // are distinct under the 64-bit hash now used for cache keys.
+    const A = 'msg-4246';
+    const B = 'msg-268273';
+
+    const hasher = await memory.hasher;
+    expect(hasher.h32(A)).toBe(hasher.h32(B)); // 32-bit collision (the latent bug)
+    expect(hasher.h64(A)).not.toBe(hasher.h64(B)); // 64-bit keys stay distinct
+
+    const resultA = await memory.embedMessageContent(A);
+    const resultB = await memory.embedMessageContent(B);
+
+    // Each content gets its own chunks; B must not receive A's cached entry.
+    expect(resultA.chunks).toEqual([A]);
+    expect(resultB.chunks).toEqual([B]);
+    expect(resultB).not.toBe(resultA);
+  });
+});

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -43,6 +43,7 @@ import type { VectorFilter } from '@mastra/core/vector';
 import { isStandardSchemaWithJSON, toStandardSchema } from '@mastra/schema-compat/schema';
 import { Mutex } from 'async-mutex';
 import type { JSONSchema7 } from 'json-schema';
+import { LRUCache } from 'lru-cache';
 import xxhash from 'xxhash-wasm';
 import type { ObservationalMemory, ObservationalMemoryConfig } from './processors/observational-memory';
 import { recallTool } from './tools/om-tools';
@@ -212,6 +213,12 @@ const CHARS_PER_TOKEN = 4;
 const DEFAULT_MESSAGE_RANGE = { before: 1, after: 1 } as const;
 const DEFAULT_TOP_K = 4;
 const VECTOR_DELETE_BATCH_SIZE = 100;
+
+// Max number of distinct contents whose embeddings are kept in the in-process
+// cache. Bounds memory so a long-running Memory instance can't accumulate every
+// message/query it has ever embedded (each entry holds chunk text + vectors).
+// Matches the default used by the core SemanticRecall embedding cache.
+const DEFAULT_EMBEDDING_CACHE_MAX_SIZE = 1000;
 
 /**
  * Concrete implementation of MastraMemory that adds support for thread configuration
@@ -970,23 +977,27 @@ ${workingMemory}`;
 
   private hasher = xxhash();
 
-  // embedding is computationally expensive so cache content -> embeddings/chunks
-  private embeddingCache = new Map<
-    number,
+  // Embedding is computationally expensive, so cache content -> embeddings/chunks.
+  // Bounded by an LRU so a long-running instance can't retain every embedded
+  // message/query (and its vectors + chunk text) for the life of the process.
+  private embeddingCache = new LRUCache<
+    bigint,
     {
       chunks: string[];
       embeddings: Awaited<ReturnType<typeof embedMany>>['embeddings'];
       usage?: { tokens: number };
       dimension: number | undefined;
     }
-  >();
+  >({ max: DEFAULT_EMBEDDING_CACHE_MAX_SIZE });
   private firstEmbed: Promise<any> | undefined;
   protected async embedMessageContent(content: string) {
-    // use fast xxhash for lower memory usage. if we cache by content string we will store all messages in memory for the life of the process
-    const key = (await this.hasher).h32(content);
+    // Key by the content hash (not the content itself) to keep keys small. Use the
+    // 64-bit hash: h32 is only 32 bits, so distinct contents collide after ~tens of
+    // thousands of entries, which would return another message's cached embeddings.
+    const key = (await this.hasher).h64(content);
     const cached = this.embeddingCache.get(key);
     if (cached) {
-      this.logger.debug('Embedding cache hit', { contentHash: key, chunks: cached.chunks.length });
+      this.logger.debug('Embedding cache hit', { contentHash: key.toString(), chunks: cached.chunks.length });
       return cached;
     }
     const chunks = this.chunkText(content);

--- a/packages/server/src/server/handlers/tools.test.ts
+++ b/packages/server/src/server/handlers/tools.test.ts
@@ -77,6 +77,73 @@ describe('Tools Handlers', () => {
       expect(result).toHaveProperty(mockTool.id);
       expect(result[mockTool.id]).toHaveProperty('id', mockTool.id);
     });
+
+    it('should merge tools from mastra.listTools() and registeredTools', async () => {
+      // Simulates MCP tools or other dynamically created tools in mastra instance
+      const dynamicTool: ToolAction = createTool({
+        id: 'dynamic-mcp-tool',
+        description: 'A dynamically created tool (e.g., MCP)',
+        execute: vi.fn(),
+      });
+      const mastra = new Mastra({
+        logger: false,
+        tools: { [dynamicTool.id]: dynamicTool },
+      });
+      // Bundler-discovered tools passed separately
+      const result = await LIST_TOOLS_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        registeredTools: mockTools,
+      });
+      // Both sources should be present
+      expect(result).toHaveProperty(mockTool.id);
+      expect(result).toHaveProperty(dynamicTool.id);
+      expect(result[mockTool.id]).toHaveProperty('id', mockTool.id);
+      expect(result[dynamicTool.id]).toHaveProperty('id', dynamicTool.id);
+    });
+
+    it('should let registeredTools take precedence on key conflicts', async () => {
+      const mastraTool: ToolAction = createTool({
+        id: 'shared-key',
+        description: 'From mastra instance',
+        execute: vi.fn(),
+      });
+      const bundlerTool: ToolAction = createTool({
+        id: 'shared-key',
+        description: 'From bundler',
+        execute: vi.fn(),
+      });
+      const mastra = new Mastra({
+        logger: false,
+        tools: { 'shared-key': mastraTool },
+      });
+      const result = await LIST_TOOLS_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        registeredTools: { 'shared-key': bundlerTool },
+      });
+      expect(result['shared-key']).toHaveProperty('description', 'From bundler');
+    });
+
+    it('should dedupe the same tool registered under different keys, preferring the registered key', async () => {
+      // Mirrors the deployer flow: an agent registers the tool by its intrinsic id
+      // (get-weather) while the CLI bundler registers the same instance by export name
+      // (weatherTool). The merged response must list it once, under the registered key.
+      const weatherTool: ToolAction = createTool({
+        id: 'get-weather',
+        description: 'Get current weather for a location',
+        execute: vi.fn(),
+      });
+      const mastra = new Mastra({
+        logger: false,
+        tools: { [weatherTool.id]: weatherTool },
+      });
+      const result = await LIST_TOOLS_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        registeredTools: { weatherTool },
+      });
+      expect(Object.keys(result)).toHaveLength(1);
+      expect(result).toHaveProperty('weatherTool');
+      expect(result).not.toHaveProperty('get-weather');
+    });
   });
 
   describe('getToolByIdHandler', () => {

--- a/packages/server/src/server/handlers/tools.ts
+++ b/packages/server/src/server/handlers/tools.ts
@@ -121,8 +121,32 @@ export const LIST_TOOLS_ROUTE = createRoute({
   requiresAuth: true,
   handler: async ({ mastra, registeredTools, requestContext }) => {
     try {
-      const allTools =
-        registeredTools && Object.keys(registeredTools).length > 0 ? registeredTools : mastra.listTools() || {};
+      // Merge tools from two sources: mastra.listTools() includes dynamically created tools
+      // (e.g. MCP tools, or agent tools registered by their intrinsic id), while registeredTools
+      // includes tools discovered by the CLI bundler (keyed by export name).
+      //
+      // The same tool instance can appear in both maps under different keys (e.g. an agent
+      // registers it by `tool.id` while the bundler registers it by export name). Dedupe by
+      // `tool.id`, preferring the registeredTools (bundler) key, so each tool appears once.
+      const registered = registeredTools && Object.keys(registeredTools).length > 0 ? registeredTools : {};
+
+      const allTools: Record<string, any> = {};
+      const seenToolIds = new Map<string, string>();
+
+      // registeredTools first so their key wins for a given tool.id.
+      for (const [key, tool] of Object.entries(registered)) {
+        const toolId = typeof (tool as any)?.id === 'string' ? (tool as any).id : undefined;
+        if (toolId !== undefined) seenToolIds.set(toolId, key);
+        allTools[key] = tool;
+      }
+
+      for (const [key, tool] of Object.entries(mastra.listTools() ?? {})) {
+        const toolId = typeof (tool as any)?.id === 'string' ? (tool as any).id : undefined;
+        // Skip if this exact tool.id was already registered (under any key) by registeredTools.
+        if (toolId !== undefined && seenToolIds.has(toolId)) continue;
+        if (toolId !== undefined) seenToolIds.set(toolId, key);
+        allTools[key] = tool;
+      }
 
       const serializedTools = Object.entries(allTools).reduce(
         (acc, [id, _tool]) => {


### PR DESCRIPTION
## Summary
- Selectively cherry-picks 10 upstream `mastra-ai/mastra` fixes onto the PapersFlow fork.
- Focuses on isolated runtime/code-logic fixes in server tools, core message ordering/conversion, workspace BM25 search, memory defaults/cache bounds, and ai-sdk approval handling.
- Deliberately avoids the broad upstream Harness Session / Harness v1 removal path, Studio auth redesign, version-package churn, and dependency/security sweep commits that should land as separate scoped PRs.

## Included upstream commits
- 57879dd3ee fix(server): merge dynamically created tools with bundler-discovered tools (#17535)
- 0c72f032ab fix(core): keep part timestamps out of message ordering (#17598)
- f084be1fcb fix(core): quiet storage-not-initialized log noise on processor workflows (#17571)
- 014e00f2b3 fix(core): BM25 tokenizer Unicode support (#17640)
- 5573693b58 fix(core): respect default memory options in tool discovery (#17175)
- 04e834d008 fix(ai-sdk): only warn about requestContext conflict when route context has entries (#17654)
- 5eeb1f0a71 fix(ai-sdk): pick most recent approval-responded part (#17904)
- eae1556eed fix(memory): bound embedding cache and avoid h32 collision (#17924)
- 17d5a9211a fix(core): preserve multimodal tool result content shape (#17879)
- 8b984f4361 fix(core): pass raw base64 images as Uint8Array in to-prompt (#17976)

## Explicitly excluded
- 7ee131e075 `getStudio?.()` guard: attempted, but it depends on upstream dual-auth helper methods not present in the fork; skipped rather than importing the surrounding Studio auth redesign.
- Harness Session / Harness v1 removal commits, including #18107, #18131, #18133, #18136: too broad and likely to regress fork Harness behavior.
- Security/dependency version sweeps such as #18017/#18060/#18069: important, but broad package/lockfile churn and should be handled in a separate dependency-security PR.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm build:core`
- `pnpm build:server`
- `pnpm --filter ./client-sdks/ai-sdk build:lib`
- `pnpm build:memory`
- `pnpm --filter ./packages/core check`
- `pnpm --filter ./packages/memory check`
- `pnpm exec vitest run packages/server/src/server/handlers/tools.test.ts --reporter=dot --bail 1`
- `pnpm exec vitest run packages/memory/src/embedding-cache.test.ts --reporter=dot --bail 1`
- `pnpm exec vitest run packages/core/src/agent/message-list/tests/message-list-om-multistep.test.ts packages/core/src/agent/__tests__/processor-workflow-storage-noise.test.ts packages/core/src/workspace/search/bm25.test.ts packages/core/src/agent/__tests__/working-memory-context.test.ts packages/core/src/loop/workflows/agentic-execution/llm-mapping-step.test.ts packages/core/src/agent/message-list/conversion/to-prompt-tool-name-sanitization.test.ts --reporter=dot --bail 1`
- `pnpm exec vitest run packages/core/src/agent/message-list/tests/message-list-ordering.test.ts --reporter=dot --bail 1 -t "normalize regular input signals using transcript timestamps"`
- `(cd client-sdks/ai-sdk && pnpm exec vitest run src/__tests__/tool-call-approval.test.ts --reporter=dot --bail 1)`

## Notes
- Full core `message-list-ordering.test.ts` still has an existing fork mismatch in `should give split prompt messages stable unique IDs when projecting signals`: it expects multiple prompt messages from a signal contents shape that is outside the current fork signal contract. The upstream timestamp fix was validated with the targeted timestamp regression test instead.
- Full `@mastra/ai-sdk` package test script currently tries unrelated package tests and fails on pre-existing setup issues (`@mastra/libsql` build output and `ai/test` resolution). The specific approval regression test from this PR passes when run directly.
- Local CodeRabbit CLI review was attempted but hung after several minutes and was terminated; please rely on the GitHub app review for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR takes 10 bug fixes from the main Mastra project and applies them to this fork. The fixes cover things like properly mixing different kinds of tools together, keeping messages in the right order in conversations, supporting non-English search, preventing memory leaks in caching, and making sure images work correctly with AI providers.

## Changes

### Tools Merging
- The `/api/tools` endpoint now merges both bundler-discovered tools and dynamically created tools (e.g., MCP tools registered via `new Mastra({ tools })`), with bundler-discovered tools taking precedence when IDs conflict

### Message Ordering & Timestamps
- Message-level `createdAt` is now the single source of truth for transcript ordering; part-level timestamps no longer affect message ordering
- `MessageList` no longer advances `createdAt` when merging messages with newer part timestamps
- Updated tests to reflect the new timestamp behavior where response signals respect message-level creation time

### Image & Content Handling
- Tool responses with `{ type: 'content', value: [...] }` multimodal shapes are now preserved as native provider content rather than being stringified
- Base64-encoded images are converted to `Uint8Array` instead of data URIs, allowing proper delivery to providers like OpenRouter and Gemini
- `normalizeModelOutput` now converts AI SDK parts to `type: 'media'` format with proper `mediaType` derivation

### BM25 Search Internationalization
- Tokenization now preserves non-Latin (CJK) characters instead of stripping them, fixing empty results for non-English content
- Added configurable `tokenizer` callback in `TokenizeOptions` for custom tokenization logic
- Updated punctuation-removal regex to use Unicode-aware patterns (`\p{L}`, `\p{N}`) instead of `\w`-based patterns
- `Workspace` config now accepts `{ bm25?: BM25Config; tokenize?: TokenizeOptions }` union type

### Memory & Embedding Cache
- Embedding cache now uses bounded in-process LRU with fixed capacity (1000 entries max) to prevent unbounded growth
- Cache keys changed from 32-bit hash to 64-bit hash to eliminate collision-based cache corruption

### AI SDK Approval Handling
- `extractV6NativeApproval` now selects the most recent approval-responded tool part within a trailing assistant message, preventing resume flows from using stale decisions

### Agent & Tool Execution
- Agent default options are now deep-merged with provided options when assembling tools for execution
- Memory context derived from `defaultOptions` is now properly available when discovering tools in supervised agents
- Internal processor workflows registered with parent `Mastra` instance and configured to skip snapshot persistence, eliminating "storage is not initialized" noise

### Workspace Configuration
- Exported `TokenizeOptions` type from workspace search module

## Testing
Added/updated test coverage for:
- Tools merging behavior with conflict resolution
- Message-level timestamp preservation during merging
- Processor workflow storage access and snapshot suppression
- Agent default options memory context availability
- Embedding cache bounds and hash collision prevention
- BM25 tokenization with CJK content and custom tokenizers
- Image conversion in both v1 and v2 prompt pathways
- AI SDK approval part selection with multiple approval-responded parts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->