### PR TITLE
Prevent harness error JSON from exposing stacks

### DIFF
--- a/packages/core/src/harness/harness.ts
+++ b/packages/core/src/harness/harness.ts
@@ -505,7 +505,7 @@ export class Harness<TState = {}> {
           workspaceName: this.workspace.name,
         });
       } catch (error) {
-        const err = getErrorFromUnknown(error);
+        const err = getErrorFromUnknown(error, { serializeStack: false });
         this.workspace = undefined;
         this.workspaceInitialized = false;
 
@@ -1124,7 +1124,7 @@ export class Harness<TState = {}> {
       try {
         await memoryStorage.clearObservationalMemory(threadId, thread.resourceId);
       } catch (error) {
-        this.emit({ type: 'error', error: getErrorFromUnknown(error) });
+        this.emit({ type: 'error', error: getErrorFromUnknown(error, { serializeStack: false }) });
       }
     }
 
@@ -1860,7 +1860,7 @@ export class Harness<TState = {}> {
       }
       if (this.followUpQueue.length > 0) {
         void this.drainFollowUpQueue(options).catch(error => {
-          this.emit({ type: 'error', error: getErrorFromUnknown(error) });
+          this.emit({ type: 'error', error: getErrorFromUnknown(error, { serializeStack: false }) });
         });
       }
     }
@@ -1937,7 +1937,7 @@ export class Harness<TState = {}> {
         this.emit({ type: 'agent_end', reason: 'aborted' });
       }
     } else {
-      this.emit({ type: 'error', error: getErrorFromUnknown(error) });
+      this.emit({ type: 'error', error: getErrorFromUnknown(error, { serializeStack: false }) });
       this.emit({ type: 'agent_end', reason: 'error' });
     }
     this.agentThreadSubscription?.unsubscribe();
@@ -2730,7 +2730,7 @@ export class Harness<TState = {}> {
       }
 
       case 'error': {
-        const streamError = getErrorFromUnknown(chunk.payload.error);
+        const streamError = getErrorFromUnknown(chunk.payload.error, { serializeStack: false });
         this.emit({ type: 'error', error: streamError });
         break;
       }
@@ -3130,7 +3130,7 @@ export class Harness<TState = {}> {
       const abortError = new Error('aborted');
       abortError.name = 'AbortError';
       void this.handleSubscribedStreamError(abortError).catch(error => {
-        this.emit({ type: 'error', error: getErrorFromUnknown(error) });
+        this.emit({ type: 'error', error: getErrorFromUnknown(error, { serializeStack: false }) });
       });
     } else if (directStreamRunId) {
       this.abortFinalizedRunIds.add(directStreamRunId);
@@ -3347,7 +3347,7 @@ export class Harness<TState = {}> {
         requestContext,
       });
     } catch (error) {
-      const err = getErrorFromUnknown(error);
+      const err = getErrorFromUnknown(error, { serializeStack: false });
       this.emit({ type: 'error', error: err });
       this.emit({ type: 'agent_end', reason: 'error' });
     } finally {

--- a/packages/core/src/harness/om-failure-abort.test.ts
+++ b/packages/core/src/harness/om-failure-abort.test.ts
@@ -19,6 +19,33 @@ function createHarness() {
 }
 
 describe('Harness OM failure abort behavior', () => {
+  it('omits stack traces when error events are JSON stringified', async () => {
+    const harness = createHarness();
+    const events: HarnessEvent[] = [];
+    harness.subscribe(event => events.push(event));
+
+    const streamError = new Error('provider failed without leaking stack');
+    streamError.stack =
+      'Error: provider failed without leaking stack\n    at /private/customer/project/secret.ts:12:34';
+
+    await (harness as any).processStream({
+      fullStream: (async function* () {
+        yield {
+          type: 'error',
+          payload: { error: streamError },
+        };
+      })(),
+    });
+
+    const errorEvent = events.find(e => e.type === 'error');
+    expect(errorEvent?.type).toBe('error');
+    const serialized = JSON.stringify(errorEvent);
+    const parsed = JSON.parse(serialized);
+    expect(parsed.error.message).toBe('provider failed without leaking stack');
+    expect(parsed.error.stack).toBeUndefined();
+    expect(serialized).not.toContain('/private/customer/project/secret.ts');
+  });
+
   it('aborts stream and emits an error when OM buffering fails', async () => {
     const harness = createHarness();
     const events: HarnessEvent[] = [];


### PR DESCRIPTION
## Summary
- addresses the post-merge Codex review comment on #213 about harness error events serialized by headless stream-json output
- keeps emitted legacy Harness errors as Error instances, but calls getErrorFromUnknown with serializeStack: false so JSON.stringify(event) includes message/name without stack traces
- adds a core regression covering JSON.stringify on an emitted harness error event

## Notes
- This is a follow-up to #213; no thread runtime control flow changes.
- Attempted mastracode focused validation, but local mastracode tests/check are blocked by unrelated workspace package/type resolution issues in this checkout (@mastra/libsql/@mastra/duckdb/@mastra/tavily and existing Harness v1 type errors). The core regression directly covers the JSON.stringify(event) mechanism used by headless stream-json.

## Validation
- pnpm -C packages/core typecheck
- pnpm -C packages/core exec vitest run src/harness/om-failure-abort.test.ts --reporter=dot --bail 1
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes sure that when the system reports errors through the API, it doesn't accidentally include debugging information (stack traces) that could expose sensitive details about how the code works internally. It does this by removing the stack traces from error messages when they're converted to JSON format.

## Overview

This PR prevents harness error JSON serialization from exposing stack traces in error events, addressing a Codex review comment from PR `#213`. The implementation ensures that emitted Harness errors remain Error instances but exclude stack traces when JSON serialized, preventing sensitive debugging information from being exposed while maintaining the error message and name properties.

## Changes

### packages/core/src/harness/harness.ts

Updated error handling across multiple asynchronous control-flow paths to call `getErrorFromUnknown(error, { serializeStack: false })` instead of `getErrorFromUnknown(error)`. This change applies to:
- Workspace initialization failure handling
- Thread deletion observational-memory cleanup error reporting
- Follow-up queue draining error reporting
- Subscribed stream error handling
- Stream chunk error handling
- Abort-induced subscribed stream error handling
- Tool suspension resume error handling

**Lines changed:** +7/-7

### packages/core/src/harness/om-failure-abort.test.ts

Added a new regression test case under `Harness OM failure abort behavior` that verifies error events produced during `processStream` omit stack traces when JSON stringified. The test:
- Constructs an Error with a populated `.stack` property
- Runs a minimal stream that yields a `{ type: 'error', payload: { error } }` event
- Asserts that the serialized/parsing round-trip preserves `error.message`
- Verifies that `error.stack` becomes `undefined` after serialization
- Ensures the serialized output does not include the original stack path

**Lines changed:** +27/-0

## Validation

The author confirmed validation including TypeCheck for packages/core, execution of the harness om-failure-abort test suite, and diff check for code formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->