### PR TITLE
[PF-865] Add selective server route registration

### DIFF
--- a/.changeset/yummy-seas-move.md
+++ b/.changeset/yummy-seas-move.md
@@ -1,0 +1,19 @@
+---
+'@mastra/server': minor
+---
+
+Added a server route selector for registering only selected built-in routes.
+
+Adapters now accept a `routes` option. Leave it out to register all built-in routes, pass a route list to register only those routes, or pass a function to choose routes from `SERVER_ROUTES` in the default order.
+
+```ts
+import { SERVER_ROUTES } from '@mastra/server/server-adapter';
+
+const harnessRoutes = SERVER_ROUTES.filter(route => route.path.startsWith('/harness/'));
+
+new MastraServer({
+  app,
+  mastra,
+  routes: harnessRoutes,
+});
+```

--- a/packages/server/src/server/handlers/system.test.ts
+++ b/packages/server/src/server/handlers/system.test.ts
@@ -3,7 +3,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ObservabilityStorage } from '@mastra/core/storage';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { GET_SYSTEM_PACKAGES_ROUTE } from './system';
+import type { ServerRoute } from '../server-adapter';
+import { SERVER_ROUTES } from '../server-adapter';
+import { GET_API_SCHEMA_ROUTE, GET_SYSTEM_PACKAGES_ROUTE } from './system';
 
 type MockStorage = {
   name?: string;
@@ -47,6 +49,12 @@ const createMockMastra = (hasEditor: boolean, storage?: MockStorage, hasObservab
     },
   }) as any;
 
