### PR TITLE
[PF-794] Fence harness-bound AgentChannels tools

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -847,11 +847,13 @@ export class Agent<
    * @internal
    */
   setChannels(agentChannels: AgentChannels): void {
+    this.#mastra?._assertHarnessAgentChannelsAdapterAllowed(this, agentChannels);
     if (this.#agentChannels && this.#agentChannels !== agentChannels) {
       this.logger?.debug(`Replacing existing AgentChannels on agent "${this.name}"`);
     }
-    this.#agentChannels = agentChannels;
     agentChannels.__setAgent(this);
+    this.#mastra?._registerAgentChannelsForAgent(this, agentChannels);
+    this.#agentChannels = agentChannels;
   }
 
   /**

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -2,7 +2,6 @@ import type { Chat, Adapter, ChatConfig, Message, StateAdapter, Thread } from 'c
 import { z } from 'zod';
 
 import type { Agent } from '../agent/agent';
-import type { AIV5Type } from '../agent/message-list/types';
 import type { MastraProviderMetadata } from '../agent/message-list/state/types';
 import type { AgentSignalContents } from '../agent/signals';
 import type { AgentThreadSubscription } from '../agent/types';
@@ -112,6 +111,7 @@ export class AgentChannels {
   private channelToolNames!: Set<string>;
   /** Platforms whose routes are managed externally (e.g., by SlackProvider). */
   private externallyManagedPlatforms: Set<string> = new Set();
