### PR TITLE
Sync narrow upstream harness error handling fix

### DIFF
--- a/.changeset/nine-nights-dream.md
+++ b/.changeset/nine-nights-dream.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed stream error display showing [object Object] instead of the actual error message. Errors from subscribed thread streams (e.g. context length exceeded) now properly extract the message from deserialized error objects using getErrorFromUnknown.

--- a/.changeset/nine-nights-dream.md
+++ b/.changeset/nine-nights-dream.md
@@ -2,4 +2,5 @@
 '@mastra/core': patch
 ---
 
-Fixed stream error display showing [object Object] instead of the actual error message. Errors from subscribed thread streams (e.g. context length exceeded) now properly extract the message from deserialized error objects using getErrorFromUnknown.
+Fixed an issue where stream errors could display as `[object Object]`.
+Subscribed thread stream errors now show the actual error message.

--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -11,6 +11,7 @@ import type {
   ToolsetsInput,
 } from '../agent/types';
 import type { MastraBrowser } from '../browser/browser';
+import { getErrorFromUnknown } from '../error';
 import { Mastra } from '../mastra';
 import type { MastraMemory } from '../memory/memory';
 import type { StorageThreadType } from '../memory/types';
@@ -504,7 +505,7 @@ export class Harness<TState = {}> {
           workspaceName: this.workspace.name,
         });
       } catch (error) {
-        const err = error instanceof Error ? error : new Error(String(error));
+        const err = getErrorFromUnknown(error);
         this.workspace = undefined;
         this.workspaceInitialized = false;
 
@@ -1123,7 +1124,7 @@ export class Harness<TState = {}> {
       try {
         await memoryStorage.clearObservationalMemory(threadId, thread.resourceId);
       } catch (error) {
-        this.emit({ type: 'error', error: error instanceof Error ? error : new Error(String(error)) });
+        this.emit({ type: 'error', error: getErrorFromUnknown(error) });
       }
     }
 
@@ -1859,7 +1860,7 @@ export class Harness<TState = {}> {
       }
       if (this.followUpQueue.length > 0) {
         void this.drainFollowUpQueue(options).catch(error => {
-          this.emit({ type: 'error', error: error instanceof Error ? error : new Error(String(error)) });
+          this.emit({ type: 'error', error: getErrorFromUnknown(error) });
         });
       }
     }
@@ -1936,7 +1937,7 @@ export class Harness<TState = {}> {
         this.emit({ type: 'agent_end', reason: 'aborted' });
       }
     } else {
-      this.emit({ type: 'error', error: error instanceof Error ? error : new Error(String(error)) });
+      this.emit({ type: 'error', error: getErrorFromUnknown(error) });
       this.emit({ type: 'agent_end', reason: 'error' });
     }
     this.agentThreadSubscription?.unsubscribe();
@@ -2729,8 +2730,7 @@ export class Harness<TState = {}> {
       }
 
       case 'error': {
-        const streamError =
-          chunk.payload.error instanceof Error ? chunk.payload.error : new Error(String(chunk.payload.error));
+        const streamError = getErrorFromUnknown(chunk.payload.error);
         this.emit({ type: 'error', error: streamError });
         break;
       }
@@ -3130,7 +3130,7 @@ export class Harness<TState = {}> {
       const abortError = new Error('aborted');
       abortError.name = 'AbortError';
       void this.handleSubscribedStreamError(abortError).catch(error => {
-        this.emit({ type: 'error', error: error instanceof Error ? error : new Error(String(error)) });
+        this.emit({ type: 'error', error: getErrorFromUnknown(error) });
       });
     } else if (directStreamRunId) {
       this.abortFinalizedRunIds.add(directStreamRunId);
@@ -3347,7 +3347,7 @@ export class Harness<TState = {}> {
         requestContext,
       });
     } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
+      const err = getErrorFromUnknown(error);
       this.emit({ type: 'error', error: err });
       this.emit({ type: 'agent_end', reason: 'error' });
     } finally {


### PR DESCRIPTION
## Summary
- selectively applies the safe part of upstream mastra-ai/mastra commit ab975d4dd9488752f05bda7afa03166d207e3e2a
- normalizes fork harness unknown-error paths with getErrorFromUnknown so object-shaped errors do not render as [object Object]
- preserves fork-specific thread-stream runtime scheduling/control flow; no broad upstream merge

## Sync notes
- checked latest official upstream/main: fa14f8db417ef973774404d2c97e848872e785be
- fork base origin/main: e8e42e175f9b98aee5942409a98da81744d86b0e
- divergence after refresh: fork 325 / upstream 329
- intentionally skipped upstream 6e3e3c3321b81c50ef317bdff0d43c6c5dceb52e because it reverts the safer execute_command approval behavior preserved in this fork

## Validation
- pnpm -C packages/core typecheck
- pnpm -C packages/core exec vitest run src/harness/workspace-resolution.test.ts src/harness/v1/session.abort.test.ts src/harness/v1/session.subscription-lifecycle.test.ts --reporter=dot --bail 1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I'm 5)

The harness sometimes catches “weird” unknown errors that are actually objects, and those could show up as `[object Object]` instead of a helpful message. This PR normalizes those unknown errors into real `Error` instances so the correct message is displayed everywhere the harness reports failures.

## Changes

### `.changeset/nine-nights-dream.md`
Publishes a patch release for `@mastra/core` documenting that subscribed thread stream errors now show the real error message (instead of `[object Object]`).

### `packages/core/src/harness/harness.ts`
Standardizes error handling in `Harness` by importing and using `getErrorFromUnknown` across multiple failure paths, including:
- Workspace initialization failures
- Observational-memory thread deletion failures
- Follow-up draining errors
- Subscribed stream error handling
- Stream chunk `"error"` payload handling
- Abort-time error emissions from `handleSubscribedStreamError` promise rejections
- Tool suspension resume error handling

All updates focus on converting unknown caught values into proper `Error` instances for consistent error display; no control-flow logic, state transitions, or public API signatures were changed.

## Implementation Details

This PR selectively ports an upstream harness error-handling fix (from mastra-ai/mastra commit `ab975d4dd9488752f05bda7afa03166d207e3e2a`) while preserving the fork’s thread-stream runtime scheduling and control-flow behavior. It intentionally skips one upstream commit (`6e3e3c3321b81c50ef317bdff0d43c6c5dceb52e`) because it reverts a safer `execute_command` approval behavior maintained by the fork.

Sync status:
- Latest upstream/main commit: `fa14f8db417ef973774404d2c97e848872e785be`
- Fork base origin/main: `e8e42e175f9b98aee5942409a98da81744d86b0e`
- Divergence: fork 325 commits ahead / upstream 329 commits

Validation performed:
- TypeScript type checking for `packages/core`
- Ran three tests (`workspace-resolution.test.ts`, `session.abort.test.ts`, `session.subscription-lifecycle.test.ts`) using dot reporter with bail-on-first-failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->