+function getBuiltInRoute(method: string, path: string): ServerRoute {
+  const route = SERVER_ROUTES.find(candidate => candidate.method === method && candidate.path === path);
+  if (!route) throw new Error(`Missing test route: ${method} ${path}`);
+  return route;
+}
+
 describe('System Handlers', () => {
   const originalEnv = process.env;
   let tempDir: string;
@@ -66,6 +74,23 @@ describe('System Handlers', () => {
     } catch {
       // File may not exist
     }
+  });
+
+  describe('GET_API_SCHEMA_ROUTE', () => {
+    it('should build the API schema manifest from the serving adapter route selection', async () => {
+      const selectedRoute = getBuiltInRoute('GET', '/agents');
+
+      const result = await GET_API_SCHEMA_ROUTE.handler({
+        mastra: {} as any,
+        requestContext: {} as any,
+        abortSignal: new AbortController().signal,
+        serverRoutes: [selectedRoute],
+      });
+      const routeKeys = result.routes.map(route => `${route.method} ${route.path}`);
+
+      expect(routeKeys).toContain('GET /agents');
+      expect(routeKeys).not.toContain('GET /workflows');
+    });
   });
 
   describe('GET_SYSTEM_PACKAGES_ROUTE', () => {

--- a/packages/server/src/server/handlers/system.ts
+++ b/packages/server/src/server/handlers/system.ts
@@ -8,13 +8,8 @@ import {
   observabilityStorageCapabilitiesSchema,
   systemPackagesResponseSchema,
 } from '../schemas/system';
-import type { ServerRoute } from '../server-adapter/routes';
 import { createRoute } from '../server-adapter/routes/route-builder';
 import { handleError } from './error';
-
-type RouteAwareMastraServer = {
-  getServerRoutes?: () => readonly ServerRoute[];
-};
 
 export const GET_API_SCHEMA_ROUTE = createRoute({
   method: 'GET',
@@ -25,10 +20,9 @@ export const GET_API_SCHEMA_ROUTE = createRoute({
   description: 'Returns the route-contract-derived API schema manifest for the machine-readable CLI',
   tags: ['System'],
   requiresAuth: true,
-  handler: async ({ mastra }) => {
+  handler: async ({ serverRoutes }) => {
     // Dynamic import to avoid circular dependency issues
     const { buildApiSchemaManifest } = await import('../server-adapter/api-schema-manifest');
-    const serverRoutes = (mastra.getMastraServer() as RouteAwareMastraServer | undefined)?.getServerRoutes?.();
     return buildApiSchemaManifest(serverRoutes);
   },
 });

--- a/packages/server/src/server/handlers/system.ts
+++ b/packages/server/src/server/handlers/system.ts
@@ -8,8 +8,13 @@ import {
   observabilityStorageCapabilitiesSchema,
   systemPackagesResponseSchema,
 } from '../schemas/system';
+import type { ServerRoute } from '../server-adapter/routes';
 import { createRoute } from '../server-adapter/routes/route-builder';
 import { handleError } from './error';
+
+type RouteAwareMastraServer = {
+  getServerRoutes?: () => readonly ServerRoute[];
+};
 
 export const GET_API_SCHEMA_ROUTE = createRoute({
   method: 'GET',
@@ -20,10 +25,11 @@ export const GET_API_SCHEMA_ROUTE = createRoute({
   description: 'Returns the route-contract-derived API schema manifest for the machine-readable CLI',
   tags: ['System'],
   requiresAuth: true,
-  handler: async () => {
+  handler: async ({ mastra }) => {
     // Dynamic import to avoid circular dependency issues
     const { buildApiSchemaManifest } = await import('../server-adapter/api-schema-manifest');
-    return buildApiSchemaManifest();
+    const serverRoutes = (mastra.getMastraServer() as RouteAwareMastraServer | undefined)?.getServerRoutes?.();
+    return buildApiSchemaManifest(serverRoutes);
   },
 });
 

--- a/packages/server/src/server/server-adapter/index.test.ts
+++ b/packages/server/src/server/server-adapter/index.test.ts
@@ -6,7 +6,8 @@ import type { IFGAProvider } from '@mastra/core/auth/ee';
 import type { ChannelProvider } from '@mastra/core/channels';
 import { Mastra } from '@mastra/core/mastra';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { MastraServer } from './index';
+import type { ServerRoute } from './index';
+import { MastraServer, SERVER_ROUTES } from './index';
 
 class TestMastraServer extends MastraServer<any, any, any> {
   stream = vi.fn();
@@ -170,6 +171,55 @@ describe('server init readiness', () => {
     await expect(adapter.init()).rejects.toThrow('channel readiness failed');
 
     expect(registerRoutes).not.toHaveBeenCalled();
+  });
+});
+
+describe('built-in route selection', () => {
+  it('registers all built-in server routes by default', async () => {
+    const adapter = createTestAdapter();
+
+    await adapter.registerRoutes();
+
+    expect(adapter.registerRoute).toHaveBeenCalledTimes(SERVER_ROUTES.length);
+    expect(adapter.registerRoute.mock.calls.map(call => call[1])).toEqual(SERVER_ROUTES);
+  });
+
+  it('registers only the provided built-in server route array', async () => {
+    const selectedRoutes = [SERVER_ROUTES[2], SERVER_ROUTES[0]].filter(Boolean) as ServerRoute[];
+    const expectedRoutes = [...selectedRoutes];
+    const adapter = new TestMastraServer({
+      app: {},
+      mastra: {
+        getServer: () => undefined,
+        setMastraServer: vi.fn(),
+      } as unknown as Mastra,
+      routes: selectedRoutes,
+    });
+    selectedRoutes.length = 0;
+
+    await adapter.registerRoutes();
+
+    expect(adapter.registerRoute).toHaveBeenCalledTimes(expectedRoutes.length);
+    expect(adapter.registerRoute.mock.calls.map(call => call[1])).toEqual(expectedRoutes);
+  });
+
+  it('registers predicate-selected built-in server routes in canonical order', async () => {
+    const selectedRoutes = [SERVER_ROUTES[0], SERVER_ROUTES[2]].filter(Boolean) as ServerRoute[];
+    const selectedRouteKeys = new Set(selectedRoutes.map(route => `${route.method} ${route.path}`));
+    const adapter = new TestMastraServer({
+      app: {},
+      mastra: {
+        getServer: () => undefined,
+        setMastraServer: vi.fn(),
+      } as unknown as Mastra,
+      routes: route => selectedRouteKeys.has(`${route.method} ${route.path}`),
+    });
+
+    await adapter.registerRoutes();
+
+    const expectedRoutes = SERVER_ROUTES.filter(route => selectedRouteKeys.has(`${route.method} ${route.path}`));
+    expect(adapter.registerRoute).toHaveBeenCalledTimes(expectedRoutes.length);
+    expect(adapter.registerRoute.mock.calls.map(call => call[1])).toEqual(expectedRoutes);
   });
 });
 

--- a/packages/server/src/server/server-adapter/index.test.ts
+++ b/packages/server/src/server/server-adapter/index.test.ts
@@ -72,6 +72,12 @@ function createMockFGAProvider(authorized = true): IFGAProvider {
   };
 }
 
+function getBuiltInRoute(method: string, path: string): ServerRoute {
+  const route = SERVER_ROUTES.find(candidate => candidate.method === method && candidate.path === path);
+  if (!route) throw new Error(`Missing test route: ${method} ${path}`);
+  return route;
+}
+
 describe('custom route forwarding', () => {
   it('should forward DELETE JSON bodies to custom routes', async () => {
     const mastra = new Mastra({
@@ -203,6 +209,77 @@ describe('built-in route selection', () => {
     expect(adapter.registerRoute.mock.calls.map(call => call[1])).toEqual(expectedRoutes);
   });
 
+  it('canonicalizes array-selected routes to built-in route objects', async () => {
+    const selectedRoute = getBuiltInRoute('GET', '/agents');
+    const spoofedRoute = {
+      ...selectedRoute,
+      handler: vi.fn(async () => ({ spoofed: true })),
+      requiresAuth: false,
+    } as ServerRoute;
+    const adapter = new TestMastraServer({
+      app: {},
+      mastra: {
+        getServer: () => undefined,
+        setMastraServer: vi.fn(),
+      } as unknown as Mastra,
+      routes: [spoofedRoute],
+    });
+
+    await adapter.registerRoutes();
+
+    expect(adapter.registerRoute).toHaveBeenCalledTimes(1);
+    expect(adapter.registerRoute.mock.calls[0]?.[1]).toBe(selectedRoute);
+    expect(adapter.registerRoute.mock.calls[0]?.[1]).not.toBe(spoofedRoute);
+  });
+
+  it('rejects unknown and duplicate array-selected built-in routes', () => {
+    const selectedRoute = getBuiltInRoute('GET', '/agents');
+    const unknownRoute = { ...selectedRoute, path: '/not-a-built-in-route' } as ServerRoute;
+
+    expect(
+      () =>
+        new TestMastraServer({
+          app: {},
+          mastra: {
+            getServer: () => undefined,
+            setMastraServer: vi.fn(),
+          } as unknown as Mastra,
+          routes: [unknownRoute],
+        }),
+    ).toThrow(
+      'routes selector can only include built-in Mastra server routes; unknown route: GET /not-a-built-in-route',
+    );
+
+    expect(
+      () =>
+        new TestMastraServer({
+          app: {},
+          mastra: {
+            getServer: () => undefined,
+            setMastraServer: vi.fn(),
+          } as unknown as Mastra,
+          routes: [selectedRoute, selectedRoute],
+        }),
+    ).toThrow('routes selector contains duplicate built-in route: GET /agents');
+  });
+
+  it('returns a defensive copy of selected server routes', () => {
+    const selectedRoutes = [SERVER_ROUTES[0], SERVER_ROUTES[2]].filter(Boolean) as ServerRoute[];
+    const adapter = new TestMastraServer({
+      app: {},
+      mastra: {
+        getServer: () => undefined,
+        setMastraServer: vi.fn(),
+      } as unknown as Mastra,
+      routes: selectedRoutes,
+    });
+
+    const exposedRoutes = adapter.getServerRoutes() as ServerRoute[];
+    exposedRoutes.length = 0;
+
+    expect(adapter.getServerRoutes()).toEqual(selectedRoutes);
+  });
+
   it('registers predicate-selected built-in server routes in canonical order', async () => {
     const selectedRoutes = [SERVER_ROUTES[0], SERVER_ROUTES[2]].filter(Boolean) as ServerRoute[];
     const selectedRouteKeys = new Set(selectedRoutes.map(route => `${route.method} ${route.path}`));
@@ -220,6 +297,29 @@ describe('built-in route selection', () => {
     const expectedRoutes = SERVER_ROUTES.filter(route => selectedRouteKeys.has(`${route.method} ${route.path}`));
     expect(adapter.registerRoute).toHaveBeenCalledTimes(expectedRoutes.length);
     expect(adapter.registerRoute.mock.calls.map(call => call[1])).toEqual(expectedRoutes);
+  });
+
+  it('generates OpenAPI from selected built-in routes only', async () => {
+    const includedRoute = getBuiltInRoute('GET', '/agents');
+    const omittedRoute = getBuiltInRoute('GET', '/workflows');
+    expect(includedRoute.openapi).toBeDefined();
+    expect(omittedRoute.openapi).toBeDefined();
+    const adapter = new TestMastraServer({
+      app: {},
+      mastra: {
+        getServer: () => undefined,
+        setMastraServer: vi.fn(),
+      } as unknown as Mastra,
+      routes: [includedRoute],
+    });
+
+    await adapter.registerOpenAPIRoute({}, { path: '/openapi.json' }, { prefix: '/api' });
+
+    const openApiRoute = adapter.registerRoute.mock.calls[0]?.[1] as ServerRoute | undefined;
+    const spec = await openApiRoute?.handler({} as any);
+
+    expect(spec.paths).toHaveProperty('/agents');
+    expect(spec.paths).not.toHaveProperty('/workflows');
   });
 });
 
@@ -893,6 +993,29 @@ describe('FGA policy coverage validation', () => {
     expect(validatePermissions.mock.calls[0]?.[0]).toContain('agents:create');
     expect(validatePermissions.mock.calls[0]?.[0]).toContain('agents:read');
     expect(validatePermissions.mock.calls[0]?.[0]).toContain('workflows:execute');
+  });
+
+  it('should validate permissions from selected built-in routes only', async () => {
+    const validatePermissions = vi.fn();
+    const mastra = new Mastra({
+      server: {
+        fga: {
+          ...createMockFGAProvider(),
+          validatePermissions,
+        },
+      },
+    });
+    const adapter = new TestMastraServer({
+      app: {},
+      mastra,
+      routes: [getBuiltInRoute('GET', '/agents')],
+    });
+
+    await adapter.validateFGAPolicyCoverage();
+
+    expect(validatePermissions).toHaveBeenCalledTimes(1);
+    expect(validatePermissions.mock.calls[0]?.[0]).toContain('agents:read');
+    expect(validatePermissions.mock.calls[0]?.[0]).not.toContain('workflows:execute');
   });
 
   it('should warn about protected routes without FGA metadata when fail-closed mode is enabled', async () => {

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -421,11 +421,29 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
   private resolveServerRoutes(routes?: ServerRouteSelector): readonly ServerRoute[] {
     if (!routes) return SERVER_ROUTES;
     if (typeof routes === 'function') return SERVER_ROUTES.filter(route => routes(route));
-    return [...routes];
+
+    const builtInsByRoute = new Map(SERVER_ROUTES.map(route => [formatRoute(route), route] as const));
+    const seen = new Set<string>();
+
+    return routes.map(route => {
+      const routeKey = formatRoute(route);
+      const canonicalRoute = builtInsByRoute.get(routeKey);
+
+      if (!canonicalRoute) {
+        throw new Error(`routes selector can only include built-in Mastra server routes; unknown route: ${routeKey}`);
+      }
+
+      if (seen.has(routeKey)) {
+        throw new Error(`routes selector contains duplicate built-in route: ${routeKey}`);
+      }
+
+      seen.add(routeKey);
+      return canonicalRoute;
+    });
   }
 
   getServerRoutes(): readonly ServerRoute[] {
-    return this.serverRoutes;
+    return [...this.serverRoutes];
   }
 
   /**

--- a/packages/server/src/server/server-adapter/index.ts
+++ b/packages/server/src/server/server-adapter/index.ts
@@ -81,6 +81,8 @@ export interface MCPOptions {
   sessionIdGenerator?: () => string;
 }
 
+export type ServerRouteSelector = readonly ServerRoute[] | ((route: ServerRoute) => boolean);
+
 /**
  * Query parameter values parsed from HTTP requests.
  * Supports both single values and arrays (for repeated query params like ?tag=a&tag=b).
@@ -355,6 +357,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
   protected httpLoggingConfig?: HttpLoggingConfig;
   protected customApiRoutes?: ApiRoute[];
   protected mcpOptions?: MCPOptions;
+  protected serverRoutes: readonly ServerRoute[];
   private customRouteHandler:
     | ((request: Request, env?: { requestContext?: RequestContext }) => Promise<Response>)
     | null = null;
@@ -371,6 +374,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     streamOptions,
     customApiRoutes,
     mcpOptions,
+    routes,
   }: {
     app: TApp;
     mastra: Mastra;
@@ -387,6 +391,11 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
      * Individual routes can override these via MCPHttpTransportResult.mcpOptions.
      */
     mcpOptions?: MCPOptions;
+    /**
+     * Built-in server routes to register. Omit to register every built-in route.
+     * Pass a route predicate to preserve the canonical SERVER_ROUTES order.
+     */
+    routes?: ServerRouteSelector;
   }) {
     super({ app, name: 'MastraServer' });
     this.mastra = mastra;
@@ -399,6 +408,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     this.streamOptions = { redact: true, ...streamOptions };
     this.customApiRoutes = customApiRoutes;
     this.mcpOptions = mcpOptions;
+    this.serverRoutes = this.resolveServerRoutes(routes);
 
     // Parse HTTP logging configuration
     const serverConfig = mastra.getServer();
@@ -406,6 +416,16 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
 
     // Automatically register this adapter with Mastra so getServerApp() works
     mastra.setMastraServer(this);
+  }
+
+  private resolveServerRoutes(routes?: ServerRouteSelector): readonly ServerRoute[] {
+    if (!routes) return SERVER_ROUTES;
+    if (typeof routes === 'function') return SERVER_ROUTES.filter(route => routes(route));
+    return [...routes];
+  }
+
+  getServerRoutes(): readonly ServerRoute[] {
+    return this.serverRoutes;
   }
 
   /**
@@ -714,7 +734,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     const customRoutes = (this.customApiRoutes ?? serverConfig?.apiRoutes ?? []).filter(
       route => !route._mastraInternal,
     );
-    const routes = [...SERVER_ROUTES, ...customRoutes] as ServerRoute[];
+    const routes = [...this.serverRoutes, ...customRoutes] as ServerRoute[];
 
     if (fgaProvider.validatePermissions) {
       const permissions = [...new Set(routes.flatMap(route => getRoutePermissions(route)))];
@@ -957,7 +977,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
    * Builds the OpenAPI spec object with servers field and custom route paths.
    */
   private buildOpenAPISpec(config: { title: string; version: string; description: string }, prefix?: string): any {
-    const openApiSpec = generateOpenAPIDocument(SERVER_ROUTES, config);
+    const openApiSpec = generateOpenAPIDocument(this.serverRoutes, config);
 
     if (prefix) {
       openApiSpec.servers = [{ url: prefix }];
@@ -1004,7 +1024,7 @@ export abstract class MastraServer<TApp, TRequest, TResponse> extends MastraServ
     // Register routes sequentially to maintain order - important for routers where
     // more specific routes (e.g., /versions/compare) must be registered before
     // parameterized routes (e.g., /versions/:versionId)
-    for (const route of SERVER_ROUTES) {
+    for (const route of this.serverRoutes) {
       await this.registerRoute(this.app, route, { prefix: this.prefix });
     }
 

--- a/packages/server/src/server/server-adapter/routes/index.ts
+++ b/packages/server/src/server/server-adapter/routes/index.ts
@@ -56,6 +56,8 @@ export type ServerContext = {
   abortSignal: AbortSignal;
   /** The route prefix configured for the server (e.g., '/api') */
   routePrefix?: string;
+  /** Built-in server routes selected for the adapter serving this request. */
+  serverRoutes?: readonly ServerRoute[];
   /** Adapter-normalized request header lookup. */
   getHeader?: (name: string) => string | undefined;
   /**

--- a/server-adapters/express/src/index.ts
+++ b/server-adapters/express/src/index.ts
@@ -539,6 +539,7 @@ export class MastraServer extends MastraServerBase<Application, Request, Respons
           taskStore: res.locals.taskStore,
           abortSignal: res.locals.abortSignal,
           routePrefix: prefix,
+          serverRoutes: this.getServerRoutes(),
           getHeader: (name: string) => req.get(name),
           requestBody: params.body,
           requestPathParams: params.urlParams,

--- a/server-adapters/fastify/src/__tests__/fastify-adapter.test.ts
+++ b/server-adapters/fastify/src/__tests__/fastify-adapter.test.ts
@@ -14,6 +14,7 @@ import {
 import { Mastra } from '@mastra/core';
 import { registerApiRoute } from '@mastra/core/server';
 import type { ServerRoute } from '@mastra/server/server-adapter';
+import { SERVER_ROUTES } from '@mastra/server/server-adapter';
 import Fastify from 'fastify';
 import type { FastifyInstance } from 'fastify';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -35,6 +36,29 @@ async function waitFor(assertion: () => boolean, timeout = 500): Promise<void> {
 
 // Wrapper describe block so the factory can call describe() inside
 describe('Fastify Server Adapter', () => {
+  it('registers only selected built-in server routes', async () => {
+    const app = Fastify();
+    try {
+      const mastra = new Mastra({ logger: false });
+      const selectedRoutes = [SERVER_ROUTES[0], SERVER_ROUTES[2]].filter(Boolean) as ServerRoute[];
+      const selectedRouteKeys = new Set(selectedRoutes.map(route => `${route.method} ${route.path}`));
+      const adapter = new MastraServer({
+        app,
+        mastra,
+        routes: route => selectedRouteKeys.has(`${route.method} ${route.path}`),
+      });
+      const registerRoute = vi.spyOn(adapter, 'registerRoute');
+
+      await adapter.registerRoutes();
+
+      const expectedRoutes = SERVER_ROUTES.filter(route => selectedRouteKeys.has(`${route.method} ${route.path}`));
+      expect(registerRoute).toHaveBeenCalledTimes(expectedRoutes.length);
+      expect(registerRoute.mock.calls.map(call => call[1])).toEqual(expectedRoutes);
+    } finally {
+      await app.close();
+    }
+  });
+
   createRouteAdapterTestSuite({
     suiteName: 'Fastify Adapter Integration Tests',
 

--- a/server-adapters/fastify/src/index.ts
+++ b/server-adapters/fastify/src/index.ts
@@ -276,11 +276,7 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
       // before the signature is checked. Mirrors the Hono adapter's getParams.
       if (route.skipBodyParse) {
         if (Buffer.isBuffer(request.body)) {
-          rawBody = new Uint8Array(
-            request.body.buffer,
-            request.body.byteOffset,
-            request.body.byteLength,
-          );
+          rawBody = new Uint8Array(request.body.buffer, request.body.byteOffset, request.body.byteLength);
         } else if (typeof request.body === 'string') {
           rawBody = request.body;
         } else if (request.body instanceof Uint8Array) {
@@ -677,6 +673,7 @@ export class MastraServer extends MastraServerBase<FastifyInstance, FastifyReque
         taskStore: request.taskStore,
         abortSignal: request.abortSignal,
         routePrefix: prefix,
+        serverRoutes: this.getServerRoutes(),
         getHeader: (name: string) => {
           const value = request.headers[name.toLowerCase()];
           return Array.isArray(value) ? value.join(',') : value;

--- a/server-adapters/hono/src/index.ts
+++ b/server-adapters/hono/src/index.ts
@@ -576,6 +576,7 @@ export class MastraServer extends MastraServerBase<HonoApp, HonoRequest, Context
           taskStore: c.get('taskStore'),
           abortSignal: c.get('abortSignal'),
           routePrefix: prefix,
+          serverRoutes: this.getServerRoutes(),
           getHeader: (name: string) => c.req.header(name),
           getHeaders: () => Object.fromEntries(c.req.raw.headers),
           rawBody: params.rawBody,

--- a/server-adapters/koa/src/index.ts
+++ b/server-adapters/koa/src/index.ts
@@ -461,6 +461,7 @@ export class MastraServer extends MastraServerBase<Koa, Context, Context> {
       taskStore: ctx.state.taskStore,
       abortSignal: ctx.state.abortSignal,
       routePrefix: prefix,
+      serverRoutes: this.getServerRoutes(),
     };
 
     // Check route permission requirement (EE feature)


### PR DESCRIPTION
## Summary
- add a server-adapter `routes` selector for built-in route registration
- apply the selected route set consistently to FGA validation, OpenAPI generation, and the system API schema manifest
- cover default, array-selected, predicate-selected, and Fastify selected-route registration behavior

## Tracking
- Linear: PF-865
- PapersFlow mirror issue: papersflow-ai/papersflow#924

## Validation
- `./node_modules/.bin/eslint src/server/server-adapter/index.ts src/server/server-adapter/index.test.ts src/server/handlers/system.ts ../../server-adapters/fastify/src/__tests__/fastify-adapter.test.ts`
- `./node_modules/.bin/vitest run src/server/server-adapter/index.test.ts -t "built-in route selection"`
- `./node_modules/.bin/vitest run src/__tests__/fastify-adapter.test.ts -t "registers only selected built-in server routes"`
- `git diff --check`
- Codex review pass 1: no correctness findings
- Codex review pass 2: no correctness findings
- CodeRabbit local review: fixed Fastify test cleanup finding and simplified changeset wording

## Known Existing Failures / Blockers
- `@mastra/server build:lib` reaches declaration generation and fails on existing harness display-state type mismatches around `assistantDrafts` in `src/server/handlers/harness-display-state.ts` and `src/server/handlers/harness.ts`.
- Package-script `pnpm --filter @mastra/server test -- src/server/server-adapter/index.test.ts` also runs broader package tests and currently fails existing server init readiness and schedules tests unrelated to this patch.

This PR does not change PapersFlow Doxa route exposure or consume a new fork package artifact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which HTTP endpoints exist and how FGA/OpenAPI/schema metadata are derived; default remains all routes, but misconfigured selectors could omit expected APIs or auth coverage.
> 
> **Overview**
> Adds a **`routes`** option on `MastraServer` so adapters can register only a subset of built-in `SERVER_ROUTES` instead of the full catalog. Omit it for today’s behavior; pass a **route array** or a **predicate** (filtered routes keep canonical `SERVER_ROUTES` order). Array selections are **canonicalized** to built-in route objects and **reject** unknown or duplicate entries.
> 
> The resolved route set drives **registration**, **OpenAPI** generation, **FGA policy coverage** validation, and the **`GET /system/api-schema`** manifest via new **`serverRoutes`** on handler context (wired through Express, Fastify, Hono, and Koa). **`getServerRoutes()`** exposes a defensive copy of the selection.
> 
> Tests cover default vs selected registration, spoofed route objects, OpenAPI/FGA scoping, the system API schema handler, and Fastify predicate selection. Documented as a minor `@mastra/server` changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23aca1e132606d7ea53d47ef2a61669a70925ca7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5 (Explain Like I’m 5)

Previously, the built-in server came with a fixed “full set” of routes. Now you can tell it which built-in routes to include (or filter them), so your server only exposes the endpoints you want.

## Overview

This PR adds **selective registration of Mastra’s built-in server routes** in `@mastra/server`. Developers can choose which built-in routes get registered, and that same selection is consistently applied to:
- **FGA policy coverage validation**
- **OpenAPI generation**
- **System API schema generation** (`GET /system/api-schema`)

## Changes

### New public API: route selection
- Introduces **`ServerRouteSelector`** (`readonly ServerRoute[] | ((route: ServerRoute) => boolean)`)
- Adds a new optional constructor option on `MastraServer`: **`routes?: ServerRouteSelector`**
- Adds **`getServerRoutes(): readonly ServerRoute[]`** to retrieve the resolved built-in routes for the adapter

### Adapter behavior: resolve + apply selected routes everywhere
- Adds **`resolveServerRoutes()`** that:
  - Defaults to **all `SERVER_ROUTES` in canonical order** when `routes` isn’t provided
  - Supports **explicit array selection**
    - Canonicalizes spoofed inputs back to the real built-in route objects
    - Rejects **unknown routes**
    - Rejects **duplicate entries** with clear errors
  - Supports **predicate-function filtering** against `SERVER_ROUTES` (canonical order preserved)
- Stores the resolved routes on the adapter and uses them consistently for:
  - **Actual built-in route registration**
  - **OpenAPI document generation** via `registerOpenAPIRoute` restricted to selected routes
  - **FGA policy coverage checks** derived only from selected routes
  - **Exposing selected routes** to route handlers via handler params

### System schema generation now uses only selected routes
- Updates the **`GET_API_SCHEMA_ROUTE`** handler so it generates the manifest using:
  - **`buildApiSchemaManifest(serverRoutes)`**
- Adds `serverRoutes` to the server context so the handler receives the adapter’s selected route set.

### Adapter handler params: expose `serverRoutes` to route handlers
- Adds `serverRoutes: this.getServerRoutes()` into `handlerParams` for multiple server adapters:
  - **Express**
  - **Fastify**
  - **Hono**
  - **Koa**
- (Fastify test also verifies correct selective registration behavior end-to-end.)

## Tests

- **Vitest unit tests** for built-in route selection (`server-adapter/index.test.ts`), including:
  - default = all routes in `SERVER_ROUTES` order
  - explicit array selection (including canonicalization behavior)
  - predicate filtering
  - rejection of unknown routes and duplicate entries
  - `getServerRoutes()` returning a defensive copy
  - OpenAPI generation limited to selected routes
  - FGA coverage validation limited to selected routes
- **Fastify integration test** ensuring `registerRoutes()` registers only the selected subset.
- **System handler test** verifying `GET /system/api-schema` includes/excludes routes based on `serverRoutes`.
- Includes mention of **ESLint checks**, **Fastify integration coverage**, and **whitespace verification**.

## Documentation / release notes
- Adds a **changeset** documenting a minor `@mastra/server` release with an example showing route filtering (e.g., by `/harness/`).

## Known unrelated test failures
- Notes **two pre-existing, unrelated** failures:
  - TypeScript declaration generation issues in harness-related files due to type mismatches
  - Broader package test failures in server initialization and scheduling tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->