+  private mastraOwner?: { mastra: Mastra; agentKey: string };
   /**
    * Per-Mastra-thread subscriptions. We lazily open one `agent.subscribeToThread()` per channel
    * thread on the first message we route through it, so any signals we send (and any signals
@@ -191,6 +191,12 @@ export class AgentChannels {
       'child' in logger && typeof (logger as any).child === 'function' ? (logger as any).child('CHANNEL') : logger;
   }
 
+  /** @internal */
+  __setMastraOwner(mastra: Mastra, agentKey: string): void {
+    mastra._assertHarnessAgentChannelsAdapterAllowed(agentKey, this);
+    this.mastraOwner = { mastra, agentKey };
+  }
+
   /**
    * Register an adapter dynamically.
    * When `managesRoutes` is true, AgentChannels will NOT create webhook routes for this platform
@@ -203,6 +209,7 @@ export class AgentChannels {
     config?: ChannelAdapterConfig,
     options?: { managesRoutes?: boolean },
   ): void {
+    this.mastraOwner?.mastra._assertHarnessAgentChannelsAdapterAllowed(this.mastraOwner.agentKey, this, platform);
     if (this.adapters[platform]) {
       if (options?.managesRoutes) {
         this.externallyManagedPlatforms.add(platform);
@@ -221,6 +228,16 @@ export class AgentChannels {
    */
   hasAdapter(platform: string): boolean {
     return platform in this.adapters;
+  }
+
+  /**
+   * Return the generic channel tools that this AgentChannels instance can expose
+   * to the model. Mastra init uses this to detect Harness-bound ownership
+   * collisions without reaching into private AgentChannels state.
+   * @internal
+   */
+  __getChannelToolNames(): string[] {
+    return Array.from(this.channelToolNames);
   }
 
   /**
@@ -1076,8 +1093,7 @@ export class AgentChannels {
     // (AgentMessageInput.providerOptions) — the runtime stamps it onto the
     // UserModelMessage + persisted `content.providerMetadata`, preserving the
     // original intent of the fork's message wrapper.
-    const signalContents: AgentSignalContents =
-      parts.length === 1 && parts[0]?.type === 'text' ? parts[0].text : parts;
+    const signalContents: AgentSignalContents = parts.length === 1 && parts[0]?.type === 'text' ? parts[0].text : parts;
 
     this.agent.sendMessage(
       {

--- a/packages/core/src/harness/v1/channel-registry.ts
+++ b/packages/core/src/harness/v1/channel-registry.ts
@@ -97,9 +97,16 @@ export class HarnessChannelRegistry {
   }
 
   bind(mastra: Mastra, harnessName: string): void {
+    this.bindings = this.resolveBindings(mastra, harnessName);
+  }
+
+  preview(mastra: Mastra, harnessName: string): HarnessChannelBinding[] {
+    return Array.from(this.resolveBindings(mastra, harnessName).values()).map(binding => ({ ...binding }));
+  }
+
+  private resolveBindings(mastra: Mastra, harnessName: string): Map<string, HarnessChannelBinding> {
     if (this.pending.size === 0) {
-      this.bindings = new Map();
-      return;
+      return new Map();
     }
     assertNonEmptyString(harnessName, 'harnessName');
     assertDurableComponent(harnessName, 'harnessName');
@@ -154,7 +161,7 @@ export class HarnessChannelRegistry {
       });
     }
 
-    this.bindings = next;
+    return next;
   }
 
   list(): HarnessChannelBinding[] {

--- a/packages/core/src/harness/v1/harness.test.ts
+++ b/packages/core/src/harness/v1/harness.test.ts
@@ -1497,13 +1497,14 @@ describe('Harness v1 — construction', () => {
       agents: { default: agent },
       storage: new InMemoryStore(),
     });
+    const routePath = '/api/agents/default/channels/slack/webhook';
 
+    agent.setChannels(new AgentChannels({ adapters: { slack: {} as any } }));
+
+    expect(mastra.getServer()?.apiRoutes?.some(route => route.path === routePath)).toBe(true);
     expect(mastra.removeAgent('default')).toBe(true);
     expect(() => agent.setChannels(new AgentChannels({ adapters: { slack: {} as any } }))).toThrow(/removed/);
-    expect(
-      mastra.getServer()?.apiRoutes?.some(route => route.path === '/api/agents/default/channels/slack/webhook') ??
-        false,
-    ).toBe(false);
+    expect(mastra.getServer()?.apiRoutes?.some(route => route.path === routePath) ?? false).toBe(false);
   });
 
   it('replaces stale webhook routes when AgentChannels are rebuilt', () => {

--- a/packages/core/src/harness/v1/harness.test.ts
+++ b/packages/core/src/harness/v1/harness.test.ts
@@ -1067,6 +1067,34 @@ describe('Harness v1 — construction', () => {
     ).not.toThrow();
   });
 
+  it('rejects AgentChannels tools when the harness uses the agent id but Mastra uses a different key', () => {
+    expect(
+      () =>
+        new Mastra({
+          agents: {
+            support: new Agent({
+              id: 'assistant',
+              name: 'assistant',
+              instructions: 'test',
+              model: TEST_MODEL,
+              channels: { adapters: { slack: {} as any } },
+            }),
+          },
+          storage: new InMemoryStore(),
+          channels: { slack: makeChannelProvider('slack') },
+          harnesses: {
+            primary: new Harness({
+              modes: [{ id: 'default', agentId: 'assistant' }],
+              defaultModeId: 'default',
+              channels: {
+                support: makeHarnessChannelConfig(),
+              },
+            }),
+          },
+        }),
+    ).toThrow(/AgentChannels tools enabled/);
+  });
+
   it('rejects durable-agent AgentChannels tools on a harness-bound provider platform', () => {
     const underlyingAgent = new Agent({
       id: 'default',
@@ -1456,6 +1484,52 @@ describe('Harness v1 — construction', () => {
     expect(initialRoutes).toHaveLength(1);
     expect(routes).toHaveLength(1);
     expect(routes[0]).not.toBe(initialRoutes[0]);
+  });
+
+  it('reconciles webhook routes when the same AgentChannels instance gains an adapter', () => {
+    const agent = new Agent({
+      id: 'default',
+      name: 'default',
+      instructions: 'test',
+      model: TEST_MODEL,
+      channels: { adapters: { slack: {} as any }, tools: false },
+    });
+    const mastra = new Mastra({
+      agents: { default: agent },
+      storage: new InMemoryStore(),
+      channels: { slack: makeChannelProvider('slack') },
+    });
+    const agentChannels = agent.getChannels();
+
+    expect(agentChannels).toBeInstanceOf(AgentChannels);
+    agentChannels?.__registerAdapter('discord', {} as any);
+    agent.setChannels(agentChannels as AgentChannels);
+
+    const routePaths = mastra.getServer()?.apiRoutes?.map(route => route.path) ?? [];
+    expect(routePaths.filter(path => path === '/api/agents/default/channels/slack/webhook')).toHaveLength(1);
+    expect(routePaths.filter(path => path === '/api/agents/default/channels/discord/webhook')).toHaveLength(1);
+  });
+
+  it('closes replaced AgentChannels instances', () => {
+    const agent = new Agent({
+      id: 'default',
+      name: 'default',
+      instructions: 'test',
+      model: TEST_MODEL,
+      channels: { adapters: { slack: {} as any }, tools: false },
+    });
+    new Mastra({
+      agents: { default: agent },
+      storage: new InMemoryStore(),
+      channels: { slack: makeChannelProvider('slack') },
+    });
+    const original = agent.getChannels();
+    const close = vi.spyOn(original as AgentChannels, 'close');
+    const replacement = new AgentChannels({ adapters: { slack: {} as any }, tools: false });
+
+    agent.setChannels(replacement);
+
+    expect(close).toHaveBeenCalledTimes(1);
   });
 
   it('enqueues durable channel outbox rows before dispatching through the adapter', async () => {

--- a/packages/core/src/harness/v1/harness.test.ts
+++ b/packages/core/src/harness/v1/harness.test.ts
@@ -1555,6 +1555,33 @@ describe('Harness v1 — construction', () => {
     expect(routePaths.filter(path => path === '/api/agents/default/channels/discord/webhook')).toHaveLength(1);
   });
 
+  it('restarts initialized AgentChannels when the same instance gains an adapter', async () => {
+    const agentChannels = new AgentChannels({ adapters: { slack: {} as any }, tools: false });
+    const initialize = vi.spyOn(agentChannels, 'initialize').mockResolvedValue(undefined);
+    const close = vi.spyOn(agentChannels, 'close');
+    const agent = new Agent({
+      id: 'default',
+      name: 'default',
+      instructions: 'test',
+      model: TEST_MODEL,
+      channels: agentChannels,
+    });
+    const mastra = new Mastra({
+      agents: { default: agent },
+      storage: new InMemoryStore(),
+      channels: { slack: makeChannelProvider('slack') },
+    });
+
+    await mastra.init();
+    expect(initialize).toHaveBeenCalledTimes(1);
+
+    agentChannels.__registerAdapter('discord', {} as any);
+    agent.setChannels(agentChannels);
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(initialize).toHaveBeenCalledTimes(2);
+  });
+
   it('closes replaced AgentChannels instances', () => {
     const agent = new Agent({
       id: 'default',

--- a/packages/core/src/harness/v1/harness.test.ts
+++ b/packages/core/src/harness/v1/harness.test.ts
@@ -13,6 +13,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
 import { Agent } from '../../agent';
+import { AgentChannels } from '../../channels';
 import type { ChannelProvider } from '../../channels';
 import { PubSub } from '../../events';
 import type { Event, EventCallback, SubscribeOptions } from '../../events';
@@ -24,6 +25,18 @@ import type {
   ChannelOutboxEnqueueOptions,
   ChannelOutboxItem,
 } from '../../storage/domains/harness';
+import {
+  HarnessStorage,
+  HarnessStorageChannelOutboxClaimConflictError,
+  HarnessStorageDeleteGuardConflictError,
+  HarnessStorageVersionConflictError,
+} from '../../storage/domains/harness';
+import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
+import { InMemoryDB } from '../../storage/domains/inmemory-db';
+import { InMemoryStore } from '../../storage/mock';
+import { MastraWorker } from '../../worker';
+
+import { extractSignalContents, MockAgent } from './__test-utils__';
 import {
   HarnessAbortedError,
   HarnessConfigError,
@@ -40,28 +53,18 @@ import {
   HarnessStorageError,
   HarnessValidationError,
 } from './errors';
-import {
-  HarnessStorage,
-  HarnessStorageChannelOutboxClaimConflictError,
-  HarnessStorageDeleteGuardConflictError,
-  HarnessStorageVersionConflictError,
-} from '../../storage/domains/harness';
-import { InMemoryHarness } from '../../storage/domains/harness/inmemory';
-import { InMemoryDB } from '../../storage/domains/inmemory-db';
-import { InMemoryStore } from '../../storage/mock';
-import { MastraWorker } from '../../worker';
-
-import { extractSignalContents, MockAgent } from './__test-utils__';
 import type { HarnessSessionDeleteBlockedError } from './errors';
 import { Harness, createHarnessOperatorThreadController } from './harness';
 import type { HarnessChannelConfig } from './types';
+
+const TEST_MODEL = 'test/model' as any;
 
 function makeAgent(name = 'test-agent') {
   return new Agent({
     id: name,
     name,
     instructions: 'test',
-    model: 'openai/gpt-4o-mini' as any,
+    model: TEST_MODEL,
   });
 }
 
@@ -1018,6 +1021,390 @@ describe('Harness v1 — construction', () => {
     expect(harness.listChannelBindings()).toHaveLength(1);
   });
 
+  it('rejects AgentChannels tools on a harness-bound provider platform', () => {
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      channels: {
+        support: makeHarnessChannelConfig(),
+      },
+    });
+
+    expect(
+      () =>
+        new Mastra({
+          agents: {
+            default: new Agent({
+              id: 'default',
+              name: 'default',
+              instructions: 'test',
+              model: TEST_MODEL,
+              channels: { adapters: { slack: {} as any } },
+            }),
+          },
+          storage: new InMemoryStore(),
+          channels: { slack: makeChannelProvider('slack') },
+          harnesses: { primary: harness },
+        }),
+    ).toThrow(/AgentChannels tools enabled/);
+
+    expect(
+      () =>
+        new Mastra({
+          agents: {
+            default: new Agent({
+              id: 'default',
+              name: 'default',
+              instructions: 'test',
+              model: TEST_MODEL,
+              channels: { adapters: { slack: {} as any }, tools: false },
+            }),
+          },
+          storage: new InMemoryStore(),
+          channels: { slack: makeChannelProvider('slack') },
+          harnesses: { primary: harness },
+        }),
+    ).not.toThrow();
+  });
+
+  it('rejects durable-agent AgentChannels tools on a harness-bound provider platform', () => {
+    const underlyingAgent = new Agent({
+      id: 'default',
+      name: 'default',
+      instructions: 'test',
+      model: TEST_MODEL,
+      channels: { adapters: { slack: {} as any } },
+    });
+    const durableAgent = {
+      id: 'default',
+      name: 'default',
+      agent: underlyingAgent,
+      stream: async () => ({}) as any,
+    };
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      channels: {
+        support: makeHarnessChannelConfig(),
+      },
+    });
+
+    expect(
+      () =>
+        new Mastra({
+          agents: { default: durableAgent as any },
+          storage: new InMemoryStore(),
+          channels: { slack: makeChannelProvider('slack') },
+          harnesses: { primary: harness },
+        }),
+    ).toThrow(/AgentChannels tools enabled/);
+  });
+
+  it('rejects rebuilt durable-agent AgentChannels using the harness registry key', () => {
+    const underlyingAgent = makeAgent('underlying');
+    const durableAgent = {
+      id: 'durable-default',
+      name: 'durable-default',
+      agent: underlyingAgent,
+      stream: async () => ({}) as any,
+      __setLogger: () => {},
+    };
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      channels: {
+        support: makeHarnessChannelConfig(),
+      },
+    });
+    new Mastra({
+      agents: { default: durableAgent as any },
+      storage: new InMemoryStore(),
+      channels: { slack: makeChannelProvider('slack') },
+      harnesses: { primary: harness },
+    });
+
+    expect(() => underlyingAgent.setChannels(new AgentChannels({ adapters: { slack: {} as any } }))).toThrow(
+      /AgentChannels tools enabled/,
+    );
+    expect(underlyingAgent.getChannels()).toBeNull();
+  });
+
+  it('allows AgentChannels tools on live-only platforms outside harness bindings', () => {
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      channels: {
+        support: makeHarnessChannelConfig(),
+      },
+    });
+
+    expect(
+      () =>
+        new Mastra({
+          agents: {
+            default: new Agent({
+              id: 'default',
+              name: 'default',
+              instructions: 'test',
+              model: TEST_MODEL,
+              channels: { adapters: { discord: {} as any } },
+            }),
+          },
+          storage: new InMemoryStore(),
+          channels: { slack: makeChannelProvider('slack') },
+          harnesses: { primary: harness },
+        }),
+    ).not.toThrow();
+  });
+
+  it('allows AgentChannels tools on same-platform agents not used by the harness', () => {
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      channels: {
+        support: makeHarnessChannelConfig(),
+      },
+    });
+
+    expect(
+      () =>
+        new Mastra({
+          agents: {
+            default: makeAgent('default'),
+            live: new Agent({
+              id: 'live',
+              name: 'live',
+              instructions: 'test',
+              model: TEST_MODEL,
+              channels: { adapters: { slack: {} as any } },
+            }),
+          },
+          storage: new InMemoryStore(),
+          channels: { slack: makeChannelProvider('slack') },
+          harnesses: { primary: harness },
+        }),
+    ).not.toThrow();
+  });
+
+  it('allows AgentChannels tools when only another harness binds that platform', () => {
+    const liveAgent = new Agent({
+      id: 'live',
+      name: 'live',
+      instructions: 'test',
+      model: TEST_MODEL,
+      channels: { adapters: { slack: {} as any } },
+    });
+    const liveHarness = new Harness({
+      modes: [{ id: 'live', agentId: 'live' }],
+      defaultModeId: 'live',
+    });
+    const channelHarness = new Harness({
+      modes: [{ id: 'worker', agentId: 'worker' }],
+      defaultModeId: 'worker',
+      channels: {
+        support: makeHarnessChannelConfig(),
+      },
+    });
+
+    expect(
+      () =>
+        new Mastra({
+          agents: {
+            live: liveAgent,
+            worker: makeAgent('worker'),
+          },
+          storage: new InMemoryStore(),
+          channels: { slack: makeChannelProvider('slack') },
+          harnesses: {
+            live: liveHarness,
+            channel: channelHarness,
+          },
+        }),
+    ).not.toThrow();
+  });
+
+  it('allows harness-bound AgentChannels when generic channel tools are disabled', () => {
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      channels: {
+        support: makeHarnessChannelConfig(),
+      },
+    });
+
+    expect(
+      () =>
+        new Mastra({
+          agents: {
+            default: new Agent({
+              id: 'default',
+              name: 'default',
+              instructions: 'test',
+              model: TEST_MODEL,
+              channels: new AgentChannels({ adapters: { slack: {} as any }, tools: false }),
+            }),
+          },
+          storage: new InMemoryStore(),
+          channels: { slack: makeChannelProvider('slack') },
+          harnesses: { primary: harness },
+        }),
+    ).not.toThrow();
+  });
+
+  it('allows dynamically added AgentChannels tools for agents not used by the harness', () => {
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      channels: {
+        support: makeHarnessChannelConfig(),
+      },
+    });
+    const mastra = new Mastra({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+      channels: { slack: makeChannelProvider('slack') },
+      harnesses: { primary: harness },
+    });
+
+    expect(() =>
+      mastra.addAgent(
+        new Agent({
+          id: 'live',
+          name: 'live',
+          instructions: 'test',
+          model: TEST_MODEL,
+          channels: { adapters: { slack: {} as any } },
+        }),
+      ),
+    ).not.toThrow();
+    expect(mastra.getAgent('live' as never)).toBeDefined();
+  });
+
+  it('rejects provider-added AgentChannels adapters that would expose tools on a harness-bound platform', () => {
+    const agent = new Agent({
+      id: 'default',
+      name: 'default',
+      instructions: 'test',
+      model: TEST_MODEL,
+      channels: new AgentChannels({ adapters: { discord: {} as any } }),
+    });
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      channels: {
+        support: makeHarnessChannelConfig(),
+      },
+    });
+    new Mastra({
+      agents: { default: agent },
+      storage: new InMemoryStore(),
+      channels: { slack: makeChannelProvider('slack') },
+      harnesses: { primary: harness },
+    });
+    const agentChannels = agent.getChannels();
+
+    expect(agentChannels).toBeInstanceOf(AgentChannels);
+    expect(() => agentChannels?.__registerAdapter('slack', {} as any)).toThrow(/AgentChannels tools enabled/);
+    expect(agentChannels?.hasAdapter('slack')).toBe(false);
+  });
+
+  it('rejects replacing a harness-bound agent with tool-enabled AgentChannels for that platform', () => {
+    const agent = makeAgent('default');
+    const harness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      channels: {
+        support: makeHarnessChannelConfig(),
+      },
+    });
+    new Mastra({
+      agents: { default: agent },
+      storage: new InMemoryStore(),
+      channels: { slack: makeChannelProvider('slack') },
+      harnesses: { primary: harness },
+    });
+
+    expect(() => agent.setChannels(new AgentChannels({ adapters: { slack: {} as any } }))).toThrow(
+      /AgentChannels tools enabled/,
+    );
+    expect(agent.getChannels()).toBeNull();
+  });
+
+  it('rejects direct-bound Harness AgentChannels tools on a harness-bound provider platform', () => {
+    const mastra = new Mastra({
+      agents: {
+        default: new Agent({
+          id: 'default',
+          name: 'default',
+          instructions: 'test',
+          model: TEST_MODEL,
+          channels: { adapters: { slack: {} as any } },
+        }),
+      },
+      storage: new InMemoryStore(),
+      channels: { slack: makeChannelProvider('slack') },
+    });
+
+    expect(
+      () =>
+        new Harness({
+          mastra,
+          modes: [{ id: 'default', agentId: 'default' }],
+          defaultModeId: 'default',
+          channels: {
+            support: makeHarnessChannelConfig(),
+          },
+        }),
+    ).toThrow(/AgentChannels tools enabled/);
+  });
+
+  it('rejects replacing AgentChannels after a direct-bound Harness claims the platform', () => {
+    const agent = makeAgent('default');
+    const mastra = new Mastra({
+      agents: { default: agent },
+      storage: new InMemoryStore(),
+      channels: { slack: makeChannelProvider('slack') },
+    });
+    new Harness({
+      mastra,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      channels: {
+        support: makeHarnessChannelConfig(),
+      },
+    });
+
+    expect(() => agent.setChannels(new AgentChannels({ adapters: { slack: {} as any } }))).toThrow(
+      /AgentChannels tools enabled/,
+    );
+    expect(agent.getChannels()).toBeNull();
+  });
+
+  it('replaces stale webhook routes when AgentChannels are rebuilt', () => {
+    const agent = new Agent({
+      id: 'default',
+      name: 'default',
+      instructions: 'test',
+      model: TEST_MODEL,
+      channels: { adapters: { slack: {} as any }, tools: false },
+    });
+    const mastra = new Mastra({
+      agents: { default: agent },
+      storage: new InMemoryStore(),
+      channels: { slack: makeChannelProvider('slack') },
+    });
+    const routePath = '/api/agents/default/channels/slack/webhook';
+    const initialRoutes = mastra.getServer()?.apiRoutes?.filter(route => route.path === routePath) ?? [];
+    const replacement = new AgentChannels({ adapters: { slack: {} as any }, tools: false });
+
+    agent.setChannels(replacement);
+
+    const routes = mastra.getServer()?.apiRoutes?.filter(route => route.path === routePath) ?? [];
+    expect(initialRoutes).toHaveLength(1);
+    expect(routes).toHaveLength(1);
+    expect(routes[0]).not.toBe(initialRoutes[0]);
+  });
+
   it('enqueues durable channel outbox rows before dispatching through the adapter', async () => {
     const storage = makeStorage();
     const delivered: string[] = [];
@@ -1204,7 +1591,9 @@ describe('Harness v1 — construction', () => {
       visibleSessionIds: expect.arrayContaining([root.id, child.id]),
       bindings: [{ channelId: 'support', providerId: 'slack', bindingId: 'support-binding' }],
       // §13.3f.1: bare row codes are projected to namespaced wire codes.
-      inbox: [{ id: 'inbox-1', status: 'received', lastError: { code: 'harness.worker_unavailable', retryable: true } }],
+      inbox: [
+        { id: 'inbox-1', status: 'received', lastError: { code: 'harness.worker_unavailable', retryable: true } },
+      ],
       actionTokens: [{ actionTokenId: 'action-token-1', owningSessionId: child.id, status: 'active' }],
       actionReceipts: [
         {
@@ -2275,7 +2664,11 @@ describe('Harness v1 — lifecycle', () => {
 
   it('Session.rename() updates the backing thread title (§4.1)', async () => {
     const harness = makeHarness();
-    await createHarnessOperatorThreadController(harness).create({ resourceId: 'r1', threadId: 't1', title: 'Original' });
+    await createHarnessOperatorThreadController(harness).create({
+      resourceId: 'r1',
+      threadId: 't1',
+      title: 'Original',
+    });
     const s = await harness.session({ threadId: 't1', resourceId: 'r1' });
     await s.rename({ title: 'Renamed conversation' });
     const thread = await createHarnessOperatorThreadController(harness).get({ resourceId: 'r1', threadId: 't1' });
@@ -2293,7 +2686,10 @@ describe('Harness v1 — lifecycle', () => {
     expect(cloned.resourceId).toBe('r1');
     expect(cloned.isClosed).toBe(false);
 
-    const clonedThread = await createHarnessOperatorThreadController(harness).get({ resourceId: 'r1', threadId: cloned.threadId });
+    const clonedThread = await createHarnessOperatorThreadController(harness).get({
+      resourceId: 'r1',
+      threadId: cloned.threadId,
+    });
     expect(clonedThread?.title).toBe('Clone');
     // Cloning never tears down or mutates the source session.
     expect(s.isClosed).toBe(false);
@@ -2488,7 +2884,10 @@ describe('Harness v1 — lifecycle', () => {
   it('does not cascade thread delete after shutdown begins', async () => {
     const storage = makeStorage();
     const harness = makeHarness({ sessions: { storage } });
-    const thread = await createHarnessOperatorThreadController(harness).create({ resourceId: 'r1', threadId: 'delete-during-shutdown' });
+    const thread = await createHarnessOperatorThreadController(harness).create({
+      resourceId: 'r1',
+      threadId: 'delete-during-shutdown',
+    });
     const s = await harness.session({ threadId: thread.id, resourceId: 'r1' });
     const originalRelease = storage.releaseSessionLease.bind(storage);
     let releaseShutdown!: () => void;
@@ -2518,7 +2917,10 @@ describe('Harness v1 — lifecycle', () => {
   it('does not delete thread data when shutdown starts during a delete cascade', async () => {
     const storage = makeStorage();
     const harness = makeHarness({ sessions: { storage } });
-    const thread = await createHarnessOperatorThreadController(harness).create({ resourceId: 'r1', threadId: 'delete-cascade-during-shutdown' });
+    const thread = await createHarnessOperatorThreadController(harness).create({
+      resourceId: 'r1',
+      threadId: 'delete-cascade-during-shutdown',
+    });
     const s = await harness.session({ threadId: thread.id, resourceId: 'r1' });
     const originalSaveSession = storage.saveSession.bind(storage);
     let releaseTerminalSave!: () => void;
@@ -2544,7 +2946,9 @@ describe('Harness v1 — lifecycle', () => {
     releaseTerminalSave();
     await Promise.all([deleting, shutdown]);
 
-    await expect(createHarnessOperatorThreadController(harness).get({ resourceId: 'r1', threadId: thread.id })).resolves.toMatchObject({
+    await expect(
+      createHarnessOperatorThreadController(harness).get({ resourceId: 'r1', threadId: thread.id }),
+    ).resolves.toMatchObject({
       id: thread.id,
     });
     const stored = await storage.loadSession({ sessionId: s.id, harnessName: 'default' });
@@ -4330,9 +4734,11 @@ describe('Harness._resolveChannelBindingForIngress (§14.1 / C2b)', () => {
 
   it('resolves a new active binding, deriving stable namespaced thread/session ids', async () => {
     const { harness } = setup();
-    const r = (await (harness as never as {
-      _resolveChannelBindingForIngress: (c: never) => Promise<ResolveResult>;
-    })._resolveChannelBindingForIngress(makeIngressCtx())) as ResolveResult;
+    const r = (await (
+      harness as never as {
+        _resolveChannelBindingForIngress: (c: never) => Promise<ResolveResult>;
+      }
+    )._resolveChannelBindingForIngress(makeIngressCtx())) as ResolveResult;
     expect(r.resolved.resourceId).toBe('resource-1');
     expect(r.resolved.threadId).toMatch(/^ch:/);
     expect(r.resolved.sessionId).toMatch(/^chs:/);
@@ -4341,17 +4747,23 @@ describe('Harness._resolveChannelBindingForIngress (§14.1 / C2b)', () => {
 
     // Stability: a fresh harness with the same inputs derives the SAME ids.
     const { harness: h2 } = setup();
-    const r2 = (await (h2 as never as {
-      _resolveChannelBindingForIngress: (c: never) => Promise<ResolveResult>;
-    })._resolveChannelBindingForIngress(makeIngressCtx())) as ResolveResult;
+    const r2 = (await (
+      h2 as never as {
+        _resolveChannelBindingForIngress: (c: never) => Promise<ResolveResult>;
+      }
+    )._resolveChannelBindingForIngress(makeIngressCtx())) as ResolveResult;
     expect(r2.resolved.threadId).toBe(r.resolved.threadId);
     expect(r2.resolved.sessionId).toBe(r.resolved.sessionId);
 
     // Separation: a different resolved resourceId derives a DIFFERENT threadId.
-    const { harness: h3 } = setup({ ingress: { resolveResource: async () => ({ resourceId: 'other', mode: 'shared-resource' }) } });
-    const r3 = (await (h3 as never as {
-      _resolveChannelBindingForIngress: (c: never) => Promise<ResolveResult>;
-    })._resolveChannelBindingForIngress(makeIngressCtx())) as ResolveResult;
+    const { harness: h3 } = setup({
+      ingress: { resolveResource: async () => ({ resourceId: 'other', mode: 'shared-resource' }) },
+    });
+    const r3 = (await (
+      h3 as never as {
+        _resolveChannelBindingForIngress: (c: never) => Promise<ResolveResult>;
+      }
+    )._resolveChannelBindingForIngress(makeIngressCtx())) as ResolveResult;
     expect(r3.resolved.threadId).not.toBe(r.resolved.threadId);
   });
 
@@ -4362,9 +4774,11 @@ describe('Harness._resolveChannelBindingForIngress (§14.1 / C2b)', () => {
     // an absent id and a literal space would derive the SAME thread/session id and
     // collide at the channel level even though storage keeps them distinct.
     const call = (h: Harness) =>
-      (h as never as {
-        _resolveChannelBindingForIngress: (c: never) => Promise<ResolveResult>;
-      })._resolveChannelBindingForIngress.bind(h) as (c: never) => Promise<ResolveResult>;
+      (
+        h as never as {
+          _resolveChannelBindingForIngress: (c: never) => Promise<ResolveResult>;
+        }
+      )._resolveChannelBindingForIngress.bind(h) as (c: never) => Promise<ResolveResult>;
 
     const { harness: hMissing } = setup();
     const missing = await call(hMissing)(makeIngressCtx({ externalChannelId: undefined }));
@@ -4384,9 +4798,11 @@ describe('Harness._resolveChannelBindingForIngress (§14.1 / C2b)', () => {
 
   it('idempotently reuses the active binding and advances lastInboundAt only forward', async () => {
     const { harness } = setup();
-    const call = (harness as never as {
-      _resolveChannelBindingForIngress: (c: never) => Promise<ResolveResult>;
-    })._resolveChannelBindingForIngress.bind(harness) as (c: never) => Promise<ResolveResult>;
+    const call = (
+      harness as never as {
+        _resolveChannelBindingForIngress: (c: never) => Promise<ResolveResult>;
+      }
+    )._resolveChannelBindingForIngress.bind(harness) as (c: never) => Promise<ResolveResult>;
     const first = await call(makeIngressCtx({ receivedAt: 1000 }));
     const second = await call(makeIngressCtx({ receivedAt: 2000 }));
     expect(second.binding.id).toBe(first.binding.id); // same active binding, not a duplicate
@@ -4400,9 +4816,11 @@ describe('Harness._resolveChannelBindingForIngress (§14.1 / C2b)', () => {
     const { harness } = setup({
       ingress: { resolveResource: async () => ({ resourceId: 'r', mode: 'custom' }) },
     });
-    const r = (await (harness as never as {
-      _resolveChannelBindingForIngress: (c: never) => Promise<ResolveResult>;
-    })._resolveChannelBindingForIngress(makeIngressCtx())) as ResolveResult;
+    const r = (await (
+      harness as never as {
+        _resolveChannelBindingForIngress: (c: never) => Promise<ResolveResult>;
+      }
+    )._resolveChannelBindingForIngress(makeIngressCtx())) as ResolveResult;
     expect(r.binding.mode).toBe('shared-resource');
   });
 
@@ -4411,9 +4829,9 @@ describe('Harness._resolveChannelBindingForIngress (§14.1 / C2b)', () => {
       ingress: { resolveResource: async () => ({ resourceId: 'r', sessionId: 's1', mode: 'shared-resource' }) },
     });
     await expect(
-      (harness as never as { _resolveChannelBindingForIngress: (c: never) => Promise<unknown> })._resolveChannelBindingForIngress(
-        makeIngressCtx(),
-      ),
+      (
+        harness as never as { _resolveChannelBindingForIngress: (c: never) => Promise<unknown> }
+      )._resolveChannelBindingForIngress(makeIngressCtx()),
     ).rejects.toBeInstanceOf(HarnessValidationError);
   });
 });
@@ -4484,9 +4902,11 @@ describe('Harness.admitChannelInbound (§14.2 ingress admission core / C4)', () 
       if (e.type.startsWith('channel_ingress_')) events.push(e as never);
     });
 
-    const r = (await (harness as never as {
-      admitChannelInbound: (c: never) => Promise<AdmitResult>;
-    }).admitChannelInbound(makeIngressCtx())) as AdmitResult;
+    const r = (await (
+      harness as never as {
+        admitChannelInbound: (c: never) => Promise<AdmitResult>;
+      }
+    ).admitChannelInbound(makeIngressCtx())) as AdmitResult;
 
     expect(r.status).toBe('queued');
     expect(r.duplicate).toBe(false);
@@ -4503,9 +4923,9 @@ describe('Harness.admitChannelInbound (§14.2 ingress admission core / C4)', () 
     harness.subscribe(e => {
       if (e.type.startsWith('channel_ingress_')) events.push(e.type);
     });
-    const call = (harness as never as { admitChannelInbound: (c: never) => Promise<AdmitResult> }).admitChannelInbound.bind(
-      harness,
-    ) as (c: never) => Promise<AdmitResult>;
+    const call = (
+      harness as never as { admitChannelInbound: (c: never) => Promise<AdmitResult> }
+    ).admitChannelInbound.bind(harness) as (c: never) => Promise<AdmitResult>;
     const first = await call(makeIngressCtx());
     const second = await call(makeIngressCtx()); // same externalMessageId → same inbox row
     expect(second.duplicate).toBe(true);
@@ -4531,9 +4951,11 @@ describe('Harness.admitChannelInbound (§14.2 ingress admission core / C4)', () 
         }),
       },
     });
-    const r = (await (harness as never as {
-      admitChannelInbound: (c: never) => Promise<AdmitResult>;
-    }).admitChannelInbound(makeIngressCtx())) as AdmitResult;
+    const r = (await (
+      harness as never as {
+        admitChannelInbound: (c: never) => Promise<AdmitResult>;
+      }
+    ).admitChannelInbound(makeIngressCtx())) as AdmitResult;
     expect(r.status).toBe('queued');
     expect(typeof r.queuedItemId).toBe('string');
   });
@@ -4558,9 +4980,9 @@ describe('Harness.admitChannelInbound (§14.2 ingress admission core / C4)', () 
     harness.subscribe(e => {
       if (e.type.startsWith('channel_ingress_')) events.push(e as never);
     });
-    const call = (harness as never as { admitChannelInbound: (c: never) => Promise<AdmitResult> }).admitChannelInbound.bind(
-      harness,
-    ) as (c: never) => Promise<AdmitResult>;
+    const call = (
+      harness as never as { admitChannelInbound: (c: never) => Promise<AdmitResult> }
+    ).admitChannelInbound.bind(harness) as (c: never) => Promise<AdmitResult>;
 
     await expect(call(makeIngressCtx())).rejects.toThrow();
     expect(events.map(e => e.type)).toEqual(['channel_ingress_received', 'channel_ingress_failed']);
@@ -4608,9 +5030,9 @@ describe('Harness.admitChannelInbound (§14.2 ingress admission core / C4)', () 
       if (e.type.startsWith('channel_ingress_')) events.push(e as never);
     });
 
-    const call = (harness as never as { admitChannelInbound: (c: never) => Promise<AdmitResult> }).admitChannelInbound.bind(
-      harness,
-    ) as (c: never) => Promise<AdmitResult>;
+    const call = (
+      harness as never as { admitChannelInbound: (c: never) => Promise<AdmitResult> }
+    ).admitChannelInbound.bind(harness) as (c: never) => Promise<AdmitResult>;
 
     // The local thrown error still carries the raw resolver text (it stays a
     // local-only cause); only the PUBLIC projection is redacted.
@@ -4668,9 +5090,9 @@ describe('Harness.admitChannelInbound (§14.2 ingress admission core / C4)', () 
         },
       },
     });
-    const call = (harness as never as { admitChannelInbound: (c: never) => Promise<AdmitResult> }).admitChannelInbound.bind(
-      harness,
-    ) as (c: never) => Promise<AdmitResult>;
+    const call = (
+      harness as never as { admitChannelInbound: (c: never) => Promise<AdmitResult> }
+    ).admitChannelInbound.bind(harness) as (c: never) => Promise<AdmitResult>;
 
     await expect(call(makeIngressCtx())).rejects.toThrow(/transient resolver outage/);
 
@@ -4709,9 +5131,9 @@ describe('Harness.admitChannelInbound (§14.2 ingress admission core / C4)', () 
       if (row.status === 'queued') throw new Error('crash before queued commit');
       return realUpdate(row, opts);
     };
-    const call = (harness as never as { admitChannelInbound: (c: never) => Promise<AdmitResult> }).admitChannelInbound.bind(
-      harness,
-    ) as (c: never) => Promise<AdmitResult>;
+    const call = (
+      harness as never as { admitChannelInbound: (c: never) => Promise<AdmitResult> }
+    ).admitChannelInbound.bind(harness) as (c: never) => Promise<AdmitResult>;
     await expect(call(makeIngressCtx())).rejects.toThrow();
     // Heal storage so recovery can commit.
     (storage as { updateChannelInboxItem: unknown }).updateChannelInboxItem = realUpdate;
@@ -4734,9 +5156,9 @@ describe('Harness.admitChannelInbound (§14.2 ingress admission core / C4)', () 
         },
       },
     });
-    const call = (harness as never as { admitChannelInbound: (c: never) => Promise<AdmitResult> }).admitChannelInbound.bind(
-      harness,
-    ) as (c: never) => Promise<AdmitResult>;
+    const call = (
+      harness as never as { admitChannelInbound: (c: never) => Promise<AdmitResult> }
+    ).admitChannelInbound.bind(harness) as (c: never) => Promise<AdmitResult>;
     await expect(call(makeIngressCtx())).rejects.toThrow(/resolver outage/);
 
     boom = false;
@@ -4789,9 +5211,9 @@ describe('Harness.admitChannelInbound (§14.2 ingress admission core / C4)', () 
         },
       },
     });
-    const call = (harness as never as { admitChannelInbound: (c: never) => Promise<AdmitResult> }).admitChannelInbound.bind(
-      harness,
-    ) as (c: never) => Promise<AdmitResult>;
+    const call = (
+      harness as never as { admitChannelInbound: (c: never) => Promise<AdmitResult> }
+    ).admitChannelInbound.bind(harness) as (c: never) => Promise<AdmitResult>;
     // First admission fails → durable 'failed' row (no admissionHash).
     await expect(call(makeIngressCtx())).rejects.toThrow();
     const failedEvents: Array<{ error?: { code: string; message: string } }> = [];
@@ -4817,7 +5239,11 @@ describe('Harness.admitChannelInbound (§14.2 ingress admission core / C4)', () 
   }
 
   it.each([
-    ['HarnessSessionLockedError', () => new HarnessSessionLockedError('chs:x', 'owner-y', WORKER_NOW + 1), 'session_locked'],
+    [
+      'HarnessSessionLockedError',
+      () => new HarnessSessionLockedError('chs:x', 'owner-y', WORKER_NOW + 1),
+      'session_locked',
+    ],
     ['HarnessLiveSessionLimitError', () => new HarnessLiveSessionLimitError(2, 2), 'live_session_limit'],
     ['HarnessQueueFullError', () => new HarnessQueueFullError('chs:x', 0, 0), 'queue_full'],
   ])('classifies %s as retryable failed with its bare code + backoff', async (_name, makeErr, code) => {
@@ -4831,7 +5257,11 @@ describe('Harness.admitChannelInbound (§14.2 ingress admission core / C4)', () 
 
   it.each([
     ['HarnessSessionClosedError', () => new HarnessSessionClosedError('chs:x'), 'session_closed'],
-    ['HarnessSessionDeletedError', () => new HarnessSessionDeletedError('chs:x', 'resource-1', 'thread-1'), 'session_deleted'],
+    [
+      'HarnessSessionDeletedError',
+      () => new HarnessSessionDeletedError('chs:x', 'resource-1', 'thread-1'),
+      'session_deleted',
+    ],
     [
       'HarnessOverrideConflictError',
       () => new HarnessOverrideConflictError('chs:x', 'run-1', ['mode']),
@@ -4923,9 +5353,13 @@ describe('Harness.admitChannelInbound (§14.2 ingress admission core / C4)', () 
 
   it('tick runs one recovery pass per configured channel', async () => {
     const harness = makeBoundHarness({ a: makeHarnessChannelConfig(), b: makeHarnessChannelConfig() });
-    probe(harness)._channelInboxRecoveryTimer && (harness as unknown as { _stopChannelInboxRecoveryLoop: () => void })._stopChannelInboxRecoveryLoop();
+    probe(harness)._channelInboxRecoveryTimer &&
+      (harness as unknown as { _stopChannelInboxRecoveryLoop: () => void })._stopChannelInboxRecoveryLoop();
     const spy = vi
-      .spyOn(harness as unknown as { recoverChannelInboxOnce: (o: unknown) => Promise<unknown> }, 'recoverChannelInboxOnce')
+      .spyOn(
+        harness as unknown as { recoverChannelInboxOnce: (o: unknown) => Promise<unknown> },
+        'recoverChannelInboxOnce',
+      )
       .mockResolvedValue({ claimed: 0, queued: 0, failed: 0, dead: 0 });
     await probe(harness)._tickChannelInboxRecovery();
     const channelArgs = spy.mock.calls.map(c => (c[0] as { channelId: string }).channelId).sort();
@@ -4936,7 +5370,10 @@ describe('Harness.admitChannelInbound (§14.2 ingress admission core / C4)', () 
   it('tick is reentrancy-guarded (a concurrent pass is a no-op)', async () => {
     const { harness } = setup(); // loop already stopped by setup
     (harness as unknown as { _channelInboxRecoveryRunning: boolean })._channelInboxRecoveryRunning = true;
-    const spy = vi.spyOn(harness as unknown as { recoverChannelInboxOnce: () => Promise<unknown> }, 'recoverChannelInboxOnce');
+    const spy = vi.spyOn(
+      harness as unknown as { recoverChannelInboxOnce: () => Promise<unknown> },
+      'recoverChannelInboxOnce',
+    );
     await probe(harness)._tickChannelInboxRecovery();
     expect(spy).not.toHaveBeenCalled();
   });
@@ -5010,9 +5447,11 @@ describe('Harness.admitChannelInbound (§14.2 ingress admission core / C4)', () 
     harness.subscribe(e => {
       if (e.type.startsWith('channel_ingress_')) events.push(e.type);
     });
-    const admit = (harness as never as {
-      admitChannelInbound: (c: never, o: { continueAdmission: boolean }) => Promise<AdmitResult>;
-    }).admitChannelInbound.bind(harness) as (c: never, o: { continueAdmission: boolean }) => Promise<AdmitResult>;
+    const admit = (
+      harness as never as {
+        admitChannelInbound: (c: never, o: { continueAdmission: boolean }) => Promise<AdmitResult>;
+      }
+    ).admitChannelInbound.bind(harness) as (c: never, o: { continueAdmission: boolean }) => Promise<AdmitResult>;
 
     const r = await admit(makeIngressCtx(), { continueAdmission: false });
     expect(r.status).toBe('received');
@@ -5028,9 +5467,11 @@ describe('Harness.admitChannelInbound (§14.2 ingress admission core / C4)', () 
 
   it('record-only is idempotent: a duplicate provider retry reports the same received row, still un-admitted', async () => {
     const { harness } = setup();
-    const admit = (harness as never as {
-      admitChannelInbound: (c: never, o: { continueAdmission: boolean }) => Promise<AdmitResult>;
-    }).admitChannelInbound.bind(harness) as (c: never, o: { continueAdmission: boolean }) => Promise<AdmitResult>;
+    const admit = (
+      harness as never as {
+        admitChannelInbound: (c: never, o: { continueAdmission: boolean }) => Promise<AdmitResult>;
+      }
+    ).admitChannelInbound.bind(harness) as (c: never, o: { continueAdmission: boolean }) => Promise<AdmitResult>;
 
     const first = await admit(makeIngressCtx(), { continueAdmission: false }); // records + releases claim
     const events: string[] = [];
@@ -5137,7 +5578,7 @@ describe('Harness.admitChannelInbound — signal delivery + attachments (§14.2 
       harness,
     ) as (c: never) => Promise<AdmitResult>;
 
-  it("queue delivery is the default — unchanged when the policy selects no delivery", async () => {
+  it('queue delivery is the default — unchanged when the policy selects no delivery', async () => {
     const { harness, rows } = setup();
     const r = await admit(harness)(makeIngressCtx());
     expect(r.status).toBe('queued');
@@ -5151,7 +5592,11 @@ describe('Harness.admitChannelInbound — signal delivery + attachments (§14.2 
   it("signal delivery admits as a SIGNAL: idle-wake → status accepted, runId/signalId persisted, event delivery: 'signal'", async () => {
     const { harness, rows, agent } = setup({
       ingress: {
-        resolveResource: async () => ({ resourceId: 'resource-1', mode: 'shared-resource', admission: { delivery: 'signal' } }),
+        resolveResource: async () => ({
+          resourceId: 'resource-1',
+          mode: 'shared-resource',
+          admission: { delivery: 'signal' },
+        }),
       },
     });
     const events: Array<{ type: string; delivery?: string; runId?: string; signalId?: string }> = [];
@@ -5187,7 +5632,11 @@ describe('Harness.admitChannelInbound — signal delivery + attachments (§14.2 
     // the pre-dispatch lost-signal window — see the next test for that.
     const { harness, storage, agent, rows } = setup({
       ingress: {
-        resolveResource: async () => ({ resourceId: 'resource-1', mode: 'shared-resource', admission: { delivery: 'signal' } }),
+        resolveResource: async () => ({
+          resourceId: 'resource-1',
+          mode: 'shared-resource',
+          admission: { delivery: 'signal' },
+        }),
       },
     });
     const wrappedUpdate = storage.updateChannelInboxItem.bind(storage);
@@ -5233,7 +5682,11 @@ describe('Harness.admitChannelInbound — signal delivery + attachments (§14.2 
     // signalId, delivering exactly one run.
     const { harness, agent, rows } = setup({
       ingress: {
-        resolveResource: async () => ({ resourceId: 'resource-1', mode: 'shared-resource', admission: { delivery: 'signal' } }),
+        resolveResource: async () => ({
+          resourceId: 'resource-1',
+          mode: 'shared-resource',
+          admission: { delivery: 'signal' },
+        }),
       },
     });
     // Crash the FIRST dispatch before any run is created: `signal()` calls
@@ -5288,7 +5741,11 @@ describe('Harness.admitChannelInbound — signal delivery + attachments (§14.2 
     });
     const { harness, rows, agent } = setup({
       ingress: {
-        resolveResource: async () => ({ resourceId: 'resource-1', mode: 'shared-resource', admission: { delivery: 'signal' } }),
+        resolveResource: async () => ({
+          resourceId: 'resource-1',
+          mode: 'shared-resource',
+          admission: { delivery: 'signal' },
+        }),
       },
     });
     // First inbound wakes a run that holds mid-flight, so the second inbound
@@ -5342,11 +5799,13 @@ describe('Harness.admitChannelInbound — signal delivery + attachments (§14.2 
     // the recovered turn carried ZERO attachments.
     const { harness, rows, agent } = setup();
     agent.enqueueRun({ text: 'ok' });
-    const { resolved } = await (harness as never as {
-      _resolveChannelBindingForIngress: (
-        c: never,
-      ) => Promise<{ resolved: { sessionId: string; resourceId: string; threadId: string } }>;
-    })._resolveChannelBindingForIngress(makeIngressCtx());
+    const { resolved } = await (
+      harness as never as {
+        _resolveChannelBindingForIngress: (
+          c: never,
+        ) => Promise<{ resolved: { sessionId: string; resourceId: string; threadId: string } }>;
+      }
+    )._resolveChannelBindingForIngress(makeIngressCtx());
     const sessionId = resolved.sessionId;
     const resourceId = resolved.resourceId;
     const session = await harness.session({
@@ -5360,9 +5819,11 @@ describe('Harness.admitChannelInbound — signal delivery + attachments (§14.2 
       data: new TextEncoder().encode('attachment-bytes'),
     });
 
-    const recordOnly = (harness as never as {
-      admitChannelInbound: (c: never, o: { continueAdmission: boolean }) => Promise<AdmitResult>;
-    }).admitChannelInbound.bind(harness) as (c: never, o: { continueAdmission: boolean }) => Promise<AdmitResult>;
+    const recordOnly = (
+      harness as never as {
+        admitChannelInbound: (c: never, o: { continueAdmission: boolean }) => Promise<AdmitResult>;
+      }
+    ).admitChannelInbound.bind(harness) as (c: never, o: { continueAdmission: boolean }) => Promise<AdmitResult>;
 
     // Record + ACK before admission, carrying the inbound provider file refs.
     const r = await recordOnly(
@@ -5412,11 +5873,13 @@ describe('Harness.admitChannelInbound — signal delivery + attachments (§14.2 
     // Resolve the binding WITHOUT admitting a turn (no competing queue drain),
     // materialize that exact channel session via its threadId, then upload an
     // attachment owned by it and reference it on the single inbound under test.
-    const { resolved } = await (harness as never as {
-      _resolveChannelBindingForIngress: (
-        c: never,
-      ) => Promise<{ resolved: { sessionId: string; resourceId: string; threadId: string } }>;
-    })._resolveChannelBindingForIngress(makeIngressCtx());
+    const { resolved } = await (
+      harness as never as {
+        _resolveChannelBindingForIngress: (
+          c: never,
+        ) => Promise<{ resolved: { sessionId: string; resourceId: string; threadId: string } }>;
+      }
+    )._resolveChannelBindingForIngress(makeIngressCtx());
     const sessionId = resolved.sessionId;
     const resourceId = resolved.resourceId;
     const session = await harness.session({
@@ -5458,11 +5921,13 @@ describe('Harness.admitChannelInbound — signal delivery + attachments (§14.2 
 
   it('the idempotency key distinguishes two inbound messages that differ only by their files', async () => {
     const { harness, rows } = setup();
-    const { resolved } = await (harness as never as {
-      _resolveChannelBindingForIngress: (
-        c: never,
-      ) => Promise<{ resolved: { sessionId: string; resourceId: string; threadId: string } }>;
-    })._resolveChannelBindingForIngress(makeIngressCtx());
+    const { resolved } = await (
+      harness as never as {
+        _resolveChannelBindingForIngress: (
+          c: never,
+        ) => Promise<{ resolved: { sessionId: string; resourceId: string; threadId: string } }>;
+      }
+    )._resolveChannelBindingForIngress(makeIngressCtx());
     const sessionId = resolved.sessionId;
     const resourceId = resolved.resourceId;
     const session = await harness.session({
@@ -5470,16 +5935,32 @@ describe('Harness.admitChannelInbound — signal delivery + attachments (§14.2 
       threadId: resolved.threadId,
       sessionId,
     } as never);
-    const a = await session.uploadAttachment({ name: 'a.txt', mimeType: 'text/plain', data: new TextEncoder().encode('A') });
-    const b = await session.uploadAttachment({ name: 'b.txt', mimeType: 'text/plain', data: new TextEncoder().encode('B') });
+    const a = await session.uploadAttachment({
+      name: 'a.txt',
+      mimeType: 'text/plain',
+      data: new TextEncoder().encode('A'),
+    });
+    const b = await session.uploadAttachment({
+      name: 'b.txt',
+      mimeType: 'text/plain',
+      data: new TextEncoder().encode('B'),
+    });
 
     // Same idempotency identity (same external ids/content) but different files →
     // a DIFFERENT payloadHash → a payload conflict, not a false duplicate.
     const withA = await admit(harness)(
-      makeIngressCtx({ externalMessageId: 'M-files', content: 'x', files: [{ attachmentId: a.attachmentId, resourceId, ownerSessionId: sessionId }] }),
+      makeIngressCtx({
+        externalMessageId: 'M-files',
+        content: 'x',
+        files: [{ attachmentId: a.attachmentId, resourceId, ownerSessionId: sessionId }],
+      }),
     );
     const withB = await admit(harness)(
-      makeIngressCtx({ externalMessageId: 'M-files', content: 'x', files: [{ attachmentId: b.attachmentId, resourceId, ownerSessionId: sessionId }] }),
+      makeIngressCtx({
+        externalMessageId: 'M-files',
+        content: 'x',
+        files: [{ attachmentId: b.attachmentId, resourceId, ownerSessionId: sessionId }],
+      }),
     );
     expect(withA.inboxItemId).toBe(withB.inboxItemId);
     expect((withB as { conflict?: boolean }).conflict).toBe(true);
@@ -5641,11 +6122,9 @@ describe('Harness.handleChannelInboundRequest (§13.2/§14.2 ingress bridge / C4
 
   it('200 and full admission when continueAdmission is true', async () => {
     const { harness } = setup();
-    const result = await harness.handleChannelInboundRequest(
-      'support',
-      inboundRequest({ content: 'hi' }),
-      { continueAdmission: true },
-    );
+    const result = await harness.handleChannelInboundRequest('support', inboundRequest({ content: 'hi' }), {
+      continueAdmission: true,
+    });
     expect(result).toMatchObject({ kind: 'ok', ackStatus: 200, status: 'queued', duplicate: false });
     expect((result as { sessionId?: string }).sessionId).toMatch(/^chs:/);
   });
@@ -5692,12 +6171,20 @@ describe('Harness.handleChannelInboundRequest (§13.2/§14.2 ingress bridge / C4
     // hash-covers-files contract is independent of that.)
     await harness.handleChannelInboundRequest(
       'support',
-      inboundRequest({ content: 'same', externalMessageId: 'M-files', files: [{ attachmentId: 'a1', resourceId: 'r1' }] }),
+      inboundRequest({
+        content: 'same',
+        externalMessageId: 'M-files',
+        files: [{ attachmentId: 'a1', resourceId: 'r1' }],
+      }),
       { continueAdmission: false },
     );
     const differentFiles = await harness.handleChannelInboundRequest(
       'support',
-      inboundRequest({ content: 'same', externalMessageId: 'M-files', files: [{ attachmentId: 'a2', resourceId: 'r1' }] }),
+      inboundRequest({
+        content: 'same',
+        externalMessageId: 'M-files',
+        files: [{ attachmentId: 'a2', resourceId: 'r1' }],
+      }),
       { continueAdmission: false },
     );
     // Same route + externalMessageId (same idempotency key) but a different attachment set must be a

--- a/packages/core/src/harness/v1/harness.test.ts
+++ b/packages/core/src/harness/v1/harness.test.ts
@@ -1380,6 +1380,59 @@ describe('Harness v1 — construction', () => {
     expect(agent.getChannels()).toBeNull();
   });
 
+  it('rejects a direct-bound default Harness when Mastra already has one', () => {
+    const existingHarness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+    const mastra = new Mastra({
+      agents: { default: makeAgent('default') },
+      storage: new InMemoryStore(),
+      harnesses: { default: existingHarness },
+    });
+
+    expect(
+      () =>
+        new Harness({
+          mastra,
+          modes: [{ id: 'other', agentId: 'default' }],
+          defaultModeId: 'other',
+        }),
+    ).toThrow(/already registered/);
+    expect(mastra.getHarness()).toBe(existingHarness);
+  });
+
+  it('adds the wakeup worker when a direct-bound Harness registers after Mastra construction', () => {
+    const mastra = new Mastra({
+      agents: { default: makeAgent('default') },
+      storage: new InMemoryStore(),
+    });
+    expect(mastra.workers.some(worker => worker.name === 'harnessWakeups')).toBe(false);
+
+    new Harness({
+      mastra,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+
+    expect(mastra.workers.some(worker => worker.name === 'harnessWakeups')).toBe(true);
+  });
+
+  it('rejects AgentChannels registration after an agent is removed', () => {
+    const agent = makeAgent('default');
+    const mastra = new Mastra({
+      agents: { default: agent },
+      storage: new InMemoryStore(),
+    });
+
+    expect(mastra.removeAgent('default')).toBe(true);
+    expect(() => agent.setChannels(new AgentChannels({ adapters: { slack: {} as any } }))).toThrow(/removed/);
+    expect(
+      mastra.getServer()?.apiRoutes?.some(route => route.path === '/api/agents/default/channels/slack/webhook') ??
+        false,
+    ).toBe(false);
+  });
+
   it('replaces stale webhook routes when AgentChannels are rebuilt', () => {
     const agent = new Agent({
       id: 'default',

--- a/packages/core/src/harness/v1/harness.test.ts
+++ b/packages/core/src/harness/v1/harness.test.ts
@@ -485,6 +485,51 @@ describe('Harness v1 — construction', () => {
     expect(mastra.getHarness()).toBe(harness);
   });
 
+  it('rejects direct-bound harnesses that would replace an existing default harness', () => {
+    const configuredHarness = new Harness({
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+    });
+    const mastra = new Mastra({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+      harness: configuredHarness,
+    });
+
+    expect(
+      () =>
+        new Harness({
+          mastra,
+          modes: [{ id: 'default', agentId: 'default' }],
+          defaultModeId: 'default',
+        }),
+    ).toThrow(/already registered/);
+    expect(mastra.getHarness()).toBe(configuredHarness);
+  });
+
+  it('starts wakeup and outbox workers for direct-bound channel harnesses', () => {
+    const mastra = new Mastra({
+      agents: { default: makeAgent() },
+      storage: new InMemoryStore(),
+      channels: { slack: makeChannelProvider('slack') },
+    });
+
+    expect(mastra.workers.some(worker => worker.name === 'harnessWakeups')).toBe(false);
+    expect(mastra.workers.some(worker => worker.name === 'harnessChannelOutbox')).toBe(false);
+
+    new Harness({
+      mastra,
+      modes: [{ id: 'default', agentId: 'default' }],
+      defaultModeId: 'default',
+      channels: {
+        support: makeHarnessChannelConfig(),
+      },
+    });
+
+    expect(mastra.workers.some(worker => worker.name === 'harnessWakeups')).toBe(true);
+    expect(mastra.workers.some(worker => worker.name === 'harnessChannelOutbox')).toBe(true);
+  });
+
   it('shuts down registered harnesses during Mastra shutdown', async () => {
     const alpha = new Harness({
       modes: [{ id: 'default', agentId: 'default' }],

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -1316,7 +1316,9 @@ export class Harness {
     //   3. Neither — defer; a parent Mastra will install itself via
     //      __registerMastra during its own construction.
     if (config.mastra) {
+      config.mastra._assertHarnessAgentChannelToolCollisionsForHarness(this, this._harnessName);
       this._bindMastra(config.mastra);
+      config.mastra._registerDirectHarness(this._harnessName, this);
     } else if (config.agents !== undefined || config.storage !== undefined) {
       if (this._channelRegistry.hasPending()) {
         throw new HarnessConfigError(
@@ -1460,6 +1462,23 @@ export class Harness {
       this._guardPreboundDefaultNamespace = previousGuardPreboundDefaultNamespace;
       throw err;
     }
+  }
+
+  /** @internal — validate prospective channel bindings without mutating this Harness. */
+  _previewChannelBindings(mastra: Mastra, harnessName = this._harnessName): HarnessChannelBinding[] {
+    return this._channelRegistry.preview(mastra, harnessName);
+  }
+
+  /** @internal — agent ids this harness can execute through modes or subagent definitions. */
+  _listRunnableAgentIds(): string[] {
+    const agentIds = new Set<string>();
+    for (const mode of this._modesById.values()) {
+      agentIds.add(mode.agentId);
+    }
+    for (const def of this._subagentTypes.values()) {
+      agentIds.add(def.agentId);
+    }
+    return Array.from(agentIds);
   }
 
   /**
@@ -6070,6 +6089,7 @@ export class Harness {
     const mastra = this._mastra;
     if (mastra) {
       boundHarnessesByMastra.get(mastra)?.delete(this);
+      mastra._unregisterDirectHarness(this);
       this._untrackMemoryStorage(mastra.getStorage()?.stores?.memory);
     }
   }

--- a/packages/core/src/harness/v1/harness.ts
+++ b/packages/core/src/harness/v1/harness.ts
@@ -1316,6 +1316,7 @@ export class Harness {
     //   3. Neither — defer; a parent Mastra will install itself via
     //      __registerMastra during its own construction.
     if (config.mastra) {
+      config.mastra._assertDirectHarnessRegistrationAvailable(this._harnessName, this);
       config.mastra._assertHarnessAgentChannelToolCollisionsForHarness(this, this._harnessName);
       this._bindMastra(config.mastra);
       config.mastra._registerDirectHarness(this._harnessName, this);

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1370,7 +1370,7 @@ export class Mastra<
       for (const [key, harness] of Object.entries(configuredHarnesses)) {
         if (harness == null) continue;
         channelBindingScopes.push({
-          agentIds: new Set(harness._listRunnableAgentIds()),
+          agentIds: this.#expandHarnessRunnableAgentIds(harness._listRunnableAgentIds()),
           bindings: harness._previewChannelBindings(this, key),
         });
       }
@@ -1429,6 +1429,8 @@ export class Mastra<
   }
 
   #deleteAgentChannelInitialization(agentKey: string): void {
+    const previous = this.#agentChannelInstances.get(agentKey);
+    previous?.close();
     this.#agentChannelInstances.delete(agentKey);
     this.#agentChannelCollisionCandidates.delete(agentKey);
     this.#removeAgentChannelRoutes(agentKey);
@@ -1566,11 +1568,24 @@ export class Mastra<
     for (const harness of Object.values(harnesses)) {
       if (harness == null) continue;
       scopes.push({
-        agentIds: new Set(harness._listRunnableAgentIds()),
+        agentIds: this.#expandHarnessRunnableAgentIds(harness._listRunnableAgentIds()),
         bindings: harness.listChannelBindings(),
       });
     }
     return scopes;
+  }
+
+  #expandHarnessRunnableAgentIds(agentIds: Iterable<string>): Set<string> {
+    const expanded = new Set(agentIds);
+    for (const [key, agent] of Object.entries(this.#agents)) {
+      if (expanded.has(key) && agent?.id) {
+        expanded.add(agent.id);
+      }
+      if (agent?.id && expanded.has(agent.id)) {
+        expanded.add(key);
+      }
+    }
+    return expanded;
   }
 
   #resolveAgentKey(agentOrKey: { id: string } | string): string {
@@ -1637,7 +1652,7 @@ export class Mastra<
   _assertHarnessAgentChannelToolCollisionsForHarness(harness: HarnessV1, harnessName: string): void {
     this.#assertNoHarnessAgentChannelToolCollisions([
       {
-        agentIds: new Set(harness._listRunnableAgentIds()),
+        agentIds: this.#expandHarnessRunnableAgentIds(harness._listRunnableAgentIds()),
         bindings: harness._previewChannelBindings(this, harnessName),
       },
     ]);
@@ -1688,12 +1703,14 @@ export class Mastra<
     agentChannelsInstance.__setLogger(this.#logger);
     agentChannelsInstance.__setMastraOwner(this, agentKey);
 
-    if (this.#agentChannelInstances.get(agentKey) === agentChannelsInstance) {
-      return;
-    }
+    const previous = this.#agentChannelInstances.get(agentKey);
+    const alreadyRegistered = previous === agentChannelsInstance;
 
     this.#removeAgentChannelRoutes(agentKey);
     this.#agentChannelCollisionCandidates.delete(agentKey);
+    if (previous && !alreadyRegistered) {
+      previous.close();
+    }
     const channelRoutes = agentChannelsInstance.getWebhookRoutes();
     if (channelRoutes.length > 0) {
       this.#agentChannelRoutes.set(agentKey, new Set(channelRoutes));
@@ -1705,7 +1722,7 @@ export class Mastra<
       this.#agentChannelRoutes.delete(agentKey);
     }
     this.#agentChannelInstances.set(agentKey, agentChannelsInstance);
-    if (this.#lifecycleState === 'ready') {
+    if (!alreadyRegistered && this.#lifecycleState === 'ready') {
       this.#startAgentChannelInitialization(agentKey, agentChannelsInstance);
     }
   }

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1705,10 +1705,11 @@ export class Mastra<
 
     const previous = this.#agentChannelInstances.get(agentKey);
     const alreadyRegistered = previous === agentChannelsInstance;
+    const shouldRestartAgentChannels = alreadyRegistered && this.#lifecycleState === 'ready';
 
     this.#removeAgentChannelRoutes(agentKey);
     this.#agentChannelCollisionCandidates.delete(agentKey);
-    if (previous && !alreadyRegistered) {
+    if (previous && (!alreadyRegistered || shouldRestartAgentChannels)) {
       previous.close();
     }
     const channelRoutes = agentChannelsInstance.getWebhookRoutes();
@@ -1722,7 +1723,7 @@ export class Mastra<
       this.#agentChannelRoutes.delete(agentKey);
     }
     this.#agentChannelInstances.set(agentKey, agentChannelsInstance);
-    if (!alreadyRegistered && this.#lifecycleState === 'ready') {
+    if ((!alreadyRegistered || shouldRestartAgentChannels) && this.#lifecycleState === 'ready') {
       this.#startAgentChannelInitialization(agentKey, agentChannelsInstance);
     }
   }

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1644,8 +1644,20 @@ export class Mastra<
   }
 
   /** @internal */
+  _assertDirectHarnessRegistrationAvailable(harnessName: string, harness: HarnessV1): void {
+    const registeredHarness = this.#harnesses[harnessName];
+    if (registeredHarness !== undefined && registeredHarness !== harness) {
+      throw new Error(
+        `Harness "${harnessName}" is already registered on this Mastra instance; direct-bound harnesses must use a unique harness name.`,
+      );
+    }
+  }
+
+  /** @internal */
   _registerDirectHarness(harnessName: string, harness: HarnessV1): void {
+    this._assertDirectHarnessRegistrationAvailable(harnessName, harness);
     this.#harnesses[harnessName] = harness;
+    this.#ensureHarnessWakeupWorker();
     this.#ensureHarnessChannelOutboxWorker();
   }
 
@@ -1661,6 +1673,9 @@ export class Mastra<
   /** @internal */
   _registerAgentChannelsForAgent(agentOrKey: { id: string } | string, agentChannelsInstance: AgentChannels): void {
     const agentKey = this.#resolveAgentKey(agentOrKey);
+    if (typeof agentOrKey !== 'string' && this.#agents[agentKey] === undefined) {
+      throw new Error(`Cannot register AgentChannels for removed or unregistered agent "${agentKey}"`);
+    }
     this.#assertNoHarnessAgentChannelToolCollisionForAgent(agentKey, agentChannelsInstance);
     if (
       typeof agentOrKey !== 'string' &&

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -18,7 +18,7 @@ import type { MastraScorer } from '../evals';
 import { EventEmitterPubSub } from '../events/event-emitter';
 import type { PubSub } from '../events/pubsub';
 import type { Event, EventCallback } from '../events/types';
-import type { Harness as HarnessV1 } from '../harness/v1';
+import type { Harness as HarnessV1, HarnessChannelBinding } from '../harness/v1';
 import { AvailableHooks, registerHook } from '../hooks';
 import type { MastraModelGateway } from '../llm/model/gateways';
 import { defaultGateways } from '../llm/model/router';
@@ -69,6 +69,11 @@ import { createOnScorerHook } from './hooks';
 import type { VersionOverrides, VersionSelector } from './types';
 
 const PENDING_WORKER_START_SHUTDOWN_TIMEOUT_MS = 30_000;
+
+type HarnessChannelBindingScope = {
+  agentIds: Set<string>;
+  bindings: HarnessChannelBinding[];
+};
 
 type PendingWorkerStart = {
   worker: MastraWorker;
@@ -646,8 +651,11 @@ export class Mastra<
   #channelInitializationPromise?: Promise<void>;
   #channelInitializationError?: unknown;
   #agentChannelInstances = new Map<string, AgentChannels>();
+  #agentChannelCollisionCandidates = new Map<string, AgentChannels>();
+  #agentChannelRoutes = new Map<string, Set<ApiRoute>>();
   #agentChannelInitializationPromises = new Map<string, Promise<void>>();
   #agentChannelInitializationErrors = new Map<string, unknown>();
+  #agentRegistryKeys = new WeakMap<object, string>();
   #environment?: string;
   #harnesses: Record<string, HarnessV1> = {};
   #toolPayloadTransform?: ToolPayloadTransformPolicy;
@@ -1358,6 +1366,16 @@ export class Mastra<
     // mode->agent validation succeeds. Each harness is single-bound; calling
     // __registerMastra a second time with a different parent throws.
     if (Object.keys(configuredHarnesses).length > 0) {
+      const channelBindingScopes: HarnessChannelBindingScope[] = [];
+      for (const [key, harness] of Object.entries(configuredHarnesses)) {
+        if (harness == null) continue;
+        channelBindingScopes.push({
+          agentIds: new Set(harness._listRunnableAgentIds()),
+          bindings: harness._previewChannelBindings(this, key),
+        });
+      }
+      this.#assertNoHarnessAgentChannelToolCollisions(channelBindingScopes);
+
       for (const [key, harness] of Object.entries(configuredHarnesses)) {
         if (harness == null) continue;
         harness.__registerMastra(this, key);
@@ -1412,6 +1430,8 @@ export class Mastra<
 
   #deleteAgentChannelInitialization(agentKey: string): void {
     this.#agentChannelInstances.delete(agentKey);
+    this.#agentChannelCollisionCandidates.delete(agentKey);
+    this.#removeAgentChannelRoutes(agentKey);
     this.#agentChannelInitializationPromises.delete(agentKey);
     this.#agentChannelInitializationErrors.delete(agentKey);
   }
@@ -1537,6 +1557,162 @@ export class Mastra<
       if (!hasGlobalHarnessStorage && harness._internalGetSessionStorage() === undefined) return false;
       return harness.listChannelBindings().some(binding => !channelFilter || channelFilter.has(binding.channelId));
     });
+  }
+
+  #listHarnessChannelBindingScopes(
+    harnesses: Record<string, HarnessV1 | undefined> = this.#harnesses,
+  ): HarnessChannelBindingScope[] {
+    const scopes: HarnessChannelBindingScope[] = [];
+    for (const harness of Object.values(harnesses)) {
+      if (harness == null) continue;
+      scopes.push({
+        agentIds: new Set(harness._listRunnableAgentIds()),
+        bindings: harness.listChannelBindings(),
+      });
+    }
+    return scopes;
+  }
+
+  #resolveAgentKey(agentOrKey: { id: string } | string): string {
+    if (typeof agentOrKey === 'string') return agentOrKey;
+    const registeredKey = this.#agentRegistryKeys.get(agentOrKey);
+    if (registeredKey) return registeredKey;
+    for (const [key, agent] of Object.entries(this.#agents)) {
+      if (agent === agentOrKey) return key;
+    }
+    return agentOrKey.id;
+  }
+
+  #assertNoHarnessAgentChannelToolCollisions(harnessBindingScopes = this.#listHarnessChannelBindingScopes()): void {
+    if (harnessBindingScopes.length === 0) return;
+
+    const candidates = new Map(this.#agentChannelCollisionCandidates);
+    for (const [agentKey, agentChannels] of this.#agentChannelInstances) {
+      candidates.set(agentKey, agentChannels);
+    }
+
+    for (const [agentKey, agentChannels] of candidates) {
+      this.#assertNoHarnessAgentChannelToolCollisionForAgent(agentKey, agentChannels, harnessBindingScopes);
+    }
+  }
+
+  #assertNoHarnessAgentChannelToolCollisionForAgent(
+    agentKey: string,
+    agentChannels: AgentChannels,
+    harnessBindingScopes = this.#listHarnessChannelBindingScopes(),
+    platform?: string,
+  ): void {
+    const channelToolNames = agentChannels.__getChannelToolNames();
+    if (channelToolNames.length === 0) return;
+
+    for (const scope of harnessBindingScopes) {
+      if (!scope.agentIds.has(agentKey)) continue;
+      for (const binding of scope.bindings) {
+        if (platform !== undefined && binding.platform !== platform) continue;
+        if (platform === undefined && !agentChannels.hasAdapter(binding.platform)) continue;
+        throw new Error(
+          `Harness channel "${binding.harnessName}/${binding.channelId}" is bound to provider "${binding.providerId}" ` +
+            `platform "${binding.platform}", but agent "${agentKey}" has AgentChannels tools enabled for that platform. ` +
+            `Set channels.tools to false for the harness-bound AgentChannels target or mount it as a separate live-only provider/installation.`,
+        );
+      }
+    }
+  }
+
+  /** @internal */
+  _assertHarnessAgentChannelsAdapterAllowed(
+    agentOrKey: { id: string } | string,
+    agentChannels: AgentChannels,
+    platform?: string,
+  ): void {
+    this.#assertNoHarnessAgentChannelToolCollisionForAgent(
+      this.#resolveAgentKey(agentOrKey),
+      agentChannels,
+      undefined,
+      platform,
+    );
+  }
+
+  /** @internal */
+  _assertHarnessAgentChannelToolCollisionsForHarness(harness: HarnessV1, harnessName: string): void {
+    this.#assertNoHarnessAgentChannelToolCollisions([
+      {
+        agentIds: new Set(harness._listRunnableAgentIds()),
+        bindings: harness._previewChannelBindings(this, harnessName),
+      },
+    ]);
+  }
+
+  /** @internal */
+  _registerDirectHarness(harnessName: string, harness: HarnessV1): void {
+    this.#harnesses[harnessName] = harness;
+    this.#ensureHarnessChannelOutboxWorker();
+  }
+
+  /** @internal */
+  _unregisterDirectHarness(harness: HarnessV1): void {
+    for (const [key, registeredHarness] of Object.entries(this.#harnesses)) {
+      if (registeredHarness === harness) {
+        delete this.#harnesses[key];
+      }
+    }
+  }
+
+  /** @internal */
+  _registerAgentChannelsForAgent(agentOrKey: { id: string } | string, agentChannelsInstance: AgentChannels): void {
+    const agentKey = this.#resolveAgentKey(agentOrKey);
+    this.#assertNoHarnessAgentChannelToolCollisionForAgent(agentKey, agentChannelsInstance);
+    if (
+      typeof agentOrKey !== 'string' &&
+      this.#agents[agentKey] !== undefined &&
+      this.#agents[agentKey] !== agentOrKey
+    ) {
+      this.#trackAgentChannelsForCollisionOnly(agentKey, agentChannelsInstance);
+      return;
+    }
+    agentChannelsInstance.__setLogger(this.#logger);
+    agentChannelsInstance.__setMastraOwner(this, agentKey);
+
+    if (this.#agentChannelInstances.get(agentKey) === agentChannelsInstance) {
+      return;
+    }
+
+    this.#removeAgentChannelRoutes(agentKey);
+    this.#agentChannelCollisionCandidates.delete(agentKey);
+    const channelRoutes = agentChannelsInstance.getWebhookRoutes();
+    if (channelRoutes.length > 0) {
+      this.#agentChannelRoutes.set(agentKey, new Set(channelRoutes));
+      this.#server = {
+        ...this.#server,
+        apiRoutes: [...(this.#server?.apiRoutes ?? []), ...channelRoutes],
+      };
+    } else {
+      this.#agentChannelRoutes.delete(agentKey);
+    }
+    this.#agentChannelInstances.set(agentKey, agentChannelsInstance);
+    if (this.#lifecycleState === 'ready') {
+      this.#startAgentChannelInitialization(agentKey, agentChannelsInstance);
+    }
+  }
+
+  #trackAgentChannelsForCollisionOnly(agentKey: string, agentChannelsInstance: AgentChannels): void {
+    this.#assertNoHarnessAgentChannelToolCollisionForAgent(agentKey, agentChannelsInstance);
+    agentChannelsInstance.__setLogger(this.#logger);
+    agentChannelsInstance.__setMastraOwner(this, agentKey);
+    this.#agentChannelCollisionCandidates.set(agentKey, agentChannelsInstance);
+  }
+
+  #removeAgentChannelRoutes(agentKey: string): void {
+    const routes = this.#agentChannelRoutes.get(agentKey);
+    if (!routes || routes.size === 0 || !this.#server?.apiRoutes) {
+      this.#agentChannelRoutes.delete(agentKey);
+      return;
+    }
+    this.#server = {
+      ...this.#server,
+      apiRoutes: this.#server.apiRoutes.filter(route => !routes.has(route)),
+    };
+    this.#agentChannelRoutes.delete(agentKey);
   }
 
   #harnessChannelOutboxFilter(
@@ -2055,6 +2231,12 @@ export class Mastra<
         logger.debug(`Agent with key ${agentKey} already exists. Skipping addition.`);
         return;
       }
+      const underlyingAgentChannels = underlyingAgent.getChannels();
+      if (underlyingAgentChannels) {
+        this.#assertNoHarnessAgentChannelToolCollisionForAgent(String(agentKey), underlyingAgentChannels);
+      }
+      this.#agentRegistryKeys.set(durableAgent, String(agentKey));
+      this.#agentRegistryKeys.set(underlyingAgent, String(agentKey));
 
       // Set the Mastra instance on the durable agent for observability
       durableAgent.__setMastra?.(this);
@@ -2069,6 +2251,9 @@ export class Mastra<
         tts: this.#tts,
         vectors: this.#vectors,
       });
+      if (underlyingAgentChannels) {
+        this.#trackAgentChannelsForCollisionOnly(String(agentKey), underlyingAgentChannels);
+      }
 
       // Store the durable wrapper in #agents (not the underlying agent)
       // This ensures getAgentById returns the wrapper so .stream() uses durable execution.
@@ -2096,6 +2281,11 @@ export class Mastra<
     const agents = this.#agents as Record<string, Agent<any>>;
     if (agents[agentKey]) {
       return;
+    }
+    this.#agentRegistryKeys.set(mastraAgent, String(agentKey));
+    const prospectiveAgentChannels = mastraAgent.getChannels();
+    if (prospectiveAgentChannels) {
+      this.#assertNoHarnessAgentChannelToolCollisionForAgent(String(agentKey), prospectiveAgentChannels);
     }
 
     // Initialize the agent
@@ -2165,18 +2355,7 @@ export class Mastra<
     // Set up AgentChannels for manual adapter configurations
     const agentChannelsInstance = mastraAgent.getChannels();
     if (agentChannelsInstance) {
-      agentChannelsInstance.__setLogger(this.#logger);
-      const channelRoutes = agentChannelsInstance.getWebhookRoutes();
-      if (channelRoutes.length > 0) {
-        this.#server = {
-          ...this.#server,
-          apiRoutes: [...(this.#server?.apiRoutes ?? []), ...channelRoutes],
-        };
-      }
-      this.#agentChannelInstances.set(String(agentKey), agentChannelsInstance);
-      if (this.#lifecycleState === 'ready') {
-        this.#startAgentChannelInitialization(String(agentKey), agentChannelsInstance);
-      }
+      this._registerAgentChannelsForAgent(String(agentKey), agentChannelsInstance);
     }
   }
 

--- a/packages/core/src/mastra/remove-agent.test.ts
+++ b/packages/core/src/mastra/remove-agent.test.ts
@@ -1,6 +1,30 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { Agent } from '../agent';
+import { AgentChannels } from '../channels';
+import { InMemoryStore } from '../storage/mock';
 import { Mastra } from './index';
+
+function createMockAdapter(name: string) {
+  return {
+    name,
+    postMessage: vi.fn().mockResolvedValue({ id: 'sent-1', text: 'ok' }),
+    editMessage: vi.fn().mockResolvedValue(undefined),
+    deleteMessage: vi.fn().mockResolvedValue(undefined),
+    addReaction: vi.fn().mockResolvedValue(undefined),
+    removeReaction: vi.fn().mockResolvedValue(undefined),
+    handleWebhook: vi.fn().mockResolvedValue(new Response('ok', { status: 200 })),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    fetchMessages: vi.fn().mockResolvedValue([]),
+    encodeThreadId: vi.fn((...parts: string[]) => parts.join(':')),
+    decodeThreadId: vi.fn((id: string) => id.split(':')),
+    channelIdFromThreadId: vi.fn((id: string) => id.split(':').slice(0, 2).join(':')),
+    renderFormatted: vi.fn((text: string) => text),
+    fetchThread: vi.fn().mockResolvedValue(null),
+    startTyping: vi.fn().mockResolvedValue(undefined),
+    parseMessage: vi.fn((raw: unknown) => raw),
+    userName: 'TestBot',
+  } as any;
+}
 
 describe('Mastra.removeAgent', () => {
   it('should remove an agent by key', () => {
@@ -177,5 +201,32 @@ describe('Mastra.removeAgent', () => {
 
     // Verify cache entry is also cleared
     expect(cache.has('cached-agent-id-2')).toBe(false);
+  });
+
+  it('rejects channel registration from a removed agent object', () => {
+    const agent = new Agent({
+      id: 'removed-channel-agent',
+      name: 'Removed Channel Agent',
+      instructions: 'You are a test agent',
+      model: 'openai/gpt-4o',
+      channels: { adapters: { slack: createMockAdapter('slack') }, tools: false },
+    });
+    const mastra = new Mastra({
+      logger: false,
+      agents: {
+        removed: agent,
+      },
+      storage: new InMemoryStore(),
+    });
+    const routePath = '/api/agents/removed-channel-agent/channels/slack/webhook';
+
+    expect(mastra.getServer()?.apiRoutes?.filter(route => route.path === routePath)).toHaveLength(1);
+    expect(mastra.removeAgent('removed')).toBe(true);
+    expect(mastra.getServer()?.apiRoutes?.filter(route => route.path === routePath)).toHaveLength(0);
+
+    expect(() =>
+      agent.setChannels(new AgentChannels({ adapters: { slack: createMockAdapter('slack') }, tools: false })),
+    ).toThrow(/removed or unregistered agent/);
+    expect(mastra.getServer()?.apiRoutes?.filter(route => route.path === routePath)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

- Adds admission-time validation for Harness-bound AgentChannels channel-tool collisions.
- Keeps the guard scoped to agents a specific harness can run and that harness's own channel bindings.
- Covers constructor registration, direct `Harness({ mastra })` binding, provider-added/rebuilt adapters, and durable-agent underlying channels.
- Preserves live-only AgentChannels and replaces stale webhook route objects safely on channel rebuilds.

## Validation

- `pnpm --filter @mastra/core exec eslint src/channels/agent-channels.ts src/agent/agent.ts src/harness/v1/channel-registry.ts src/harness/v1/harness.ts src/mastra/index.ts src/harness/v1/harness.test.ts`
- `pnpm --filter ./packages/core check`
- `pnpm --filter @mastra/core exec vitest run src/harness/v1/harness.test.ts -t 'AgentChannels|durable-agent|another harness|provider-added|webhook routes|direct-bound'` — 14 passed, 201 skipped
- `pnpm --filter @mastra/core exec vitest run src/agent/agent.channel-tool-fence.test.ts` — 9 passed
- `git diff --check`
- `similarity-ts packages/core/src/channels packages/core/src/agent packages/core/src/mastra packages/core/src/harness/v1 --threshold 0.95 --min-lines 20 --no-types --exclude dist --exclude node_modules --exclude .turbo` — existing duplicate pairs only, outside modified files
- CodeRabbit CLI final pass: 0 findings

## Notes

- Parent PapersFlow PR: https://github.com/papersflow-ai/papersflow/pull/1577
- Linear: PF-794
- Final Codex review rerun was blocked by Codex usage limit until 2026-06-23 01:21, so it is recorded as unavailable rather than claimed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes channel registration, webhook routing, and harness worker wiring at init and runtime; mis-scoped checks could block valid setups or leave stale routes, though behavior is heavily test-covered.
> 
> **Overview**
> Adds **admission-time guards** so agents a harness can run cannot expose generic **AgentChannels** tools on platforms that harness already binds through a **ChannelProvider**. Collisions throw at Mastra init, `Harness({ mastra })` binding, `Agent.setChannels`, dynamic `__registerAdapter`, and durable-agent underlying channels; **`channels.tools: false`** or live-only platforms stay allowed.
> 
> **Mastra** now owns AgentChannels lifecycle: centralized `_registerAgentChannelsForAgent` replaces stale webhook routes, closes replaced instances, blocks registration after `removeAgent`, and registers **direct-bound** harnesses (duplicate name checks, wakeup/outbox workers). **Harness** previews bindings via non-mutating `channel-registry.preview()` and lists runnable agent ids for scoped checks.
> 
> **AgentChannels** tracks a Mastra owner and exposes `__getChannelToolNames()` for collision detection without reaching into private state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 619ca231b6455adccdd0ff1a1ca44b597ee1cdc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a “permission check” when agents are being wired up, so a harness will only advertise the channel tools it can actually deliver. That prevents two different setups from accidentally trying to use the same channel routes and sending messages to the wrong place.

---

## Summary of Changes

### `packages/core/src/agent/agent.ts`
- `Agent.setChannels()` now routes through Mastra for centralized, harness-scoped admission-time validation/registration.
- Ensures the `AgentChannels` instance is linked to the agent (`agentChannels.__setAgent(this)`) **before** Mastra registration.
- Registers channels via Mastra (`_registerAgentChannelsForAgent(...)`) and only assigns `#agentChannels` **after** registration.
- Keeps `live-only` `AgentChannels` and `AgentChannels` configured with `tools: false` allowed (i.e., not fenced by collision checks).

### `packages/core/src/channels/agent-channels.ts`
- `AgentChannels` becomes harness-aware to enforce ownership and prevent harness ↔ adapter channel-tool collisions:
  - Adds `__setMastraOwner(mastra, agentKey)` which calls `mastra._assertHarnessAgentChannelsAdapterAllowed(...)`.
  - Adds `__getChannelToolNames()` to support collision detection.
  - During `__registerAdapter`, conditionally re-validates harness ownership (when Mastra owner is set) before mutating adapter state.
- Minor internal cleanup/formatting/typing adjustments.

### `packages/core/src/harness/v1/channel-registry.ts`
- Makes binding resolution non-mutating:
  - `bind()` now assigns `this.bindings` from `resolveBindings(...)`’s return value.
  - `preview()` computes from `resolveBindings(...)` (no dependency on existing stored state).
  - `resolveBindings(...)` now returns a computed `Map` (including the empty/no-pending case) instead of mutating `this.bindings`.

### `packages/core/src/harness/v1/harness.ts`
- When constructing a harness with `config.mastra`:
  - Performs harness-level collision validation.
  - Binds to Mastra and registers itself as a “direct harness” (including unique name tracking and related worker/wakeup/outbox behavior).
- Adds admission-time helpers:
  - `_previewChannelBindings(mastra, harnessName?)`
  - `_listRunnableAgentIds()`
- During unbinding, mirrors direct-harness cleanup by unregistering from Mastra.

### `packages/core/src/mastra/index.ts`
- Centralizes admission-time fencing and webhook route management for `AgentChannels` to prevent channel-tool collisions:
  - Computes harness binding scopes during construction and asserts no harness ↔ agent `AgentChannels` tool collisions before registering harnesses.
  - Adds collision/routing state to track:
    - collision-only candidates
    - per-agent owned webhook routes
    - stable “agent key” resolution and identity mapping
  - Introduces `_registerAgentChannelsForAgent(...)` to:
    - resolve/validate agent identity
    - assert collisions against the harness’ channel bindings and the agent’s enabled `AgentChannels` platform adapters
    - safely replace/unregister stale webhook route objects during adapter/channel rebuilds
    - handle durable-wrapper vs underlying-agent cases, including deferring full initialization when appropriate while still enforcing collision constraints
    - clean up routes and collision tracking when an `AgentChannels` initialization is deleted/removed
  - Refactors `addAgent()` behavior for durable-agent underlying-channel assertions and registry-key mapping updates.

### Tests
- `packages/core/src/harness/v1/harness.test.ts`
  - Adds extensive `AgentChannels` configuration tests covering:
    - rejection when provider platforms are harness-bound (direct-bound harnesses and durable/wrapped variants)
    - acceptance when harness bindings are not involved (live-only, non-harness-used platforms, and `tools: false` behavior)
    - dynamic scenarios (agents added after Mastra construction)
    - lifecycle correctness for set/rebuild/replace, including stale webhook route replacement and reconciliation
    - rejection after agent removal
- `packages/core/src/mastra/remove-agent.test.ts`
  - Verifies that removing an agent deletes its previously registered channel webhook route from `server.apiRoutes`.
  - Confirms re-registering channels via the removed agent object throws (and does not restore routes).

---

## Verification
- ESLint passed for modified files
- `pnpm check` (type checking) passed
- Harness test suite: 14 passed, 201 skipped
- New agent channel-tool-fence test suite: 9 passed
- Git diff check completed
- Duplicate similarity analysis: no new duplicates in modified files
- CodeRabbit CLI: 0 findings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->